### PR TITLE
Fix small mistake with squid-deb-proxy hook

### DIFF
--- a/hooks/squid-deb-proxy-client
+++ b/hooks/squid-deb-proxy-client
@@ -24,10 +24,10 @@
 
 discovery_script=/usr/share/squid-deb-proxy-client/apt-avahi-discover
 proxy_file=/etc/apt/apt.conf.d/50squid-deb-proxy
+container_proxy_file=$LXC_ROOTFS_PATH$proxy_file
 
 if [ -f $proxy_file ]; then
     # The host has a proxy file - let's propagate the config to the guest.
-    container_proxy_file=$LXC_ROOTFS_PATH$proxy_file
     cat $proxy_file > $container_proxy_file
     exit 0
 fi


### PR DESCRIPTION
I unfortunately realized that I did not push the latest version of the file. This fixes an issue in the case where we want to create the proxy file in the container (not nested).

Signed-off-by: Chris Glass tribaal@gmail.com
