### PR TITLE
handle simple bashisms:

### DIFF
--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 key_sha256sums="9c102bcc376af1498d549b77bdbfa815ae86faa1d2d82f040e616b18ef2df2d4  alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
 2adcf7ce224f476330b5360ca5edb92fd0bf91c92d83292ed028d7c4e26333ab  alpine-devel@lists.alpinelinux.org-4d07755e.rsa.pub"

--- a/templates/lxc-altlinux.in
+++ b/templates/lxc-altlinux.in
@@ -198,7 +198,7 @@ install_altlinux()
 {
     mkdir -p @LOCALSTATEDIR@/lock/subsys/
     (
-        flock -x 200
+        flock -x 9
         if [ $? -ne 0 ]; then
             echo "Cache repository is busy."
             return 1
@@ -228,7 +228,7 @@ install_altlinux()
             return 1
         fi
         return 0
-    ) 200>@LOCALSTATEDIR@/lock/subsys/lxc-altlinux
+    ) 9>@LOCALSTATEDIR@/lock/subsys/lxc-altlinux
 
     return $?
 }
@@ -317,7 +317,7 @@ clean()
 
     # lock, so we won't purge while someone is creating a repository
     (
-        flock -x 200
+        flock -x 9
         if [ $? != 0 ]; then
             echo "Cache repository is busy."
             exit 1
@@ -326,7 +326,7 @@ clean()
         echo -n "Purging the download cache for ALTLinux-$release..."
         rm --preserve-root --one-file-system -rf $cache && echo "Done." || exit 1
         exit 0
-    ) 200>@LOCALSTATEDIR@/lock/subsys/lxc-altlinux
+    ) 9>@LOCALSTATEDIR@/lock/subsys/lxc-altlinux
 }
 
 usage()

--- a/templates/lxc-archlinux.in
+++ b/templates/lxc-archlinux.in
@@ -65,7 +65,7 @@ declare -a additional_packages
 # ${1} - string to split
 # ${2} - separator (default is ",")
 # ${result} - result value on success
