### PR TITLE
doc: Improve Japanese man pages

### DIFF
--- a/doc/ja/lxc-attach.sgml.in
+++ b/doc/ja/lxc-attach.sgml.in
@@ -76,7 +76,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       specified by <replaceable>name</replaceable>. The container
       has to be running already.
       -->
-      <command>lxc-attach</command> は <replaceable>name</replaceable> で指定したコンテナ内で指定した <replaceable>command</replaceable> を実行します．実行する時点でコンテナが実行中でなければなりません．
+      <command>lxc-attach</command> は <replaceable>name</replaceable> で指定したコンテナ内で指定した <replaceable>command</replaceable> を実行します．
+      実行する時点でコンテナが実行中でなければなりません．
     </para>
     <para>
       <!--
@@ -87,7 +88,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       inside the container or the container does not have a working
       nsswitch mechanism.
       -->
-      もし <replaceable>command</replaceable> が指定されていない場合，<command>lxc-attach</command> コマンドを実行したユーザのデフォルトシェルをコンテナ内で調べて実行します．もしコンテナ内にユーザが存在しない場合や，コンテナで nsswitch 機構が働いていない場合はこの動作は失敗します．
+      もし <replaceable>command</replaceable> が指定されていない場合，<command>lxc-attach</command> コマンドを実行したユーザのデフォルトシェルをコンテナ内で調べて実行します．
+      もしコンテナ内にユーザが存在しない場合や，コンテナで nsswitch 機構が働いていない場合はこの動作は失敗します．
     </para>
 
   </refsect1>
@@ -115,7 +117,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    </citerefentry>. By default, the current archictecture of the
 	    running container will be used.
             -->
-            コマンドを実行するコンテナのアーキテクチャを指定します．このオプションは，コンテナの設定ファイルで指定する <option>lxc.arch</option> オプションと同じものとして受け入れられます．
+            コマンドを実行するコンテナのアーキテクチャを指定します．
+            このオプションは，コンテナの設定ファイルで指定する <option>lxc.arch</option> オプションと同じものが使用可能です．
             <citerefentry>
 	      <refentrytitle><filename>lxc.conf</filename></refentrytitle>
 	      <manvolnum>5</manvolnum>
@@ -139,7 +142,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <emphasis>not</emphasis> be added to the container's cgroup(s)
 	    and it will not drop its capabilities before executing.
             -->
-            コンテナの内部で <replaceable>command</replaceable> を実行する時に特権を削除しません．もしこのオプションが指定された場合，新しいプロセスはコンテナの cgroup に追加 <emphasis>されず</emphasis>，実行する前にケーパビリティ (capability) も削除しません．
+            コンテナの内部で <replaceable>command</replaceable> を実行する時に特権を削除しません．
+            もしこのオプションが指定された場合，新しいプロセスはコンテナの cgroup に追加 <emphasis>されず</emphasis>，実行する前にケーパビリティ (capability) も削除しません．
 	  </para>
           <para>
 	    <!--
@@ -163,7 +167,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <command>cron</command> or <command>sshd</command>.
 	    <emphasis>Use with great care.</emphasis>
             -->
-            <emphasis>警告：</emphasis>もし実行するコマンドが，アタッチするメインプロセスが終了した後も実行されたままのサブプロセスを開始するような場合，このオプションの指定はコンテナ内への特権のリークとなる可能性があります．コンテナ内でのデーモンの開始(もしくは再起動)は問題となります．デーモンが多数のサブプロセスを開始する <command>cron</command> や <command>sshd</command> のような場合は特に問題となります．<emphasis>充分な注意を払って使用してください．</emphasis>
+            <emphasis>警告：</emphasis>
+            もし実行するコマンドが，アタッチするメインプロセスが終了した後も実行されたままのサブプロセスを開始するような場合，このオプションの指定はコンテナ内への特権のリークとなる可能性があります．
+            コンテナ内でのデーモンの開始(もしくは再起動)は問題となります．
+            デーモンが多数のサブプロセスを開始する <command>cron</command> や <command>sshd</command> のような場合は特に問題となります．
+            <emphasis>充分な注意を払って使用してください．</emphasis>
 	  </para>
 	</listitem>
       </varlistentry>
@@ -185,7 +193,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    container while retaining the other namespaces as those of the
 	    host.
             -->
-            アタッチする名前空間をパイプで連結したリストで指定します．例えば <replaceable>NETWORK|IPC</replaceable> のようにです．ここで使用可能な値は <replaceable>MOUNT</replaceable>, <replaceable>PID</replaceable>, <replaceable>UTSNAME</replaceable>, <replaceable>IPC</replaceable>, <replaceable>USER </replaceable>, <replaceable>NETWORK</replaceable> です．これにより指定した名前空間にプロセスのコンテキストを変更できます．例えばコンテナのネットワーク名前空間に変更する一方で，他の名前空間はホストの名前空間のままにするというような事が可能です．
+            アタッチする名前空間をパイプで連結したリストで指定します．
+            例えば <replaceable>NETWORK|IPC</replaceable> のようにです．
+            ここで使用可能な値は <replaceable>MOUNT</replaceable>, <replaceable>PID</replaceable>, <replaceable>UTSNAME</replaceable>, <replaceable>IPC</replaceable>, <replaceable>USER </replaceable>, <replaceable>NETWORK</replaceable> です．
+            これにより指定した名前空間にプロセスのコンテキストを変更できます．
+            例えばコンテナのネットワーク名前空間に変更する一方で，他の名前空間はホストの名前空間のままにするというような事が可能です．
 	  </para>
 	  <para>
             <!--
@@ -210,7 +222,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <replaceable>/sys</replaceable> to reflect the current other
 	    namespace contexts.
             -->
-            <option>-s</option> を指定し，そこにマウント名前空間が含まれない時，このオプションにより <command>lxc-attach</command> は <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> をリマウントします．これは現在の他の名前空間のコンテキストを反映させるためです．
+            <option>-s</option> を指定し，そこにマウント名前空間が含まれない時，このオプションにより <command>lxc-attach</command> は <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> をリマウントします．
+            これは現在の他の名前空間のコンテキストを反映させるためです．
 	  </para>
 	  <para>
             <!--
@@ -244,7 +257,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    please use this option to be future-proof. In addition to
 	    current environment variables, container=lxc will be set.
             -->
-            アタッチされるプログラムに対して現在の環境を保持したままにします．これは現在 (バージョン 0.9 時点) のデフォルトの動作ですが，将来は変更される予定です．この動作がコンテナ内への望ましくない情報の漏洩につながる可能性があるためです．アタッチするプログラムで環境変数が利用可能であることを期待している場合，将来的にもそれが保証されるようにこのオプションを使用するようにしてください．現在の環境変数に加えて，container=lxc が設定されます．
+            アタッチされるプログラムに対して現在の環境を保持したままにします．
+            これは現在 (バージョン 0.9 時点) のデフォルトの動作ですが，将来は変更される予定です．
+            この動作がコンテナ内への望ましくない情報の漏洩につながる可能性があるためです．
+            アタッチするプログラムで環境変数が利用可能であることを期待している場合，将来的にもそれが保証されるようにこのオプションを使用するようにしてください．
+            現在の環境変数に加えて，container=lxc が設定されます．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -261,7 +278,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    container=lxc will be the only environment with which the
 	    attached program starts.
             -->
-            アタッチする前に環境変数をクリアします．これによりコンテナへの不要な環境変数の漏洩が起こらなくなります．変数 container=lxc のみがアタッチするプログラムの開始の時の環境変数となります．
+            アタッチする前に環境変数をクリアします．
+            これによりコンテナへの不要な環境変数の漏洩が起こらなくなります．
+            変数 container=lxc のみがアタッチするプログラムの開始の時の環境変数となります．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -324,7 +343,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       details. <command>lxc-attach</command> will fail in that case if
       used with an unpatched kernel.
       -->
-      (pid とマウント名前空間を含む) コンテナに対する完全なアタッチを行うにはパッチを適用したカーネルが必要となります．詳しくは lxc のウェブサイトを参照してください．(訳注: 3.8 カーネルから PID, マウント名前空間に対するアタッチも可能になっている)
+      (pid とマウント名前空間を含む) コンテナに対する完全なアタッチを行うにはパッチを適用したカーネルが必要となります．
+      詳しくは lxc のウェブサイトを参照してください．
+      (訳注: 3.8 カーネルから PID, マウント名前空間に対するアタッチも可能になっている)
     </para>
     <para>
       <!--
@@ -342,7 +363,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       by the kernel. <command>lxc-attach</command> should however be able
       to do this once once future kernel versions implement this.
       -->
-      ユーザ名前空間へのアタッチは，現時点ではカーネルで完全にサポートされていません．しかし，<command>lxc-attach</command> は，将来のカーネルがこの機能を実装した時点ですぐに，アタッチが可能になるはずです．
+      ユーザ名前空間へのアタッチは，現時点ではカーネルで完全にサポートされていません．
+      しかし，<command>lxc-attach</command> は，将来のカーネルがこの機能を実装した時点ですぐに，アタッチが可能になるはずです．
     </para>
   </refsect1>
 
@@ -361,7 +383,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       accessing <replaceable>/proc</replaceable> or
       <replaceable>/sys</replaceable>.
       -->
-      Linux の <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> ファイルシステムは名前空間によって影響を受けるいくつかの情報を持っています．これは <replaceable>/proc</replaceable> 内のプロセス ID の名前のディレクトリや，<replaceable>/sys/class/net</replaceable> 内のネットワークインターフェース名のディレクトリなどです．擬似ファイルシステムをマウントしているプロセスの名前空間が，どのような情報を表示するかを決定します．<replaceable>/proc</replaceable> や <replaceable>/sys</replaceable> にアクセスしているプロセスの名前空間が決定するのではありません．
+      Linux の <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> ファイルシステムは名前空間によって影響を受けるある程度の情報を持っています．
+      これは <replaceable>/proc</replaceable> 内のプロセス ID の名前のディレクトリや，<replaceable>/sys/class/net</replaceable> 内のネットワークインターフェース名のディレクトリなどです．
+      擬似ファイルシステムをマウントしているプロセスの名前空間が，どのような情報を表示するかを決定します．
+      <replaceable>/proc</replaceable> や <replaceable>/sys</replaceable> にアクセスしているプロセスの名前空間が決定するのではありません．
     </para>
     <para>
       <!--
@@ -374,7 +399,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <replaceable>/sys/class/net</replaceable> and attaching to just
       the network namespace.
       -->
-      <option>-s</option> を使ってコンテナの pid 名前空間のみをアタッチし，マウント名前空間 (これはコンテナの <replaceable>/proc</replaceable> を含み，ホストのは含まないでしょう) はアタッチしない場合，<option>/proc</option> のコンテンツはコンテナのものではなく，ホストのものとなります．似たような事例として，ネットワーク名前空間のみをアタッチして，<replaceable>/sys/class/net</replaceable> のコンテンツを読んだ場合も同じような事が起こるでしょう．
+      <option>-s</option> を使ってコンテナの pid 名前空間のみをアタッチし，マウント名前空間 (これはコンテナの <replaceable>/proc</replaceable> を含み，ホストのは含まないでしょう) はアタッチしない場合，<option>/proc</option> のコンテンツはコンテナのものではなく，ホストのものとなります．
+      似たような事例として，ネットワーク名前空間のみをアタッチして，<replaceable>/sys/class/net</replaceable> のコンテンツを読んだ場合も同じような事が起こるでしょう．
     </para>
     <para>
       <!--
@@ -389,7 +415,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       except for the <replaceable>/proc</replaceable> and
       <replaceable>/sys</replaceable> filesystems.
       -->
-      この問題への対処のために，<option>-R</option> オプションが <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> が提供されています．これにより，アタッチするプロセスのネットワーク/pid 名前空間のコンテキストを反映させることができます．ホストの実際のファイルシステムに影響を与えないために，実行前にはマウント名前空間は unshare されます (<command>lxc-unshare</command> のように)．これは，<replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> ファイルシステム以外はホストのマウント名前空間と同じである，新しいマウント名前空間がプロセスに与えられるということです．
+      この問題への対処のために，<option>-R</option> オプションが <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> が提供されています．
+      これにより，アタッチするプロセスのネットワーク/pid 名前空間のコンテキストを反映させることができます．ホストの実際のファイルシステムに影響を与えないために，実行前にはマウント名前空間は unshare されます (<command>lxc-unshare</command> のように)．
+      これは，<replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> ファイルシステム以外はホストのマウント名前空間と同じである，新しいマウント名前空間がプロセスに与えられるということです．
     </para>
   </refsect1>
 
@@ -401,7 +429,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       be used with care, as it may break the isolation of the containers
       if used improperly.
       -->
-      <option>-e</option> と <option>-s</option> オプションの使用には注意を払うべきです．不適切に使用した場合，コンテナの隔離を破壊してしまう可能性があります．
+      <option>-e</option> と <option>-s</option> オプションの使用には注意を払うべきです．
+      不適切に使用した場合，コンテナの隔離を破壊してしまう可能性があります．
     </para>
   </refsect1>
 

--- a/doc/ja/lxc-autostart.sgml.in
+++ b/doc/ja/lxc-autostart.sgml.in
@@ -74,9 +74,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             will be shown.
             -->
           <command>lxc-autostart</command> は lxc.start.auto が設定されたコンテナの処理を行います．
-          ユーザがコンテナの開始，シャットダウン，kill，再起動を，設定した時間待機を行い，正しい順番で行えるようにします．
+          ユーザがコンテナの開始，シャットダウン，kill，再起動を，設定した時間間隔で，設定した順番で行えるようにします．
           lxc.group でのフィルタリングによって，もしくは定義された全てのコンテナを実行します．
-          何の動作も行わず，対象のコンテナ (とコンテナに設定された待機時間) のリストを表示するリストモードを外部ツールから使用することも可能です．
+          何の動作も行わず，対象のコンテナ (とコンテナに設定された起動待機時間) のリストを表示するリストモードを外部ツールから使用することも可能です．
         </para>
 
         <para>
@@ -92,7 +92,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             or reboot.
             -->
           <optional>-r</optional>, <optional>-s</optional>, <optional>-k</optional> オプションは実行する動作を指定します．何も指定しない場合は，コンテナを起動します．
-          <optional>-a</optional>, <optional>-g</optional> は，どのコンテナを対象にするかを指定するのに使います．デフォルトでは，lxc.group が指定されていないコンテナにだけ影響します．
+          <optional>-a</optional>, <optional>-g</optional> は，どのコンテナを対象にするかを指定するのに使います．デフォルトでは，lxc.group が指定されていないコンテナにだけが対象となります．
           <optional>-t TIMEOUT</optional> はコンテナが完全にシャットダウンもしくはリブートを待つ最大時間を指定します．
         </para>
     </refsect1>

--- a/doc/ja/lxc-cgroup.sgml.in
+++ b/doc/ja/lxc-cgroup.sgml.in
@@ -73,7 +73,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       current value of the <replaceable>state-object</replaceable> is
       displayed; otherwise it is set.
       -->
-      <command>lxc-cgroup</command> は，コンテナの cgroup の一致するサブシステム (例えば 'cpuset') の <replaceable>state-object</replaceable> (例えば 'cpuset.cpus') の値を取得したり，値を設定したりします．もし <optional>value</optional> が指定されないときは，<replaceable>state-object</replaceable> の値を表示します．指定されている場合は値を設定します．
+      <command>lxc-cgroup</command> は，コンテナの cgroup の一致するサブシステム (例えば 'cpuset') の <replaceable>state-object</replaceable> (例えば 'cpuset.cpus') の値を取得したり，値を設定したりします．
+      <optional>value</optional> が指定されないときは，<replaceable>state-object</replaceable> の値を表示します．指定されている場合は値を設定します．
     </para>
 
     <para>
@@ -83,7 +84,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       kernel, or that the corresponding subsystem is contained in any
       mounted cgroup hierarchy.
       -->
-      <command>lxc-cgroup</command> は <replaceable>state-object</replaceable> が実行中のカーネルで有効かどうかのチェックを行いません．また，一致するサブシステムがマウントされた cgroup の階層構造に含まれているかどうかのチェックを行いません．
+      <command>lxc-cgroup</command> は <replaceable>state-object</replaceable> が実行中のカーネルで有効かどうかのチェックを行いません．
+      また，指定したサブシステムがマウントされた cgroup の階層構造に含まれているかどうかのチェックを行いません．
     </para>
 
   </refsect1>

--- a/doc/ja/lxc-checkconfig.sgml.in
+++ b/doc/ja/lxc-checkconfig.sgml.in
@@ -77,7 +77,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           check the current kernel.
           CONFIG can be set in the environment to an alternate location.
           -->
-          現在のカーネルをチェックします．CONFIG 環境変数に別の場所を設定することも可能です．(訳注: カーネルビルド時の設定オプションのファイルの位置を指定します．デフォルトは /proc/config.gz です．)
+          現在のカーネルをチェックします．
+          CONFIG 環境変数に別の場所を設定することも可能です．
+          (訳注: カーネルビルド時の設定オプションのファイルの位置を指定します．デフォルトは /proc/config.gz です．)
         </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-checkpoint.sgml.in
+++ b/doc/ja/lxc-checkpoint.sgml.in
@@ -64,7 +64,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   </refsynopsisdiv>
 
   <refsect1>
-    <title>Description</title>
+    <title><!-- Description --></title>
 
     <para>
       <!--
@@ -80,7 +80,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       execution. The command <command>lxc-unfreeze</command> will
       resume its execution.
       -->
-      <command>lxc-checkpoint</command> は，<replaceable>NAME</replaceable> 指定したコンテナのチェックポイントを作成し，その状態を <replaceable>FILE</replaceable> で指定したファイルにダンプします．<option>--kill</option> が指定された場合，チェックポイントの取得後，コンテナ内で実行されているアプリケーションは，実行が再開する直前に終了します．<option>--pause</option> が指定された場合，チェックポイントの取得後，コンテナ内で実行されているアプリケーションは，実行が再開する直前に休止します．<command>lxc-unfreeze</command> コマンドで，実行を再開させます．
+      <command>lxc-checkpoint</command> は，<replaceable>NAME</replaceable> 指定したコンテナのチェックポイントを作成し，その状態を <replaceable>FILE</replaceable> で指定したファイルにダンプします．
+      <option>--kill</option> が指定された場合，チェックポイントの取得後，コンテナ内で実行されているアプリケーションは，実行が再開する直前に終了します．
+      <option>--pause</option> が指定された場合，チェックポイントの取得後，コンテナ内で実行されているアプリケーションは，実行が再開する直前に休止します．
+      <command>lxc-unfreeze</command> コマンドで，実行を再開させます．
     </para>
 
   </refsect1>
@@ -99,7 +102,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <replaceable>FILE</replaceable>.
 	    This option is exclusive with <option>&#045;&#045;statefd</option> below.
             -->
-            コンテナの実行状態を <replaceable>FILE</replaceable> に書き込みます．このオプションは以下の <option>--statefd</option> と同時に指定できません．
+            コンテナの実行状態を <replaceable>FILE</replaceable> に書き込みます．
+            このオプションは以下の <option>--statefd</option> と同時に指定できません．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -113,7 +117,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <replaceable>FD</replaceable> file descriptor.
 	    This option is exclusive with above <option>&#045;&#045;statefile</option>.
             -->
-            コンテナの実行状態を指定した <replaceable>FD</replaceable> ファイルディスクリプタに書き込みます．このオプションは前述の <option>--statefile</option> と同時に指定出来ません．
+            コンテナの実行状態を指定した <replaceable>FD</replaceable> ファイルディスクリプタに書き込みます．
+            このオプションは前述の <option>--statefile</option> と同時に指定出来ません．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -126,7 +131,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Kill container processes after checkpoint. the processes are sent
 	    a <literal>SIGKILL</literal> signal.
             -->
