### PR TITLE
Latest Mandriva distro release was in 2011 and nowadays distro named OpennMandriva Lx

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ AC_GNU_SOURCE
 # Detect the distribution. This is used for the default configuration and
 # for some distro-specific build options.
 AC_MSG_CHECKING([host distribution])
-AC_ARG_WITH(distro, AS_HELP_STRING([--with-distro=DISTRO], [Specify the Linux distribution to target: One of redhat, oracle, fedora, suse, gentoo, debian, arch, slackware, paldo, mandriva or pardus.]))
+AC_ARG_WITH(distro, AS_HELP_STRING([--with-distro=DISTRO], [Specify the Linux distribution to target: One of redhat, oracle, fedora, suse, gentoo, debian, arch, slackware, paldo, openmandriva or pardus.]))
 if test "z$with_distro" = "z"; then
 	with_distro=`lsb_release -is`
 fi
@@ -28,8 +28,8 @@ if test "z$with_distro" = "z"; then
 	AC_CHECK_FILE(/etc/arch-release,with_distro="arch")
 	AC_CHECK_FILE(/etc/slackware-version,with_distro="slackware")
 	AC_CHECK_FILE(/etc/frugalware-release,with_distro="frugalware")
-	AC_CHECK_FILE(/etc/mandrakelinux-release, with_distro="mandriva")
-	AC_CHECK_FILE(/etc/mandriva-release,with_distro="mandriva")
+	AC_CHECK_FILE(/etc/mandrakelinux-release, with_distro="openmandriva")
+	AC_CHECK_FILE(/etc/mandriva-release,with_distro="openmandriva")
 	AC_CHECK_FILE(/etc/pardus-release,with_distro="pardus")
 fi
 with_distro=`echo ${with_distro} | tr '[[:upper:]]' '[[:lower:]]'`


### PR DESCRIPTION
Latest Mandriva distro release was in 2011 and nowadays distro named OpennMandriva Lx
openmandriva.org

Signed-off-by: Alexander Khryukin alexander@mezon.ru