-function split_string {
+split_string() {
     local ifs=${IFS}
     IFS="${2:-,}"
     read -a result < <(echo "${1}")
@@ -76,7 +76,7 @@ function split_string {
 [ -f /etc/arch-release ] && is_arch=true
 
 # Arch-specific preconfiguration for container
-function configure_arch {
+configure_arch() {
     # read locale and timezone defaults from system rc.conf if running on Arch
     if [ "${is_arch}" ]; then
         cp -p /etc/vconsole.conf /etc/locale.conf /etc/locale.gen "${rootfs_path}/etc/"
@@ -118,7 +118,7 @@ EOF
 }
 
 # write container configuration files
-function copy_configuration {
+copy_configuration() {
     mkdir -p "${config_path}"
     cat > "${config_path}/config" << EOF
 lxc.utsname=${name}
@@ -165,7 +165,7 @@ EOF
 }
 
 # install packages within container chroot
-function install_arch {
+install_arch() {
     if ! pacstrap -dcC "${pacman_config}" "${rootfs_path}" ${base_packages[@]}; then
         echo "Failed to install container packages"
         return 1

--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -255,8 +255,8 @@ EOF
 
         # add necessary config files
         mkdir $rootfs/etc/dropbear
-        dropbearkey -t rsa -f $rootfs/etc/dropbear/dropbear_rsa_host_key &> /dev/null
-        dropbearkey -t dss -f $rootfs/etc/dropbear/dropbear_dss_host_key &> /dev/null
+        dropbearkey -t rsa -f $rootfs/etc/dropbear/dropbear_rsa_host_key > /dev/null 2>&1
+        dropbearkey -t dss -f $rootfs/etc/dropbear/dropbear_dss_host_key > /dev/null 2>&1
 
         echo "'dropbear' ssh utility installed"
     fi

--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -133,7 +133,7 @@ configure_centos()
     echo 0 > $rootfs_path/selinux/enforce
 
     # Also kill it in the /etc/selinux/config file if it's there...
-    if [[ -f $rootfs_path/etc/selinux/config ]]
+    if [ -f $rootfs_path/etc/selinux/config ]
     then
         sed -i '/^SELINUX=/s/.*/SELINUX=disabled/' $rootfs_path/etc/selinux/config
     fi
@@ -419,7 +419,7 @@ install_centos()
 {
     mkdir -p /var/lock/subsys/
     (
-    flock -x 200
+    flock -x 9
     if [ $? -ne 0 ]; then
         echo "Cache repository is busy."
         return 1
@@ -451,7 +451,7 @@ install_centos()
 
     return 0
 
-    ) 200>/var/lock/subsys/lxc-centos
+    ) 9>/var/lock/subsys/lxc-centos
 
     return $?
 }
@@ -522,7 +522,7 @@ clean()
 
     # lock, so we won't purge while someone is creating a repository
     (
-    flock -x 200
+    flock -x 9
     if [ $? != 0 ]; then
         echo "Cache repository is busy."
         exit 1
@@ -532,7 +532,7 @@ clean()
     rm --preserve-root --one-file-system -rf $cache && echo "Done." || exit 1
     exit 0
 
-    ) 200>/var/lock/subsys/lxc-centos
+    ) 9>/var/lock/subsys/lxc-centos
 }
 
 usage()

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -98,7 +98,7 @@ EOF
         cat /etc/timezone > $rootfs/etc/timezone
         chroot $rootfs dpkg-reconfigure -f noninteractive tzdata
     elif [ -f /etc/sysconfig/clock ]; then
-        source /etc/sysconfig/clock
+        . /etc/sysconfig/clock
         echo $ZONE > $rootfs/etc/timezone
         chroot $rootfs dpkg-reconfigure -f noninteractive tzdata
     else
@@ -184,7 +184,7 @@ install_debian()
     arch=$3
     mkdir -p @LOCALSTATEDIR@/lock/subsys/
     (
-        flock -x 200
+        flock -x 9
         if [ $? -ne 0 ]; then
             echo "Cache repository is busy."
             return 1
@@ -207,7 +207,7 @@ install_debian()
 
         return 0
 
-        ) 200>@LOCALSTATEDIR@/lock/subsys/lxc-debian
+        ) 9>@LOCALSTATEDIR@/lock/subsys/lxc-debian
 
     return $?
 }
@@ -277,7 +277,7 @@ clean()
 
     # lock, so we won't purge while someone is creating a repository
     (
-        flock -x 200
+        flock -x 9
         if [ $? != 0 ]; then
             echo "Cache repository is busy."
             exit 1
@@ -287,7 +287,7 @@ clean()
         rm --preserve-root --one-file-system -rf $cache && echo "Done." || exit 1
         exit 0
 
-    ) 200>@LOCALSTATEDIR@/lock/subsys/lxc-debian
+    ) 9>@LOCALSTATEDIR@/lock/subsys/lxc-debian
 }
 
 usage()
@@ -341,11 +341,11 @@ if [ ! -z "$clean" -a -z "$path" ]; then
     exit 0
 fi
 
-if [ "$arch" == "i686" ]; then
+if [ "$arch" = "i686" ]; then
     arch=i386
 fi
 
-if [ "$arch" == "x86_64" ]; then
+if [ "$arch" = "x86_64" ]; then
     arch=amd64
 fi
 

--- a/templates/lxc-openmandriva.in
+++ b/templates/lxc-openmandriva.in
@@ -96,7 +96,7 @@ populate_dev()
 
 set_guest_root_password()
 {
-    [[ -z "$root_password" ]] && return # pass is empty, abort
+    [ -z "$root_password" ] && return # pass is empty, abort
 
     echo " - setting guest root password.."
     echo "root passwd is: $root_password"
@@ -173,7 +173,7 @@ install_openmandriva()
 {
     mkdir -p @LOCALSTATEDIR@/lock/subsys/
     (
-        flock -x 200
+        flock -x 9
         if [ $? -ne 0 ]; then
             echo "Cache repository is busy."
             return 1
@@ -204,7 +204,7 @@ install_openmandriva()
             return 1
         fi
         return 0
-    ) 200>@LOCALSTATEDIR@/lock/subsys/lxc-openmandriva
+    ) 9>@LOCALSTATEDIR@/lock/subsys/lxc-openmandriva
 
     return $?
 }