-            チェックポイントを取得した後，コンテナプロセスを kill します．プロセスには <literal>SIGKILL</literal> シグナルが送られます．
+            チェックポイントを取得した後，コンテナプロセスを kill します．
+            プロセスには <literal>SIGKILL</literal> シグナルが送られます．
 	  </para>
 	  <para>
             <!--
@@ -148,7 +154,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    mutually exclusive with previously mentionned
 	    <option>&#045;&#045;kill</option> option.
             -->
-            チェックポイントを取得した後，コンテナプロセスを休止させます．コンテナを再開させるまで止まったままとなります．このオプションは前述の <option>--kill</option> オプションと同時に指定することはできません．
+            チェックポイントを取得した後，コンテナプロセスを休止させます．
+            コンテナを再開させるまで止まったままとなります．
+            このオプションは前述の <option>--kill</option> オプションと同時に指定することはできません．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -165,7 +173,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <!--
       To start a new container <literal>123</literal> computing decimals of pi
       -->
-      円周率の小数点以下を計算する新しいコンテナを起動させるために，以下を実行します．
+      円周率の小数点以下を計算する新しいコンテナ <literal>123</literal> を起動させるために，以下を実行します．
     </para>
     <programlisting>
       lxc-execute -n 123 -- pi1 -d 500000
@@ -204,7 +212,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     helps to define a CLI api for future Checkpoint / Restart
     solution</para>
     -->
-    実際はこのコマンドは動作しません．この説明は将来的なチェックポイント/再起動機能の解決策となる CLI API を定義するのを助けるためのものです．
+    実際はこのコマンドは動作しません．
+    この説明は将来的なチェックポイント/再起動機能の解決策となる CLI API を定義するのを助けるためのものです．
   </refsect1>
 
   &seealso;

--- a/doc/ja/lxc-clone.sgml.in
+++ b/doc/ja/lxc-clone.sgml.in
@@ -98,7 +98,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       this includes only btrfs, lvm, overlayfs and zfs.  LVM devices do not support
       snapshots of snapshots.
       -->
-      <command>lxc-clone</command> は，新しいコンテナを既に存在するコンテナのクローンとして作製します．クローンは 2 つのタイプをサポートします: コピーとスナップショットです．コピータイプのクローンは元のコンテナから新しいコンテナへ root ファイルシステムをコピーします．スナップショットファイルシステムは，バッキングストアのスナップショット機能を使い，元のコンテナの非常に小さな copy-on-write でのスナップショットを作製します．スナップショットでのクローンは，新しいコンテナのバッキングストアとしてスナップショット機能のサポートが必要になります．現時点では，このようなバッキングストアとしては btrfs, lvm, overlayfs, zfs のみをサポートします．LVM デバイスはスナップショットのスナップショットはサポートしていません．
+      <command>lxc-clone</command> は，新しいコンテナを既に存在するコンテナのクローンとして作製します．
+      クローンは 2 つのタイプをサポートします: コピーとスナップショットです．
+      コピータイプのクローンは元のコンテナから新しいコンテナへ root ファイルシステムをコピーします．
+      スナップショットファイルシステムは，バッキングストアのスナップショット機能を使い，元のコンテナの非常に小さな copy-on-write でのスナップショットを作製します．
+      スナップショットでのクローンは，新しいコンテナのバッキングストアとしてスナップショット機能のサポートが必要になります．
+      現時点では，このようなバッキングストアとしては btrfs, lvm, overlayfs, zfs のみをサポートします．
+      LVM デバイスはスナップショットのスナップショットはサポートしていません．
     </para>
 
     <para>
@@ -109,7 +115,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       containers.  This can be requested by using the <replaceable>-B overlayfs</replaceable>
       arguments.
       -->
-      新しいコンテナのバッキングストアは，一つの例外を除いては，元のコンテナのタイプと同じになります: overlayfs では，ディレクトリバックエンドのコンテナのスナップショットを作製することが可能です．これは，<replaceable>-B overlayfs</replaceable> という引数を使って指定することが可能です．
+      新しいコンテナのバッキングストアは，一つの例外を除いては，元のコンテナのタイプと同じになります: overlayfs では，ディレクトリバックエンドのコンテナのスナップショットを作製することが可能です．
+      これは，<replaceable>-B overlayfs</replaceable> という引数を使って指定することが可能です．
     </para>
 
     <para>
@@ -154,7 +161,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Do not change the hostname of the container (in the root
 	    filesystem).
             -->
-            コンテナのホスト名を変更しません (root ファイルシステム内では)．
+            (root ファイルシステム内では) コンテナのホスト名を変更しません．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -184,7 +191,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Copy all mount hooks into the new container's directory, and
 	    update any lxcpaths and container names as needed.
             -->
-            全てのマウントフックを新しいコンテナのディレクトリにコピーします．そして，lxcpath とコンテナ名を必要に応じて更新します．
+            全てのマウントフックを新しいコンテナのディレクトリにコピーします．
+            そして，lxcpath とコンテナ名を必要に応じて更新します．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -200,7 +208,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    block device.  By default, the new device will be made the
 	    same size as the original.
             -->
-            ブロックデバイスのバックエンドのコンテナの場合，新しいブロックデバイスのサイズ．デフォルトでは，新しいデバイスは元のデバイスと同じサイズとなります．
+            ブロックデバイスのバックエンドのコンテナの場合，新しいブロックデバイスのサイズ．
+            デフォルトでは，新しいデバイスは元のデバイスと同じサイズとなります．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -232,7 +241,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    changing lxcpaths may not be possible, as subvolume snapshots
 	    must be in the same btrfs filesystem.
             -->
-            新しいコンテナの lxcpath．デフォルトでは，オリジナルの lxcpath と同じものが使われます．btrfs のスナップショットの場合は注意が必要で，lxcpath の変更はできない可能性があります．これは subvolume のスナップショットが，同じ btrfs ファイルシステム上に存在しなければならないからです．
+            新しいコンテナの lxcpath．
+            デフォルトでは，オリジナルの lxcpath と同じものが使われます．
+            btrfs のスナップショットの場合は注意が必要で，lxcpath の変更はできない可能性があります．
+            これは subvolume のスナップショットが，同じ btrfs ファイルシステム上に存在しなければならないからです．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -251,7 +263,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    backing stores include dir (directory), btrfs, lvm, zfs, loop
 	    and overlayfs.
             -->
-            新しいコンテナで元のコンテナと違うバッキングストアを使う場合のバッキングストアを選択します．デフォルトでは元のコンテナと同じものが使われます．現時点では，バッキングストアの変更は，ディレクトリバックエンドのコンテナに対する overlayfs スナップショットに対してのみサポートされます．有効なバッキングストアは dir(directory), btrfs, lvm, zfs, loop, overlayfs を含みます．
+            新しいコンテナで元のコンテナと違うバッキングストアを使う場合のバッキングストアを選択します．
+            デフォルトでは元のコンテナと同じものが使われます．
+            現時点では，バッキングストアの変更は，ディレクトリバックエンドのコンテナに対する overlayfs スナップショットに対してのみサポートされます．
+            有効なバッキングストアは dir(directory), btrfs, lvm, zfs, loop, overlayfs を含みます．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -305,7 +320,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <filename>LXC_SRC_NAME</filename>, and the path or device on which
       the rootfs is located is in <filename>LXC_ROOTFS_PATH</filename>.
       -->
-      クローンされたコンテナに 1 つ以上の <filename>lxc.hook.clone</filename> の指定が存在する場合，指定されたフックは新しいコンテナに対して呼ばれます．クローンフックに渡される最初の 3 つの引数は，コンテナ名，セクション ('lxc')，フックタイプ ('clone') となります．<command>lxc-clone</command> に渡される追加の引数は，フックプログラムに渡される引数の 4 番目以降となります．<filename>LXC_ROOTFS_MOUNT</filename> 環境変数には，コンテナの root ファイルシステムがマウントされるパスが与えられます．設定ファイルのパス名は <filename>LXC_CONFIG_FILE</filename> に，新しいコンテナ名は <filename>LXC_NAME</filename>，古いコンテナ名は <filename>LXC_SRC_NAME</filename> に，rootfs のあるパスまたはデバイスは <filename>LXC_ROOTFS_PATH</filename> に保存されます．
+      クローンされるコンテナに 1 つ以上の <filename>lxc.hook.clone</filename> の指定が存在する場合，指定されたフックは新しいコンテナに対して呼ばれます．
+      クローンフックに渡される最初の 3 つの引数は，コンテナ名，セクション ('lxc')，フックタイプ ('clone') となります．
+      <command>lxc-clone</command> に渡される追加の引数は，フックプログラムに渡される引数の 4 番目以降となります．
+      <filename>LXC_ROOTFS_MOUNT</filename> 環境変数には，コンテナの root ファイルシステムがマウントされるパスが与えられます．
+      設定ファイルのパス名は <filename>LXC_CONFIG_FILE</filename> に，新しいコンテナ名は <filename>LXC_NAME</filename>，古いコンテナ名は <filename>LXC_SRC_NAME</filename> に，rootfs のあるパスまたはデバイスは <filename>LXC_ROOTFS_PATH</filename> に保存されます．
     </para>
   </refsect1>
 

--- a/doc/ja/lxc-console.sgml.in
+++ b/doc/ja/lxc-console.sgml.in
@@ -48,7 +48,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <!--
       Launch a console for the specified container
       -->
-      指定されたコンテナのコンソールの起動
+      指定したコンテナのコンソールの起動
     </refpurpose>
   </refnamediv>
 
@@ -70,7 +70,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       container specified as parameter, this command will launch a
       console allowing to log on the container.
       -->
-      パラメータで指定されたコンテナで tty サービスが設定され，利用可能である場合，このコマンドはコンテナにログイン出来るコンソールを起動します．
+      パラメータで指定したコンテナで tty サービスが設定され，利用可能である場合，このコマンドはコンテナにログイン出来るコンソールを起動します．
     </para>
 
     <para>
@@ -80,7 +80,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       has been launched four times each taking a different tty, the
       fifth command will fail because no console will be available.
       -->
-      利用可能な tty は，このコマンドが取得した空いている tty です．これは，コンテナに 4 つの利用可能な tty がある場合，コマンドは 4 個までそれぞれ異なる tty を取得して開きます．5 回目のコマンドは利用可能なコンソールがないため，失敗します．
+      利用可能な tty は，このコマンドが取得した空いている tty です．
+      これは，コンテナに 4 つの利用可能な tty がある場合，コマンドは 4 個までそれぞれ異なる tty を取得して開きます．5 回目のコマンドは利用可能なコンソールがないため，失敗します．
     </para>
 
     <para>
@@ -89,7 +90,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       broken, the command can be launched again and regain the tty at
       the state it was before the disconnection.
       -->
-      コマンドは tty に接続します．もし，接続が失われたり，切断された場合，コマンドは再度起動し，切断前の状態で tty の再取得をしようとします．
+      コマンドは tty に接続します．
+      もし，接続が失われたり，切断された場合，コマンドは再度起動し，切断前の状態で tty の再取得をしようとします．
     </para>
 
     <para>
@@ -106,7 +108,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       A keyboard escape sequence may be used to disconnect from the tty
       and quit lxc-console. The default escape sequence is &lt;Ctrl+a q&gt;.
       -->
-      tty からの接続を切断し，lxc-console を抜ける時に，キーボードのエスケープシーケンスを使います．デフォルトのエスケープシーケンスは &lt;Ctrl+a q&gt; です．
+      tty からの接続を切断し，lxc-console を抜ける時に，キーボードのエスケープシーケンスを使います．
+      デフォルトのエスケープシーケンスは &lt;Ctrl+a q&gt; です．
     </para>
 
   </refsect1>
@@ -127,7 +130,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             This may be given as '^letter' or just 'letter'. For example
             to use &lt;Ctrl+b q&gt; as the escape sequence use -e '^b'.
             -->
-            &lt;Ctrl a&gt; の代わりに使用するエスケープシーケンスのプレフィックスを指定します．これは '^文字' または単なる '文字' で指定します．例えば，&lt;Ctrl+b q&gt; をエスケープシーケンスとして使うには -e '^b' とします．
+            &lt;Ctrl a&gt; の代わりに使用するエスケープシーケンスのプレフィックスを指定します．
+            これは '^文字' または単なる '文字' で指定します．
+            例えば，&lt;Ctrl+b q&gt; をエスケープシーケンスとして使うには -e '^b' とします．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -142,7 +147,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    specified the next available tty number will be automatically
 	    chosen by the container.
             -->
-            接続する tty の番号か，コンソールに接続するために 0 を指定します．指定しない場合は，次に利用可能な tty 番号を自動的にコンテナが選択します．
+            接続する tty の番号か，コンソールに接続するために 0 を指定します．
+            指定しない場合は，次に利用可能な tty 番号を自動的にコンテナが選択します．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -167,7 +173,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    use the console. For example, the container belongs to
 	    user "foo" and "bar" is trying to open a console to it.
             -->
-            利用可能な tty がないか，コンソールを使うのに十分な権限がありません．例えば，コンテナが "foo" ユーザの所有であるのに，"bar" ユーザがコンソールを開こうとしている場合などです．
+            利用可能な tty がないか，コンソールを使うのに十分な権限がありません．
+            例えば，コンテナが "foo" ユーザの所有であるのに，"bar" ユーザがコンソールを開こうとしている場合などです．
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-create.sgml.in
+++ b/doc/ja/lxc-create.sgml.in
@@ -64,7 +64,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   </refsynopsisdiv>
 
   <refsect1>
-    <title>Description</title>
+    <title><!-- Description -->説明</title>
 
     <para>
       <!--
@@ -74,7 +74,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       is used to specify the container to be used with the different
       lxc commands.
       -->
-      <command>lxc-create</command> は，設定情報とユーザ情報が保存されているシステムオブジェクトを作成します．<replaceable>name</replaceable> で指定された名前が，他の lxc コマンドで，コンテナを特定する名前として使われます．
+      <command>lxc-create</command> は，設定情報とユーザ情報が保存されているシステムオブジェクトを作成します．
+      <replaceable>name</replaceable> で指定された名前が，他の lxc コマンドで，コンテナを特定する名前として使われます．
     </para>
     <para>
       <!--
@@ -91,7 +92,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       contains information, the more the container is isolated and
       the more the application is jailed.
       -->
-      オブジェクトは，アプリケーションが使用したり，参照したりする様々なリソースの定義です．設定ファイルがより多くの情報を持つほど，コンテナやアプリケーションはより隔離されたものになります．
+      オブジェクトは，アプリケーションが使用したり，参照したりする様々なリソースの定義です．
+      設定ファイルがより多くの情報を持つほど，コンテナやアプリケーションはより隔離されたものになります．
     </para>
 
     <para>
@@ -138,7 +140,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Alternatively, the full path to an executable template script
 	    can also be passed as a parameter.
             -->
-            <replaceable>template</replaceable> は lxc-create コマンドが呼び出す，存在する 'lxc-template' スクリプトの短い名前です．例えば，busybox, debian, fedora, ubuntu, sshd があります．期待されるスクリプトの構造の詳細は，<filename>@LXCTEMPLATEDIR@</filename> 内の例を参照してください．加えて，実行可能なテンプレートスクリプトへのフルパスも指定することが可能です．
+            <replaceable>template</replaceable> は lxc-create コマンドが呼び出す，存在する 'lxc-template' スクリプトの短い名前です．
+            例えば，busybox, debian, fedora, ubuntu, sshd があります．
+            期待されるスクリプトの構造の詳細は，<filename>@LXCTEMPLATEDIR@</filename> 内の例を参照してください．
+            加えて，実行可能なテンプレートスクリプトへのフルパスも指定することが可能です．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -177,11 +182,19 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <replaceable>&#045;&#045;fssize SIZE</replaceable> will create a LV (and
 	    filesystem) of size SIZE rather than the default, which is 1G.
             -->
-            <replaceable>backingstore</replaceable> には 'none' か 'dir' か 'lvm' か 'btrfs' のいずれかを指定します．デフォルトは 'none' で，コンテナのルートファイルシステムが <filename>@LXCPATH@/container/rootfs</filename> 以下のディレクトリであることを意味します．
-'dir' は 'none' と同じ意味ですが，オプションとして <replaceable>--dir ROOTFS</replaceable> を指定することも可能です．このオプションは，デフォルトの代わりに特定のパス以下にコンテナの rootfs を置くということになります．'btrfs' が指定された場合，ターゲットのファイルシステムは btrfs でなければいけません．そして，コンテナの rootfs は新しい subvolume として作製されます．このことにより，スナップショットによるクローンが作製可能になりますが，rsync --one-filesystem が，別々のファイルシステムとして取り扱ってしまうことも引き起こします．
-backingstore が 'lvm' である場合，lvm ブロックデバイスを使用します．この時，以下のオプションが有効になります: <replaceable>--lvname lvname1</replaceable> はデフォルト値のコンテナ名の LV の代わりに <filename>lvname1</filename> という名前の LV を作成します．<replaceable>--vgname vgname1</replaceable> は，デフォルト値である <filename>lxc</filename> という volume group の代わりに <filename>vgname1</filename> という名前の volume group 内に LV を作成します．
+            <replaceable>backingstore</replaceable> には 'none' か 'dir' か 'lvm' か 'btrfs' のいずれかを指定します．
+            デフォルトは 'none' で，コンテナのルートファイルシステムが <filename>@LXCPATH@/container/rootfs</filename> 以下のディレクトリであることを意味します．
+'dir' は 'none' と同じ意味ですが，オプションとして <replaceable>--dir ROOTFS</replaceable> を指定することも可能です．
+            このオプションは，デフォルトの代わりに特定のパス以下にコンテナの rootfs を置くということになります．
+            'btrfs' が指定された場合，ターゲットのファイルシステムは btrfs でなければいけません．
+            そして，コンテナの rootfs は新しい subvolume として作製されます．
+            このことにより，スナップショットによるクローンが作製可能になりますが，結果として rsync --one-filesystem が，別々のファイルシステムとして取り扱ってしまうことにもなります．
+            backingstore が 'lvm' である場合，lvm ブロックデバイスを使用します．
+            この時，以下のオプションが有効になります: <replaceable>--lvname lvname1</replaceable> はデフォルト値のコンテナ名の LV の代わりに <filename>lvname1</filename> という名前の LV を作成します．
+            <replaceable>--vgname vgname1</replaceable> は，デフォルト値である <filename>lxc</filename> という volume group の代わりに <filename>vgname1</filename> という名前の volume group 内に LV を作成します．
             <replaceable>--thinpool thinpool1</replaceable> は，デフォルトである <filename>lxc</filename> のという名前のプールの代わりに <filename>thinpool1</filename> という名前のプール内にシンプロビジョニングされたボリュームとして LV を作成します．
-            <replaceable>--fstype FSTYPE</replaceable> は LV 上のファイルシステムをデフォルト値である ext4 の代わりに FSTYPE で指定したもので作成します．<replaceable>--fssize SIZE</replaceable> はデフォルト値である 1G の代わりに SIZE で指定したサイズで LV を作成します．
+            <replaceable>--fstype FSTYPE</replaceable> は LV 上のファイルシステムをデフォルト値である ext4 の代わりに FSTYPE で指定したもので作成します．
+            <replaceable>--fssize SIZE</replaceable> はデフォルト値である 1G の代わりに SIZE で指定したサイズで LV を作成します．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -198,7 +211,8 @@ backingstore が 'lvm' である場合，lvm ブロックデバイスを使用�
 	    the template, you can run
 	    <command>lxc-create -t TEMPLATE -h</command>.
             -->
