### PR TITLE
use "uname -m" instead of "arch"

### DIFF
--- a/templates/lxc-altlinux.in
+++ b/templates/lxc-altlinux.in
@@ -25,7 +25,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 #Configurations
-arch=$(arch)
+arch=$(uname -m)
 cache_base=@LOCALSTATEDIR@/cache/lxc/altlinux/$arch
 default_path=@LXCPATH@
 default_profile=default

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -175,7 +175,7 @@ install_debian()
         if which dpkg >/dev/null 2>&1 ; then
             arch=$(dpkg --print-architecture)
         else
-            arch=$(arch)
+            arch=$(uname -m)
             if [ "$arch" = "i686" ]; then
                 arch="i386"
             elif [ "$arch" = "x86_64" ]; then

--- a/templates/lxc-fedora.in
+++ b/templates/lxc-fedora.in
@@ -26,7 +26,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 #Configurations
-arch=$(arch)
+arch=$(uname -m)
 cache_base=@LOCALSTATEDIR@/cache/lxc/fedora/$arch
 default_path=@LXCPATH@
 root_password=root

--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -212,7 +212,7 @@ install_opensuse()
             return 1
         fi
 
-        arch=$(arch)
+        arch=$(uname -m)
 
         echo "Checking cache download in $cache/rootfs-$arch ... "
         if [ ! -e "$cache/rootfs-$arch" ]; then

--- a/templates/lxc-oracle.in
+++ b/templates/lxc-oracle.in
@@ -615,7 +615,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-arch=$(arch)
+arch=$(uname -m)
 eval set -- "$options"
 while true
 do

--- a/templates/lxc-ubuntu-cloud.in
+++ b/templates/lxc-ubuntu-cloud.in
@@ -148,7 +148,7 @@ if [ -f /etc/lsb-release ]; then
     esac
 fi
 
-arch=$(arch)
+arch=$(uname -m)
 
 # Code taken from debootstrap
 if [ -x /usr/bin/dpkg ] && /usr/bin/dpkg --print-architecture >/dev/null 2>&1; then
@@ -156,7 +156,7 @@ if [ -x /usr/bin/dpkg ] && /usr/bin/dpkg --print-architecture >/dev/null 2>&1; t
 elif type udpkg >/dev/null 2>&1 && udpkg --print-architecture >/dev/null 2>&1; then
     arch=`/usr/bin/udpkg --print-architecture`
 else
-    arch=$(arch)
+    arch=$(uname -m)
     if [ "$arch" = "i686" ]; then
         arch="i386"
     elif [ "$arch" = "x86_64" ]; then

--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -605,7 +605,7 @@ if [ -f /etc/lsb-release ]; then
 fi
 
 bindhome=
-arch=$(arch)
+arch=$(uname -m)
 
 # Code taken from debootstrap
 if [ -x /usr/bin/dpkg ] && /usr/bin/dpkg --print-architecture >/dev/null 2>&1; then
@@ -613,7 +613,7 @@ if [ -x /usr/bin/dpkg ] && /usr/bin/dpkg --print-architecture >/dev/null 2>&1; t
 elif which udpkg >/dev/null 2>&1 && udpkg --print-architecture >/dev/null 2>&1; then
     arch=`/usr/bin/udpkg --print-architecture`
 else
-    arch=$(arch)
+    arch=$(uname -m)
     if [ "$arch" = "i686" ]; then
         arch="i386"
     elif [ "$arch" = "x86_64" ]; then


### PR DESCRIPTION
uname is in the FHS, arch is not
ArchLinux does not provide arch

Signed-off-by: Christian Bühler christian@cbuehler.de
