### PR TITLE
lxc-checkconfig fails on ArchLinux

### DIFF
--- a/src/lxc/lxc-checkconfig.in
+++ b/src/lxc/lxc-checkconfig.in
@@ -10,7 +10,7 @@ SETCOLOR_WARNING="printf \\033[1;33m"
 SETCOLOR_NORMAL="printf \\033[0;39m"
 
 is_set() {
-    $GREP -q "$1=[y|m]" $CONFIG
+    $GREP "$1=[y|m]" $CONFIG > /dev/null
     return $?
 }
 


### PR DESCRIPTION
Hi, 

On ArchLinux, lxc-checkconfig fails:

```
$ lxc-checkconfig 
--- Namespaces ---
Namespaces: zgrep -q CONFIG_NAMESPACES=[y|m] /proc/config.gz

gzip: stdout: Broken pipe
required
Utsname namespace: zgrep -q CONFIG_UTS_NS=[y|m] /proc/config.gz

gzip: stdout: Broken pipe
missing
Ipc namespace: zgrep -q CONFIG_IPC_NS=[y|m] /proc/config.gz

gzip: stdout: Broken pipe
required
Pid namespace: zgrep -q CONFIG_PID_NS=[y|m] /proc/config.gz

gzip: stdout: Broken pipe
required
User namespace: zgrep -q CONFIG_USER_NS=[y|m] /proc/config.gz
missing
Network namespace: zgrep -q CONFIG_NET_NS=[y|m] /proc/config.gz

gzip: stdout: Broken pipe
missing
Multiple /dev/pts instances: zgrep -q DEVPTS_MULTIPLE_INSTANCES=[y|m] /proc/config.gz
enabled
...
```

This is because `zgrep -q` is mysteriously failing:

```
$ zgrep -q 'CONFIG_VLAN_8021Q=[y|m]' /proc/config.gz

gzip: stdout: Broken pipe
```

```
$ zgrep  'CONFIG_VLAN_8021Q=[y|m]' /proc/config.gz
CONFIG_VLAN_8021Q=m
```

```
$ zgrep --version
zgrep (gzip) 1.5
Copyright (C) 2010-2012 Free Software Foundation, Inc.
This is free software.  You may redistribute copies of it under the terms of
the GNU General Public License <http://www.gnu.org/licenses/gpl.html>.
There is NO WARRANTY, to the extent permitted by law.

Written by Jean-loup Gailly.
```

```
$ grep --version
grep (GNU grep) 2.14
Copyright (c) 2012 Free Software Foundation, Inc.
Licence GPLv3+: GNU GPL version 3 ou ultérieure <http://gnu.org/licenses/gpl.html>.
Logiciel libre : vous êtes libre de le modifier ou de le redistribuer.
Il n'y a AUCUNE GARANTIE, dans les limites autorisées par la loi.

Conçu par Mike Haertel et pour les autres, voir <http://git.sv.gnu.org/cgit/grep.git/tree/AUTHORS>.
```
