### PR TITLE
Change default unit for blockdev size (unbreak on 32-bit machines)

### DIFF
--- a/src/lxc/arguments.h
+++ b/src/lxc/arguments.h
@@ -25,6 +25,7 @@
 #define __arguments_h
 
 #include <getopt.h>
+#include <stdint.h>
 
 struct lxc_arguments;
 
@@ -85,7 +86,7 @@ struct lxc_arguments {
 	/* lxc-create */
 	char *bdevtype, *configfile, *template;
 	char *fstype;
-	unsigned long fssize;
+	uint64_t fssize;
 	char *lvname, *vgname, *thinpool;
 	char *zfsroot, *lowerdir, *dir;
 

--- a/src/lxc/bdev.h
+++ b/src/lxc/bdev.h
@@ -29,6 +29,7 @@
  */
 
 #include "config.h"
+#include <stdint.h>
 #include <lxc/lxccontainer.h>
 
 struct bdev;
@@ -38,7 +39,7 @@ struct bdev;
  */
 struct bdev_specs {
 	char *fstype;
-	unsigned long fssize;  // fs size in bytes
+	uint64_t fssize;  // fs size in bytes
 	struct {
 		char *zfsroot;
 	} zfs;
@@ -61,7 +62,7 @@ struct bdev_ops {
 	/* given original mount, rename the paths for cloned container */
 	int (*clone_paths)(struct bdev *orig, struct bdev *new, const char *oldname,
 			const char *cname, const char *oldpath, const char *lxcpath,
-			int snap, unsigned long newsize);
+			int snap, uint64_t newsize);
 };
 
 /*
@@ -99,7 +100,7 @@ struct bdev *bdev_init(const char *src, const char *dst, const char *data);
 
 struct bdev *bdev_copy(const char *src, const char *oldname, const char *cname,
 			const char *oldpath, const char *lxcpath, const char *bdevtype,
-			int snap, const char *bdevdata, unsigned long newsize,
+			int snap, const char *bdevdata, uint64_t newsize,
 			int *needs_rdep);
 struct bdev *bdev_create(const char *dest, const char *type,
 			const char *cname, struct bdev_specs *specs);

--- a/src/lxc/lxc_clone.c
+++ b/src/lxc/lxc_clone.c
@@ -22,6 +22,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <sys/types.h>
+#include <stdint.h>
 #include <sys/wait.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -37,21 +38,38 @@
 
 lxc_log_define(lxc_clone, lxc);
 
-static unsigned long get_fssize(char *s)
+/* we pass fssize in bytes */
+static uint64_t get_fssize(char *s)
 {
-       unsigned long ret;
-       char *end;
+	uint64_t ret;
+	char *end;
 
-       ret = strtoul(s, &end, 0);
-       if (end == s)
-               return 0;
-       while (isblank(*end))
-               end++;
-       if (!(*end))
-               return ret;
-       if (*end == 'g' || *end == 'G')
-               ret *= 1024;
-       return ret;
+	ret = strtoull(s, &end, 0);
+	if (end == s)
+	{
+		fprintf(stderr, "Invalid blockdev size '%s', defaulting to 1G\n", s); 
+		return 0;
+	}
+	while (isblank(*end))
+		end++;
+	if (*end == '\0')
+		ret *= 1024ULL * 1024ULL; // MB by default
+	else if (*end == 'b' || *end == 'B')
+		ret *= 1ULL;
+	else if (*end == 'k' || *end == 'K')
+		ret *= 1024ULL;
+	else if (*end == 'm' || *end == 'M')
+		ret *= 1024ULL * 1024ULL;
+	else if (*end == 'g' || *end == 'G')
+		ret *= 1024ULL * 1024ULL * 1024ULL;
+	else if (*end == 't' || *end == 'T')
+		ret *= 1024ULL * 1024ULL * 1024ULL * 1024ULL;
+	else
+	{		
+		fprintf(stderr, "Invalid blockdev unit size '%c' in '%s', defaulting to 1G\n", *end, s);
+		return 0;
+	}
+	return ret;
 }
 
 static void usage(const char *me)
@@ -92,7 +110,7 @@ int main(int argc, char *argv[])
 	struct lxc_container *c1 = NULL, *c2 = NULL;
 	int snapshot = 0, keepname = 0, keepmac = 0;
 	int flags = 0, option_index;
-	long newsize = 0;
+	uint64_t newsize = 0;
 	char *bdevtype = NULL, *lxcpath = NULL, *newpath = NULL, *fstype = NULL;
 	char *orig = NULL, *new = NULL, *vgname = NULL;
 	char **args = NULL;

--- a/src/lxc/lxc_create.c
+++ b/src/lxc/lxc_create.c
@@ -25,6 +25,7 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <sys/types.h>
+#include <stdint.h>
 
 #include "lxc.h"
 #include "log.h"
@@ -34,21 +35,36 @@
 
 lxc_log_define(lxc_create, lxc);
 
-/* we pass fssize in bytes */
-static unsigned long get_fssize(char *s)
+static uint64_t get_fssize(char *s)
 {
-	unsigned long ret;
+	uint64_t ret;
 	char *end;
 
-	ret = strtoul(s, &end, 0);
+	ret = strtoull(s, &end, 0);
 	if (end == s)
+	{   
+		fprintf(stderr, "Invalid blockdev size '%s', defaulting to 1G\n", s);
 		return 0;
+	}
 	while (isblank(*end))
 		end++;
-	if (!(*end))
-		return ret;
-	if (*end == 'g' || *end == 'G')
-		ret *= 1024;
+	if (*end == '\0')
+		ret *= 1024ULL * 1024ULL; // MB by default
+	else if (*end == 'b' || *end == 'B')
+		ret *= 1ULL;
+	else if (*end == 'k' || *end == 'K')
+		ret *= 1024ULL;
+	else if (*end == 'm' || *end == 'M')
+		ret *= 1024ULL * 1024ULL;
+	else if (*end == 'g' || *end == 'G')
+		ret *= 1024ULL * 1024ULL * 1024ULL;
+	else if (*end == 't' || *end == 'T')
+		ret *= 1024ULL * 1024ULL * 1024ULL * 1024ULL;
+	else
+	{		
+		fprintf(stderr, "Invalid blockdev unit size '%c' in '%s', defaulting to 1G\n", *end, s);
+		return 0;
+	}
 	return ret;
 }
 
@@ -126,16 +142,16 @@ Options :\n\
   --lvname=LVNAME    Use LVM lv name LVNAME\n\
                      (Default: container name)\n\
   --vgname=VG        Use LVM vg called VG\n\
-                     (Default: lxc))\n\
+                     (Default: lxc)\n\
   --thinpool=TP      Use LVM thin pool called TP\n\