-            これは <replaceable>template-options</replaceable> で指定したものをオプションとしてテンプレートへ渡します．テンプレートでサポートされているオプションを調べるには，<command>lxc-create -t TEMPLATE -h</command> というコマンドが使えます．
+            これは <replaceable>template-options</replaceable> で指定したものをオプションとしてテンプレートへ渡します．
+            テンプレートでサポートされているオプションを調べるには，<command>lxc-create -t TEMPLATE -h</command> というコマンドが使えます．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -222,7 +236,8 @@ backingstore が 'lvm' である場合，lvm ブロックデバイスを使用�
 	    the <command>lxc-ls -l</command> command to list the
 	    available containers on the system.
             -->
-            メッセージの通り，コンテナを作成しようとしたけれども，同じ名前のコンテナが存在しています．<command>lxc-ls -l</command> コマンドを使って，システム上に存在する利用可能なコンテナのリストが表示できます．
+            メッセージの通り，コンテナを作成しようとしたけれども，同じ名前のコンテナが存在しています．
+            <command>lxc-ls -l</command> コマンドを使って，システム上に存在する利用可能なコンテナのリストが表示できます．
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-destroy.sgml.in
+++ b/doc/ja/lxc-destroy.sgml.in
@@ -89,7 +89,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    not specified and the container is running, then
 	    <command>lxc-destroy</command> will be aborted.
             -->
-            コンテナが実行中の場合，まずコンテナを停止させます．このオプションが指定されていない場合でコンテナが実行中の場合，<command>lxc-destroy</command> コマンドは実行を中断します．
+            コンテナが実行中の場合，まずコンテナを停止させます．
+            このオプションが指定されていない場合でコンテナが実行中の場合，<command>lxc-destroy</command> コマンドは実行を中断します．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -125,7 +126,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    destroyed.You can use the <command>lxc-ls -l</command>
 	    command to list the available containers on the system.
             -->
-            破壊するために指定したコンテナが見つかりません．おそらくそのコンテナが存在しないのか，既に破壊された後なのでしょう．<command>lxc-ls -l</command> コマンドを使って，システム上に存在するコンテナのリストを得ることができます．
+            破壊するために指定したコンテナが見つかりません．
+            おそらくそのコンテナが存在しないのか，既に破壊された後なのでしょう．
+            <command>lxc-ls -l</command> コマンドを使って，システム上に存在するコンテナのリストを得ることができます．
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-execute.sgml.in
+++ b/doc/ja/lxc-execute.sgml.in
@@ -71,7 +71,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <replaceable>command</replaceable> inside the container
       specified by <replaceable>name</replaceable>.
       -->
-      <command>lxc-execute</command> は特定の <replaceable>command</replaceable> を，<replaceable>name</replaceable> で指定したコンテナ内で実行します．
+      <command>lxc-execute</command> は指定した <replaceable>command</replaceable> を，<replaceable>name</replaceable> で指定したコンテナ内で実行します．
     </para>
     <para>
       <!--
@@ -81,7 +81,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       If no configuration is
       defined, the default isolation is used.
       -->
-      このコマンドは，lxc-create コマンドであらかじめ定義した設定，もしくはパラメータとして与えた設定ファイルを元にコンテナをセットアップします．もし設定が定義されていない場合，デフォルトの隔離を使用します．
+      このコマンドは，lxc-create コマンドであらかじめ定義した設定，もしくはパラメータとして与えた設定ファイルを元にコンテナをセットアップします．
+      もし設定が定義されていない場合，デフォルトの隔離を使用します．
     </para>
     <para>
       <!--
@@ -102,7 +103,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       container, <command>lxc-init</command> has the pid 1 and the
       first process of the application has the pid 2.
       -->
-      <command>lxc-execute</command> は，<command>lxc-init</command> を間にはさんで，コンテナ内で特定のコマンドを実行します．lxc-init は，指定されたコマンドが実行された後は，そのコマンドの終了と，そのコマンドから生成された全てのプロセスの終了を待ちます (これにより，コンテナ内でデーモンのサポートが可能になります)．言いかえると，コンテナ内では <command>lxc-init</command> が pid 1 となり，アプリケーションの最初のプロセスの pid が 2 となります．
+      <command>lxc-execute</command> は，<command>lxc-init</command> を間にはさんで，コンテナ内で特定のコマンドを実行します．
+      lxc-init は，指定されたコマンドが実行された後は，そのコマンドの終了と，そのコマンドから生成された全てのプロセスの終了を待ちます (これにより，コンテナ内でデーモンのサポートが可能になります)．
+      言いかえると，コンテナ内では <command>lxc-init</command> が pid 1 となり，アプリケーションの最初のプロセスの pid が 2 となります．
      </para>
      <para>
        <!--
@@ -111,7 +114,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       So <command>lxc-kill</command> (1) sent signal is received
       by the user specified command (pid 2 in the container).
        -->
-       前述の <command>lxc-init</command> は，受け取ったシグナルを開始したコマンドに送るように設計されています．なので，<command>lxc-kill</command> (1) が送ったシグナルは，ユーザが指定したコマンド (コンテナ内の pid 2 のプロセス) が受けとります．
+       前述の <command>lxc-init</command> は，受け取ったシグナルを開始したコマンドに送るように設計されています．
+       なので，<command>lxc-kill</command> (1) が送ったシグナルは，ユーザが指定したコマンド (コンテナ内の pid 2 のプロセス) が受けとります．
      </para>
   </refsect1>
 
@@ -165,7 +169,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    processing. Any arguments after the &#045;&#045; are treated as
 	    arguments to <replaceable>command</replaceable>.
             -->
-            オプション指定の最後の印で，それ以上のオプションの処理を止めます．-- の後の引数は実行する <replaceable>command</replaceable> の引数として扱われます．
+            オプション指定の最後の印で，それ以上のオプションの処理を止めます．
+            -- の後の引数は実行する <replaceable>command</replaceable> の引数として扱われます．
 	  </para>
 	  <para>
             <!--

--- a/doc/ja/lxc-freeze.sgml.in
+++ b/doc/ja/lxc-freeze.sgml.in
@@ -70,7 +70,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       command. This command is useful for batch managers to schedule a
       group of processes.
       -->
-      <command>lxc-freeze</command> は，コンテナ内部で実行中のプロセスを全て凍結します．プロセスは <command>lxc-unfreeze</command> コマンドによって明示的に解凍されるまでブロックされます．このコマンドはプロセスのグループをスケジューリングするバッチマネージャに便利なコマンドです．
+      <command>lxc-freeze</command> は，コンテナ内部で実行中のプロセスを全て凍結します．
+      プロセスは <command>lxc-unfreeze</command> コマンドによって明示的に解凍されるまでブロックされます．
+      このコマンドはプロセスのグループをスケジューリングするバッチマネージャに便利なコマンドです．
     </para>
 
   </refsect1>

--- a/doc/ja/lxc-info.sgml.in
+++ b/doc/ja/lxc-info.sgml.in
@@ -88,7 +88,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             Print a configuration key from the running container. This option
             may be given mulitple times to print out multiple key = value pairs.
             -->
-            実行中のコンテナの設定値を表示します．このオプションは複数の key = value のペアを表示したい場合には複数回指定することも可能です．
+            実行中のコンテナの設定値を表示します．
+            このオプションは複数の key = value のペアを表示したい場合には複数回指定することも可能です．
           </para>
         </listitem>
       </varlistentry>
@@ -116,7 +117,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             Just print the container's pid.
             -->
-            コンテナの pid のみを表示します．
+            コンテナの pid を表示します．
           </para>
         </listitem>
       </varlistentry>
@@ -156,7 +157,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <manvolnum>5</manvolnum>
             </citerefentry>.
             -->
-            コンテナの統計情報を表示します．パフォーマンスへの影響を考慮して，カーネルメモリの使用量は，カーネルメモリの制限値が設定されない限りはカウントされません．もし，制限が設定されていない場合，<command>lxc-info</command> はカーネルメモリの使用量を 0 と表示します．制限は
+            コンテナの統計情報を表示します．
+            パフォーマンスへの影響を考慮して，カーネルメモリの使用量は，カーネルメモリの制限値が設定されない限りはカウントされません．
+            もし，制限が設定されていない場合，<command>lxc-info</command> はカーネルメモリの使用量を 0 と表示します．制限は
             <programlisting>
             lxc.cgroup.memory.kmem.limit_in_bytes = <replaceable>number</replaceable>
             </programlisting>
@@ -180,7 +183,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             Print the container's statistics in raw, non-humanized form. The
             default is to print statistics in humanized form.
             -->
-            コンテナの統計情報を人間が読みやすい形に加工しないでそのまま表示します．デフォルトは人間が読みやすい形の統計情報を表示します．
+            コンテナの統計情報を人間が読みやすい形に加工しないでそのまま表示します．
+            デフォルトは人間が読みやすい形の統計情報を表示します．
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-ls.sgml.in
+++ b/doc/ja/lxc-ls.sgml.in
@@ -206,7 +206,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             The filter passed to <command>lxc-ls</command> will be
             applied to the container name. The format is a regular expression.
             -->
-            コンテナ名に対して適用する <command>lxc-ls</command> に与えるフィルタ．フォーマットは正規表現です．
+            コンテナ名に対して適用する <command>lxc-ls</command> に与えるフィルタ．
+            フォーマットは正規表現です．
           </para>
         </listitem>
       </varlistentry>
@@ -219,15 +220,17 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     <title><!-- Examples -->例</title>
     <variablelist>
       <varlistentry>
-	<term>lxc-ls -l</term>
-	<listitem>
-	<para>
+        <term>lxc-ls --fancy</term>
+        <listitem>
+        <para>
           <!--
-	  list all the container and their permissions.
+          list all the containers, listing one per line along with its
+          name, state, ipv4 and ipv6 addresses.
           -->
-          全てのコンテナとそのパーミッションをリスト表示します．
-	</para>
-	</listitem>
+          全てのコンテナをリスト表示します．
+          一行にはコンテナの名前，状態，IPv4 アドレス，IPv6 アドレスが表示されます．
+        </para>
+        </listitem>
       </varlistentry>
 
       <varlistentry>

--- a/doc/ja/lxc-monitor.sgml.in
+++ b/doc/ja/lxc-monitor.sgml.in
@@ -73,7 +73,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <replaceable>name</replaceable> will default to '.*' which will
       monitor all containers in <command>lxcpath</command>.
       -->
-      <command>lxc-monitor</command> はコンテナの状態を監視します．<replaceable>name</replaceable> をモニタ対象のコンテナを指定するために使うことも可能です．これは posix2 準拠の正規表現であり，全てのコンテナの監視を行ったり，いくつかのコンテナの監視を行ったり，1 つだけのコンテナの監視を行ったりすることが可能です．<replaceable>name</replaceable> を指定しない場合，デフォルトで '.' となり，<command>lxcpath</command> 以下の全てのコンテナの監視を行います．
+      <command>lxc-monitor</command> はコンテナの状態を監視します．
+      <replaceable>name</replaceable> をモニタ対象のコンテナを指定するために使うことも可能です．
+      これは posix2 準拠の正規表現であり，全てのコンテナの監視を行ったり，いくつかのコンテナの監視を行ったり，1 つだけのコンテナの監視を行ったりすることが可能です．
+      <replaceable>name</replaceable> を指定しない場合，デフォルトで '.*' となり，<command>lxcpath</command> 以下の全てのコンテナの監視を行います．
     </para>
 
     <para>
@@ -83,7 +86,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       containers with the same name in multiple paths will be
       indistinguishable in the output.
       -->
-      1 つ以上のコンテナパスをモニタリングするために，複数回の <option>-P, --lxcpath</option>=PATH オプションを指定することが可能です．しかし，複数のパスで同じ名前のコンテナの場合は，出力の見分けがつかない事に注意が必要です．
+      1 つ以上のコンテナパスをモニタリングするために，複数回の <option>-P, --lxcpath</option>=PATH オプションを指定することが可能です．
+      しかし，複数のパスに同じ名前のコンテナが存在する場合は，出力の見分けがつかない事に注意が必要です．
     </para>
 
   </refsect1>
@@ -105,7 +109,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    normal 30 seconds for new clients. This is useful if you need to
 	    unmount the filesystem <command>lxcpath</command> is on.
             -->
-            指定したそれぞれの <command>lxcpath</command> に対する lxc-monitord デーモンを終了させる要求を行います．lxc-monitord は通常は新しいクライアントを 30 秒待ちますが，このコマンドを受け取ると，クライアントがいなくなるとすぐに終了します．このオプションは，<command>lxcpath</command> のファイルシステムをアンマウントする必要があるときに役に立ちます．
+            指定したそれぞれの <command>lxcpath</command> に対する lxc-monitord デーモンを終了させる要求を行います．
+            lxc-monitord は通常は新しいクライアントを 30 秒待ちますが，このコマンドを受け取ると，クライアントがいなくなるとすぐに終了します．
+            このオプションは，<command>lxcpath</command> のファイルシステムをアンマウントする必要があるときに役に立ちます．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -115,7 +121,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   &commonoptions;
 
   <refsect1>
-    <title>Examples</title>
+    <title><!-- Examples -->例</title>
     <variablelist>
       <varlistentry>
 	<term>lxc-monitor -n foo</term>

--- a/doc/ja/lxc-netstat.sgml.in
+++ b/doc/ja/lxc-netstat.sgml.in
@@ -68,7 +68,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   </refsect1>
 
   <refsect1>
-    <title><!-- Options --></title>
+    <title><!-- Options -->オプション</title>
     <variablelist>
 
       <varlistentry>
@@ -96,7 +96,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    from <command>lxc-netstat</command> options by
 	    the <option>&#045;&#045;</option> parameter.
             -->
-            <command>netstat</command> オプションは <command>lxc-netstat</command> のオプションと <option>--</option> で分けなければならない．
+            <command>netstat</command> オプションは <command>lxc-netstat</command> のオプションと <option>--</option> で分けなければなりません．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -115,7 +115,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  Call netstat -lnp for container foo.
           -->
-          コンテナ foo に対して netstat -lnp を呼び出す
+          コンテナ foo に対して netstat -lnp を呼び出します．
 	</para>
 	</listitem>
       </varlistentry>

--- a/doc/ja/lxc-ps.sgml.in
+++ b/doc/ja/lxc-ps.sgml.in
@@ -69,7 +69,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	to report the name of lxc container associated
 	to reported processes.
       -->
-      <command>lxc-ps</command> は，プロセスと関連した lxc コンテナ名を報告する ps コマンドのラッパーです．
+      <command>lxc-ps</command> は，プロセスが属する lxc コンテナ名を報告する ps コマンドのラッパーです．
     </para>
     <para>
       <!--
@@ -161,7 +161,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   </refsect1>
 
   <refsect1>
-    <title><!-- Example --></title>
+    <title><!-- Example -->例</title>
     <variablelist>
       <varlistentry>
 	<term>lxc-ps --name foo -- --forest</term>

--- a/doc/ja/lxc-restart.sgml.in
+++ b/doc/ja/lxc-restart.sgml.in
@@ -65,7 +65,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   </refsynopsisdiv>
 
   <refsect1>
-    <title>Description</title>
+    <title><!-- Description -->説明</title>
 
     <para>
       <!--
@@ -79,7 +79,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-unfreeze</command> will be needed to resume its
       execution.
       -->
-      <command>lxc-restart</command> は <replaceable>FILE</replaceable> で指定したファイルから状態を読み取り，<replaceable>NAME</replaceable> で指定したコンテナ内のアプリケーションを再起動するコマンドです．もし <option>--pause</option> が指定された場合，アプリケーションは再起動後に直前の実行状態で再開する前に停止します．この実行状態の再開には <command>lxc-unfreeze</command> コマンドが必要になります．
+      <command>lxc-restart</command> は <replaceable>FILE</replaceable> で指定したファイルから状態を読み取り，<replaceable>NAME</replaceable> で指定したコンテナ内のアプリケーションを再起動するコマンドです．
+      もし <option>--pause</option> が指定された場合，アプリケーションは再起動後に直前の実行状態で再開する前に停止します．
+      この実行状態の再開には <command>lxc-unfreeze</command> コマンドが必要になります．
     </para>
   </refsect1>
 
@@ -96,7 +98,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <replaceable>FILE</replaceable>.
 	    This option is exclusive with <option>&#045;&#045;statefd</option> below.
             -->
-            コンテナの状態を <replaceable>FILE</replaceable> で指定したファイルから読み取ります．このオプションは，後の <option>--statefd</option> と同時に指定できません．
+            コンテナの状態を <replaceable>FILE</replaceable> で指定したファイルから読み取ります．
+            このオプションは，後の <option>--statefd</option> と同時に指定できません．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -110,7 +113,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <replaceable>FD</replaceable> file descriptor.
 	    This option is exclusive with above <option>&#045;&#045;statefile</option>.
             -->
-            コンテナの状態を <replaceable>FD</replaceable> で指定したファイル記述子から読み取ります．このオプションは，前の <option>--statefile</option> と同時に指定できません．
+            コンテナの状態を <replaceable>FD</replaceable> で指定したファイル記述子から読み取ります．
+            このオプションは，前の <option>--statefile</option> と同時に指定できません．
 	  </para>
 	</listitem>
 	</varlistentry>
@@ -123,7 +127,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Pause container processes after restart. The container will be
 	    stopped until you resume it with the lxc-unfreeze command.
             -->
-            再起動後にコンテナプロセスを一時停止します．コンテナは lxc-unfreeze コマンドで再開するまでは停止しています．
+            再起動後にコンテナプロセスを一時停止します．
+            コンテナは lxc-unfreeze コマンドで再開するまでは停止しています．
 	  </para>
 	</listitem>
 	</varlistentry>

--- a/doc/ja/lxc-snapshot.sgml.in
+++ b/doc/ja/lxc-snapshot.sgml.in
@@ -85,7 +85,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <!--
     Snapshots are stored as snapshotted containers under a private configuration path.  For instance, if the container's configuration path is <filename>/var/lib/lxc</filename> and the container is <filename>c1</filename>, then the first snapshot will be stored as container <filename>snap0</filename> under configuration path <filename>/var/lib/lxcsnaps/c1</filename>.
     -->
-      スナップショットは，専用の設定されたパス以下にスナップショット化されたコンテナとして保存されます．例えば，もしコンテナパスが <filename>/var/lib/lxc</filename> で，コンテナが <filename>c1</filename> である場合，最初に取得するスナップショットは，パス <filename>/var/lib/lxcsnaps/c1</filename> の下の <filename>snap0</filename> として保存されます．
+      スナップショットは，専用の設定されたパス以下にスナップショット化されたコンテナとして保存されます．
+      例えば，もしコンテナパスが <filename>/var/lib/lxc</filename> で，コンテナが <filename>c1</filename> である場合，最初に取得するスナップショットは，パス <filename>/var/lib/lxcsnaps/c1</filename> の下の <filename>snap0</filename> として保存されます．
     </para>
   </refsect1>
 
@@ -138,7 +139,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               Restore the named snapshot, meaning a full new container is created which is a copy of the snapshot.
               -->
-              指定のスナップショットをリストアする．これはスナップショットのコピーである完全に新しいコンテナが作製されるということです．
+              指定のスナップショットをリストアします．
+              これはスナップショットのコピーである完全に新しいコンテナが作製されるということです．
             </para>
 	   </listitem>
 	  </varlistentry>
@@ -150,7 +152,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               When restoring a snapshot, the last optional argument is the name to use for the restored container.  If no name is given, then the original container will be destroyed and the restored container will take its place.  Note that deleting the original snapshot is not possible in the case of overlayfs or zfs backed snapshots.
               -->
