### PR TITLE
use "uname -m" instead of "arch"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,7 +67,7 @@ if test "x$enable_doc" = "xyes" -o "x$enable_doc" = "xauto"; then
 	db2xman=""
 
 	AC_MSG_CHECKING(for docbook2x-man)
-	for name in docbook2x-man db2x_docbook2man; do
+	for name in docbook2x-man db2x_docbook2man docbook2man; do
 		if "$name" --help >/dev/null 2>&1; then
 			db2xman="$name"
 			break;


### PR DESCRIPTION
uname is in the FHS while arch is not
ArchLinux does not provide arch

Signed-off-by: Christian Bühler christian@cbuehler.de
