### PR TITLE
Store fssize and fstype in the right struct.

### DIFF
--- a/src/lxc/lxc_create.c
+++ b/src/lxc/lxc_create.c
@@ -233,9 +233,9 @@ int main(int argc, char *argv[])
 			spec.u.lvm.fssize = my_args.fssize;
 	} else if (strcmp(my_args.bdevtype, "loop") == 0) {
 		if (my_args.fstype)
-			spec.u.lvm.fstype = my_args.fstype;
+			spec.u.loop.fstype = my_args.fstype;
 		if (my_args.fssize)
-			spec.u.lvm.fssize = my_args.fssize;
+			spec.u.loop.fssize = my_args.fssize;
 	} else if (my_args.dir) {
 		ERROR("--dir is not yet supported");
 		exit(1);


### PR DESCRIPTION
When using the -Bloop option, fstype and fssize arguments were copied into the lvm struct of bdev specs instead of the loop struct.
