### PR TITLE
Improve check for systemd in a template for Fedora

### DIFF
--- a/templates/lxc-fedora.in
+++ b/templates/lxc-fedora.in
@@ -567,7 +567,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-type /bin/systemd >/dev/null 2>&1
+test $(ps --noheaders -o comm 1) = 'systemd'
 if [ $? -ne 0 ]; then
     configure_fedora_init
 else


### PR DESCRIPTION
The /usr/bin/systemd symlink has been removed from the systemd package in Fedora Rawhide.
- http://pkgs.fedoraproject.org/cgit/systemd.git/commit/?id=c3b79820c74b69289284bcbdf5f5ebc359feae3b

Therefore, the current template script fails to find systemd on such a host.

```
# lxc-create -n test -t fedora -- --release=19
Host CPE ID from /etc/os-release: cpe:/o:fedoraproject:fedora:20
Checking cache download in /usr/local/var/cache/lxc/fedora/x86_64/19/rootfs ...
...
sed: can't read /usr/local/var/lib/lxc/test/rootfs/etc/rc.sysinit: No such file or directory
sed: can't read /usr/local/var/lib/lxc/test/rootfs/etc/rc.d/rc.sysinit: No such file or directory
sed: can't read /usr/local/var/lib/lxc/test/rootfs/etc/rc.sysinit: No such file or directory
sed: can't read /usr/local/var/lib/lxc/test/rootfs/etc/rc.d/rc.sysinit: No such file or directory
error reading information on service udev-post: No such file or directory
container rootfs and config created
```

I've created a patch to fix this problem.