-              スナップショットをリストアする際，最後のオプション引数はリストアされたコンテナの名前として使用されます．もし名前が与えられてない場合，元のコンテナが破壊され，リストアされるコンテナに置き換えられます．スナップショット元を削除することは，overlayfs と zfs がバックエンドのスナップショットでは出来ないことに注意が必要です．
+              スナップショットをリストアする際，最後のオプション引数はリストアされたコンテナの名前として使用されます．
+              もし名前が与えられてない場合，元のコンテナが破壊され，リストアされるコンテナに置き換えられます．
+              スナップショット元を削除することは，overlayfs と zfs がバックエンドのスナップショットでは出来ないことに注意が必要です．
             </para>
 	   </listitem>
 	  </varlistentry>

--- a/doc/ja/lxc-start-ephemeral.sgml.in
+++ b/doc/ja/lxc-start-ephemeral.sgml.in
@@ -66,7 +66,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   </refsynopsisdiv>
 
   <refsect1>
-    <title><!-- Description --></title>
+    <title><!-- Description -->説明</title>
     <para>
       <!--
       <command>lxc-start-ephemeral</command> start an ephemeral copy of an
@@ -77,7 +77,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   </refsect1>
 
   <refsect1>
-    <title><!-- Options --></title>
+    <title><!-- Options -->オプション</title>
     <variablelist>
       <varlistentry>
         <term>
@@ -150,7 +150,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             Used when passing a command to lxc-start-ephemeral.
             -->
             コンテナに接続するためのユーザ．
-            lxc-start-ephemeral コマンドを実行するときに使います．
+            lxc-start-ephemeral にコマンドを指定するときに使います．
           </para>
         </listitem>
       </varlistentry>
