### PR TITLE
Add workaround to force locales generation

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -81,7 +81,7 @@ EOF
         chroot $rootfs update-locale LANG=en_US.UTF-8
     else
         encoding=$(echo $LANG | cut -d. -f2)
-        chroot $rootfs perl -pe "s/^# (${LANG} ${encoding})/\1/" \
+        chroot $rootfs sed -e "s/^# \(${LANG} ${encoding}\)/\1/" \
             -i /etc/locale.gen 2>/dev/null
         chroot $rootfs locale-gen $LANG $encoding
         chroot $rootfs update-locale LANG=$LANG


### PR DESCRIPTION
Signed-off-by: Laurent Vallar val@zbla.net

Before, with LANG=fr_FR.UTF-8 :

```
# lxc-create -n test -t debian -B lvm --lvname test --vgname lvm --fstype ext4 --fssize 512M

lxc-create: No config file specified, using the default config /etc/lxc/default.conf
  Logical volume "test" created
mke2fs 1.42.5 (29-Jul-2012)
Étiquette de système de fichiers=
Type de système d'exploitation : Linux
Taille de bloc=4096 (log=2)
Taille de fragment=4096 (log=2)
« Stride » = 0 blocs, « Stripe width » = 0 blocs
32768 i-noeuds, 131072 blocs
6553 blocs (5.00%) réservés pour le super utilisateur
Premier bloc de données=0
Nombre maximum de blocs du système de fichiers=134217728
4 groupes de blocs
32768 blocs par groupe, 32768 fragments par groupe
8192 i-noeuds par groupe
Superblocs de secours stockés sur les blocs : 
    32768, 98304

Allocation des tables de groupe : complété                        
Écriture des tables d'i-noeuds : complété                        
Création du journal (4096 blocs) : complété
Écriture des superblocs et de l'information de comptabilité du système de
fichiers : complété

debootstrap est /usr/sbin/debootstrap
Checking cache download in /var/cache/lxc/debian/rootfs-wheezy-amd64 ... 
Copying rootfs to /var/lib/lxc/test/rootfs...Generating locales (this might take a while)...
Generation complete.
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
    LANGUAGE = "fr_FR.UTF-8",
    LC_ALL = "fr_FR.UTF-8",
    LC_MESSAGES = "fr_FR.UTF-8",
    LANG = "fr_FR.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
*** update-locale: Error: invalid locale settings:  LANG=fr_FR.UTF-8
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
    LANGUAGE = "fr_FR.UTF-8",
    LC_ALL = "fr_FR.UTF-8",
    LC_MESSAGES = "fr_FR.UTF-8",
    LANG = "fr_FR.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
update-rc.d: using dependency based boot sequencing
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
    LANGUAGE = "fr_FR.UTF-8",
    LC_ALL = "fr_FR.UTF-8",
    LC_MESSAGES = "fr_FR.UTF-8",
    LANG = "fr_FR.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
update-rc.d: using dependency based boot sequencing
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
    LANGUAGE = "fr_FR.UTF-8",
    LC_ALL = "fr_FR.UTF-8",
    LC_MESSAGES = "fr_FR.UTF-8",
    LANG = "fr_FR.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
update-rc.d: using dependency based boot sequencing
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
    LANGUAGE = "fr_FR.UTF-8",
    LC_ALL = "fr_FR.UTF-8",
    LC_MESSAGES = "fr_FR.UTF-8",
    LANG = "fr_FR.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
update-rc.d: using dependency based boot sequencing
Root password is 'root', please change !
'debian' template installed
Unmounting LVM
'test' created
```

After workaround, locales are properly configured : 

```
# lxc-create -n test -t debian -B lvm --lvname test --vgname lvm --fstype ext4 --fssize 512M

lxc-create: No config file specified, using the default config /etc/lxc/default.conf
  Logical volume "test" created
mke2fs 1.42.5 (29-Jul-2012)
Étiquette de système de fichiers=
Type de système d'exploitation : Linux
Taille de bloc=4096 (log=2)
Taille de fragment=4096 (log=2)
« Stride » = 0 blocs, « Stripe width » = 0 blocs
32768 i-noeuds, 131072 blocs
6553 blocs (5.00%) réservés pour le super utilisateur
Premier bloc de données=0
Nombre maximum de blocs du système de fichiers=134217728
4 groupes de blocs
32768 blocs par groupe, 32768 fragments par groupe
8192 i-noeuds par groupe
Superblocs de secours stockés sur les blocs : 
    32768, 98304

Allocation des tables de groupe : complété                        
Écriture des tables d'i-noeuds : complété                        
Création du journal (4096 blocs) : complété
Écriture des superblocs et de l'information de comptabilité du système de
fichiers : complété

debootstrap est /usr/sbin/debootstrap
Checking cache download in /var/cache/lxc/debian/rootfs-wheezy-amd64 ... 
Copying rootfs to /var/lib/lxc/test/rootfs...Generating locales (this might take a while)...
  fr_FR.UTF-8... done
Generation complete.
update-rc.d: using dependency based boot sequencing
update-rc.d: using dependency based boot sequencing
update-rc.d: using dependency based boot sequencing
update-rc.d: using dependency based boot sequencing
Root password is 'root', please change !
'debian' template installed
Unmounting LVM
'test' created
```
