### PR TITLE
Fix error message if nodename is too long

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1585,7 +1585,7 @@ static int config_utsname(const char *key, const char *value,
 
 	if (strlen(value) >= sizeof(utsname->nodename)) {
 		ERROR("node name '%s' is too long",
-			      utsname->nodename);
+			      value);
 		free(utsname);
 		return -1;
 	}


### PR DESCRIPTION
```
if (strlen(value) >= sizeof(utsname->nodename)) {
    ERROR("node name '%s' is too long",
              utsname->nodename);
    free(utsname);
    return -1;
}
```

if value is too long then print message that the value actual _value_ is to long not the _empty_ buffer (utsname->nodename).
