### PR TITLE
Add missing option -t/--fstype

### DIFF
--- a/src/lxc/lxc-clone.in
+++ b/src/lxc/lxc-clone.in
@@ -85,6 +85,11 @@ while [ $# -gt 0 ]; do
             lxc_size=$1
             shift
             ;;
+        -t|--fstype)
+            optarg_check $opt $1
+            fstype=$1
+            shift
+            ;;
         -v|--vgname)
             optarg_check $opt $1
             lxc_vg=$1


### PR DESCRIPTION
As far as I can see the documentation of lxc-clone, it seems to be able to specify a file system of the clone being created, but in fact it is impossible. The error message looks like:

```
# lxc-clone -o foo -n bar -t ext4
Unknown option: '-t'
```

This PR fixes this problem.
