### PR TITLE
python-lxc: Convert state to uppercase

### DIFF
--- a/src/python-lxc/lxc/__init__.py
+++ b/src/python-lxc/lxc/__init__.py
@@ -362,6 +362,15 @@ class Container(_lxc.Container):
             self.clear_config_item(key)
             return False
 
+    def wait(self, state, timeout = -1):
+        """
+            Wait for the container to reach a given state or timeout.
+        """
+
+        if isinstance(state, str):
+            state = state.upper()
+
+        _lxc.Container.wait(self, state, timeout)
 
 def list_containers(as_object=False):
     """


### PR DESCRIPTION
At Serge's suggestion, always convert the state passed to the wait()
function in the python API to its uppercase equivalent.

Signed-off-by: Stéphane Graber stgraber@ubuntu.com
