### PR TITLE
Regenerate ssh keys in container and change hostname inside them.

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -93,6 +93,13 @@ EOF
     chroot $rootfs /usr/sbin/update-rc.d -f hwclock.sh remove
     chroot $rootfs /usr/sbin/update-rc.d -f hwclockfirst.sh remove
 
+    # regenerate ssh keys
+    rm $rootfs/etc/ssh/ssh_host_*
+    chroot $rootfs /usr/sbin/dpkg-reconfigure openssh-server
+
+    # change hostname comment in newly generated keys
+    sed -i "s/root@$HOSTNAME/root@$hostname/g" $rootfs/etc/ssh/ssh_host_*.pub
+
     echo "root:root" | chroot $rootfs chpasswd
     echo "Root password is 'root', please change !"
 


### PR DESCRIPTION
SSH keys need to be regenerated inside container to make them unique. During regeneration host's hostname is put in comment area of public keys, so need to be changed to container's hostname.

Signed-off-by: funditus funditus@mail.ru
