### PR TITLE
Fix segfault on lxc-create when no template specified

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -1089,9 +1089,11 @@ static bool lxcapi_create(struct lxc_container *c, const char *t,
 		lxc_conf_free(c->lxc_conf);
 	c->lxc_conf = NULL;
 
-	if (!prepend_lxc_header(c->configfile, tpath, argv)) {
-		ERROR("Error prepending header to configuration file");
-		goto out_unlock;
+	if (t) {
+		if (!prepend_lxc_header(c->configfile, tpath, argv)) {
+			ERROR("Error prepending header to configuration file");
+			goto out_unlock;
+		}
 	}
 	bret = load_config_locked(c, c->configfile);
 


### PR DESCRIPTION
When no template file is specified on lxc-create, recieve segfault.
So change not to append header in config when no template is specified.

Signed-off-by: KATOH Yasufumi karma@jazz.email.ne.jp