@@ -294,7 +294,7 @@ clean()
 
     # lock, so we won't purge while someone is creating a repository
     (
-        flock -x 200
+        flock -x 9
         if [ $? != 0 ]; then
             echo "Cache repository is busy."
             exit 1
@@ -303,7 +303,7 @@ clean()
         echo -n "Purging the download cache for OpenMandriva-$release..."
         rm --preserve-root --one-file-system -rf $cache && echo "Done." || exit 1
         exit 0
-    ) 200>@LOCALSTATEDIR@/lock/subsys/lxc-openmandriva
+    ) 9>@LOCALSTATEDIR@/lock/subsys/lxc-openmandriva
 }
 
 usage()

--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -150,7 +150,7 @@ Support: pwdutils rpcbind sysconfig
 Ignore: rpm:suse-build-key,build-key
 Ignore: systemd:systemd-presets-branding
 EOF
-    if [ "$arch" == "i686" ]; then
+    if [ "$arch" = "i686" ]; then
         mkdir -p $cache/partial-$arch-packages/var/cache/zypp/packages/repo-oss/suse/i686/
         for i in "$cache/partial-$arch-packages/var/cache/zypp/packages/repo-oss/suse/i586/*" ; do
             ln -s $i $cache/partial-$arch-packages/var/cache/zypp/packages/repo-oss/suse/i686/
@@ -209,7 +209,7 @@ install_opensuse()
     rootfs=$1
     mkdir -p @LOCALSTATEDIR@/lock/subsys/
     (
-        flock -x 200
+        flock -x 9
         if [ $? -ne 0 ]; then
             echo "Cache repository is busy."
             return 1
@@ -234,7 +234,7 @@ install_opensuse()
         fi
 
         return 0
-    ) 200>@LOCALSTATEDIR@/lock/subsys/lxc-opensuse
+    ) 9>@LOCALSTATEDIR@/lock/subsys/lxc-opensuse
 
     return $?
 }
@@ -325,7 +325,7 @@ clean()
 
     # lock, so we won't purge while someone is creating a repository
     (
-        flock -x 200
+        flock -x 9
         if [ $? != 0 ]; then
             echo "Cache repository is busy."
             exit 1
@@ -334,7 +334,7 @@ clean()
         echo -n "Purging the download cache..."
         rm --preserve-root --one-file-system -rf $cache && echo "Done." || exit 1
         exit 0
-    ) 200>@LOCALSTATEDIR@/lock/subsys/lxc-opensuse
+    ) 9>@LOCALSTATEDIR@/lock/subsys/lxc-opensuse
 }
 
 usage()

--- a/templates/lxc-oracle.in
+++ b/templates/lxc-oracle.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Template script for generating Oracle Enterprise Linux container for LXC
 # based on lxc-fedora, lxc-ubuntu
@@ -362,8 +362,8 @@ EOF
     chroot $container_rootfs useradd -m -s /bin/bash oracle
     echo "oracle:oracle" | chroot $container_rootfs chpasswd
     echo "root:root" | chroot $container_rootfs chpasswd
-    echo -e "Added container user:\033[1moracle\033[0m password:\033[1moracle\033[0m"
-    echo -e "Added container user:\033[1mroot\033[0m password:\033[1mroot\033[0m"
+    printf "Added container user:\033[1moracle\033[0m password:\033[1moracle\033[0m\n"
+    printf "Added container user:\033[1mroot\033[0m password:\033[1mroot\033[0m\n"
 }
 
 # create the container's lxc config file
