### PR TITLE
run_buffer(): unblock all signals for spawned scripts.

### DIFF
--- a/src/lxc/bdev.c
+++ b/src/lxc/bdev.c
@@ -501,24 +501,24 @@ struct bdev_ops dir_ops = {
 
 static int zfs_list_entry(const char *path, char *output, size_t inlen)
 {
-	FILE *f;
+	struct lxc_popen_FILE *f;
 	int found=0;
 
 	process_lock();
-	f = popen("zfs list 2> /dev/null", "r");
+	f = lxc_popen("zfs list 2> /dev/null");
 	process_unlock();
 	if (f == NULL) {
 		SYSERROR("popen failed");
 		return 0;
 	}
-	while (fgets(output, inlen, f)) {
+	while (fgets(output, inlen, f->f)) {
 		if (strstr(output, path)) {
 			found = 1;
 			break;
 		}
 	}
 	process_lock();
-	(void) pclose(f);
+	(void) lxc_pclose(f);
 	process_unlock();
 
 	return found;
@@ -813,7 +813,7 @@ static int lvm_umount(struct bdev *bdev)
 }
 
 static int lvm_compare_lv_attr(const char *path, int pos, const char expected) {
-	FILE *f;
+	struct lxc_popen_FILE *f;
 	int ret, len, status, start=0;
 	char *cmd, output[12];
 	const char *lvscmd = "lvs --unbuffered --noheadings -o lv_attr %s 2>/dev/null";
@@ -826,7 +826,7 @@ static int lvm_compare_lv_attr(const char *path, int pos, const char expected) {
 		return -1;
 
 	process_lock();
-	f = popen(cmd, "r");
+	f = lxc_popen(cmd);
 	process_unlock();
 
 	if (f == NULL) {
@@ -834,10 +834,10 @@ static int lvm_compare_lv_attr(const char *path, int pos, const char expected) {
 		return -1;
 	}
 
-	ret = fgets(output, 12, f) == NULL;
+	ret = fgets(output, 12, f->f) == NULL;
 
 	process_lock();
-	status = pclose(f);
+	status = lxc_pclose(f);
 	process_unlock();
 
 	if (ret || WEXITSTATUS(status))

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -350,12 +350,12 @@ static char *mkifname(char *template)
 
 static int run_buffer(char *buffer)
 {
-	FILE *f;
+	struct lxc_popen_FILE *f;
 	char *output;
 	int ret;
 
 	process_lock();
-	f = popen(buffer, "r");
+	f = lxc_popen(buffer);
 	process_unlock();
 	if (!f) {
 		SYSERROR("popen failed");
@@ -366,18 +366,18 @@ static int run_buffer(char *buffer)
 	if (!output) {
 		ERROR("failed to allocate memory for script output");
 		process_lock();
-		pclose(f);
+		lxc_pclose(f);
 		process_unlock();
 		return -1;
 	}
 
-	while(fgets(output, LXC_LOG_BUFFER_SIZE, f))
+	while(fgets(output, LXC_LOG_BUFFER_SIZE, f->f))
 		DEBUG("script output: %s", output);
 
 	free(output);
 
 	process_lock();
-	ret = pclose(f);
+	ret = lxc_pclose(f);
 	process_unlock();
 	if (ret == -1) {
 		SYSERROR("Script exited on error");


### PR DESCRIPTION
Currently, all scripts, specified as "lxc.network.script.up", inherit
lxc-execute's signal mask.
This, for example, includes blocked SIGALRM signal which, in turn, makes
alarm(2), sleep(3) and setitimer(2) functions silently unusable in all programs,
invoked in turn by the "lxc.network.script.up".
To fix this, run_buffer() should restore default signal mask prior to
executing "lxc.network.script.up".

A naive implementation would temprorary unblock all signals just before
calling popen() and block them back immediately after it.
But that would result in an immediate delivery of all pending signals just
after their unblocking.
Thus, we should restore default signal mask exactly in child (after fork())
just before calling exec().
To achieve this, a home-brewed popen() alternative is needed.
The added my_popen() and my_close() are mostly taken from glibc with
several simplifications (as we currently need only "re" mode).
The implementation uses Linux-specific pipe2() system-call,
which is only available since Linux 2.6.27 and supported by glibc since
version 2.9 (according to pipe(2) man-page), but this shouldn't be a
problem as lxc requires a fairly recent kernel too.

(mazo: don't clear close-on-exec flag for parent's end;
coding style fixes;
commit message tweaks)

Signed-off-by: Ivan Bolsunov bolsunov@telum.ru
Signed-off-by: Andrey Mazo mazo@telum.ru
