### PR TITLE
Make ubuntu templates squid-deb-proxy-client aware

### DIFF
--- a/hooks/Makefile.am
+++ b/hooks/Makefile.am
@@ -4,6 +4,7 @@ hooks_SCRIPTS = \
 	clonehostname \
 	mountcgroups \
 	mountecryptfsroot \
-	ubuntu-cloud-prep
+	ubuntu-cloud-prep \
+	squid-deb-proxy-client
 
 EXTRA_DIST=$(hooks_SCRIPTS)

--- a/hooks/squid-deb-proxy-client
+++ b/hooks/squid-deb-proxy-client
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Make the cloned container aware of squid-deb-proxy settings at start.
+#
+# Copyright ©  2014 Christopher Glass.
+#
+# This library is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# When starting a container, inject the squid-deb-proxy-client proxy
+# address in the container's apt configuration.
+# This script should be added to templates as a pre-start script, such as:
+#lxc.hook.pre-start=/usr/share/lxc/hooks/squid-deb-proxy-client
+
+discovery_script=/usr/share/squid-deb-proxy-client/apt-avahi-discover
+proxy_file=/etc/apt/apt.conf.d/50squid-deb-proxy
+
+if [ -f $proxy_file ]; then
+    # The host has a proxy file - let's propagate the config to the guest.
+    container_proxy_file=$LXC_ROOTFS_PATH$proxy_file
+    cat $proxy_file > $container_proxy_file
+    exit 0
+fi
+
+if [ ! -f $discovery_script ]; then
+    # There is no squid-deb-proxy-client package installed. Do nothing.
+    exit 0
+fi
+
+proxy_line=$($discovery_script)  #XXX: Could be multiline?
+
+if [ -n "$proxy_line" ]; then
+    doc="# Detected at container start from the host's squid-deb-proxy-client"
+    echo "Acquire::http::proxy \"$proxy_line\"; $doc" > $container_proxy_file
+else
+    if [ -f $proxy_file ]; then
+        rm $proxy_file
+    fi
+fi
+exit 0

--- a/templates/lxc-ubuntu-cloud.in
+++ b/templates/lxc-ubuntu-cloud.in
@@ -94,6 +94,11 @@ lxc.utsname = $name
 lxc.arch = $arch
 EOF
 
+    # Add the squid-deb-proxy autodetection hook
+    echo "" >> $path/config
+    echo "# This pre-start hook will attempt to detect squid-deb-proxy services"
+    echo "lxc.hook.pre-start = /usr/share/lxc/hooks/squid-deb-proxy-client"
+
     ## Re-add the previously removed network config
     echo "" >> $path/config
     echo "# Network configuration" >> $path/config

--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -147,6 +147,34 @@ finalize_user()
     return 0
 }
 
+# A function to try and autodetect squid-deb-proxy servers on the local network
+# if either the squid-deb-proxy-client package is installed on the host or
+# a parent container set the 50squid-deb-proxy-client file.
+squid_deb_proxy_autodetect()
+{
+    
+    local apt_discover=/usr/share/squid-deb-proxy-client/apt-avahi-discover
+    local proxy_file=/etc/apt/apt.conf.d/50squid-deb-proxy-client
+    squid_proxy_line=  # That's a global :/
+
+    # Maybe the host is aware of a squid-deb-proxy?
+    if [ -f $apt_discover ]; then
+        echo -n "Discovering squid-deb-proxy..."
+        squid_proxy_line=$($apt_discover)
+        if [ -n "$squid_proxy_line" ]; then
+            echo "found squid-deb-proxy: $squid_proxy_line"
+        else
+            echo "no squid-deb-proxy found"
+        fi
+    fi
+
+    # Are we in a nested container, and the parent already knows of a proxy?
+    if [ -f $proxy_file ]; then
+        # Extract the squid URL from the file (whatever is between "")
+        squid_proxy_line=`cat $proxy_file | sed "s/.*\"\(.*\)\".*/\1/"`
+    fi
+}
+
 #
 # Choose proxies for container
 # http_proxy will be used by debootstrap on the host.
@@ -162,7 +190,13 @@ choose_container_proxy()
     fi
     case "$HTTP_PROXY" in
     none)
-        APT_PROXY=
+        squid_deb_proxy_autodetect
+        if [ -n "$squid_proxy_line" ]; then
+            APT_PROXY=$squid_proxy_line
+            export http_proxy=$squid_proxy_line
+        else
+            APT_PROXY=
+        fi
         ;;
     apt)
         RES=`apt-config shell APT_PROXY Acquire::http::Proxy`
@@ -423,6 +457,11 @@ lxc.mount = $path/fstab
 lxc.utsname = $name
 lxc.arch = $arch
 EOF
+
+    # Add the squid-deb-proxy autodetection hook
+    echo "" >> $path/config
+    echo "# This pre-start hook will attempt to detect squid-deb-proxy services" >> $path/config
+    echo "lxc.hook.pre-start = /usr/share/lxc/hooks/squid-deb-proxy-client" >> $path/config
 
     ## Re-add the previously removed network config
     echo "" >> $path/config


### PR DESCRIPTION
This makes the ubuntu and ubuntu-cloud templates automatically aware of apt
proxy settings when the LXC host has "squid-deb-proxy-client" installed. It
makes installations _much_ faster when a suitable squid-deb-proxy is
found on the network (or installed on the host).

If forwards the information to nested containers, too.

Signed-off-by: Chris Glass tribaal@gmail.com
