### PR TITLE
Fix syntax error in aufs code path of lxc-start-ephemeral

### DIFF
--- a/src/lxc/lxc-start-ephemeral.in
+++ b/src/lxc/lxc-start-ephemeral.in
@@ -212,7 +212,7 @@ LXC_NAME="%s"
                      entry[1]))
         elif args.union_type == "aufs":
             fd.write("mount -n -t aufs "
-                     "-o br=${upper}=rw:${lower}=ro,noplink none %s\n" % (
+                     "-o br=%s=rw:%s=ro,noplink none %s\n" % (
                      target,
                      entry[0],
                      entry[1]))


### PR DESCRIPTION
This fixes #135.