-                     (Default: lxc))\n\
+                     (Default: lxc)\n\
   --fstype=TYPE      Create fstype TYPE\n\
-                     (Default: ext3))\n\
-  --fssize=SIZE[MG]  Create filesystem of size SIZE\n\
-                     (Default: 1G))\n\
+                     (Default: ext3)\n\
+  --fssize=SIZE[U]   Create filesystem of size SIZE * unit U (bBkKmMgGtT)\n\
+                     (Default: 1G, default unit: M)\n\
   --dir=DIR          Place rootfs directory under DIR\n\
   --zfsroot=PATH     Create zfs under given zfsroot\n\
-                     (Default: tank/lxc))\n",
+                     (Default: tank/lxc)\n",
 	.options  = my_longopts,
 	.parser   = my_parser,
 	.checker  = NULL,

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -33,6 +33,7 @@
 #include <sched.h>
 #include <arpa/inet.h>
 #include <libgen.h>
+#include <stdint.h>
 
 #include <lxc/lxccontainer.h>
 #include <lxc/version.h>
@@ -2276,7 +2277,7 @@ static bool add_rdepends(struct lxc_container *c, struct lxc_container *c0)
 }
 
 static int copy_storage(struct lxc_container *c0, struct lxc_container *c,
-		const char *newtype, int flags, const char *bdevdata, unsigned long newsize)
+		const char *newtype, int flags, const char *bdevdata, uint64_t newsize)
 {
 	struct bdev *bdev;
 	int need_rdep;
@@ -2416,7 +2417,7 @@ static int create_file_dirname(char *path)
 
 static struct lxc_container *lxcapi_clone(struct lxc_container *c, const char *newname,
 		const char *lxcpath, int flags,
-		const char *bdevtype, const char *bdevdata, unsigned long newsize,
+		const char *bdevtype, const char *bdevdata, uint64_t newsize,
 		char **hookargs)
 {
 	struct lxc_container *c2 = NULL;

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -26,6 +26,7 @@
 #include <semaphore.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include <lxc/attach_options.h>
 
@@ -541,7 +542,7 @@ struct lxc_container {
 	 */
 	struct lxc_container *(*clone)(struct lxc_container *c, const char *newname,
 			const char *lxcpath, int flags, const char *bdevtype,
-			const char *bdevdata, unsigned long newsize, char **hookargs);
+			const char *bdevdata, uint64_t newsize, char **hookargs);
 
 	/*!
 	 * \brief Allocate a console tty for the container.


### PR DESCRIPTION
This allows 32-bit machines to create blockdevs larger than 4GB, which is
  supported by the backingstores (LVM / btrfs) but awkward
  to specify in units of bytes.
