### PR TITLE
Use the cgroup name for cpuset for lxc-ps

### DIFF
--- a/src/lxc/lxc-ps.in
+++ b/src/lxc/lxc-ps.in
@@ -118,7 +118,7 @@ for container in ${containers}; do
 
     if ! lxc-wait -P $lxc_path -s STOPPED -n $container -t 0; then
         initpid=`lxc-info -P $lxc_path -p -n $container | awk -F: '{ print $2 }' | awk '{ print $1 }'`
-        cgroup=`head -n 1 /proc/$initpid/cgroup | awk -F: '{ print $3}'`
+        cgroup=`grep cpuset /proc/$initpid/cgroup | awk -F: '{ print $3}'`
         if [ -f "$parent_cgroup/$cgroup/tasks" ]; then
             tasks_files="$tasks_files $parent_cgroup$cgroup/tasks"
         fi


### PR DESCRIPTION
On my Ubuntu 13.10 system, lxc-ps was always giving empty output. The output of /proc/$initpid/cgroup was

11:name=systemd:/user/1000.user/c3.session
10:hugetlb:/container
9:perf_event:/container
8:blkio:/container
7:freezer:/container
6:devices:/container
5:memory:/container
4:cpuacct:/container
3:cpu:/container
2:cpuset:/container

Using the cpuset line should be a safer option.
