### PR TITLE
Added a commented squid-deb-proxy hook to ubuntu

### DIFF
--- a/config/templates/ubuntu.common.conf.in
+++ b/config/templates/ubuntu.common.conf.in
@@ -27,6 +27,10 @@ lxc.cap.drop = sys_module mac_admin mac_override sys_time
 #lxc.aa_profile = lxc-container-default-with-nesting
 #lxc.hook.mount = /usr/share/lxc/hooks/mountcgroups
 
+# Uncomment the following line to autodetect squid-deb-proxy configuration on the
+# host and forward it to the guest at start time.
+#lxc.hook.pre-start = /usr/share/lxc/hooks/squid-deb-proxy-client
+
 # If you wish to allow mounting block filesystems, then use the following
 # line instead, and make sure to grant access to the block device and/or loop
 # devices below in lxc.cgroup.devices.allow.


### PR DESCRIPTION
Added a commented squid-deb-proxy hook to the common ubuntu config file as suggested when merging the squid-deb-proxy-client hook.

Signed-off-by: Chris Glass tribaal@gmail.com
