### PR TITLE
lxc-destroy: Fix regular expression for getting rootfs

### DIFF
--- a/src/lxc/lxc-destroy.in
+++ b/src/lxc/lxc-destroy.in
@@ -157,9 +157,9 @@ if ! lxc-info -n $lxc_name -P $lxc_path --state-is "STOPPED"; then
 fi
 
 # Deduce the type of rootfs
-# If LVM partition, destroy it. For btrfs, we delete the subvolue. If anything
+# If LVM partition, destroy it. For btrfs, we delete the subvolume. If anything
 # else, ignore it. We'll support deletion of others later.
-rootdev=`grep lxc.rootfs $lxc_path/$lxc_name/config 2>/dev/null | sed -e 's/^[^/]*//'`
+rootdev=`grep '^\s*lxc\.rootfs' $lxc_path/$lxc_name/config 2>/dev/null | sed -e 's/^[^/]*//'`
 if [ -n "$rootdev" ]; then
     if [ `verify_lvm $rootdev` = "lvm" ]; then
         if [ `busy_lvm $rootdev` = "busy" ]; then


### PR DESCRIPTION
The `lxc-destroy` script was using a simple `grep` for extracting
`lxc.rootfs` from the lxc config. This regex also matches commented lines
and breaks at least removing btrfs subvolumes if the string `lxc.rootfs`
is mentioned in a comment. Furthermore, due to the unescaped dot in the
regex it would also match other wrong strings like `lxc rootfs`.

This patch modifies the regular expression to correctly match the beginning
of the line plus potential whitespace characters and the string
`lxc.rootfs`.

Signed-off-by: Franz Pletz fpletz@fnordicwalking.de