@@ -478,7 +478,7 @@ container_rootfs_create()
 
     mkdir -p @LOCALSTATEDIR@/lock/subsys/lxc
     (
-        flock -x 200
+        flock -x 9
         if [ $? -ne 0 ]; then
             die "The template is busy."
         fi
@@ -612,7 +612,7 @@ container_rootfs_create()
         rm -f $container_rootfs/var/lib/rpm/__db*
         chroot $container_rootfs rpm --rebuilddb >/dev/null 2>&1
 
-    ) 200>@LOCALSTATEDIR@/lock/subsys/lxc-oracle-$name
+    ) 9>@LOCALSTATEDIR@/lock/subsys/lxc-oracle-$name
 }
 
 container_release_get()

--- a/templates/lxc-sshd.in
+++ b/templates/lxc-sshd.in
@@ -202,7 +202,7 @@ if [ "$(id -u)" != "0" ]; then
     exit 1
 fi
 
-if [ $0 == "/sbin/init" ]; then
+if [ $0 = "/sbin/init" ]; then
 
     PATH="$PATH:/bin:/sbin:/usr/sbin"
     check_for_cmd @LXCINITDIR@/lxc/lxc-init

--- a/templates/lxc-ubuntu-cloud.in
+++ b/templates/lxc-ubuntu-cloud.in
@@ -105,7 +105,7 @@ EOF
         cat /etc/timezone > $rootfs/etc/timezone
         chroot $rootfs dpkg-reconfigure -f noninteractive tzdata
     elif [ -f /etc/sysconfig/clock ]; then
-        source /etc/sysconfig/clock
+        . /etc/sysconfig/clock
         echo $ZONE > $rootfs/etc/timezone
         chroot $rootfs dpkg-reconfigure -f noninteractive tzdata
     else
@@ -222,7 +222,7 @@ if [ $debug -eq 1 ]; then
     set -x
 fi
 
-if [ "$arch" == "i686" ]; then
+if [ "$arch" = "i686" ]; then
     arch=i386
 fi
 
@@ -373,9 +373,9 @@ if [ -n "$tarball" ]; then
 else
     mkdir -p "$STATE_DIR/lock/subsys/"
     (
-        flock -x 200
+        flock -x 9
         do_extract_rootfs
-    ) 200>"$STATE_DIR/lock/subsys/lxc-ubuntu-cloud"
+    ) 9>"$STATE_DIR/lock/subsys/lxc-ubuntu-cloud"
 fi
 
 copy_configuration $path $rootfs $name $arch $release

--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -338,7 +338,7 @@ install_ubuntu()
     mkdir -p $LOCALSTATEDIR/lock/subsys/
 
     (
-        flock -x 200
+        flock -x 9
         if [ $? -ne 0 ]; then
             echo "Cache repository is busy."
             return 1
@@ -369,7 +369,7 @@ install_ubuntu()
 
         return 0
 
-    ) 200>$LOCALSTATEDIR/lock/subsys/lxc-ubuntu$release
+    ) 9>$LOCALSTATEDIR/lock/subsys/lxc-ubuntu$release
 
     return $?
 }
@@ -519,7 +519,7 @@ EOF
         cat /etc/timezone > $rootfs/etc/timezone
         chroot $rootfs dpkg-reconfigure -f noninteractive tzdata
     elif [ -f /etc/sysconfig/clock ]; then
-        source /etc/sysconfig/clock
+        . /etc/sysconfig/clock
         echo $ZONE > $rootfs/etc/timezone
         chroot $rootfs dpkg-reconfigure -f noninteractive tzdata
     else
@@ -670,7 +670,7 @@ if [ -n "$bindhome" ]; then
 fi
 
 
-if [ "$arch" == "i686" ]; then
+if [ "$arch" = "i686" ]; then
     arch=i386
 fi
 


### PR DESCRIPTION
- [[ ]] -> [ ]
- == -> =
- source -> .
- redirect of fd 200 is error in mksh, use fd 9
- &> /dev/null -> > /dev/null 2>&1
- useless function keyword
- echo -e -> printf

still left bash shebang which did not validate with checkbashism, mostly
due 'type' being reported as bashism
