### PR TITLE
Lxc archlinux

### DIFF
--- a/templates/lxc-archlinux.in
+++ b/templates/lxc-archlinux.in
@@ -9,6 +9,7 @@
 
 # Authors:
 # Alexander Vladimirov <idkfa@vlan1.ru>
+# John Lane <lxc@jelmail.com>
 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -204,12 +205,13 @@ Optional args:
   -a,--arch         use specified architecture instead of host's architecture 
   -t,--network_type set container network interface type (${lxc_network_type})
   -l,--network_link set network link device (${lxc_network_link})
+  -r,--root_passwd  set container root password
   -h,--help         print this help
 EOF
     return 0
 }
 
-options=$(getopt -o hp:P:e:n:c:a:l:t: -l help,rootfs:,path:,packages:,enable_units:,name:,config:,arch:,network_type:,network_link: -- "${@}")
+options=$(getopt -o hp:P:e:n:c:a:l:t:r: -l help,rootfs:,path:,packages:,enable_units:,name:,config:,arch:,network_type:,network_link:,root_passwd: -- "${@}")
 if [ ${?} -ne 0 ]; then
     usage $(basename ${0})
     exit 1
@@ -229,6 +231,7 @@ do
     -a|--arch)          arch=${2}; shift 2;;
     -t|--network_type)  lxc_network_type=${2}; shift 2;;
     -l|--network_link)  lxc_network_link=${2}; shift 2;;
+    -r|--root_passwd)   root_passwd=${2}; shift 2;;
     --)             shift 1; break ;;
     *)              break ;;
     esac
@@ -308,6 +311,10 @@ if [ ${#enable_units[@]} -gt 0 ]; then
         ln -s /usr/lib/systemd/system/"${unit}" \
             "${rootfs_path}"/etc/systemd/system/multi-user.target.wants
     done
+fi
+
+if [ -n "${root_passwd}" ]; then
+    echo "root:${root_passwd}" | chroot "${rootfs_path}" chpasswd
 fi
 
 echo "container config is ${config_path}/config"


### PR DESCRIPTION
Having experimented with the `lxc-archlinux` to create a Linux container, I found it lacking in a few areas. I normally roll my own containers from scratch so I thought the template could be improved upon.

The thing I changed was to remove the functionality that created an `fstab` file. Originally this mounted `/sys`, `/proc` and `/proc/sys/` and it mounted them read-only which I noticed caused problems with my _DHCP_ client, `dhcpcd`. These filesystems are mounted by systemd and should not be explicitly mounted like this.

The next thing I did to remove the _mknod_ capability drop. I did this because it is unnecessary and prevents the container from creating its own device nodes. Originally, this was required to stop _systemd_ from trying to start _udev_ in the container (_udev_ does not work inside a container). However, the correct and preffereed way to do this is to mask the services, which prevents _systemd_ from starting them. The template does this anyway so having it drop its _mknod_ capability is unnecessary overkill.

I wanted to support building a 32-bit container on a 64-bit host. This requires a modified _Pacman_ configuration that sets its architecture to _i686_. The improved template accepts a `--arch` or `-a` argumment and, if this is given and differs from the host's architecture, will make a temporary copy of the configuration files and modify them to specify the given architecture. After building the container's file system using these modified files, it copies them into the container as  `/etc/pacman.conf` and `/etc/pacman.d/mirrorlist`.

<small>**note** the template assumes the Pacman mirrorlist file specified in the Pacman configuration file is `/etc/pacman.d/mirrorlist`.</small>

The template can install additional packages while creating a container: such packages are specified using its `--packages` or `-P` argument. It doesn't provide a way to enable their services, however. I wanted to support this, so I added a `--enable_units` or `-e` argument that allows a comma-separate list of _systemd_ unit names to be given. Each unit will be enabled in the container so that they will start when it is booted up. If the unit name does not contain a dot `.` then `.service` will be appended to it, making the unit type to default to _service_ if this is not specified.

The final thing that I did was to provide a way to set the root password of the container. A new `--root_passwd` or `-r` can supplied on the command-line to set the container's root password.

Example command-line for the improved template:

```
lxc-create -n test32 -t archlinux -- --arch i686 -P dhcpcd,openssh --enable_units dhcpcd,sshd.socket --root_passwd mysecret
```
