### PR TITLE
Add note for automake req for ./autogen.sh step.

### DIFF
--- a/README
+++ b/README
@@ -39,8 +39,13 @@ Downloading the current source code:
   ./autogen.sh && ./configure && make && sudo make install
   preceded by ./autogen.sh if configure do not exist yet.
 
+Troubleshooting:
+
   If the ./autogen.sh script outputs error message "aclocal: not found",
   run `sudo apt-get install automake` then try again.
+
+  If the ./configure step outputs error message "configure: error: Please install the libcap development files."  
+  run `sudo apt-get install libcap-dev` then try again.
 
 Getting help:
 


### PR DESCRIPTION
Ran into error:

``` bash
~/lxc-0.8.0$ ./autogen.sh 
+ test -d autom4te.cache
+ aclocal -I config
./autogen.sh: 6: ./autogen.sh: aclocal: not found
+ exit 1
```

Solved by apt-get install automake. Worth noting as not all cloud linux images come pre-installed with automake.