@@ -196,8 +196,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             With this option, you can lxc-stop and lxc-start the no longer so
             ephemeral container (it's still an overlay, but a persistent one).
             -->
-            tmpfs の代わりに永続的なバックエンドを使用します．
-            このオプションを使うことにより，もはや一時的なコンテナではないので，lxc-stop や lxc-start を使用することができます (オーバーレイな状態ですが，永続的です)．
+            tmpfs の代わりに永続的なバックエンドを使用します．このオプションを使うことにより，もはや一時的なコンテナではないので，lxc-stop や lxc-start を使用することができます (オーバーレイな状態ですが，永続的です)．
           </para>
         </listitem>
       </varlistentry>
@@ -213,8 +212,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             This currently uses ssh (not attach) and is incompatible
             with daemon mode.
             -->
-            即座に指定したコマンドをコンテナ内で実行します．
-            現時点では (attach ではなく) ssh を使用します．そしてデーモンモードと両方を指定することはできません．
+            即座に指定したコマンドをコンテナ内で実行します．現時点では (attach ではなく) ssh を使用します．そしてデーモンモードと両方を指定することはできません．
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-start.sgml.in
+++ b/doc/ja/lxc-start.sgml.in
@@ -87,7 +87,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       If no configuration is
       defined, the default isolation is used.
       -->
-      このコマンドは，lxc-create コマンドもしくは設定ファイルのパラメータであらかじめ定義された設定に従ってコンテナをセットアップします．もし設定が定義されていない場合は，デフォルトの隔離状態を使用します．
+      このコマンドは，lxc-create コマンドもしくは設定ファイルのパラメータであらかじめ定義された設定に従ってコンテナをセットアップします．
+      もし設定が定義されていない場合は，デフォルトの隔離状態を使用します．
     </para>
     <para>
       <!--
@@ -118,7 +119,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    more tty, if an error occurs nothing will be displayed,
 	    the log file can be used to check the error.
             -->
-            コンテナをデーモンとして実行します．コンテナはそれ以上の tty を持ちませんので，もしエラーが起きても何も表示されません．エラーのチェックにはログファイルを使用することができます．
+            コンテナをデーモンとして実行します．
+            コンテナはそれ以上の tty を持ちませんので，もしエラーが起きても何も表示されません．
+            エラーのチェックにはログファイルを使用することができます．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -172,7 +175,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             /dev/tty8. If this option is not specified the current terminal
             will be used unless <option>-d</option> is specified.
             -->
-            コンテナのコンソールに使用するデバイスを指定します．例えば /dev/tty8 のように指定します．このオプションが指定されない時は，<option>-d</option> が指定されない限りは，現在のターミナルを使用します．
+            コンテナのコンソールに使用するデバイスを指定します．例えば /dev/tty8 のように指定します．
+            このオプションが指定されない時は，<option>-d</option> が指定されない限りは，現在のターミナルを使用します．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -203,7 +207,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    variable <replaceable>KEY</replaceable>. This overrides any
 	    assignment done in <replaceable>config_file</replaceable>.
             -->
-            設定変数 <replaceable>KEY</replaceable> に対する設定値として <replaceable>VAL</replaceable> を設定します．この設定は，<replaceable>config_file</replaceable> で既に設定されている値も上書きします．
+            設定変数 <replaceable>KEY</replaceable> に対する設定値として <replaceable>VAL</replaceable> を設定します．
+            この設定は，<replaceable>config_file</replaceable> で既に設定されている値も上書きします．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -221,7 +226,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  failure instead. Note: <replaceable>&#045;&#045;daemon</replaceable> implies
 	  <replaceable>&#045;&#045;close-all-fds</replaceable>.
           -->
-            継承しているファイルディスクリプタが存在する場合，それをクローズします．このオプションが指定されない場合，<command>lxc-start</command> の実行は失敗して終了します．注意: <replaceable>--daemon</replaceable> オプションは，<replaceable>--close-all-fds</replaceable> オプションを指定しなくても指定している場合と同様の動きをします．
+            継承しているファイルディスクリプタが存在する場合，それをクローズします．
+            このオプションが指定されない場合，<command>lxc-start</command> の実行は失敗して終了します．
+            注意: <replaceable>--daemon</replaceable> オプションは，<replaceable>--close-all-fds</replaceable> オプションを指定しなくても指定している場合と同様の動きをします．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -240,7 +247,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    network configuration of the starting container is ignored
 	    and the up/down scripts won't be executed.
             -->
-            名前が <replaceable>name</replaceable> である，もしくは PID が <replaceable>pid</replaceable> であるコンテナとネットワーク名前空間を共有します．ネットワーク名前空間は引き続き元の所有者が管理します．開始するコンテナのネットワーク設定は無視され，up/down のスクリプトは実行されません．
+            名前が <replaceable>name</replaceable> である，もしくは PID が <replaceable>pid</replaceable> であるコンテナとネットワーク名前空間を共有します．
+            ネットワーク名前空間は引き続き元の所有者が管理します．
+            開始するコンテナのネットワーク設定は無視され，up/down のスクリプトは実行されません．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -274,7 +283,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    not set the hostname, but the container OS may do it
 	    anyway.
             -->
-            名前が <replaceable>name</replaceable> である，もしくは PID が <replaceable>pid</replaceable> であるコンテナと UTS 名前空間を共有します．LXC は開始するときににはホスト名を設定しませんが，コンテナ内の OS が何らかの方法でホスト名を設定するかもしれません．
+            名前が <replaceable>name</replaceable> である，もしくは PID が <replaceable>pid</replaceable> であるコンテナと UTS 名前空間を共有します．
+            LXC は開始するときににはホスト名を設定しませんが，コンテナ内の OS が何らかの方法でホスト名を設定するかもしれません．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -299,7 +309,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    application. You should stop it before reuse this
 	    container or create a new one.
             -->
-            指定したコンテナは既に実行済みです．このコンテナを使用するまえに既に起動しているコンテナを停止するか，新しいものを作成する必要があります．
+            指定したコンテナは既に実行済みです．
+            このコンテナを使用する前に既に起動しているコンテナを停止するか，新しいものを作成する必要があります．
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-stop.sgml.in
+++ b/doc/ja/lxc-stop.sgml.in
@@ -77,7 +77,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       seconds the container will be sent the
       <command>lxc.stopsignal</command> to force it to shut down.
       -->
-      <command>lxc-stop</command> は，リブート，クリーンシャットダウン，コンテナ内の全てのプロセスの kill のどれかを行います．デフォルトでは，コンテナのクリーンなシャットダウンを (SIGPWR をコンテナに送ることで) 行い，コンテナの終了を 60 秒待ち，return します．コンテナがクリーンに終了するのに失敗した場合，60 秒待った後，コンテナに <command>lxc.stopsignal</command> で指定したシグナルを送り，強制的にシャットダウンします．
+      <command>lxc-stop</command> は，リブート，クリーンシャットダウン，コンテナ内の全てのプロセスの kill のどれかを行います．
+      デフォルトでは，コンテナのクリーンなシャットダウンを (SIGPWR をコンテナに送ることで) 行い，コンテナの終了を 60 秒待ち，return します．
+      コンテナがクリーンに終了するのに失敗した場合，60 秒待った後，コンテナに <command>lxc.stopsignal</command> で指定したシグナルを送り，強制的にシャットダウンします．
     </para>
 
     <para>
@@ -89,13 +91,15 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <optional>-t TIMEOUT</optional> specifies the maximum amount of time
       to wait for the container to complete the shutdown or reboot.
       -->
-      <optional>-W</optional>, <optional>-r</optional>, <optional>-s</optional>, <optional>-k</optional> オプションは実行する際のアクションを指定します．<optional>-W</optional> は，指定したアクションの後に，<command>lxc-stop</command> は速やかに終了します．一方，<optional>-t TIMEOUT</optional> はコンテナが完全にシャットダウンやリブートするのを待つ時間の最大値を設定します．
+      <optional>-W</optional>, <optional>-r</optional>, <optional>-s</optional>, <optional>-k</optional> オプションは実行する際のアクションを指定します．
+      <optional>-W</optional> は，指定したアクションの後に，<command>lxc-stop</command> は速やかに終了します．
+      一方，<optional>-t TIMEOUT</optional> はコンテナが完全にシャットダウンやリブートするのを待つ時間の最大値を設定します．
     </para>
 
   </refsect1>
 
   <refsect1>
-    <title>Options</title>
+    <title><!-- Options -->オプション</title>
     <variablelist>
 
     <varlistentry>
@@ -122,7 +126,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Only request a clean shutdown, do not kill the container tasks if the
 		clean shutdown fails.
               -->
-            クリーンシャットダウンだけをリクエストします．クリーンなシャットダウンに失敗した場合でも，コンテナのタスクを kill しません．
+            クリーンシャットダウンだけをリクエストします．
+            クリーンなシャットダウンに失敗した場合でも，コンテナのタスクを kill しません．
 	  </para>
 	</listitem>
 	</varlistentry>
@@ -138,7 +143,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         kill all tasks in the container.  This is the legacy
         <command>lxc-stop</command> behavior.
         -->
-           コンテナのクリーンシャットダウンをリクエストするのでなく，明確にコンテナ内の全てのタスクを kill します．これは，以前の <command>lxc-stop</command> の動作です．
+           コンテナのクリーンシャットダウンをリクエストするのでなく，明確にコンテナ内の全てのタスクを kill します．
+            これは，以前の <command>lxc-stop</command> の動作です．
 	  </para>
 	</listitem>
     </varlistentry>
@@ -154,7 +160,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	only be used if <command>lxc-stop</command> is hanging due to a bad
 	system state.
               -->
-            このオプションはいかなる場合でも API の lxc のロックの使用を回避します．システム状態が不良な場合に lxc-stop の応答がない状態の場合のみ使用すべきです．
+            このオプションはいかなる場合でも API の lxc のロックの使用を回避します．
+            システム状態が不良な場合に lxc-stop の応答がない状態の場合のみ使用すべきです．
 	  </para>
 	</listitem>
     </varlistentry>
@@ -169,7 +176,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Simply perform the requestion action (reboot, shutdown, or hard
 		kill) and exit.
               -->
-            リクエストされたアクション (reboot, shutdown, 強制的な kill) を実行するだけで (すぐに) 終了します．
+            リクエストされたアクション (reboot, shutdown, 強制的な kill) を実行するだけで (すぐに) 終了 (exit) します．
 	  </para>
 	</listitem>
 	</varlistentry>

--- a/doc/ja/lxc-top.sgml.in
+++ b/doc/ja/lxc-top.sgml.in
@@ -68,7 +68,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       number of containers displayed, otherwise <command>lxc-top</command>
       will display as many containers as can fit in your terminal.
       -->
-      <command>lxc-top</command> はコンテナの統計情報を表示します．出力は <replaceable>delay</replaceable> 秒ごとに更新されます．そして，<replaceable>sortby</replaceable> で指定した値に従ってソートされます．<replaceable>count</replaceable> を指定すると表示するコンテナ数を制限しますが，指定しなければ使用しているターミナルに合うようなコンテナ数で表示します．
+      <command>lxc-top</command> はコンテナの統計情報を表示します．出力は <replaceable>delay</replaceable> 秒ごとに更新されます．
+      そして，<replaceable>sortby</replaceable> で指定した値に従ってソートされます．<replaceable>count</replaceable> を指定すると表示するコンテナ数を制限しますが，指定しなければ使用しているターミナルに合うようなコンテナ数で表示します．
     </para>
   </refsect1>
 
@@ -103,7 +104,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             rational number, for example 0.5 for a half second delay. The
             default is 3 seconds.
             -->
-            表示を更新する間隔を秒で指定します．有理数を指定することにより，1 秒以下を指定することも可能です．例えば，1 秒の半分で更新を行うために 0.5 を指定します．デフォルトは 3 秒です．
+            表示を更新する間隔を秒で指定します．有理数を指定することにより，1 秒以下を指定することも可能です．
+            例えば，1 秒の半分で更新を行うために 0.5 を指定します．デフォルトは 3 秒です．
           </para>
         </listitem>
       </varlistentry>
@@ -119,7 +121,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             the letters n,c,d,m,k to sort by name, cpu use, disk I/O, memory,
             or kernel memory use respectively. The default is 'n'.
             -->
-            名前，CPU 使用量，メモリ使用量でコンテナをソートします．<replaceable>sortby</replaceable> で指定する引数は n,c,d,m,k のどれかでなければなりません．これはそれぞれ名前，CPU 使用量，disk I/O，メモリ使用量，カーネルメモリ使用量を表します．デフォルトは 'n' です．
+            名前，CPU 使用量，メモリ使用量でコンテナをソートします．<replaceable>sortby</replaceable> で指定する引数は n,c,d,m,k のどれかでなければなりません．
+            これはそれぞれ名前，CPU 使用量，disk I/O，メモリ使用量，カーネルメモリ使用量を表します．デフォルトは 'n' です．
           </para>
         </listitem>
       </varlistentry>
@@ -176,7 +179,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         <manvolnum>5</manvolnum>
       </citerefentry>.
       -->
-      パフォーマンスへの影響を考慮して，カーネルメモリの使用量は，カーネルメモリの制限値が設定されない限りはカウントされません．もし，制限が設定されていない場合，<command>lxc-top</command> はカーネルメモリの使用量を 0 と表示します．もし，カウントされているコンテナが存在しない場合，KMem カラムは表示されません．制限は
+      パフォーマンスへの影響を考慮して，カーネルメモリの使用量は，カーネルメモリの制限値が設定されない限りはカウントされません．
+      もし，制限が設定されていない場合，<command>lxc-top</command> はカーネルメモリの使用量を 0 と表示します．
+      もし，カウントされているコンテナが存在しない場合，KMem カラムは表示されません．制限は
       <programlisting>
       lxc.cgroup.memory.kmem.limit_in_bytes = <replaceable>number</replaceable>
       </programlisting>

--- a/doc/ja/lxc-unshare.sgml.in
+++ b/doc/ja/lxc-unshare.sgml.in
@@ -73,7 +73,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       the new task with fresh namespaces.  Apart from testing kernel
       regressions this should make no difference.
       -->
-      <command>lxc-unshare</command> はクローンされた名前空間の組の中でタスクを実行するのに使います．このコマンドは主にテスト目的で使います．このような名前であるにもかかわらず，このコマンドは常に，新しい名前空間で新しいタスクを作成するために unshare ではなく clone を使います．テスト中のカーネルの退行は別として，これで違いは生じないはずです．
+      <command>lxc-unshare</command> はクローンされた名前空間の組の中でタスクを実行するのに使います．
+      このコマンドは主にテスト目的で使います．
+      このような名前であるにもかかわらず，このコマンドは常に，新しい名前空間で新しいタスクを作成するために unshare ではなく clone を使います．
+      テスト中のカーネルの退行は別として，これで違いは生じないはずです．
     </para>
 
   </refsect1>
@@ -101,7 +104,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    container while retaining the other namespaces as those of the
 	    host.
             -->
-            アタッチする名前空間を，パイプでつなげたリストで指定します．例えば <replaceable>NETWORK|IPC</replaceable> のようにです．指定できる値は <replaceable>MOUNT</replaceable>，<replaceable>PID</replaceable>，<replaceable>UTSNAME</replaceable>，<replaceable>IPC</replaceable>，<replaceable>USER </replaceable>，<replaceable>NETWORK</replaceable> です．これにより，プロセスのコンテキストを変更することができます．例えば，コンテナのネットワーク名前空間だけを変更し，他の名前空間をホストのものと同じものに保ったままにするというようなことです．
+            アタッチする名前空間を，パイプでつなげたリストで指定します．
+            例えば <replaceable>NETWORK|IPC</replaceable> のようにです．
+            指定できる値は <replaceable>MOUNT</replaceable>，<replaceable>PID</replaceable>，<replaceable>UTSNAME</replaceable>，<replaceable>IPC</replaceable>，<replaceable>USER </replaceable>，<replaceable>NETWORK</replaceable> です．
+            これにより，プロセスのコンテキストを変更することができます．
+            例えば，コンテナのネットワーク名前空間だけを変更し，他の名前空間をホストのものと同じものに保ったままにするというようなことです．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -116,7 +123,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Specify a user which the new task should become.  This option is
 	    only valid if a user namespace is unshared.
             -->
-            新しいタスクを実行するユーザを指定します．このオプションはユーザ名前空間を unshare する時のみ有効です．
+            新しいタスクを実行するユーザを指定します．
+            このオプションはユーザ名前空間を unshare する時のみ有効です．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -159,7 +167,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         <programlisting>
           lxc-unshare -s "NETWORK|PID|MOUNT" /bin/bash
         </programlisting>
-        その結果起動するシェルは pid が 1 となり，ネットワークインターフェースがないでしょう．そのシェル上で /proc を再マウントした後
+        その結果起動するシェルは pid が 1 となり，ネットワークインターフェースがないでしょう．
+        そのシェル上で /proc を再マウントした後
         <programlisting>
           mount -t proc proc /proc
         </programlisting>

--- a/doc/ja/lxc-user-nic.sgml.in
+++ b/doc/ja/lxc-user-nic.sgml.in
@@ -82,7 +82,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       user is privileged over the network namespace to which the interface
       will be attached.
       -->
-      このプログラムは，<filename>@LXC_USERNIC_CONF@</filename> という設定ファイルを参照して，呼び出したユーザが作成することができるインターフェースの数と，どのブリッジに接続するかを決定します．また，ユーザが作成したインターフェースの数を <filename>@LXC_USERNIC_DB@</filename> を使ってチェックします．これにより，呼び出したユーザが，インターフェースを割り当てるネットワーク名前空間上で特権を持つことが保証されます．
+      このプログラムは，<filename>@LXC_USERNIC_CONF@</filename> という設定ファイルを参照して，呼び出したユーザが作成することができるインターフェースの数と，どのブリッジに接続するかを決定します．
+      また，ユーザが作成したインターフェースの数を <filename>@LXC_USERNIC_DB@</filename> を使ってチェックします．
+      これにより，呼び出したユーザが，インターフェースを割り当てるネットワーク名前空間上で特権を持つことが保証されます．
     </para>
 
   </refsect1>
@@ -138,7 +140,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  The bridge to which to attach the network interface, for
 	  instance <filename>lxcbr0</filename>.
               -->
-            ネットワークインターフェースを接続するブリッジ．例えば <filename>lxcbr0</filename> のように指定します．
+            ネットワークインターフェースを接続するブリッジ．
+            例えば <filename>lxcbr0</filename> のように指定します．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -153,7 +156,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  The desired interface name in the container.  This will be
 	  <filename>eth0</filename> if unspecified.
           -->
-            コンテナ内に作られるインターフェースの名前．もし指定しない場合，<filename>eth0</filename> となります．
+            コンテナ内に作られるインターフェースの名前．
+            もし指定しない場合，<filename>eth0</filename> となります．
 	  </para>
 	</listitem>
       </varlistentry>

--- a/doc/ja/lxc-usernet.sgml.in
+++ b/doc/ja/lxc-usernet.sgml.in
@@ -123,7 +123,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      is the bridge to which the network interfaces may be attached, for
 	      instance <filename>lxcbr0</filename>.
               -->
-              ネットワークインターフェースが接続されるブリッジ．例えば <filename>lxcbr0</filename> のように指定します．
+              ネットワークインターフェースが接続されるブリッジ．
+              例えば <filename>lxcbr0</filename> のように指定します．
 	     </para>
 	  </listitem>
 	</varlistentry>
@@ -138,7 +139,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      is the number of network interfaces of the given type which the
 	      given user may attach to the given bridge, for instance <filename>2</filename>.
               -->
-              指定したユーザが，指定したブリッジに接続できる，指定した形式のネットワークインターフェースの数．例えば <filename>2</filename> のように指定します．
+              指定したユーザが，指定したブリッジに接続できる，指定した形式のネットワークインターフェースの数．
+              例えば <filename>2</filename> のように指定します．
 	     </para>
 	  </listitem>
 	</varlistentry>

--- a/doc/ja/lxc-wait.sgml.in
+++ b/doc/ja/lxc-wait.sgml.in
@@ -67,7 +67,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-wait</command> waits for a specific container state
       before exiting, this is useful for scripting.
       -->
-      <command>lxc-wait</command> は，コンテナが指定した状態になるのを待って終了します．スクリプトで使用するときに役に立ちます．
+      <command>lxc-wait</command> は，コンテナが指定した状態になるのを待って終了します．
+      スクリプトで使用するときに役に立ちます．
     </para>
   </refsect1>
 
@@ -85,7 +86,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Specify the container state(s) to wait for. The container
 	    states can be ORed to specify several states.
             -->
-            待つ対象のコンテナの状態を指定します．コンテナの状態として，いくつかの状態を OR で指定することが可能です．
+            待つ対象のコンテナの状態を指定します．
+            コンテナの状態として，いくつかの状態を OR で指定することが可能です．
 	  </para>
 	</listitem>
       </varlistentry>
@@ -111,7 +113,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   &commonoptions;
 
   <refsect1>
-    <title>Examples</title>
+    <title><!-- Examples -->例</title>
     <variablelist>
       <varlistentry>
 	<term>lxc-wait -n foo -s RUNNING</term>

--- a/doc/ja/lxc.conf.sgml.in
+++ b/doc/ja/lxc.conf.sgml.in
@@ -68,7 +68,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       specified, a new network stack is created for the container and
       the container can no longer use the network of its ancestor.
       -->
-      linux コンテナ (<command>lxc</command>) は，常に使用する前に作成されます．コンテナは，プロセスがコンテナを使う時に仮想化/隔離するシステムリソースのセットを定義することによって作成します．デフォルトでは，pid, sysv ipc, マウントポイントが仮想化され，隔離されます．他のシステムリソースは，設定ファイルで明確に定義されない限りは，コンテナをまたいで共有されます．例えば，もしネットワークが設定されていなければ，コンテナを作成する側とコンテナでネットワークを共有します．もし，ネットワークが指定されれば，新しいネットワークスタックがコンテナ用に作成され，コンテナは作成元の環境のネットワークを使いません．
+      linux コンテナ (<command>lxc</command>) は，常に使用する前に作成されます．
+      コンテナは，プロセスがコンテナを使う時に仮想化/隔離するシステムリソースのセットを定義することによって作成します．
+      デフォルトでは，pid, sysv ipc, マウントポイントが仮想化され，隔離されます．
+      他のシステムリソースは，設定ファイルで明確に定義されない限りは，コンテナをまたいで共有されます．
+      例えば，もしネットワークが設定されていなければ，コンテナを作成する側とコンテナでネットワークを共有します．
+      しかし，ネットワークが指定されれば，新しいネットワークスタックがコンテナ用に作成され，コンテナは作成元の環境のネットワークを使いません．
     </para>
 
     <para>
@@ -78,7 +83,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       network, the mount points, the root file system, the user namespace,
       and the control groups are supported.
       -->
-      設定ファイルは，コンテナに割り当てられる様々なシステムリソースを定義します．現時点では，utsname，ネットワーク，マウントポイント，root ファイルシステム，ユーザ名前空間，control groups がサポートされます．
+      設定ファイルは，コンテナに割り当てられる様々なシステムリソースを定義します．
+      現時点では，utsname，ネットワーク，マウントポイント，root ファイルシステム，ユーザ名前空間，control groups がサポートされます．
     </para>
 
     <para>
@@ -87,7 +93,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       = value</command> fitting in one line. The '#' character means
       the line is a comment.
       -->
-      設定ファイルのオプション一つを，<command>key = value</command> の形で一行で表します．'#' は，その行はコメントであることを示します．
+      設定ファイルのオプション一つを，<command>key = value</command> の形で一行で表します．
+      '#' は，その行はコメントであることを示します．
     </para>
 
     <refsect2>
@@ -101,7 +108,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	containers.  Then, if the containers are moved to another host,
 	only one file may need to be updated.
         -->
-        複数の関係するコンテナの管理を容易にするために，コンテナの設定ファイルに別のファイルをロードすることが可能です．例えば，ネットワークの設定を，複数のコンテナから include させるように 1 つのファイルに定義することが可能です．その場合，コンテナが他のホストに移動すると，そのファイルだけを更新する必要があるかもしれません．
+        複数の関係するコンテナの管理を容易にするために，コンテナの設定ファイルに別のファイルをロードすることが可能です．
+        例えば，ネットワークの設定を，複数のコンテナから include させるように 1 つのファイルに定義することが可能です．
+        その場合，コンテナが他のホストに移動すると，そのファイルだけを更新する必要があるかもしれません．
       </para>
 
       <variablelist>
@@ -115,7 +124,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Specify the file to be included.  The included file must be
 	      in the same valid lxc configuration file format.
               -->
-              include させたいファイルを指定します．include するファイルは，lxc 設定ファイルのフォーマットとして有効でなければいけません．
+              include させたいファイルを指定します．
+              include するファイルは，lxc 設定ファイルのフォーマットとして有効でなければいけません．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -132,7 +142,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	which rely on the architecture to do some work like
 	downloading the packages.
         -->
-        コンテナに対してアーキテクチャを設定することが可能です．例えば，64 ビットのホスト上で 32 ビットのバイナリを動かすために 32 ビットアーキテクチャを設定することが可能です．この設定を行うことにより，パッケージのダウンロードを行うなどの作業のうち，アーキテクチャ名に依存するような作業を行うコンテナスクリプトの修正を行います．
+        コンテナに対してアーキテクチャを設定することが可能です．
+        例えば，64 ビットのホスト上で 32 ビットのバイナリを動かすために 32 ビットアーキテクチャを設定することが可能です．
+        この設定を行うことにより，パッケージのダウンロードを行うなどの作業のうち，アーキテクチャ名に依存するような作業を行うコンテナスクリプトの修正を行います．
       </para>
 
       <variablelist>
@@ -176,7 +188,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	without changing the one from the system. That makes the
 	hostname private for the container.
         -->
-        utsname セクションは，コンテナに設定されるホスト名を定義します．コンテナは，システムのホスト名を変えることなく，自身のホスト名を持つ事が可能です．このことにより，ホスト名はコンテナ専用となります．
+        utsname セクションは，コンテナに設定されるホスト名を定義します．
+        コンテナは，システムのホスト名を変えることなく，自身のホスト名を持つ事が可能です．
+        このことにより，ホスト名はコンテナ専用となります．
       </para>
       <variablelist>
 	<varlistentry>
@@ -205,7 +219,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     allows signal to be specified in kill(1) fashion, e.g.
     SIGKILL, SIGRTMIN+14, SIGRTMAX-10 or plain number.
     -->
-        lxc-stop がコンテナをシャットダウンするときに送出するシグナル名か番号を指定可能です．様々な init システムが，クリーンなシャットダウンシーケンスを実行するために，様々なシグナルを用いる可能性があります．オプションとして，シグナルを kill(1) の形式で指定することが可能です．例えば SIGKILL, SIGRTMIN+14, SIGRTMAX-10 のような形式，もしくは数字を指定します．
+        lxc-stop がコンテナをシャットダウンするときに送出するシグナル名か番号を指定可能です．
+        様々な init システムが，クリーンなシャットダウンシーケンスを実行するために，様々なシグナルを用いる可能性があります．
+        オプションとして，シグナルを kill(1) の形式で指定することが可能です．
+        例えば SIGKILL, SIGRTMIN+14, SIGRTMAX-10 のような形式，もしくは数字を指定します．
       </para>
       <variablelist>
     <varlistentry>
@@ -236,7 +253,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	in a container even if the system has only one physical
 	network interface.
         -->
-        ネットワークセクションは，コンテナ内でどのようにネットワークを仮想化するかを定義します．ネットワークの仮想化はレイヤー 2 で作動します．ネットワークの仮想化を使用するためには，コンテナのネットワークインターフェースを定義しなければなりません．いくつかの仮想インターフェースをアサインすることができます．そして，仮に物理ネットワークインターフェースが一つしかなくても，コンテナ内でいくつもの仮想インターフェースを使うことができます．
+        ネットワークセクションは，コンテナ内でどのようにネットワークを仮想化するかを定義します．
+        ネットワークの仮想化はレイヤー 2 で作動します．
+        ネットワークの仮想化を使用するためには，コンテナのネットワークインターフェースを定義しなければなりません．
+        いくつかの仮想インターフェースをアサインすることができます．
+        そして，仮に物理ネットワークインターフェースが一つしかなくても，コンテナ内でいくつもの仮想インターフェースを使うことができます．
       </para>
       <variablelist>
 	<varlistentry>
@@ -255,7 +276,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      network interfaces for one container. The different
 	      virtualization types can be:
               -->
-              コンテナがどの種類のネットワーク仮想化を使うかを指定します．一つのネットワークの設定ごとに <option>lxc.network.type</option> フィールドを指定します．このように，一つのコンテナに複数のネットワークインターフェースを割り当てることができるだけでなく，同じコンテナに対して複数のネットワーク仮想化の種類を指定することが出来ます．仮想化の種類は以下の値を取る事が出来ます:
+              コンテナがどの種類のネットワーク仮想化を使うかを指定します．
+              一つのネットワークの設定ごとに <option>lxc.network.type</option> フィールドを指定します．
+              このように，一つのコンテナに複数のネットワークインターフェースを割り当てることができるだけでなく，同じコンテナに対して複数のネットワーク仮想化の種類を指定することが出来ます．
+              仮想化の種類は以下の値を取る事が出来ます:
 	    </para>
 
 	    <para>
@@ -285,7 +309,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      to set a specific name with
 	      the <option>lxc.network.veth.pair</option> option.
               -->
-              <option>veth:</option> 一方がコンテナに，もう一方が <option>lxc.network.link</option> で指定されるブリッジにアタッチされる，ピアネットワークデバイスを作成します．もし，ブリッジが指定されていない場合，veth ペアデバイスは作成されますが，ブリッジにはアタッチされません．ブリッジはシステムで事前に設定する必要があります．さもなければ，<command>lxc</command> はコンテナ外のいかなる設定も扱うことはできないでしょう．デフォルトでは，<command>lxc</command> はコンテナの外部に属するネットワークデバイスに対する名前を決定し，<command>lxc</command> はこの名前を使います．しかし，もしこの名前を自分で指定したい場合，<option>lxc.network.veth.pair</option> オプションを使って名前を設定し，lxc に対して指定をすることができます．
+              <option>veth:</option> 一方がコンテナに，もう一方が <option>lxc.network.link</option> で指定されるブリッジにアタッチされる，ピアネットワークデバイスを作成します．
+              もし，ブリッジが指定されていない場合，veth ペアデバイスは作成されますが，ブリッジにはアタッチされません．
+              ブリッジはシステムで事前に設定する必要があります．
+              さもなければ，<command>lxc</command> はコンテナ外のいかなる設定も扱うことはできないでしょう．
+              デフォルトでは，<command>lxc</command> はコンテナの外部に属するネットワークデバイスに対する名前を決定し，<command>lxc</command> はこの名前を使います．
+              しかし，もしこの名前を自分で指定したい場合，<option>lxc.network.veth.pair</option> オプションを使って名前を設定し，lxc に対して指定をすることができます．
 	    </para>
 
 	    <para>
@@ -296,7 +325,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      the container. The vlan identifier is specified with the
 	      option <option>lxc.network.vlan.id</option>.
               -->
-              <option>vlan:</option> vlan インターフェースは <option>lxc.network.link</option> で指定されたインターフェースとリンクし，コンテナに割り当てられます．vlan の指定は <option>lxc.network.vlan.id</option> オプションで指定します．
+              <option>vlan:</option> vlan インターフェースは <option>lxc.network.link</option> で指定されたインターフェースとリンクし，コンテナに割り当てられます．
+              vlan の指定は <option>lxc.network.vlan.id</option> オプションで指定します．
 	    </para>
 
 	    <para>
@@ -328,7 +358,18 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      the MAC addresses, the macvlan bridge mode does not
 	      require learning or STP like the bridge module does.
               -->
-              <option>macvlan:</option> macvlan インターフェースは <option>lxc.network.link</option> により指定されるインターフェースとリンクし，コンテナに割り当てられます．<option>lxc.network.macvlan.mode</option> でモードを指定すると，その macvlan の指定を，同じ上位デバイスで異なる macvlan の間の通信をする時に使います．受け入れられたモードが <option>private</option> であれば，デバイスは同じ上位デバイスの他のデバイスとの通信を行いません (デフォルト)．新しい仮想イーサネットポート集約モード (Virtual Ethernet Port Aggregator (VEPA)) である <option>vepa</option> は，隣接したポートが，ソースとデスティネーションの両方が macvlan ポートに対してローカルであるフレームを全て返すと仮定します．すなわち，ブリッジが reflective relay として設定されているということです．上位デバイスから入ってくるブロードキャストフレームは，VEPA モードである全ての macvlan インターフェースに送りつけられます．ローカルのフレームはローカルには配送されません．<option>bridge</option> の指定は，同じポートの異なる macvlan インターフェースの間のシンプルなブリッジとして動作します．あるインターフェースから他のインターフェースへのフレームは，直接配送され，外部には送出されません．ブロードキャストフレームは，全ての他のブリッジと外部のインターフェースに対して送られます．しかし，reflective relay からフレームが返ってきたときは，再度それを配送することはしません．全ての MAC アドレスを知っているので，ブリッジモジュールのように，macvlan ブリッジモードは学習や STP の必要はありません．
+              <option>macvlan:</option> macvlan インターフェースは <option>lxc.network.link</option> により指定されるインターフェースとリンクし，コンテナに割り当てられます．
+              <option>lxc.network.macvlan.mode</option> でモードを指定すると，その macvlan の指定を，同じ上位デバイスで異なる macvlan の間の通信をする時に使います．
+              受け入れられたモードが <option>private</option> であれば，デバイスは同じ上位デバイスの他のデバイスとの通信を行いません (デフォルト)．
+              新しい仮想イーサネットポート集約モード (Virtual Ethernet Port Aggregator (VEPA)) である <option>vepa</option> は，隣接したポートが，ソースとデスティネーションの両方が macvlan ポートに対してローカルであるフレームを全て返すと仮定します．
+              すなわち，ブリッジが reflective relay として設定されているということです．
+              上位デバイスから入ってくるブロードキャストフレームは，VEPA モードである全ての macvlan インターフェースに送りつけられます．
+              ローカルのフレームはローカルには配送されません．
+              <option>bridge</option> の指定は，同じポートの異なる macvlan インターフェースの間のシンプルなブリッジとして動作します．
+              あるインターフェースから他のインターフェースへのフレームは，直接配送され，外部には送出されません．
+              ブロードキャストフレームは，全ての他のブリッジと外部のインターフェースに対して送られます．
+              しかし，reflective relay からフレームが返ってきたときは，再度それを配送することはしません．
+              全ての MAC アドレスを知っているので，ブリッジモジュールのように，macvlan ブリッジモードは学習や STP の必要はありません．
 	    </para>
 
 	    <para>
@@ -392,7 +433,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      eg. eth0, this option will rename the interface in the
 	      container.
               -->
-              インターフェース名は動的に割り当てられます．しかし，もしコンテナが使用する設定ファイルが一般的な名前を使用するために，他の特定の名前が必要であれば (例えば eth0 など)，コンテナ内のインターフェースは，このオプションで指定した名前にリネームされます．
+              インターフェース名は動的に割り当てられます．
+              しかし，もしコンテナが使用する設定ファイルが一般的な名前を使用するために，他の特定の名前が必要であれば (例えば eth0 など)，コンテナ内のインターフェースは，このオプションで指定した名前にリネームされます．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -409,7 +451,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      this is needed to resolve a mac address conflict or to
 	      always have the same link-local ipv6 address
               -->
-              インターフェースの MAC アドレスは，デフォルトでは動的に割り当てられます．しかし，MAC アドレスの衝突や，リンクローカルIPv6 アドレスを常に同じにした場合などは，このオプションが必要です．
+              インターフェースの MAC アドレスは，デフォルトでは動的に割り当てられます．
+              しかし，MAC アドレスの衝突や，リンクローカルIPv6 アドレスを常に同じにした場合などは，このオプションが必要です．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -428,7 +471,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      specified on the same line, right after the ipv4
 	      address.
               -->
-              仮想インターフェースに割り当てる ipv4 アドレスを指定します．複数行により複数の ipv4 アドレスを指定します．このアドレスは x.y.z.t/m というフォーマットで指定します．例えば，192.168.1.123/24．ブロードキャストアドレスも同じ行の ipv4 アドレスのすぐ後で指定しなくてはなりません．
+              仮想インターフェースに割り当てる ipv4 アドレスを指定します．
+              複数行により複数の ipv4 アドレスを指定します．
+              このアドレスは x.y.z.t/m というフォーマットで指定します．
+              例えば，192.168.1.123/24．ブロードキャストアドレスも同じ行の ipv4 アドレスのすぐ後で指定しなくてはなりません．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -452,9 +498,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      using the <option>veth</option> and
 	      <option>macvlan</option> network types.
               -->
-              コンテナでゲートウェイとして使う IPv4 アドレスを指定します．アドレスは x.y.z.t というフォーマットです．例えば，192.168.1.123．
+              コンテナでゲートウェイとして使う IPv4 アドレスを指定します．
+              アドレスは x.y.z.t というフォーマットです．
+              例えば，192.168.1.123．
 
-              <option>auto</option> という特別な値を記述する事も可能です．これは (<option>lxc.network.link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し，それをゲートウェイに使うという意味になります．<option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります．
+              <option>auto</option> という特別な値を記述する事も可能です．
+              これは (<option>lxc.network.link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し，それをゲートウェイに使うという意味になります．
+              <option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -472,7 +522,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      The address is in format x::y/m,
 	      eg. 2003:db8:1:0:214:1234:fe0b:3596/64
               -->
-              仮想インターフェースに割り当てる ipv6 アドレスを指定します．複数行により複数の ipv6 アドレスを指定します．このアドレスは x::y/m というフォーマットで指定します．例えば，2003:db8:1:0:214:1234:fe0b:3596/64．
+              仮想インターフェースに割り当てる ipv6 アドレスを指定します．
+              複数行により複数の ipv6 アドレスを指定します．
+              このアドレスは x::y/m というフォーマットで指定します．
+              例えば，2003:db8:1:0:214:1234:fe0b:3596/64．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -496,9 +549,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      using the <option>veth</option> and
 	      <option>macvlan</option> network types.
               -->
-              コンテナでゲートウェイとして使う IPv6 アドレスを指定します．アドレスは x::y というフォーマットです．例えば，2003:db8:1:0::1．
+              コンテナでゲートウェイとして使う IPv6 アドレスを指定します．
+              アドレスは x::y というフォーマットです．例えば，2003:db8:1:0::1．
 
-              <option>auto</option> という特別な値を記述する事も可能です．これは (<option>lxc.network.link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し，それをゲートウェイに使うという意味になります．<option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります．
+              <option>auto</option> という特別な値を記述する事も可能です．
+              これは (<option>lxc.network.link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し，それをゲートウェイに使うという意味になります．
+              <option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -521,8 +577,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      type, other arguments may be passed:
 	      veth/macvlan/phys. And finally (host-sided) device name.
               -->
-              ホスト側から使われる，ネットワークの作成と設定が済んだ後に実行するスクリプトを指定します．以下の引数がスクリプトに渡されます: コンテナ名，設定セクション名(net)．
-              その後の引数はスクリプトのフックで使われる設定セクションに依存します．以下がネットワークシステムによって使われます: 実行コンテキスト (up)，ネットワークのタイプ (empty/veth/macvlan/phys)
+              ホスト側から使われる，ネットワークの作成と設定が済んだ後に実行するスクリプトを指定します．
+              以下の引数がスクリプトに渡されます: コンテナ名，設定セクション名(net)．
+              その後の引数はスクリプトのフックで使われる設定セクションに依存します．
+              以下がネットワークシステムによって使われます: 実行コンテキスト (up)，ネットワークのタイプ (empty/veth/macvlan/phys)
               ネットワークのタイプによっては，更に別の引数が渡されるかもしれません: veth/macvlan/phys の場合 (ホスト側の) デバイス名
             </para>
 	    <para>
@@ -531,7 +589,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Standard error is not logged, but can be captured by the
 	      hook redirecting its standard error to standard output.
               -->
-              スクリプトからの標準出力は debug レベルでロギングされます．標準エラー出力はロギングされません．しかし，フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です．
+              スクリプトからの標準出力は debug レベルでロギングされます．
+              標準エラー出力はロギングされません．
+              しかし，フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -554,8 +614,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      type, other arguments may be passed:
 	      veth/macvlan/phys. And finally (host-sided) device name.
               -->
-              ホスト側から使われる，ネットワークを破壊する前に実行するスクリプトを指定します．以下の引数がスクリプトに渡されます: コンテナ名，設定セクション名(net)．
-              その後の引数はスクリプトのフックで使われる設定セクションに依存します．以下がネットワークシステムによって使われます: 実行コンテキスト (up)，ネットワークのタイプ (empty/veth/macvlan/phys)．
+              ホスト側から使われる，ネットワークを破壊する前に実行するスクリプトを指定します．
+              以下の引数がスクリプトに渡されます: コンテナ名，設定セクション名(net)．
+              その後の引数はスクリプトのフックで使われる設定セクションに依存します．
+              以下がネットワークシステムによって使われます: 実行コンテキスト (up)，ネットワークのタイプ (empty/veth/macvlan/phys)．
               ネットワークのタイプによっては，更に別の引数が渡されるかもしれません: veth/macvlan/phys．そして最後に (ホスト側の) デバイス名が渡されます．
             </para>
 	    <para>
@@ -564,7 +626,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Standard error is not logged, but can be captured by the
 	      hook redirecting its standard error to standard output.
               -->
-              スクリプトからの標準出力は debug レベルでロギングされます．標準エラー出力はロギングされません．しかし，フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です．
+              スクリプトからの標準出力は debug レベルでロギングされます．
+              標準エラー出力はロギングされません．
+              しかし，フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -594,7 +658,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               the maximum number of pseudo ttys allowed for a pts
               instance (this limitation is not implemented yet).
               -->
-              もし設定された場合，コンテナは新しい psuedo tty インスタンスを持ち，それを自身のプライベートとします．この値は pts インスタンスに許可される pseudo tty の最大数を指定します (この制限はまだ実装されていません)．
+              もし設定された場合，コンテナは新しい psuedo tty インスタンスを持ち，それを自身のプライベートとします．
+              この値は pts インスタンスに許可される pseudo tty の最大数を指定します (この制限はまだ実装されていません)．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -620,9 +685,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <para>
               <!--
 	      Specify a path to a file where the console output will
-	      be written.
+	      be written. The keyword 'none' will simply disable the
+	      console. This is dangerous once if have a rootfs with a
+	      console device file where the application can write, the
+	      messages will fall in the host.
               -->
-              コンソールの出力が書かれるファイルのパスを指定します．
+              コンソールの出力が書かれるファイルのパスを指定します．'none' というキーワードは，単純にコンソールを無効にします．
+              この設定は，アプリケーションが書き込む事ができるコンソールデバイスファイルが rootfs に存在する場合，メッセージがホスト側に出力されるので危険です．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -642,7 +711,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	respawn indefinitely giving annoying messages on the console or in
 	<filename>/var/log/messages</filename>.
         -->
-        このオプションはコンテナが root ファイルシステムを持つように設定されており，inittab ファイルで tty 上に getty の起動が設定されている場合に役に立ちます．このオプションはコンテナで利用できる tty の数を指定します．inittab ファイルに設定する getty の数は，このオプションの指定する tty の数より大きくしてはいけません．さもなければ，超過した分の getty セッションはコンソールか /var/log/messages にうっとうしいメッセージを生死を表示しながら，永久に生死を繰り返すでしょう．
+        このオプションはコンテナが root ファイルシステムを持つように設定されており，inittab ファイルで tty 上に getty の起動が設定されている場合に役に立ちます．
+        このオプションはコンテナで利用できる tty の数を指定します．
+        inittab ファイルに設定する getty の数は，このオプションの指定する tty の数より大きくしてはいけません．
+        さもなければ，超過した分の getty セッションはコンソールか /var/log/messages にうっとうしいメッセージを生死を表示しながら，永久に生死を繰り返すでしょう．
       </para>
       <variablelist>
 	<varlistentry>
@@ -677,7 +749,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	A package upgrade can then succeed as it is able to remove and replace
 	the symbolic links.
         -->
-        LXC のコンソールはホストによって作られ，コンテナ内で要求されたデバイスに bind マウントされた Unix98 PTY 経由で提供されます．デフォルトでは <filename>/dev/console</filename> と <filename>/dev/ttyN</filename> に bind マウントされます．これはゲスト内でのパッケージのアップグレードを妨げる可能性があります．なので <filename>/dev</filename> 以下のディレクトリを指定することができます．LXC はこのディレクトリ以下にファイルを作成し，これらのファイルを bind マウントします．そして，これらの (作成された) ファイルは <filename>/dev/console</filename> と <filename>/dev/ttyN</filename> にシンボリックリンクされます．シンボリックリンクを消去したり置き換えたりすることは可能ですから，パッケージのアップグレードは成功します．
+        LXC のコンソールはホストによって作られ，コンテナ内で要求されたデバイスに bind マウントされた Unix98 PTY 経由で提供されます．
+        デフォルトでは <filename>/dev/console</filename> と <filename>/dev/ttyN</filename> に bind マウントされます．
+        これはゲスト内でのパッケージのアップグレードを妨げる可能性があります．
+        なので <filename>/dev</filename> 以下のディレクトリを指定することができます．
+        LXC はこのディレクトリ以下にファイルを作成し，これらのファイルを bind マウントします．
+        そして，これらの (作成された) ファイルは <filename>/dev/console</filename> と <filename>/dev/ttyN</filename> にシンボリックリンクされます．
+        シンボリックリンクを消去したり置き換えたりすることは可能ですから，パッケージのアップグレードは成功します．
       </para>
       <variablelist>
 	<varlistentry>
@@ -712,7 +790,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         devices in the containers /dev directory may be created through the
         use of the <option>lxc.hook.autodev</option> hook.
         -->
-        デフォルトでは，lxc はコンテナの <filename>/dev</filename> については何も行いません．これは，コンテナの rootfs で必要な設定を行えるようにするものです．lxc.autodev が 1 に設定されている場合，コンテナの rootfs をマウントした後，LXC は新しい tmpfs を <filename>/dev</filename> 以下にマウントします (100k 制限の)．そして初期デバイスの最小限のセットを作成します．これは，"systemd" ベースの "init" 環境のコンテナを起動する時に通常必要ですが，他の環境の場合はオプショナルなものです．コンテナの /dev ディレクトリ内の追加デバイスは <option>lxc.hook.autodev</option> フックを使用して作成されます．
+        デフォルトでは，lxc はコンテナの <filename>/dev</filename> については何も行いません．
+        これは，コンテナの rootfs で必要な設定を行えるようにするものです．
+        lxc.autodev が 1 に設定されている場合，コンテナの rootfs をマウントした後，LXC は新しい tmpfs を <filename>/dev</filename> 以下にマウントします (100k 制限の)．
+        そして初期デバイスの最小限のセットを作成します．
+        これは，"systemd" ベースの "init" 環境のコンテナを起動する時に通常必要ですが，他の環境の場合はオプショナルなものです．
+        コンテナの /dev ディレクトリ内の追加デバイスは <option>lxc.hook.autodev</option> フックを使用して作成されます．
       </para>
       <variablelist>
 	<varlistentry>
@@ -767,7 +850,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	container. This is useful to mount /etc, /var or /home for
 	examples.
         -->
-        マウントポイントセクションは，マウントするための区別された場所を指定します．これらのマウントポイントは，コンテナだけに見え，コンテナ外で実行されるプロセスから見えることはありません．例えば，/etc や /var や /home をマウントするときに役に立つでしょう．
+        マウントポイントセクションは，マウントするための区別された場所を指定します．
+        これらのマウントポイントは，コンテナだけに見え，コンテナ外で実行されるプロセスから見えることはありません．
+        例えば，/etc や /var や /home をマウントするときに役に立つでしょう．
       </para>
       <variablelist>
 	<varlistentry>
@@ -794,7 +879,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               </citerefentry>
               but must be explicitly specified.
               -->
-              マウントに関する情報が書かれた <filename>fstab</filename> フォーマットのファイルの場所を指定します．rootfs がイメージファイルやブロックデバイスで，fstab ファイルがこの rootfs 内のどこかをマウントするために使われる場合，rootfs のマウントポイントのパスはデフォルトパスである <filename>@LXCROOTFSMOUNT@</filename> か，もしくは <option>lxc.rootfs.mount</option> が指定されている場合は，その値を前に付ける必要があります．ファイルシステムがイメージファイルやブロックデバイスからマウントされている場合，3 つ目のフィールド (fs_vfstype) は
+              マウントに関する情報が書かれた <filename>fstab</filename> フォーマットのファイルの場所を指定します．
+              rootfs がイメージファイルやブロックデバイスで，fstab ファイルがこの rootfs 内のどこかをマウントするために使われる場合，rootfs のマウントポイントのパスはデフォルトパスである <filename>@LXCROOTFSMOUNT@</filename> か，もしくは <option>lxc.rootfs.mount</option> が指定されている場合は，その値を前に付ける必要があります．
+              ファイルシステムがイメージファイルやブロックデバイスからマウントされている場合，3 つ目のフィールド (fs_vfstype) は
               <citerefentry>
 		<refentrytitle>mount</refentrytitle>
                 <manvolnum>8</manvolnum>
@@ -830,7 +917,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      automatically mounted. This may dramatically simplify
 	      the configuration. The file systems are:
               -->
-              標準のカーネルファイルシステムで自動的にマウントするものを指定します．これは劇的に設定を容易にする可能性があります．
+              標準のカーネルファイルシステムで自動的にマウントするものを指定します．
+              これは劇的に設定を容易にする可能性があります．
 	    </para>
 	    <itemizedlist>
 	      <listitem>
@@ -845,7 +933,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
                   <option>proc:mixed</option> (or <option>proc</option>):
-                  <filename>/proc</filename> を読み書き可能でマウントします．ただし，<filename>/proc/sys</filename> と <filename>/proc/sysrq-trigger</filename> は，セキュリティとコンテナの隔離の目的でリードオンリーで再マウントされます．
+                  <filename>/proc</filename> を読み書き可能でマウントします．
+                  ただし，<filename>/proc/sys</filename> と <filename>/proc/sysrq-trigger</filename> は，セキュリティとコンテナの隔離の目的でリードオンリーで再マウントされます．
                 </para>
 	      </listitem>
 	      <listitem>
@@ -902,7 +991,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>cgroup:mixed</option> (or <option>cgroup</option>):
-                  <filename>/sys/fs/cgroup</filename> を tmpfs でマウントし，そのコンテナの追加が行われた全ての階層構造に対するディレクトリを作製し，その cgroup の名前でその中にサブディレクトリを作製し，そのコンテナ自身の cgroup をそのディレクトリにバインドマウントします．コンテナは自身の cgroup ディレクトリに書き込みが可能ですが，親ディレクトリはリードオンリーで再マウントされているため書き込めません．
+                  <filename>/sys/fs/cgroup</filename> を tmpfs でマウントし，そのコンテナの追加が行われた全ての階層構造に対するディレクトリを作製し，その cgroup の名前でその中にサブディレクトリを作製し，そのコンテナ自身の cgroup をそのディレクトリにバインドマウントします．
+                  コンテナは自身の cgroup ディレクトリに書き込みが可能ですが，親ディレクトリはリードオンリーで再マウントされているため書き込めません．
                 </para>
 	      </listitem>
 	      <listitem>
@@ -931,7 +1021,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>cgroup:rw</option>:
-                  <option>cgroup:mixed</option> と同様にマウントされますが，全て読み書き可能でマウントされます．コンテナ自身の cgroup に至るまでのパスも書き込み可能になることに注意が必要ですが，cgroup ファイルシステムにはならず，<filename>/sys/fs/cgroup</filename> の tmpfs の一部分になるでしょう．
+                  <option>cgroup:mixed</option> と同様にマウントされますが，全て読み書き可能でマウントされます．
+                  コンテナ自身の cgroup に至るまでのパスも書き込み可能になることに注意が必要ですが，cgroup ファイルシステムにはならず，
+                  <filename>/sys/fs/cgroup</filename> の tmpfs の一部分になるでしょう．
                 </para>
 	      </listitem>
 	      <listitem>
@@ -957,7 +1049,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>cgroup-full:mixed</option> (or <option>cgroup-full</option>):
-                  <filename>/sys/fs/cgroup</filename> を tmpfs でマウントし，そのコンテナの追加が行われた全ての階層構造に対するディレクトリを作製し，ホストからコンテナまでの階層構造を全てバインドマウントし，コンテナ自身の cgroup を除いてリードオンリーにします．<option>cgroup</option> と比べると，コンテナ自身の cgroup に至るまでの全てのパスが tmpfs の下層のシンプルなディレクトリとなり，コンテナ自身の cgroup の外ではリードオンリーになりますが，<filename>/sys/fs/cgroup/$hierarchy</filename> はホストの全ての cgroup 階層構造を含みます．これにより，コンテナにはかなりの情報が漏洩します．
+                  <filename>/sys/fs/cgroup</filename> を tmpfs でマウントし，そのコンテナの追加が行われた全ての階層構造に対するディレクトリを作製し，ホストからコンテナまでの階層構造を全てバインドマウントし，コンテナ自身の cgroup を除いてリードオンリーにします．
+                  <option>cgroup</option> と比べると，コンテナ自身の cgroup に至るまでの全てのパスが tmpfs の下層のシンプルなディレクトリとなり，コンテナ自身の cgroup の外ではリードオンリーになりますが，<filename>/sys/fs/cgroup/$hierarchy</filename> はホストの全ての cgroup 階層構造を含みます．
+                  これにより，コンテナにはかなりの情報が漏洩します．
                 </para>
 	      </listitem>
 	      <listitem>
@@ -987,7 +1081,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>cgroup-full:rw</option>:
-	          <option>cgroup-full:mixed</option>と同様にマウントされますが，全て読み書き可能でマウントされます．この場合，コンテナは自身の cgroup から脱出する可能性があることに注意してください (コンテナが CAP_SYS_ADMIN を持ち，自身で cgroup ファイルシステムをマウント可能なら，いずれにせよそのようにするかもしれないことにも注意してください)．
+	          <option>cgroup-full:mixed</option>と同様にマウントされますが，全て読み書き可能でマウントされます．
+                  この場合，コンテナは自身の cgroup から脱出する可能性があることに注意してください (コンテナが CAP_SYS_ADMIN を持ち，自身で cgroup ファイルシステムをマウント可能なら，いずれにせよそのようにするかもしれないことにも注意してください)．
                 </para>
 	      </listitem>
 	    </itemizedlist>
@@ -1029,7 +1124,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      specified, the container shares its root file system
 	      with the host.
               -->
-              コンテナのルートファイルシステムになるディレクトリを指定します．この値はイメージファイル，ディレクトリ，ブロックデバイスのどれかを取ることができます．もし指定されない場合，コンテナはホストとルートファイルシステムを共有します．
+              コンテナのルートファイルシステムになるディレクトリを指定します．
+              この値はイメージファイル，ディレクトリ，ブロックデバイスのどれかを取ることができます．
+              もし指定されない場合，コンテナはホストとルートファイルシステムを共有します．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1055,7 +1152,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 		<refentrytitle><command>pivot_root</command></refentrytitle>
 		<manvolnum>8</manvolnum>
 	      </citerefentry>
-              システムコールが確実に成功する事を保証します．どんなディレクトリでも良く，デフォルトでも通常は動くはずです．
+              システムコールが確実に成功する事を保証します．
+              どんなディレクトリでも良く，デフォルトでも通常は動くはずです．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1073,7 +1171,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      It is created if necessary, and also removed after
 	      unmounting everything from it during container setup.
               -->
-              元の root ファイルシステムを，<option>lxc.rootfs</option> 以下のどこに移動させるかを <option>lxc.rootfs</option> からの相対パスで指定します．デフォルトは <filename>mnt</filename> です．これはもし必要であれば作成され，そしてコンテナのセットアップの間，全てアンマウントされた後で消去されます．
+              元の root ファイルシステムを，<option>lxc.rootfs</option> 以下のどこに移動させるかを <option>lxc.rootfs</option> からの相対パスで指定します．
+              デフォルトは <filename>mnt</filename> です．
+              これはもし必要であれば作成され，そしてコンテナのセットアップの間，全てアンマウントされた後で消去されます．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1091,7 +1191,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	started, but has the advantage of permitting any future
 	subsystem.
         -->
-        CONTROL GROUP セクションは，(lxc とは) 別のサブシステムの設定を含みます．<command>lxc</command> は，このサブシステム名の正しさはチェックしません．実行時のエラーを検出するのに不便ですが，別の将来のサブシステムをサポート出来るという有利な点もあります．
+        CONTROL GROUP セクションは，(lxc とは) 別のサブシステムの設定を含みます．
+        <command>lxc</command> は，このサブシステム名の正しさはチェックしません．
+        実行時のエラーを検出するのに不便ですが，別の将来のサブシステムをサポート出来るという有利な点もあります．
       </para>
       <variablelist>
 	<varlistentry>
@@ -1109,7 +1211,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      container is started,
 	      eg. <option>lxc.cgroup.cpuset.cpus</option>
               -->
-              設定する control group の値を指定します．サブシステム名は，control group のそのままの名前です．許される名前や値の書式は LXC が指示することはなく，コンテナが実行された時に実行されている Linux カーネルの機能に依存します．
+              設定する control group の値を指定します．
+              サブシステム名は，control group のそのままの名前です．
+              許される名前や値の書式は LXC が指示することはなく，コンテナが実行された時に実行されている Linux カーネルの機能に依存します．
               例えば <option>lxc.cgroup.cpuset.cpus</option>
 	    </para>
 	  </listitem>
@@ -1145,7 +1249,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 		<manvolnum>7</manvolnum>
 	      </citerefentry>,
               -->
-              コンテナ内で削除するケーパビリティ (capability) を指定します．一行でスペース区切りで複数のケーパビリティを指定することも可能です．指定は，"CAP_" というプレフィックスなしで，小文字でケーパビリティを指定します．例えば，CAP_SYS_MODULE というケーパビリティは sys_module と指定する必要があります．詳しくは以下を参照してください．
+              コンテナ内で削除するケーパビリティ (capability) を指定します．
+              一行でスペース区切りで複数のケーパビリティを指定することも可能です．
+              指定は，"CAP_" というプレフィックスなしで，小文字でケーパビリティを指定します．
+              例えば，CAP_SYS_MODULE というケーパビリティは sys_module と指定する必要があります．
+              詳しくは以下を参照してください．
 	      <citerefentry>
 		<refentrytitle><command>capabilities</command></refentrytitle>
 		<manvolnum>7</manvolnum>
@@ -1163,7 +1271,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Specify the capability to be kept in the container. All other
 	      capabilities will be dropped.
               -->
-              コンテナ内で維持するケーパビリティを指定します．指定した以外の全てのケーパビリティはドロップされます．
+              コンテナ内で維持するケーパビリティを指定します．
+              指定した以外の全てのケーパビリティはドロップされます．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1179,7 +1288,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	container should be run can be specified in the container
 	configuration.  The default is <command>lxc-container-default</command>.
         -->
-        lxc が apparmor サポートでコンパイルされ，インストールされている場合で，ホストで apparmor が有効な場合，コンテナが従って動くべき apparmor プロファイルは，コンテナの設定で指定することが可能です．デフォルトは <command>lxc-container-default</command> です．
+        lxc が apparmor サポートでコンパイルされ，インストールされている場合で，ホストで apparmor が有効な場合，コンテナが従って動くべき apparmor プロファイルは，コンテナの設定で指定することが可能です．
+        デフォルトは <command>lxc-container-default</command> です．
       </para>
       <variablelist>
 	<varlistentry>
@@ -1193,7 +1303,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      be run.  To specify that the container should be unconfined,
 	      use
               -->
-              コンテナが従うべき apparmor プロファイルを指定します．コンテナが apparmor による制限を受けないように設定するには，以下のように設定します．
+              コンテナが従うべき apparmor プロファイルを指定します．
+              コンテナが apparmor による制限を受けないように設定するには，以下のように設定します．
 	    </para>
 	      <programlisting>lxc.aa_profile = unconfined</programlisting>
 	  </listitem>
@@ -1211,7 +1322,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	configuration.  The default is <command>unconfined_t</command>,
 	which means that lxc will not attempt to change contexts.
         -->
-        lxc が SELinux サポートでコンパイルされ，インストールされている場合で，ホストで SELinux が有効な場合，コンテナが従って動くべき SELinux コンテキストは，コンテナの設定で指定することが可能です．デフォルトは <command>unconfined_t</command> であり，これは lxc がコンテキストを変えないという意味になります．
+        lxc が SELinux サポートでコンパイルされ，インストールされている場合で，ホストで SELinux が有効な場合，コンテナが従って動くべき SELinux コンテキストは，コンテナの設定で指定することが可能です．
+        デフォルトは <command>unconfined_t</command> であり，これは lxc がコンテキストを変えないという意味になります．
       </para>
       <variablelist>
 	<varlistentry>
@@ -1243,7 +1355,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	(which must be 'whitelist') on the second line, followed by a
 	list of allowed system call numbers, one per line.
         -->
-        コンテナは，起動時に seccomp プロファイルをロードすることで，利用可能なシステムコールを減らして起動することが可能です．seccomp の設定ファイルは，最初の行がバージョン番号 (現在は 1 でなければならない) で，2 行目はポリシーのタイプ ('whitelist' でなければならない)，で始まる必要があり，その後に 1 行ごとに利用可能なシステムコールの番号が書かれたリストが続きます．
+        コンテナは，起動時に seccomp プロファイルをロードすることで，利用可能なシステムコールを減らして起動することが可能です．
+        seccomp の設定ファイルは，最初の行がバージョン番号 (現在は 1 でなければならない) で，2 行目はポリシーのタイプ ('whitelist' でなければならない)，で始まる必要があり，その後に 1 行ごとに利用可能なシステムコールの番号が書かれたリストが続きます．
       </para>
       <variablelist>
 	<varlistentry>
@@ -1276,7 +1389,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	user and group ids 0 through 20,000 in the container to the
 	ids 200,000 through 220,000.
         -->
-        コンテナは，ユーザとグループの id のマッピングを持った専用のユーザ名前空間で起動することが可能です．たとえば，コンテナ内のユーザ id 0 を，ホストのユーザ id 200000 にマッピングすることが可能です．コンテナの root ユーザはコンテナ内では特権を持ちますが，ホストでは特権を持ちません．通常は，システムコンテナは id の範囲を要求し，それをマッピングします．例えば，コンテナ内のユーザとグループの id 0 から 20,000 を 200,000 から 220,000 にマッピングします．
+        コンテナは，ユーザとグループの id のマッピングを持った専用のユーザ名前空間で起動することが可能です．
+        たとえば，コンテナ内のユーザ id 0 を，ホストのユーザ id 200000 にマッピングすることが可能です．
+        コンテナの root ユーザはコンテナ内では特権を持ちますが，ホストでは特権を持ちません．
+        通常は，システムコンテナは id の範囲を要求し，それをマッピングします．
+        例えば，コンテナ内のユーザとグループの id 0 から 20,000 を 200,000 から 220,000 にマッピングします．
       </para>
       <variablelist>
 	<varlistentry>
@@ -1293,7 +1410,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      seen on the host.  Finally, a range indicating the number
 	      of consecutive ids to map.
               -->
-              4 つの値を記述する必要があります．最初の文字は 'u' か 'g' のどちらかで，ユーザかグループの ID のどちらをマッピングするかを指定します．次はコンテナのユーザ名前空間内に現れる最初のユーザ ID です．その次は，そのユーザ ID のホスト上での値です．最後は，ID のマッピングをいくつ連続して行うかの数を指定します．
+              4 つの値を記述する必要があります．
+              最初の文字は 'u' か 'g' のどちらかで，ユーザかグループの ID のどちらをマッピングするかを指定します．
+              次はコンテナのユーザ名前空間内に現れる最初のユーザ ID です．
+              その次は，そのユーザ ID のホスト上での値です．
+              最後は，ID のマッピングをいくつ連続して行うかの数を指定します．
 	     </para>
 	  </listitem>
 	</varlistentry>
@@ -1353,7 +1474,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         Standard error is not logged, but can be captured by the
         hook redirecting its standard error to standard output.
         -->
-        スクリプトからの標準出力は debug レベルでロギングされます．標準エラー出力はロギングされません．しかし，フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です．
+        スクリプトからの標準出力は debug レベルでロギングされます．
+        標準エラー出力はロギングされません．
+        しかし，フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です．
       </para>
       <variablelist>
 	<varlistentry>
@@ -1386,7 +1509,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      mounts propagation), so they will be automatically cleaned up
 	      when the container shuts down.
               -->
-              コンテナのファイルシステムの名前空間で実行されますが，rootfs が設定される前に実行するフック．これにより rootfs の操作が可能になります．例えば，暗号化されたファイルシステムのマウントなどです．このフック内でなされるマウントはホストには影響しません (mounts propagation を除いて)．なので，それらはコンテナがシャットダウンする時に自動的にクリーンアップされます．
+              コンテナのファイルシステムの名前空間で実行されますが，rootfs が設定される前に実行するフック．
+              これにより rootfs の操作が可能になります．
+              例えば，暗号化されたファイルシステムのマウントなどです．
+              このフック内でなされるマウントはホストには影響しません (mounts propagation を除いて)．
+              なので，それらはコンテナがシャットダウンする時に自動的にクリーンアップされます．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1444,7 +1571,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      before executing the container's init.  This requires the
 	      program to be available in the container.
               -->
-              コンテナの init が実行される直前にコンテナの名前空間で実行されるフック．コンテナ内で利用可能なプログラムである必要があります．
+              コンテナの init が実行される直前にコンテナの名前空間で実行されるフック．
+              コンテナ内で利用可能なプログラムである必要があります．
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1497,7 +1625,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         contexts.  In particular, all paths are relative to the host system
         and, as such, not valid during the <option>lxc.hook.start</option> hook.
         -->
-        起動時のフックに設定情報を提供し，フックの機能を助けるための環境変数がいくつか利用可能です．全ての変数が全てのコンテキストで利用可能なわけではありません．具体的には，全てのパスはホストシステム上のパスであり，そのため，<option>lxc.hook.start</option> フックの時点では使用できません．
+        起動時のフックに設定情報を提供し，フックの機能を助けるための環境変数がいくつか利用可能です．
+        全ての変数が全てのコンテキストで利用可能なわけではありません．
+        具体的には，全てのパスはホストシステム上のパスであり，そのため，<option>lxc.hook.start</option> フックの時点では使用できません．
       </para>
       <variablelist>
 	<varlistentry>
@@ -1529,7 +1659,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      additional configuration information not otherwise made
 	      available.  [<option>-f</option>]
               -->
-              コンテナの設定ファイルのホスト上でのパス．これは，他の方法では得られない追加の設定情報を見つけるために，コンテナに，元の，トップレベルの設定ファイルの位置を与えるものです． [<option>-f</option>]
+              コンテナの設定ファイルのホスト上でのパス．
+              これは，他の方法では得られない追加の設定情報を見つけるために，コンテナに，元の，トップレベルの設定ファイルの位置を与えるものです． [<option>-f</option>]
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1582,7 +1713,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      should be made for that instance.
 	      [<option>lxc.rootfs.mount</option>]
               -->
-              初期にコンテナがマウントされる場所．これは，コンテナインスタンスが起動するためのコンテナの rootfs へのホスト上のパスであり，インスタンスのための移行が行われる場所です．
+              初期にコンテナがマウントされる場所．
+              これは，コンテナインスタンスが起動するためのコンテナの rootfs へのホスト上のパスであり，インスタンスのための移行が行われる場所です．
 	      [<option>lxc.rootfs.mount</option>]
 	    </para>
 	  </listitem>
@@ -1618,7 +1750,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       the container (with '.log' appended) either under the container path,
       or under @LOGPATH@.
       -->
-      ロギングはコンテナごとに設定することが可能です．デフォルトでは，lxc パッケージのコンパイル条件に依存し，コンテナのスタートアップは ERROR レベルでのみロギングされ，コンテナのパス以下か，@LOGPATH@ 以下のどちらかにコンテナ名 (の後に '.log' が付与される) をもとにした名前でロギングされます．
+      ロギングはコンテナごとに設定することが可能です．
+      デフォルトでは，lxc パッケージのコンパイル条件に依存し，コンテナのスタートアップは ERROR レベルでのみロギングされ，コンテナのパス以下か，@LOGPATH@ 以下のどちらかにコンテナ名 (の後に '.log' が付与される) をもとにした名前でロギングされます．
     </para>
     <para>
       <!--
@@ -1627,7 +1760,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       that the configuration file entries can in turn be overridden by the
       command line options to <command>lxc-start</command>.
       -->
-      デフォルトのログレベルとログファイルは両方とも，コンテナの設定ファイル内で指定され，デフォルトの値を上書きします．同様に，設定ファイルのエントリは <command>lxc-start</command> のコマンドラインオプションで上書きすることも可能です．
+      デフォルトのログレベルとログファイルは両方とも，コンテナの設定ファイル内で指定され，デフォルトの値を上書きします．
+      同様に，設定ファイルのエントリは <command>lxc-start</command> のコマンドラインオプションで上書きすることも可能です．
     </para>
       <variablelist>
 	<varlistentry>
@@ -1644,7 +1778,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    alert, and 8 = fatal.  If unspecified, the level defaults
 	    to 5 (error), so that only errors and above are logged.
             -->
-              ログを取得するレベル．ログレベルは 0..8 の範囲の整数です．数字が小さいほど冗長なデバッグを意味します．具体的には，0 = trace, 1 = debug, 2 = info, 3 = notice, 4 = warn, 5 = error, 6 = critical, 7 = alert, and 8 = fatal です．指定されない場合，レベルのデフォルトは 5 (error) で，それ以上のエラーがロギングされます．
+              ログを取得するレベル．
+              ログレベルは 0..8 の範囲の整数です．
+              数字が小さいほど冗長なデバッグを意味します．
+              具体的には，0 = trace, 1 = debug, 2 = info, 3 = notice, 4 = warn, 5 = error, 6 = critical, 7 = alert, and 8 = fatal です．
+              指定されない場合，レベルのデフォルトは 5 (error) で，それ以上のエラーがロギングされます．
 	    </para>
 	    <para>
               <!--
@@ -1695,7 +1833,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               Whether the container should be auto-started.
               Valid values are 0 (off) and 1 (on).
               -->
-              コンテナを自動起動させるかどうかを設定します．有効な値は 0(オフ) か 1(オン) です．
+              コンテナを自動起動させるかどうかを設定します．
+              有効な値は 0(オフ) か 1(オン) です．
             </para>
           </listitem>
         </varlistentry>
@@ -1739,7 +1878,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               used (amongst other things) to start a series of related
               containers.
               -->
-              コンテナを追加したいコンテナグループ名を指定します．(複数回使用される可能性のある) 複数の値を設定可能です．
+              コンテナを追加したいコンテナグループ名を指定します．
+              (複数回使用される可能性のある) 複数の値を設定可能です．
               設定されたグループは，関連する一連のコンテナを起動させるために使われます．
             </para>
           </listitem>
@@ -1768,7 +1908,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	virtual network device visible in the container is renamed to
 	eth0.
         -->
-        この設定は，片方をブリッジである br0 と接続される veth ペアデバイスを使うコンテナを設定します (ブリッジは管理者によりあらかじめシステム上に設定済みである必要があります)．仮想ネットワークデバイスは，コンテナ内では eth0 とリネームされます．
+        この設定は，片方をブリッジである br0 と接続される veth ペアデバイスを使うコンテナを設定します (ブリッジは管理者によりあらかじめシステム上に設定済みである必要があります)．
+        仮想ネットワークデバイスは，コンテナ内では eth0 とリネームされます．
       </para>
       <programlisting>
 	lxc.utsname = myhostname
@@ -1801,7 +1942,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       the application, cpuset.cpus restricts usage of the defined cpu,
       cpus.share prioritize the control group, devices.allow makes
       usable the specified devices.-->
-        この設定は，アプリケーションのための control group をいくつか設定します．cpuset.cpus は定義された cpu のみ使用できるように制限します．cpus.share は，control group の (cpu) 優先度を指定します．devices.allow は，特定のデバイスを使用可能にします．
+        この設定は，アプリケーションのための control group をいくつか設定します．
+        cpuset.cpus は定義された cpu のみ使用できるように制限します．
+        cpus.share は，control group の (cpu) 優先度を指定します．
+        devices.allow は，特定のデバイスを使用可能にします．
       </para>
       <programlisting>
 	lxc.cgroup.cpuset.cpus = 0,1

--- a/doc/ja/lxc.sgml.in
+++ b/doc/ja/lxc.sgml.in
@@ -68,7 +68,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>@BINDIR@/lxc-execute -n foo -f
       @DOCDIR@/examples/lxc-macvlan.conf /bin/bash</command>
       -->
-      急いでいて，この man ページすら読みたくないという場合は，いいでしょう，保証はないですが，あらかじめ準備されている設定テンプレートを使ったコンテナ内でシェルを動かすためのコマンドを紹介しましょう．
+      急いでいて，この man ページすら読みたくないという場合は，いいでしょう，
+      保証はないですが，あらかじめ準備されている設定テンプレートを使ったコンテナ内でシェルを動かすためのコマンドを紹介しましょう．
       <command>@BINDIR@/lxc-execute -n foo -f
       @DOCDIR@/examples/lxc-macvlan.conf /bin/bash</command>
     </para>
@@ -83,7 +84,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       through the control groups aka process containers and resource
       isolation through the namespaces.
       -->
-      コンテナ技術は，メインストリームの linux kernel で活発に開発が進んでいる技術です．コンテナ技術は，control groups の機能を使って，リソース管理を提供します．例えば，namespace を通して，プロセスのコンテナやリソースの隔離の機能を提供するものです．
+      コンテナ技術は，メインストリームの linux kernel で活発に開発が進んでいる技術です．
+      コンテナ技術は，process container という名前でも知られる control groups の機能を使って，リソース管理を提供し，名前空間を使って，リソースの隔離を提供します．
     </para>
 
     <para>
@@ -93,7 +95,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       which provides full resource isolation and resource control for
       an applications or a system.
       -->
-      linux コンテナ (<command>lxc</command>) は，ユーザースペースのコンテナオブジェクトを提供するための新しい機能を使う事を目指しています．この新しい機能とは，アプリケーションやシステムでの利用を目的とした，完全なリソースの隔離やリソースコントロールを提供する機能です．
+      linux コンテナ (<command>lxc</command>) は，ユーザースペースのコンテナオブジェクトを提供するための新しい機能を使う事を目指しています．
+      この新しい機能とは，アプリケーションやシステムでの利用を目的とした，完全なリソースの隔離やリソースコントロールを提供する機能です．
     </para>
 
     <para>
@@ -105,7 +108,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       manage a container with simple command lines and complete enough
       to be used for other purposes.
       -->
-      このプロジェクトの最初の目的は，カーネル開発者がコンテナプロジェクトに参加するのを容易にする事，特に新機能である Checkpoint/Restart 機能への取り組みを続ける事です．<command>lxc</command> コマンドは，シンプルなコマンドでコンテナの管理を簡単に行えるように小さく，他の目的のために使うのに充分な機能を持っています．
+      このプロジェクトの第一の目的は，コンテナプロジェクトに参加するカーネル開発者の作業を快適にすることと，特に新機能である Checkpoint/Restart 機能への取り組みを続ける事です．
+      <command>lxc</command> コマンドは，シンプルなコマンドでコンテナの管理を簡単に行えるように小さく，他の目的のために使うのに充分な機能を持っています．
     </para>
   </refsect1>
 
@@ -119,7 +123,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       work with a restricted number of functionalities or will simply
       fail.
       -->
-      <command>lxc</command> は，カーネルが提供するいくつかの機能に依存しており，その機能がアクティブになっている必要があります．機能が足りない場合は，<command>lxc</command> は，いくつかの機能が制限されるか，単純に動作が失敗します．
+      <command>lxc</command> は，カーネルが提供するいくつかの機能に依存しており，その機能がアクティブになっている必要があります．
+      機能が足りない場合は，<command>lxc</command> は，いくつかの機能が制限されるか，単純に動作が失敗します．
     </para>
 
     <para>
@@ -171,7 +176,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	The helper script <command>lxc-checkconfig</command> will give
 	you information about your kernel configuration.
 	-->
-	2.6.27 以上のバージョンが採用されているディストリビューションならば，<command>lxc</command> は動作するでしょう．機能的には若干少ない形ですが，充分に楽しめるはずです．2.6.29 カーネルであれば，<command>lxc</command> は完全に機能します．ヘルパースクリプトの <command>lxc-checkconfig</command> を使って，あなたのカーネルの設定に関する情報を取得できるでしょう．
+	2.6.27 以上のバージョンが採用されているディストリビューションならば，<command>lxc</command> は動作するでしょう．
+        機能的には若干少ない形ですが，充分に楽しめるはずです．
+        2.6.29 カーネルであれば，<command>lxc</command> は完全に機能します．
+        ヘルパースクリプトの <command>lxc-checkconfig</command> を使って，あなたのカーネルの設定に関する情報を取得できるでしょう．
       </para>
 
       <para>
@@ -197,7 +205,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  <command>mount -t cgroup -ons,cpuset,freezer,devices
 	  lxc /cgroup4lxc</command>
 	 -->
-	control group は，どこにでもマウント可能です．例えば，<command>mount -t cgroup cgroup /cgroup</command> のようにです．
+	control group は，どこにでもマウント可能です．
+        例えば，<command>mount -t cgroup cgroup /cgroup</command> のようにです．
 
 	もし，異なる場所で，異なるオプションでマウントされた別々の cgroup を持ち，一つの場所の <command>lxc</command> コマンドを使うための，特定の <command>lxc</command> のための専用の cgroup のマウントポイントを提供したければ，lxc という名前でマウントポイントにバインドすることが出来ます．例えば以下のようにです．
 	  <command>mount -t cgroup lxc /cgroup4lxc</command> or
@@ -250,7 +259,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       so you can still use your distro but with your
       own <filename>/etc</filename> and <filename>/home</filename>
       -->
-      アプリケーションを実行する前に，隔離したいリソースについて知っておくべきです．デフォルトの設定では，pid，sysv ipc，マウントポイントが隔離されます．コンテナ内でシンプルなシェルを実行したい場合で，特に rootfs を共有したい場合，基本的な設定が必要です．もし，<command>sshd</command> のようなアプリケーションを実行したい場合，新しいネットワークスタックと，新しいホスト名を準備しなくてはなりません．もし，同じファイル (<filename>/var/run/httpd.pid</filename> 等) の衝突を避けたい場合，空の <filename>/var/run/</filename> を再度マウントしなければなりません．どんな場合でも，衝突を避けたい場合，コンテナ専用の rootfs を指定することができます．rootfs はディレクトリツリーとなる事も可能で，前もって元の rootfs を bind マウントし，しかし，自身の <filename>/etc</filename> や <filename>/home</filename>を使って．自身のディストリビューションを使うことが可能です．
+      アプリケーションを実行する前に，隔離したいリソースについて知っておくべきです．
+      デフォルトの設定では，pid，sysv ipc，マウントポイントが隔離されます．
+      コンテナ内でシンプルなシェルを実行したい場合で，特に rootfs を共有したい場合，基本的な設定が必要です．
+      もし，<command>sshd</command> のようなアプリケーションを実行したい場合，新しいネットワークスタックと，新しいホスト名を準備しなくてはなりません．
+      もし，同じファイル (<filename>/var/run/httpd.pid</filename> 等) の衝突を避けたい場合，空の <filename>/var/run/</filename> を再度マウントしなければなりません．
+      どんな場合でも，衝突を避けたい場合，コンテナ専用の rootfs を指定することができます．
+      rootfs はディレクトリツリーとなる事も可能で，前もって元の rootfs を bind マウントし，しかし，自身の <filename>/etc</filename> や <filename>/home</filename>を使って．自身のディストリビューションを使うことが可能です．
     </para>
     <para>
       <!--
@@ -364,7 +379,11 @@ rootfs
 	/etc/resolv.conf /home/root/debian/rootfs/etc/resolv.conf none bind 0 0
       </programlisting>
       -->
-      コンテナ内でシステムを実行するのは，逆説的ではありますが，アプリケーションを実行するよりも簡単です．それは，隔離するリソースについて考える必要がないからで，全てを隔離する必要があるからです．他のリソースは，コンテナが設定を行うので，設定なしで隔離されるように指定されます．例えば，IPv4 アドレスはコンテナの init スクリプトでシステムによってセットアップされるでしょう．以下に，(システムを実行するときの) マウントポイントファイルを示します．
+      コンテナ内でシステムを実行するのは，逆説的ではありますが，アプリケーションを実行するよりも簡単です．
+      それは，隔離するリソースについて考える必要がないからで，全てを隔離する必要があるからです．
+      他のリソースは，コンテナが設定を行うので，設定なしで隔離されるように指定されます．
+      例えば，IPv4 アドレスはコンテナの init スクリプトでシステムによってセットアップされるでしょう．
+      以下に，(システムを実行するときの) マウントポイントファイルを示します．
 
       <programlisting>
 	[root@lxc debian]$ cat fstab
@@ -373,7 +392,8 @@ rootfs
 	/dev/pts /home/root/debian/rootfs/dev/pts  none bind 0 0
       </programlisting>
 
-      設定を手助けするために，コンテナに更なる情報を追加することも可能です．例えば，ホスト上に存在する resolv.conf ファイルをコンテナからアクセス可能にするには，以下のようにします．
+      設定を手助けするために，コンテナに更なる情報を追加することも可能です．
+      例えば，ホスト上に存在する resolv.conf ファイルをコンテナからアクセス可能にするには，以下のようにします．
 
       <programlisting>
 	/etc/resolv.conf /home/root/debian/rootfs/etc/resolv.conf none bind 0 0
@@ -389,7 +409,9 @@ rootfs
 	starting and running. When the last process running inside the
 	container exits, the container is stopped.
 	-->
-	コンテナが作成されたとき，コンテナは設定情報を含みます．プロセスが生成されたとき，コンテナは開始され，実行されるでしょう．コンテナ内で実行されている最後のプロセスが終了したとき，コンテナは停止します．
+	コンテナが作成されるとき，コンテナは設定情報を含みます．
+        プロセスが生成されるとき，コンテナは開始し，実行されるでしょう．
+        コンテナ内で実行されている最後のプロセスが終了したとき，コンテナは停止します．
       </para>
       <para>
 	<!--
@@ -466,7 +488,10 @@ rootfs
 	  lxc-destroy -n foo
 	</programlisting>
 	-->
-	持続性のコンテナオブジェクトは <command>lxc-create</command> コマンドで作成することができます．コマンドにはコンテナ名をパラメータとして，オプションで設定ファイルとテンプレートを指定します．ここで指定する名前は，他のコマンドからこのコンテナを参照する際に使います．<command>lxc-destroy</command> コマンドはコンテナオブジェクトを破壊します．
+	持続性のコンテナオブジェクトは <command>lxc-create</command> コマンドで作成することができます．
+        コマンドにはコンテナ名をパラメータとして，オプションで設定ファイルとテンプレートを指定します．
+        ここで指定する名前は，他のコマンドからこのコンテナを参照する際に使います．
+        <command>lxc-destroy</command> コマンドはコンテナオブジェクトを破壊します．
 	<programlisting>
 	  lxc-create -n foo
 	  lxc-destroy -n foo
@@ -483,7 +508,8 @@ rootfs
 	The container can be directly started with a
 	configuration file as parameter.
         -->
-          コンテナを開始する前にコンテナオブジェクトを作成する必要はありません．コンテナを設定ファイルのパラメータで指定して直接開始することができます．
+          コンテナを開始する前にコンテナオブジェクトを作成する必要はありません．
+          コンテナを設定ファイルのパラメータで指定して直接開始することができます．
 	</para>
     </refsect2>
 
@@ -504,7 +530,11 @@ rootfs
       but if needed the <command>lxc-stop</command> command can
       be used to kill the still running application.
       -->
-        コンテナが作成されると，アプリケーションもしくはシステムとして実行することができます．このために使用するのが <command>lxc-execute</command> と <command>lxc-start</command> コマンドです．アプリケーションが開始する前にコンテナが作成されなかった場合，コンテナはコマンドへ与えるパラメータを取得するのに設定ファイルを使うでしょう．もし，このようなパラメータもない場合は，デフォルトで指定されている通りに隔離されます．アプリケーションが終了した場合，コンテナも停止しますが，実行中のアプリケーションを停止するには <command>lxc-stop</command> を使用する必要があります．
+        コンテナが作成されると，アプリケーションもしくはシステムとして実行することができます．
+        このために使用するのが <command>lxc-execute</command> と <command>lxc-start</command> コマンドです．
+        アプリケーションが開始する前にコンテナが作成されなかった場合，コンテナはコマンドへ与えるパラメータを取得するのに設定ファイルを使うでしょう．
+        もし，このようなパラメータもない場合は，デフォルトで指定されている通りに隔離されます．
+        アプリケーションが終了した場合，コンテナも停止しますが，実行中のアプリケーションを停止するには <command>lxc-stop</command> を使用する必要があります．
       </para>
 
       <para>
@@ -517,7 +547,8 @@ rootfs
 	  lxc-start -n foo [-f config] [/bin/bash]
 	</programlisting>
         -->
-        コンテナ内のアプリケーションの実行は，正確にはシステムとして実行するのとは異なります．そのような理由で，コンテナ内でアプリケーションを実行するためのコマンドには，2 種類の違ったものがあります．
+        コンテナ内のアプリケーションの実行は，正確にはシステムとして実行するのとは異なります．
+        そのような理由で，コンテナ内でアプリケーションを実行するためのコマンドには，2 種類の違ったものがあります．
         <programlisting>
 	  lxc-execute -n foo [-f config] /bin/bash
 	  lxc-start -n foo [-f config] [/bin/bash]
@@ -536,7 +567,9 @@ rootfs
 	container, <command>lxc-init</command> has the pid 1 and the
 	first process of the application has the pid 2.
         -->
-        <command>lxc-execute</command> コマンドは，<command>lxc-init</command> プロセス経由で，コンテナ内で特定のコマンドを実行します．lxc-init はコマンドを実行した後，実行したコマンドと，(コンテナ内のデーモンが実行することを許可した) 生成された全てのプロセスが終了するのを待ちます．言いかえると，コンテナ内では <command>lxc-init</command> は pid 1 を持ち，アプリケーションの最初のプロセスは pid 2 をもちます．
+        <command>lxc-execute</command> コマンドは，<command>lxc-init</command> プロセス経由で，コンテナ内で特定のコマンドを実行します．
+        lxc-init はコマンドを実行した後，(コンテナ内でのデーモンの実行をサポートするために) 実行したコマンドと生成された全てのプロセスが終了するのを待ちます．
+        言いかえると，コンテナ内では <command>lxc-init</command> は pid 1 を持ち，アプリケーションの最初のプロセスは pid 2 をもちます．
       </para>
 
       <para>
@@ -547,7 +580,9 @@ rootfs
 	specified <command>lxc-start</command> will
 	run <filename>/sbin/init</filename>.
         -->
-        <command>lxc-start</command> コマンドは，コンテナ内の特定のコマンドを直接実行します．最初のプロセスの pid が 1 となります．もし，実行するコマンドが指定されない場合は，<command>lxc-start</command> は <filename>/sbin/init</filename> を実行します．
+        <command>lxc-start</command> コマンドは，コンテナ内の特定のコマンドを直接実行します．
+        最初のプロセスの pid が 1 となります．
+        もし，実行するコマンドが指定されない場合は，<command>lxc-start</command> は <filename>/sbin/init</filename> を実行します．
       </para>
 
       <para>
@@ -586,7 +621,9 @@ rootfs
 	  lxc-console -n foo -t 3
 	</programlisting>
         -->
-        コンテナが tty を持つように設定されているならば，tty を通してコンテナにアクセスすることができます．それは以下のコマンドが使う tty がコンテナで利用可能に設定されているか次第です．tty が失われたとき，再度のログインなしでその tty に再接続することが可能です．
+        コンテナが tty を持つように設定されているならば，tty を通してコンテナにアクセスすることができます．
+        それは以下のコマンドが使う tty がコンテナで利用可能に設定されているか次第です．
+        tty が失われたとき，再度のログインなしでその tty に再接続することが可能です．
 	<programlisting>
 	  lxc-console -n foo -t 3
 	</programlisting>
@@ -611,7 +648,8 @@ rootfs
 
 	will resume them.
         -->
-        ジョブスケジューリングなどで，コンテナに属する全てのプロセスを停止する事が役に立つときがあります．コマンド
+        ジョブスケジューリングなどで，コンテナに属する全てのプロセスを停止する事が役に立つときがあります．
+        コマンド
 	<programlisting>
 	  lxc-freeze -n foo
 	</programlisting>
@@ -648,7 +686,8 @@ rootfs
 	  lxc-info -n foo
 	</programlisting>
         -->
-        多数のコンテナが存在する場合，それらが実行されたり破壊されたりすること，何が実行されていて，特定のコンテナ内で実行されている pid が何であるかをフォローするのは大変です．このような時には，以下のようなコマンドが役に立つかもしれません．
+        多数のコンテナが存在する場合，それらが実行されたり破壊されたりすること，何が実行されていて，特定のコンテナ内で実行されている pid が何であるかをフォローするのは大変です．
+        このような時には，以下のようなコマンドが役に立つかもしれません．
 	<programlisting>
 	  lxc-ls
 	  lxc-ps --name foo
@@ -670,7 +709,9 @@ rootfs
 	</programlisting>
 	will display the containers list and their permissions.
         -->
-        <command>lxc-ls</command> は，システムのコンテナを一覧します．このコマンドは <command>ls</command> をうまく利用して作られているスクリプトです．なので，ls コマンドのオプションを受け付けます．例えば
+        <command>lxc-ls</command> は，システムのコンテナを一覧します．
+        このコマンドは <command>ls</command> をうまく利用して作られているスクリプトです．
+        なので，ls コマンドのオプションを受け付けます．例えば
 	<programlisting>
 	  lxc-ls -C1
 	</programlisting>
@@ -694,7 +735,9 @@ rootfs
 	<programlisting>lxc-ps &#045;&#045;lxc</programlisting>
 	will display all the containers and their processes.
         -->
-        <command>lxc-ps</command> は特定のコンテナに対する pid を表示します．<command>lxc-ls</command> のように，<command>lxc-ps</command> は  <command>ps</command> コマンドをうまく利用して作られており，同じオプションを利用可能です．例えば，
+        <command>lxc-ps</command> は特定のコンテナに対する pid を表示します．
+        <command>lxc-ls</command> のように，<command>lxc-ps</command> は  <command>ps</command> コマンドをうまく利用して作られており，同じオプションを利用可能です．
+        例えば，
         <programlisting>lxc-ps --name foo --forest</programlisting>
         は 'foo' という名前のコンテナに属するプロセスを階層構造で表示します．
 
@@ -708,7 +751,8 @@ rootfs
 	container, at present time, only the state of the container is
 	displayed.
         -->
-        <command>lxc-info</command> は，指定したコンテナに対する情報を与えます．現時点では，コンテナの状態だけを表示します．
+        <command>lxc-info</command> は，指定したコンテナに対する情報を与えます．
+        現時点では，コンテナの状態だけを表示します．
       </para>
 
       <para>
@@ -752,7 +796,8 @@ rootfs
 	the <command>netstat</command> command and will accept its
 	options
         -->
-        <command>lxc-netstat</command> は，指定したコンテナのネットワークの情報を表示します．このコマンドは <command>netstat</command> をうまく利用して作られており，<command>netstat</command> のオプションを受け付けます．
+        <command>lxc-netstat</command> は，指定したコンテナのネットワークの情報を表示します．
+        このコマンドは <command>netstat</command> をうまく利用して作られており，<command>netstat</command> のオプションを受け付けます．
       </para>
 
       <para>
@@ -779,7 +824,8 @@ rootfs
       for example to monitor it or just to wait for a specific
       state in a script.
         -->
-        時々，コンテナの状態を追跡することが出来ると便利な事があります．例えば，状態をモニタリングしたり，スクリプト内で特定の状態を待ったりするような場合です．
+        時々，コンテナの状態を追跡することが出来ると便利な事があります．
+        例えば，状態をモニタリングしたり，スクリプト内で特定の状態を待ったりするような場合です．
       </para>
 
       <para>
@@ -796,7 +842,8 @@ rootfs
 	</programlisting>
 	will monitor all the containers.
         -->
-        <command>lxc-monitor</command> コマンドは，一つもしくはいくつかのコンテナをモニタリングします．このコマンドのパラメータは，正規表現を受け付けます．例えば
+        <command>lxc-monitor</command> コマンドは，一つもしくはいくつかのコンテナをモニタリングします．
+        このコマンドのパラメータは，正規表現を受け付けます．例えば
 	<programlisting>
 	  lxc-monitor -n "foo|bar"
 	</programlisting>
@@ -851,7 +898,10 @@ rootfs
 ]]>
 	</programlisting>
         -->
-        <command>lxc-wait</command> コマンドは指定した状態を待って，終了します．これは，コンテナの開始や終了に同期したいスクリプトで役に立ちます．パラメータは，異なった状態の論理和 (OR) を指定します．以下の例は，バックグラウンドで実行されたコンテナをどのようにして待つかを示します．
+        <command>lxc-wait</command> コマンドは指定した状態を待って，終了します．
+        これは，コンテナの開始や終了に同期したいスクリプトで役に立ちます．
+        パラメータは，異なった状態の論理和 (OR) を指定します．
+        以下の例は，バックグラウンドで実行されたコンテナをどのようにして待つかを示します．
 
 	<programlisting>
 <![CDATA[
@@ -883,7 +933,9 @@ rootfs
 	with it. The control group properties can be read and modified
 	when the container is running by using the lxc-cgroup command.
         -->
-        コンテナは control group と結合しています．コンテナが開始すると control group が生成され，それと結びつけられます．control group のプロパティは，lxc-cgroup コマンドを使って，コンテナが実行中に読み取ったり，変更したりすることができます．
+        コンテナは control group と結合しています．
+        コンテナが開始すると control group が生成され，それと結びつけられます．
+        control group のプロパティは，lxc-cgroup コマンドを使って，コンテナが実行中に読み取ったり，変更したりすることができます．
       </para>
       <para>
         <!--
@@ -893,7 +945,9 @@ rootfs
 	command won't do any syntax checking on the subsystem name, if
 	the subsystem name does not exists, the command will fail.
         -->
-        <command>lxc-cgroup</command> コマンドは，コンテナと結びつけられている control group サブシステムを設定したり，取得したりするのに使います．サブシステム名の指定はユーザが行ない，このコマンドはサブシステム名の文法チェックは一切行ないません．もし，指定したサブシステム名が存在しない場合は，コマンドの実行は失敗します．
+        <command>lxc-cgroup</command> コマンドは，コンテナと結びつけられている control group サブシステムを設定したり，取得したりするのに使います．
+        サブシステム名の指定はユーザが行ない，このコマンドはサブシステム名の文法チェックは一切行ないません．
+        もし，指定したサブシステム名が存在しない場合は，コマンドの実行は失敗します．
       </para>
       <para>
         <!--
@@ -926,7 +980,9 @@ rootfs
     command syntax and the API can change. The version 1.0.0 will be
     the frozen version.
       -->
-      <command>lxc</command> はまだ開発中です．従って，コマンドの文法や API は変更される可能性があります．バージョン 1.0.0 がそれらを凍結するバージョンとなるでしょう．
+      <command>lxc</command> はまだ開発中です．
+      従って，コマンドの文法や API は変更される可能性があります．
+      バージョン 1.0.0 がそれらを凍結するバージョンとなるでしょう．
     </para>
   </refsect1>
 


### PR DESCRIPTION
- Improve Japanese translation
- Fix mis-translation
- Insert linefeed between paragraph, because some paragraph is too
  long, so sometimes git send-email could not use.

Signed-off-by: KATOH Yasufumi karma@jazz.email.ne.jp
