### PR TITLE
Avoid annoying error '/etc/init.d/mountall.sh: 59: kill: Illegal number:...

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -93,6 +93,9 @@ EOF
     chroot $rootfs /usr/sbin/update-rc.d -f hwclock.sh remove
     chroot $rootfs /usr/sbin/update-rc.d -f hwclockfirst.sh remove
 
+    # avoid annoying error '/etc/init.d/mountall.sh: 59: kill: Illegal number: 3 1' message during boot
+    sed -i 's/PID="\$(pidof \/sbin\/init || echo 1)"/PID="\$(pidof -s \/sbin\/init || echo 1)"/' $rootfs/etc/init.d/mountall.sh
+
     echo "root:root" | chroot $rootfs chpasswd
     echo "Root password is 'root', please change !"
 


### PR DESCRIPTION
... 3 1' message during container's boot

Based on http://lists.debian.org/debian-hurd/2013/08/msg00050.html

Signed-off-by: funditus funditus@mail.ru
