### PR TITLE
Convert punctuation marks in Japanese man pages on stable-1.0

### DIFF
--- a/doc/ja/common_options.sgml.in
+++ b/doc/ja/common_options.sgml.in
@@ -33,7 +33,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     <!--
     These options are common to most of lxc commands.
     -->
-    ここで紹介するオプションは lxc コマンドの大部分で共通のものです．
+    ここで紹介するオプションは lxc コマンドの大部分で共通のものです。
   </para>
 
   <variablelist>
@@ -44,7 +44,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  Print a longer usage message than normal.
           -->
-          通常より長い使い方のメッセージを表示します．
+          通常より長い使い方のメッセージを表示します。
 	</para>
       </listitem>
     </varlistentry>
@@ -55,7 +55,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  Give the usage message
           -->
-          使い方を表示します．
+          使い方を表示します。
 	</para>
       </listitem>
     </varlistentry>
@@ -67,7 +67,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  mute on
           -->
-          出力を抑制します．
+          出力を抑制します。
 	</para>
       </listitem>
     </varlistentry>
@@ -79,7 +79,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  Use an alternate container path.  The default is @LXCPATH@.
           -->
-          デフォルトと別のコンテナパスを使用します．デフォルトは @LXCPATH@ です．
+          デフォルトと別のコンテナパスを使用します。デフォルトは @LXCPATH@ です。
 	</para>
       </listitem>
     </varlistentry>
@@ -92,7 +92,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  Output to an alternate log
 	  <replaceable>FILE</replaceable>. The default is no log.
           -->
-          追加のログを <replaceable>FILE</replaceable> に出力します．デフォルトは出力しません．
+          追加のログを <replaceable>FILE</replaceable> に出力します。デフォルトは出力しません。
 	</para>
       </listitem>
     </varlistentry>
@@ -110,11 +110,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  <literal>NOTICE</literal>, <literal>INFO</literal>,
 	  <literal>DEBUG</literal>.
           -->
-          ログの優先度を <replaceable>LEVEL</replaceable> に設定します．デフォルトの優先度は <literal>ERROR</literal> です．以下の値を設定可能です:
+          ログの優先度を <replaceable>LEVEL</replaceable> に設定します。デフォルトの優先度は <literal>ERROR</literal> です。以下の値を設定可能です:
 	  <literal>FATAL</literal>, <literal>CRIT</literal>,
 	  <literal>WARN</literal>, <literal>ERROR</literal>,
 	  <literal>NOTICE</literal>, <literal>INFO</literal>,
-	  <literal>DEBUG</literal>．
+	  <literal>DEBUG</literal>。
 	</para>
 	<para>
           <!--
@@ -122,7 +122,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	log in the alternate log file. It do not have effect on the
 	ERROR events log on stderr.
         -->
-          このオプションは追加のログファイルへのイベントログの優先度の設定である事に注意してください．stderr への ERROR イベントのログには影響しません．
+          このオプションは追加のログファイルへのイベントログの優先度の設定である事に注意してください。stderr への ERROR イベントのログには影響しません。
 	</para>
       </listitem>
     </varlistentry>
@@ -135,7 +135,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  Use container identifier <replaceable>NAME</replaceable>.
 	  The container identifier format is an alphanumeric string.
           -->
-          <replaceable>NAME</replaceable> という名前でコンテナを識別します．コンテナ識別子のフォーマットは英数字の文字列です．
+          <replaceable>NAME</replaceable> という名前でコンテナを識別します。コンテナ識別子のフォーマットは英数字の文字列です。
 	</para>
       </listitem>
     </varlistentry>

--- a/doc/ja/legacy/lxc-ls.sgml.in
+++ b/doc/ja/legacy/lxc-ls.sgml.in
@@ -47,7 +47,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <!--
       list the containers existing on the system
       -->
-      システム上に存在するコンテナをリスト表示する．
+      システム上に存在するコンテナをリスト表示する。
     </refpurpose>
   </refnamediv>
 
@@ -66,7 +66,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-ls</command> list the containers existing on the
       system.
       -->
-      <command>lxc-ls</command> はシステム上に存在するコンテナをリスト表示します．
+      <command>lxc-ls</command> はシステム上に存在するコンテナをリスト表示します。
     </para>
   </refsect1>
 
@@ -83,7 +83,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    List active containers.
             -->
-            稼働中のコンテナをリスト表示します．
+            稼働中のコンテナをリスト表示します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -98,7 +98,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    The option passed to <command>lxc-ls</command> are the
 	    same as the <command>ls</command> command.
             -->
-            <command>lxc-ls</command> が受け付けるオプションは，<command>ls</command> コマンドと同じです．
+            <command>lxc-ls</command> が受け付けるオプションは、<command>ls</command> コマンドと同じです。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -117,7 +117,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  list all the container and their permissions.
           -->
-          全てのコンテナとそのパーミッションをリスト表示します．
+          全てのコンテナとそのパーミッションをリスト表示します。
 	</para>
 	</listitem>
       </varlistentry>
@@ -129,7 +129,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  list active containers and display the list in one column.
           -->
-          稼働中のコンテナを一列にリスト表示します．
+          稼働中のコンテナを一列にリスト表示します。
 	</para>
 	</listitem>
       </varlistentry>

--- a/doc/ja/lxc-attach.sgml.in
+++ b/doc/ja/lxc-attach.sgml.in
@@ -76,8 +76,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       specified by <replaceable>name</replaceable>. The container
       has to be running already.
       -->
-      <command>lxc-attach</command> は <replaceable>name</replaceable> で指定したコンテナ内で指定した <replaceable>command</replaceable> を実行します．
-      実行する時点でコンテナが実行中でなければなりません．
+      <command>lxc-attach</command> は <replaceable>name</replaceable> で指定したコンテナ内で指定した <replaceable>command</replaceable> を実行します。
+      実行する時点でコンテナが実行中でなければなりません。
     </para>
     <para>
       <!--
@@ -88,8 +88,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       inside the container or the container does not have a working
       nsswitch mechanism.
       -->
-      もし <replaceable>command</replaceable> が指定されていない場合，<command>lxc-attach</command> コマンドを実行したユーザのデフォルトシェルをコンテナ内で調べて実行します．
-      もしコンテナ内にユーザが存在しない場合や，コンテナで nsswitch 機構が働いていない場合はこの動作は失敗します．
+      もし <replaceable>command</replaceable> が指定されていない場合、<command>lxc-attach</command> コマンドを実行したユーザのデフォルトシェルをコンテナ内で調べて実行します。
+      もしコンテナ内にユーザが存在しない場合や、コンテナで nsswitch 機構が働いていない場合はこの動作は失敗します。
     </para>
 
   </refsect1>
@@ -117,12 +117,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    </citerefentry>. By default, the current archictecture of the
 	    running container will be used.
             -->
-            コマンドを実行するコンテナのアーキテクチャを指定します．
-            このオプションは，コンテナの設定ファイルで指定する <option>lxc.arch</option> オプションと同じものが使用可能です．
+            コマンドを実行するコンテナのアーキテクチャを指定します。
+            このオプションは、コンテナの設定ファイルで指定する <option>lxc.arch</option> オプションと同じものが使用可能です。
             <citerefentry>
 	      <refentrytitle><filename>lxc.conf</filename></refentrytitle>
 	      <manvolnum>5</manvolnum>
-	    </citerefentry> を参照してください．デフォルトでは，実行しているコンテナのアーキテクチャになります．
+	    </citerefentry> を参照してください。デフォルトでは、実行しているコンテナのアーキテクチャになります。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -142,8 +142,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <emphasis>not</emphasis> be added to the container's cgroup(s)
 	    and it will not drop its capabilities before executing.
             -->
-            コンテナの内部で <replaceable>command</replaceable> を実行する時に特権を削除しません．
-            もしこのオプションが指定された場合，新しいプロセスはコンテナの cgroup に追加 <emphasis>されず</emphasis>，実行する前にケーパビリティ (capability) も削除しません．
+            コンテナの内部で <replaceable>command</replaceable> を実行する時に特権を削除しません。
+            もしこのオプションが指定された場合、新しいプロセスはコンテナの cgroup に追加 <emphasis>されず</emphasis>、実行する前にケーパビリティ (capability) も削除しません。
 	  </para>
           <para>
 	    <!--
@@ -154,8 +154,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <replaceable>LSM</replaceable> representing cgroup, capabilities and
 	    restriction privileges respectively.
 	    -->
-            全ての特権の取得したくない場合は，パイプで連結したリストとして，例えば <replaceable>CGROUP|LSM</replaceable> のように，特権を指定することが可能です．
-            指定できる値は，それぞれ cgroup，ケーパビリティ，特権の制限を表す <replaceable>CGROUP</replaceable>，<replaceable>CAP</replaceable>，<replaceable>LSM</replaceable> です．
+            全ての特権の取得したくない場合は、パイプで連結したリストとして、例えば <replaceable>CGROUP|LSM</replaceable> のように、特権を指定することが可能です。
+            指定できる値は、それぞれ cgroup、ケーパビリティ、特権の制限を表す <replaceable>CGROUP</replaceable>、<replaceable>CAP</replaceable>、<replaceable>LSM</replaceable> です。
           </para>
 	  <para>
             <!--
@@ -168,10 +168,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <emphasis>Use with great care.</emphasis>
             -->
             <emphasis>警告：</emphasis>
-            もし実行するコマンドが，アタッチするメインプロセスが終了した後も実行されたままのサブプロセスを開始するような場合，このオプションの指定はコンテナ内への特権のリークとなる可能性があります．
-            コンテナ内でのデーモンの開始(もしくは再起動)は問題となります．
-            デーモンが多数のサブプロセスを開始する <command>cron</command> や <command>sshd</command> のような場合は特に問題となります．
-            <emphasis>充分な注意を払って使用してください．</emphasis>
+            もし実行するコマンドが、アタッチするメインプロセスが終了した後も実行されたままのサブプロセスを開始するような場合、このオプションの指定はコンテナ内への特権のリークとなる可能性があります。
+            コンテナ内でのデーモンの開始(もしくは再起動)は問題となります。
+            デーモンが多数のサブプロセスを開始する <command>cron</command> や <command>sshd</command> のような場合は特に問題となります。
+            <emphasis>充分な注意を払って使用してください。</emphasis>
 	  </para>
 	</listitem>
       </varlistentry>
@@ -193,18 +193,18 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    container while retaining the other namespaces as those of the
 	    host.
             -->
-            アタッチする名前空間をパイプで連結したリストで指定します．
-            例えば <replaceable>NETWORK|IPC</replaceable> のようにです．
-            ここで使用可能な値は <replaceable>MOUNT</replaceable>, <replaceable>PID</replaceable>, <replaceable>UTSNAME</replaceable>, <replaceable>IPC</replaceable>, <replaceable>USER </replaceable>, <replaceable>NETWORK</replaceable> です．
-            これにより指定した名前空間にプロセスのコンテキストを変更できます．
-            例えばコンテナのネットワーク名前空間に変更する一方で，他の名前空間はホストの名前空間のままにするというような事が可能です．
+            アタッチする名前空間をパイプで連結したリストで指定します。
+            例えば <replaceable>NETWORK|IPC</replaceable> のようにです。
+            ここで使用可能な値は <replaceable>MOUNT</replaceable>, <replaceable>PID</replaceable>, <replaceable>UTSNAME</replaceable>, <replaceable>IPC</replaceable>, <replaceable>USER </replaceable>, <replaceable>NETWORK</replaceable> です。
+            これにより指定した名前空間にプロセスのコンテキストを変更できます。
+            例えばコンテナのネットワーク名前空間に変更する一方で、他の名前空間はホストの名前空間のままにするというような事が可能です。
 	  </para>
 	  <para>
             <!--
 	    <emphasis>Important:</emphasis> This option implies
 	    <option>&#045;e</option>.
             -->
-            <emphasis>重要:</emphasis> このオプションは <option>-e</option> オプションを指定しなくても指定している場合と同様の動作をします．
+            <emphasis>重要:</emphasis> このオプションは <option>-e</option> オプションを指定しなくても指定している場合と同様の動作をします。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -222,22 +222,22 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <replaceable>/sys</replaceable> to reflect the current other
 	    namespace contexts.
             -->
-            <option>-s</option> を指定し，そこにマウント名前空間が含まれない時，このオプションにより <command>lxc-attach</command> は <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> をリマウントします．
-            これは現在の他の名前空間のコンテキストを反映させるためです．
+            <option>-s</option> を指定し、そこにマウント名前空間が含まれない時、このオプションにより <command>lxc-attach</command> は <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> をリマウントします。
+            これは現在の他の名前空間のコンテキストを反映させるためです。
 	  </para>
 	  <para>
             <!--
 	    Please see the <emphasis>Notes</emphasis> section for more
 	    details.
             -->
-            もっと詳細な説明は <emphasis>注意</emphasis> を参照してください．
+            もっと詳細な説明は <emphasis>注意</emphasis> を参照してください。
 	  </para>
 	  <para>
             <!--
 	    This option will be ignored if one tries to attach to the
 	    mount namespace anyway.
             -->
-            このオプションは，マウント名前空間へのアタッチが行われる場合は無視されます．
+            このオプションは、マウント名前空間へのアタッチが行われる場合は無視されます。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -257,11 +257,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    please use this option to be future-proof. In addition to
 	    current environment variables, container=lxc will be set.
             -->
-            アタッチされるプログラムに対して現在の環境を保持したままにします．
-            これは現在 (バージョン 0.9 時点) のデフォルトの動作ですが，将来は変更される予定です．
-            この動作がコンテナ内への望ましくない情報の漏洩につながる可能性があるためです．
-            アタッチするプログラムで環境変数が利用可能であることを期待している場合，将来的にもそれが保証されるようにこのオプションを使用するようにしてください．
-            現在の環境変数に加えて，container=lxc が設定されます．
+            アタッチされるプログラムに対して現在の環境を保持したままにします。
+            これは現在 (バージョン 0.9 時点) のデフォルトの動作ですが、将来は変更される予定です。
+            この動作がコンテナ内への望ましくない情報の漏洩につながる可能性があるためです。
+            アタッチするプログラムで環境変数が利用可能であることを期待している場合、将来的にもそれが保証されるようにこのオプションを使用するようにしてください。
+            現在の環境変数に加えて、container=lxc が設定されます。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -278,9 +278,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    container=lxc will be the only environment with which the
 	    attached program starts.
             -->
-            アタッチする前に環境変数をクリアします．
-            これによりコンテナへの不要な環境変数の漏洩が起こらなくなります．
-            変数 container=lxc のみがアタッチするプログラムの開始の時の環境変数となります．
+            アタッチする前に環境変数をクリアします。
+            これによりコンテナへの不要な環境変数の漏洩が起こらなくなります。
+            変数 container=lxc のみがアタッチするプログラムの開始の時の環境変数となります。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -300,7 +300,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           lxc-attach -n container
         </programlisting>
         -->
-        存在するコンテナ内で新しいシェルを生成するには，以下のようにします．
+        存在するコンテナ内で新しいシェルを生成するには、以下のようにします。
         <programlisting>
           lxc-attach -n container
         </programlisting>
@@ -312,7 +312,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           lxc-attach -n container &#045;&#045; /etc/init.d/cron restart
         </programlisting>
         -->
-        実行中の Debian コンテナの cron サービスを再起動するには，以下のように実行します．
+        実行中の Debian コンテナの cron サービスを再起動するには、以下のように実行します。
         <programlisting>
           lxc-attach -n container -- /etc/init.d/cron restart
         </programlisting>
@@ -327,7 +327,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           lxc-attach -n container -e &#045;&#045; /sbin/ip link delete eth1
         </programlisting>
         -->
-        NET_ADMIN ケーパビリティを持たない実行中のコンテナのネットワークインターフェース eth1 の動作を停止させるには，ケーパビリティを増加させるために <option>-e</option> オプションを指定し，<command>ip</command> ツールがインストールされていることを前提に，以下のように実行します．
+        NET_ADMIN ケーパビリティを持たない実行中のコンテナのネットワークインターフェース eth1 の動作を停止させるには、ケーパビリティを増加させるために <option>-e</option> オプションを指定し、<command>ip</command> ツールがインストールされていることを前提に、以下のように実行します。
         <programlisting>
           lxc-attach -n container -e -- /sbin/ip link delete eth1
         </programlisting>
@@ -344,9 +344,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       details. <command>lxc-attach</command> will fail in that case if
       used with an unpatched kernel of version 3.7 and prior.
       -->
-      (pid とマウント名前空間を含む) コンテナに対する完全なアタッチを行うには 3.8 以上，もしくはパッチを適用したカーネルが必要となります．
-      詳しくは lxc のウェブサイトを参照してください．
-      パッチが当たっていない 3.8 より小さなバージョンのカーネルを使った場合は，<command>lxc-attach</command> の実行は失敗するでしょう．
+      (pid とマウント名前空間を含む) コンテナに対する完全なアタッチを行うには 3.8 以上、もしくはパッチを適用したカーネルが必要となります。
+      詳しくは lxc のウェブサイトを参照してください。
+      パッチが当たっていない 3.8 より小さなバージョンのカーネルを使った場合は、<command>lxc-attach</command> の実行は失敗するでしょう。
     </para>
     <para>
       <!--
@@ -356,14 +356,14 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <replaceable>NETWORK</replaceable>, <replaceable>IPC</replaceable>
       and <replaceable>UTSNAME</replaceable>.
       -->
-      しかし，もし <option>-s</option> を使用して，アタッチするものを <replaceable>NETWORK</replaceable>, <replaceable>IPC</replaceable>, <replaceable>UTSNAME</replaceable> の 1 つか複数の名前空間に限定して使用すれば，バージョン 3.0 以上のパッチを適用していないカーネルでもアタッチが成功するでしょう．
+      しかし、もし <option>-s</option> を使用して、アタッチするものを <replaceable>NETWORK</replaceable>, <replaceable>IPC</replaceable>, <replaceable>UTSNAME</replaceable> の 1 つか複数の名前空間に限定して使用すれば、バージョン 3.0 以上のパッチを適用していないカーネルでもアタッチが成功するでしょう。
     </para>
     <para>
       <!--
       Attaching to user namespaces is supported by kernel 3.8 or higher
       with enabling user namespace.
       -->
-      ユーザ名前空間へのアタッチは，ユーザ名前空間機能を有効にした 3.8 以上のカーネルでサポートされます．
+      ユーザ名前空間へのアタッチは、ユーザ名前空間機能を有効にした 3.8 以上のカーネルでサポートされます。
     </para>
   </refsect1>
 
@@ -382,10 +382,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       accessing <replaceable>/proc</replaceable> or
       <replaceable>/sys</replaceable>.
       -->
-      Linux の <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> ファイルシステムは名前空間によって影響を受けるある程度の情報を持っています．
-      これは <replaceable>/proc</replaceable> 内のプロセス ID の名前のディレクトリや，<replaceable>/sys/class/net</replaceable> 内のネットワークインターフェース名のディレクトリなどです．
-      擬似ファイルシステムをマウントしているプロセスの名前空間が，どのような情報を表示するかを決定します．
-      <replaceable>/proc</replaceable> や <replaceable>/sys</replaceable> にアクセスしているプロセスの名前空間が決定するのではありません．
+      Linux の <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> ファイルシステムは名前空間によって影響を受けるある程度の情報を持っています。
+      これは <replaceable>/proc</replaceable> 内のプロセス ID の名前のディレクトリや、<replaceable>/sys/class/net</replaceable> 内のネットワークインターフェース名のディレクトリなどです。
+      擬似ファイルシステムをマウントしているプロセスの名前空間が、どのような情報を表示するかを決定します。
+      <replaceable>/proc</replaceable> や <replaceable>/sys</replaceable> にアクセスしているプロセスの名前空間が決定するのではありません。
     </para>
     <para>
       <!--
@@ -398,8 +398,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <replaceable>/sys/class/net</replaceable> and attaching to just
       the network namespace.
       -->
-      <option>-s</option> を使ってコンテナの pid 名前空間のみをアタッチし，マウント名前空間 (これはコンテナの <replaceable>/proc</replaceable> を含み，ホストのは含まないでしょう) はアタッチしない場合，<option>/proc</option> のコンテンツはコンテナのものではなく，ホストのものとなります．
-      似たような事例として，ネットワーク名前空間のみをアタッチして，<replaceable>/sys/class/net</replaceable> のコンテンツを読んだ場合も同じような事が起こるでしょう．
+      <option>-s</option> を使ってコンテナの pid 名前空間のみをアタッチし、マウント名前空間 (これはコンテナの <replaceable>/proc</replaceable> を含み、ホストのは含まないでしょう) はアタッチしない場合、<option>/proc</option> のコンテンツはコンテナのものではなく、ホストのものとなります。
+      似たような事例として、ネットワーク名前空間のみをアタッチして、<replaceable>/sys/class/net</replaceable> のコンテンツを読んだ場合も同じような事が起こるでしょう。
     </para>
     <para>
       <!--
@@ -414,9 +414,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       except for the <replaceable>/proc</replaceable> and
       <replaceable>/sys</replaceable> filesystems.
       -->
-      この問題への対処のために，<option>-R</option> オプションが <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> が提供されています．
-      これにより，アタッチするプロセスのネットワーク/pid 名前空間のコンテキストを反映させることができます．ホストの実際のファイルシステムに影響を与えないために，実行前にはマウント名前空間は unshare されます (<command>lxc-unshare</command> のように)．
-      これは，<replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> ファイルシステム以外はホストのマウント名前空間と同じである，新しいマウント名前空間がプロセスに与えられるということです．
+      この問題への対処のために、<option>-R</option> オプションが <replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> が提供されています。
+      これにより、アタッチするプロセスのネットワーク/pid 名前空間のコンテキストを反映させることができます。ホストの実際のファイルシステムに影響を与えないために、実行前にはマウント名前空間は unshare されます (<command>lxc-unshare</command> のように)。
+      これは、<replaceable>/proc</replaceable> と <replaceable>/sys</replaceable> ファイルシステム以外はホストのマウント名前空間と同じである、新しいマウント名前空間がプロセスに与えられるということです。
     </para>
   </refsect1>
 
@@ -428,8 +428,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       be used with care, as it may break the isolation of the containers
       if used improperly.
       -->
-      <option>-e</option> と <option>-s</option> オプションの使用には注意を払うべきです．
-      不適切に使用した場合，コンテナの隔離を破壊してしまう可能性があります．
+      <option>-e</option> と <option>-s</option> オプションの使用には注意を払うべきです。
+      不適切に使用した場合、コンテナの隔離を破壊してしまう可能性があります。
     </para>
   </refsect1>
 

--- a/doc/ja/lxc-autostart.sgml.in
+++ b/doc/ja/lxc-autostart.sgml.in
@@ -76,10 +76,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             and the list of affected containers (and if relevant, delays)
             will be shown.
             -->
-          <command>lxc-autostart</command> は lxc.start.auto が設定されたコンテナの処理を行います．
-          ユーザがコンテナの開始，シャットダウン，kill，再起動を，設定した時間間隔で，設定した順番で行えるようにします．
-          lxc.group でのフィルタリングによって，もしくは定義された全てのコンテナを実行します．
-          何の動作も行わず，対象のコンテナ (とコンテナに設定された起動待機時間) のリストを表示するリストモードを外部ツールから使用することも可能です．
+          <command>lxc-autostart</command> は lxc.start.auto が設定されたコンテナの処理を行います。
+          ユーザがコンテナの開始、シャットダウン、kill、再起動を、設定した時間間隔で、設定した順番で行えるようにします。
+          lxc.group でのフィルタリングによって、もしくは定義された全てのコンテナを実行します。
+          何の動作も行わず、対象のコンテナ (とコンテナに設定された起動待機時間) のリストを表示するリストモードを外部ツールから使用することも可能です。
         </para>
 
         <para>
@@ -94,9 +94,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             of time to wait for the container to complete the shutdown
             or reboot.
             -->
-          <optional>-r</optional>, <optional>-s</optional>, <optional>-k</optional> オプションは実行する動作を指定します．何も指定しない場合は，コンテナを起動します．
-          <optional>-a</optional>, <optional>-g</optional> は，どのコンテナを対象にするかを指定するのに使います．デフォルトでは，lxc.group が指定されていないコンテナにだけが対象となります．
-          <optional>-t TIMEOUT</optional> はコンテナが完全にシャットダウンもしくはリブートを待つ最大時間を指定します．
+          <optional>-r</optional>, <optional>-s</optional>, <optional>-k</optional> オプションは実行する動作を指定します。何も指定しない場合は、コンテナを起動します。
+          <optional>-a</optional>, <optional>-g</optional> は、どのコンテナを対象にするかを指定するのに使います。デフォルトでは、lxc.group が指定されていないコンテナにだけが対象となります。
+          <optional>-t TIMEOUT</optional> はコンテナが完全にシャットダウンもしくはリブートを待つ最大時間を指定します。
         </para>
     </refsect1>
 
@@ -112,7 +112,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                       <!--
                         Request a reboot of the container.
                         -->
-                      コンテナのリブートを要求します．
+                      コンテナのリブートを要求します。
                     </para>
                 </listitem>
             </varlistentry>
@@ -130,7 +130,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                         this period, it will be killed as with the
                         <optional>-k kill</optional> option.
                         -->
-                      クリーンなシャットダウンを要求します．もし，<optional>-t timeout</optional> が 0 より大きい場合で，コンテナがこの時間内にシャットダウンしない場合は，コンテナは <optional>-k kill</optional> オプションを指定した時のように kill されます．
+                      クリーンなシャットダウンを要求します。もし、<optional>-t timeout</optional> が 0 より大きい場合で、コンテナがこの時間内にシャットダウンしない場合は、コンテナは <optional>-k kill</optional> オプションを指定した時のように kill されます。
                     </para>
                 </listitem>
             </varlistentry>
@@ -145,7 +145,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                         Rather than requesting a clean shutdown of the
                         container, explicitly kill all tasks in the container.
                         -->
-                      コンテナのクリーンなシャットダウンを要求するのではなく，明確にコンテナの全てのタスクを kill します．
+                      コンテナのクリーンなシャットダウンを要求するのではなく、明確にコンテナの全てのタスクを kill します。
                     </para>
                 </listitem>
             </varlistentry>
@@ -160,7 +160,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                         Rather than performing the action, just print
                         the container name.
                         -->
-                      実際の動作は行わず，コンテナ名の表示だけを行います．
+                      実際の動作は行わず、コンテナ名の表示だけを行います。
                     </para>
                 </listitem>
             </varlistentry>
@@ -174,7 +174,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                       <!--
                         Wait TIMEOUT seconds before hard-stopping the container.
                         -->
-                      コンテナの強制停止まで TIMEOUT 秒待ちます．
+                      コンテナの強制停止まで TIMEOUT 秒待ちます。
                     </para>
                 </listitem>
             </varlistentry>
@@ -189,7 +189,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                         Comma separate list of groups to select
                         (defaults to those without a lxc.group).
                         -->
-                      対象にするコンテナのグループのカンマ区切りのリスト (デフォルトでは lxc.group 指定のないコンテナが対象になります)．
+                      対象にするコンテナのグループのカンマ区切りのリスト (デフォルトでは lxc.group 指定のないコンテナが対象になります)。
                     </para>
                 </listitem>
             </varlistentry>
@@ -203,7 +203,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                       <!--
                         Ignore lxc.group and select all auto-started containers.
                         -->
-                      lxc.group の指定を無視して，自動起動が設定されているコンテナを全て選択します．
+                      lxc.group の指定を無視して、自動起動が設定されているコンテナを全て選択します。
                     </para>
                 </listitem>
             </varlistentry>

--- a/doc/ja/lxc-cgroup.sgml.in
+++ b/doc/ja/lxc-cgroup.sgml.in
@@ -73,8 +73,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       current value of the <replaceable>state-object</replaceable> is
       displayed; otherwise it is set.
       -->
-      <command>lxc-cgroup</command> は，コンテナの cgroup の一致するサブシステム (例えば 'cpuset') の <replaceable>state-object</replaceable> (例えば 'cpuset.cpus') の値を取得したり，値を設定したりします．
-      <optional>value</optional> が指定されないときは，<replaceable>state-object</replaceable> の値を表示します．指定されている場合は値を設定します．
+      <command>lxc-cgroup</command> は、コンテナの cgroup の一致するサブシステム (例えば 'cpuset') の <replaceable>state-object</replaceable> (例えば 'cpuset.cpus') の値を取得したり、値を設定したりします。
+      <optional>value</optional> が指定されないときは、<replaceable>state-object</replaceable> の値を表示します。指定されている場合は値を設定します。
     </para>
 
     <para>
@@ -84,8 +84,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       kernel, or that the corresponding subsystem is contained in any
       mounted cgroup hierarchy.
       -->
-      <command>lxc-cgroup</command> は <replaceable>state-object</replaceable> が実行中のカーネルで有効かどうかのチェックを行いません．
-      また，指定したサブシステムがマウントされた cgroup の階層構造に含まれているかどうかのチェックを行いません．
+      <command>lxc-cgroup</command> は <replaceable>state-object</replaceable> が実行中のカーネルで有効かどうかのチェックを行いません。
+      また、指定したサブシステムがマウントされた cgroup の階層構造に含まれているかどうかのチェックを行いません。
     </para>
 
   </refsect1>
@@ -103,7 +103,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    Specify the state object name.
             -->
-            (cgroup の) 状態オブジェクト (state object) 名を指定します．
+            (cgroup の) 状態オブジェクト (state object) 名を指定します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -117,7 +117,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    Specify the value to assign to the state object.
             -->
-            (cgroup の) 状態オブジェクト (state object) に設定する値を指定します．
+            (cgroup の) 状態オブジェクト (state object) に設定する値を指定します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -138,7 +138,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  display the allowed devices to be used.
           -->
-          使用が許可されているデバイスを表示します．
+          使用が許可されているデバイスを表示します。
 	</para>
 	</listitem>
       </varlistentry>
@@ -150,7 +150,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  assign the processors 0 and 3 to the container.
           -->
-          コンテナにプロセッサ番号 0 と 3 のプロセッサを割り当てます．
+          コンテナにプロセッサ番号 0 と 3 のプロセッサを割り当てます。
 	</para>
 	</listitem>
       </varlistentry>
@@ -170,7 +170,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    The container is not running.
             -->
-            コンテナが実行されていません．
+            コンテナが実行されていません。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-checkconfig.sgml.in
+++ b/doc/ja/lxc-checkconfig.sgml.in
@@ -62,7 +62,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-checkconfig</command> check the current kernel for
       lxc support
       -->
-      <command>lxc-checkconfig</command> は，現在のカーネルが lxc に必要な機能をサポートしているかをチェックします．
+      <command>lxc-checkconfig</command> は、現在のカーネルが lxc に必要な機能をサポートしているかをチェックします。
     </para>
   </refsect1>
 
@@ -77,9 +77,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           check the current kernel.
           CONFIG can be set in the environment to an alternate location.
           -->
-          現在のカーネルをチェックします．
-          CONFIG 環境変数に別の場所を設定することも可能です．
-          (訳注: カーネルビルド時の設定オプションのファイルの位置を指定します．デフォルトは /proc/config.gz です．)
+          現在のカーネルをチェックします。
+          CONFIG 環境変数に別の場所を設定することも可能です。
+          (訳注: カーネルビルド時の設定オプションのファイルの位置を指定します。デフォルトは /proc/config.gz です。)
         </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-clone.sgml.in
+++ b/doc/ja/lxc-clone.sgml.in
@@ -98,13 +98,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       this includes only aufs, btrfs, lvm, overlayfs and zfs.  LVM devices do not support
       snapshots of snapshots.
       -->
-      <command>lxc-clone</command> は，新しいコンテナを既に存在するコンテナのクローンとして作製します．
-      クローンは 2 つのタイプをサポートします: コピーとスナップショットです．
-      コピータイプのクローンは元のコンテナから新しいコンテナへ root ファイルシステムをコピーします．
-      スナップショットファイルシステムは，バッキングストアのスナップショット機能を使い，元のコンテナの非常に小さな copy-on-write でのスナップショットを作製します．
-      スナップショットでのクローンは，新しいコンテナのバッキングストアとしてスナップショット機能のサポートが必要になります．
-      現時点では，このようなバッキングストアとしては aufs, btrfs, lvm, overlayfs, zfs のみをサポートします．
-      LVM デバイスはスナップショットのスナップショットはサポートしていません．
+      <command>lxc-clone</command> は、新しいコンテナを既に存在するコンテナのクローンとして作製します。
+      クローンは 2 つのタイプをサポートします: コピーとスナップショットです。
+      コピータイプのクローンは元のコンテナから新しいコンテナへ root ファイルシステムをコピーします。
+      スナップショットファイルシステムは、バッキングストアのスナップショット機能を使い、元のコンテナの非常に小さな copy-on-write でのスナップショットを作製します。
+      スナップショットでのクローンは、新しいコンテナのバッキングストアとしてスナップショット機能のサポートが必要になります。
+      現時点では、このようなバッキングストアとしては aufs, btrfs, lvm, overlayfs, zfs のみをサポートします。
+      LVM デバイスはスナップショットのスナップショットはサポートしていません。
     </para>
 
     <para>
@@ -115,9 +115,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       containers.  This can be requested by using (for overlayfs) the
       <replaceable>-B overlayfs</replaceable> arguments.
       -->
-      新しいコンテナのバッキングストアは，オーバーレイタイプのコンテナを除いては元のコンテナのタイプと同じになります．
-      ディレクトリバックエンドのコンテナのスナップショットを aufs もしくは overlayfs で作成することは可能です．
-      例えば，overlayfs の場合は <replaceable>-B overlayfs</replaceable> という引数を使って指定することが可能です．
+      新しいコンテナのバッキングストアは、オーバーレイタイプのコンテナを除いては元のコンテナのタイプと同じになります。
+      ディレクトリバックエンドのコンテナのスナップショットを aufs もしくは overlayfs で作成することは可能です。
+      例えば、overlayfs の場合は <replaceable>-B overlayfs</replaceable> という引数を使って指定することが可能です。
     </para>
 
     <para>
@@ -127,7 +127,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <replaceable>-o</replaceable> and <replaceable>-n</replaceable> options,
       respectively.
       -->
-      元のコンテナと新しいコンテナの名前は，全てのオプションの後に順番に与えることも，<replaceable>-o</replaceable> と <replaceable>-n</replaceable> オプションを使ってそれぞれ指定することも可能です．
+      元のコンテナと新しいコンテナの名前は、全てのオプションの後に順番に与えることも、<replaceable>-o</replaceable> と <replaceable>-n</replaceable> オプションを使ってそれぞれ指定することも可能です。
     </para>
 
   </refsect1>
@@ -147,7 +147,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             The new container's rootfs should be a LVM or btrfs snapshot of the original.
             -->
-            新しいコンテナの rootfs は，オリジナルの LVM か btrfs のスナップショットになります．
+            新しいコンテナの rootfs は、オリジナルの LVM か btrfs のスナップショットになります。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -162,7 +162,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Do not change the hostname of the container (in the root
 	    filesystem).
             -->
-            (root ファイルシステム内では) コンテナのホスト名を変更しません．
+            (root ファイルシステム内では) コンテナのホスト名を変更しません。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -177,7 +177,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Use the same MAC address as the original container, rather than
 	    generating a new random one.
             -->
-            新しい MAC アドレスをランダムに生成せずに，元のコンテナと同じ MAC アドレスを使用します．
+            新しい MAC アドレスをランダムに生成せずに、元のコンテナと同じ MAC アドレスを使用します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -192,8 +192,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Copy all mount hooks into the new container's directory, and
 	    update any lxcpaths and container names as needed.
             -->
-            全てのマウントフックを新しいコンテナのディレクトリにコピーします．
-            そして，lxcpath とコンテナ名を必要に応じて更新します．
+            全てのマウントフックを新しいコンテナのディレクトリにコピーします。
+            そして、lxcpath とコンテナ名を必要に応じて更新します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -209,8 +209,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    block device.  By default, the new device will be made the
 	    same size as the original.
             -->
-            ブロックデバイスのバックエンドのコンテナの場合，新しいブロックデバイスのサイズ．
-            デフォルトでは，新しいデバイスは元のデバイスと同じサイズとなります．
+            ブロックデバイスのバックエンドのコンテナの場合、新しいブロックデバイスのサイズ。
+            デフォルトでは、新しいデバイスは元のデバイスと同じサイズとなります。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -225,7 +225,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    The lxcpath of the original container.  By default, the system
 	    wide configured lxcpath will be used.
             -->
-            オリジナルのコンテナの lxcpath．デフォルトでは，システム全体で設定された lxcpath が使われます．
+            オリジナルのコンテナの lxcpath。デフォルトでは、システム全体で設定された lxcpath が使われます。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -242,10 +242,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    changing lxcpaths may not be possible, as subvolume snapshots
 	    must be in the same btrfs filesystem.
             -->
-            新しいコンテナの lxcpath．
-            デフォルトでは，オリジナルの lxcpath と同じものが使われます．
-            btrfs のスナップショットの場合は注意が必要で，lxcpath の変更はできない可能性があります．
-            これは subvolume のスナップショットが，同じ btrfs ファイルシステム上に存在しなければならないからです．
+            新しいコンテナの lxcpath。
+            デフォルトでは、オリジナルの lxcpath と同じものが使われます。
+            btrfs のスナップショットの場合は注意が必要で、lxcpath の変更はできない可能性があります。
+            これは subvolume のスナップショットが、同じ btrfs ファイルシステム上に存在しなければならないからです。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -264,10 +264,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    backing stores include dir (directory), aufs, btrfs, lvm, zfs, loop
 	    and overlayfs.
             -->
-            新しいコンテナで元のコンテナと違うバッキングストアを使う場合のバッキングストアを選択します．
-            デフォルトでは元のコンテナと同じものが使われます．
-            現時点では，バッキングストアの変更は，ディレクトリバックエンドのコンテナに対する aufs と overlayfs のスナップショットに対してのみサポートされます．
-            有効なバッキングストアは dir(directory), aufs, btrfs, lvm, zfs, loop, overlayfs です．
+            新しいコンテナで元のコンテナと違うバッキングストアを使う場合のバッキングストアを選択します。
+            デフォルトでは元のコンテナと同じものが使われます。
+            現時点では、バッキングストアの変更は、ディレクトリバックエンドのコンテナに対する aufs と overlayfs のスナップショットに対してのみサポートされます。
+            有効なバッキングストアは dir(directory), aufs, btrfs, lvm, zfs, loop, overlayfs です。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -281,7 +281,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    The name of the original container to clone.
             -->
-            クローンしたい元のコンテナの名前．
+            クローンしたい元のコンテナの名前。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -295,7 +295,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    The name of the new container to create.
             -->
-            作製する新しいコンテナの名前．
+            作製する新しいコンテナの名前。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -321,11 +321,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <filename>LXC_SRC_NAME</filename>, and the path or device on which
       the rootfs is located is in <filename>LXC_ROOTFS_PATH</filename>.
       -->
-      クローンされるコンテナに 1 つ以上の <filename>lxc.hook.clone</filename> の指定が存在する場合，指定されたフックは新しいコンテナに対して呼ばれます．
-      クローンフックに渡される最初の 3 つの引数は，コンテナ名，セクション ('lxc')，フックタイプ ('clone') となります．
-      <command>lxc-clone</command> に渡される追加の引数は，フックプログラムに渡される引数の 4 番目以降となります．
-      <filename>LXC_ROOTFS_MOUNT</filename> 環境変数には，コンテナの root ファイルシステムがマウントされるパスが与えられます．
-      設定ファイルのパス名は <filename>LXC_CONFIG_FILE</filename> に，新しいコンテナ名は <filename>LXC_NAME</filename>，古いコンテナ名は <filename>LXC_SRC_NAME</filename> に，rootfs のあるパスまたはデバイスは <filename>LXC_ROOTFS_PATH</filename> に保存されます．
+      クローンされるコンテナに 1 つ以上の <filename>lxc.hook.clone</filename> の指定が存在する場合、指定されたフックは新しいコンテナに対して呼ばれます。
+      クローンフックに渡される最初の 3 つの引数は、コンテナ名、セクション ('lxc')、フックタイプ ('clone') となります。
+      <command>lxc-clone</command> に渡される追加の引数は、フックプログラムに渡される引数の 4 番目以降となります。
+      <filename>LXC_ROOTFS_MOUNT</filename> 環境変数には、コンテナの root ファイルシステムがマウントされるパスが与えられます。
+      設定ファイルのパス名は <filename>LXC_CONFIG_FILE</filename> に、新しいコンテナ名は <filename>LXC_NAME</filename>、古いコンテナ名は <filename>LXC_SRC_NAME</filename> に、rootfs のあるパスまたはデバイスは <filename>LXC_ROOTFS_PATH</filename> に保存されます。
     </para>
   </refsect1>
 

--- a/doc/ja/lxc-config.sgml.in
+++ b/doc/ja/lxc-config.sgml.in
@@ -66,7 +66,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             configuration and lets you list all valid keys or query
             individual keys for their value.
             -->
-          <command>lxc-config</command> は LXC のシステム設定の有効な設定項目名を一覧表示したり，個々の設定項目に設定されている値を表示したりします．
+          <command>lxc-config</command> は LXC のシステム設定の有効な設定項目名を一覧表示したり、個々の設定項目に設定されている値を表示したりします。
         </para>
     </refsect1>
 
@@ -82,7 +82,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                       <!--
                         List all supported keys.
                         -->
-                      サポートされている全ての設定項目を表示します．
+                      サポートされている全ての設定項目を表示します。
                     </para>
                 </listitem>
             </varlistentry>
@@ -96,7 +96,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                       <!--
                         Query the value of the specified key.
                         -->
-                      指定した設定項目に設定されている値を表示します．
+                      指定した設定項目に設定されている値を表示します。
                     </para>
                 </listitem>
             </varlistentry>

--- a/doc/ja/lxc-console.sgml.in
+++ b/doc/ja/lxc-console.sgml.in
@@ -70,7 +70,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       container specified as parameter, this command will launch a
       console allowing to log on the container.
       -->
-      パラメータで指定したコンテナで tty サービスが設定され，利用可能である場合，このコマンドはコンテナにログイン出来るコンソールを起動します．
+      パラメータで指定したコンテナで tty サービスが設定され、利用可能である場合、このコマンドはコンテナにログイン出来るコンソールを起動します。
     </para>
 
     <para>
@@ -80,8 +80,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       has been launched four times each taking a different tty, the
       fifth command will fail because no console will be available.
       -->
-      利用可能な tty は，このコマンドが取得した空いている tty です．
-      これは，コンテナに 4 つの利用可能な tty がある場合，コマンドは 4 個までそれぞれ異なる tty を取得して開きます．5 回目のコマンドは利用可能なコンソールがないため，失敗します．
+      利用可能な tty は、このコマンドが取得した空いている tty です。
+      これは、コンテナに 4 つの利用可能な tty がある場合、コマンドは 4 個までそれぞれ異なる tty を取得して開きます。5 回目のコマンドは利用可能なコンソールがないため、失敗します。
     </para>
 
     <para>
@@ -90,8 +90,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       broken, the command can be launched again and regain the tty at
       the state it was before the disconnection.
       -->
-      コマンドは tty に接続します．
-      もし，接続が失われたり，切断された場合，コマンドは再度起動し，切断前の状態で tty の再取得をしようとします．
+      コマンドは tty に接続します。
+      もし、接続が失われたり、切断された場合、コマンドは再度起動し、切断前の状態で tty の再取得をしようとします。
     </para>
 
     <para>
@@ -100,7 +100,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       to the container's /dev/console instead of its
       dev/tty&lt;<replaceable>ttynum</replaceable>&gt;.
       -->
-      <replaceable>ttynum</replaceable> を 0 に設定すると，dev/tty&lt;<replaceable>ttynum</replaceable>&gt;の代わりにコンテナの /dev/console に接続します．
+      <replaceable>ttynum</replaceable> を 0 に設定すると、dev/tty&lt;<replaceable>ttynum</replaceable>&gt;の代わりにコンテナの /dev/console に接続します。
     </para>
 
     <para>
@@ -108,8 +108,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       A keyboard escape sequence may be used to disconnect from the tty
       and quit lxc-console. The default escape sequence is &lt;Ctrl+a q&gt;.
       -->
-      tty からの接続を切断し，lxc-console を抜ける時に，キーボードのエスケープシーケンスを使います．
-      デフォルトのエスケープシーケンスは &lt;Ctrl+a q&gt; です．
+      tty からの接続を切断し、lxc-console を抜ける時に、キーボードのエスケープシーケンスを使います。
+      デフォルトのエスケープシーケンスは &lt;Ctrl+a q&gt; です。
     </para>
 
   </refsect1>
@@ -130,9 +130,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             This may be given as '^letter' or just 'letter'. For example
             to use &lt;Ctrl+b q&gt; as the escape sequence use -e '^b'.
             -->
-            &lt;Ctrl a&gt; の代わりに使用するエスケープシーケンスのプレフィックスを指定します．
-            これは '^文字' または単なる '文字' で指定します．
-            例えば，&lt;Ctrl+b q&gt; をエスケープシーケンスとして使うには -e '^b' とします．
+            &lt;Ctrl a&gt; の代わりに使用するエスケープシーケンスのプレフィックスを指定します。
+            これは '^文字' または単なる '文字' で指定します。
+            例えば、&lt;Ctrl+b q&gt; をエスケープシーケンスとして使うには -e '^b' とします。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -147,8 +147,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    specified the next available tty number will be automatically
 	    chosen by the container.
             -->
-            接続する tty の番号か，コンソールに接続するために 0 を指定します．
-            指定しない場合は，次に利用可能な tty 番号を自動的にコンテナが選択します．
+            接続する tty の番号か、コンソールに接続するために 0 を指定します。
+            指定しない場合は、次に利用可能な tty 番号を自動的にコンテナが選択します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -173,8 +173,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    use the console. For example, the container belongs to
 	    user "foo" and "bar" is trying to open a console to it.
             -->
-            利用可能な tty がないか，コンソールを使うのに十分な権限がありません．
-            例えば，コンテナが "foo" ユーザの所有であるのに，"bar" ユーザがコンソールを開こうとしている場合などです．
+            利用可能な tty がないか、コンソールを使うのに十分な権限がありません。
+            例えば、コンテナが "foo" ユーザの所有であるのに、"bar" ユーザがコンソールを開こうとしている場合などです。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-create.sgml.in
+++ b/doc/ja/lxc-create.sgml.in
@@ -74,15 +74,15 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       is used to specify the container to be used with the different
       lxc commands.
       -->
-      <command>lxc-create</command> は，設定情報とユーザ情報が保存されているシステムオブジェクトを作成します．
-      <replaceable>name</replaceable> で指定された名前が，他の lxc コマンドで，コンテナを特定する名前として使われます．
+      <command>lxc-create</command> は、設定情報とユーザ情報が保存されているシステムオブジェクトを作成します。
+      <replaceable>name</replaceable> で指定された名前が、他の lxc コマンドで、コンテナを特定する名前として使われます。
     </para>
     <para>
       <!--
       The object is a directory created in <filename>@LXCPATH@</filename>
       and identified by its name.
       -->
-      オブジェクトは <filename>@LXCPATH@</filename> 内に作られる，自身の名前がついたディレクトリです．
+      オブジェクトは <filename>@LXCPATH@</filename> 内に作られる、自身の名前がついたディレクトリです。
     </para>
 
     <para>
@@ -92,8 +92,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       contains information, the more the container is isolated and
       the more the application is jailed.
       -->
-      オブジェクトは，アプリケーションが使用したり，参照したりする様々なリソースの定義です．
-      設定ファイルがより多くの情報を持つほど，コンテナやアプリケーションはより隔離されたものになります．
+      オブジェクトは、アプリケーションが使用したり、参照したりする様々なリソースの定義です。
+      設定ファイルがより多くの情報を持つほど、コンテナやアプリケーションはより隔離されたものになります。
     </para>
 
     <para>
@@ -102,7 +102,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       is not specified, the container will be created with the default
       isolation: processes, sysv ipc and mount points.
       -->
-      設定ファイルが <replaceable>config_file</replaceable> で指定されない場合，コンテナはデフォルトの隔離状態で作られます: プロセス，sysv ipc，マウントポイントです．
+      設定ファイルが <replaceable>config_file</replaceable> で指定されない場合、コンテナはデフォルトの隔離状態で作られます: プロセス、sysv ipc、マウントポイントです。
     </para>
   </refsect1>
 
@@ -120,7 +120,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Specify the configuration file to configure the virtualization
 	    and isolation functionalities for the container.
             -->
-            コンテナの仮想化と隔離機能を設定するための設定ファイルを指定します．
+            コンテナの仮想化と隔離機能を設定するための設定ファイルを指定します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -140,10 +140,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Alternatively, the full path to an executable template script
 	    can also be passed as a parameter.
             -->
-            <replaceable>template</replaceable> は lxc-create コマンドが呼び出す，存在する 'lxc-template' スクリプトの短い名前です．
-            例えば，busybox, debian, fedora, ubuntu, sshd があります．
-            期待されるスクリプトの構造の詳細は，<filename>@LXCTEMPLATEDIR@</filename> 内の例を参照してください．
-            加えて，実行可能なテンプレートスクリプトへのフルパスも指定することが可能です．
+            <replaceable>template</replaceable> は lxc-create コマンドが呼び出す、存在する 'lxc-template' スクリプトの短い名前です。
+            例えば、busybox, debian, fedora, ubuntu, sshd があります。
+            期待されるスクリプトの構造の詳細は、<filename>@LXCTEMPLATEDIR@</filename> 内の例を参照してください。
+            加えて、実行可能なテンプレートスクリプトへのフルパスも指定することが可能です。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -182,26 +182,26 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    <replaceable>&#045;&#045;fssize SIZE</replaceable> will create a LV (and
 	    filesystem) of size SIZE rather than the default, which is 1G.
             -->
-            'backingstore' には 'none' か 'dir' か 'lvm' か 'btrfs' か 'best' のいずれかを指定します．
-            デフォルトは 'none' で，コンテナのルートファイルシステムが <filename>@LXCPATH@/container/rootfs</filename> 以下のディレクトリであることを意味します．
-'dir' は 'none' と同じ意味ですが，オプションとして <replaceable>--dir ROOTFS</replaceable> を指定することも可能です．
-            このオプションは，デフォルトの代わりに特定のパス以下にコンテナの rootfs を置くということになります．
-            'btrfs' が指定された場合，ターゲットのファイルシステムは btrfs でなければいけません．
-            そして，コンテナの rootfs は新しい subvolume として作製されます．
-            このことにより，スナップショットによるクローンが作製可能になりますが，結果として rsync --one-filesystem が，別々のファイルシステムとして取り扱ってしまうことにもなります．
-            backingstore が 'lvm' である場合，lvm ブロックデバイスを使用します．
-            この時，以下のオプションが有効になります: <replaceable>--lvname lvname1</replaceable> はデフォルト値のコンテナ名の LV の代わりに <filename>lvname1</filename> という名前の LV を作成します．
-            <replaceable>--vgname vgname1</replaceable> は，デフォルト値である <filename>lxc</filename> という volume group の代わりに <filename>vgname1</filename> という名前の volume group 内に LV を作成します．
-            <replaceable>--thinpool thinpool1</replaceable> は，デフォルトである <filename>lxc</filename> のという名前のプールの代わりに <filename>thinpool1</filename> という名前のプール内にシンプロビジョニングされたボリュームとして LV を作成します．
-            <replaceable>--fstype FSTYPE</replaceable> は LV 上のファイルシステムをデフォルト値である ext4 の代わりに FSTYPE で指定したもので作成します．
-            <replaceable>--fssize SIZE</replaceable> はデフォルト値である 1G の代わりに SIZE で指定したサイズで LV を作成します．
+            'backingstore' には 'none' か 'dir' か 'lvm' か 'btrfs' か 'best' のいずれかを指定します。
+            デフォルトは 'none' で、コンテナのルートファイルシステムが <filename>@LXCPATH@/container/rootfs</filename> 以下のディレクトリであることを意味します。
+'dir' は 'none' と同じ意味ですが、オプションとして <replaceable>--dir ROOTFS</replaceable> を指定することも可能です。
+            このオプションは、デフォルトの代わりに特定のパス以下にコンテナの rootfs を置くということになります。
+            'btrfs' が指定された場合、ターゲットのファイルシステムは btrfs でなければいけません。
+            そして、コンテナの rootfs は新しい subvolume として作製されます。
+            このことにより、スナップショットによるクローンが作製可能になりますが、結果として rsync --one-filesystem が、別々のファイルシステムとして取り扱ってしまうことにもなります。
+            backingstore が 'lvm' である場合、lvm ブロックデバイスを使用します。
+            この時、以下のオプションが有効になります: <replaceable>--lvname lvname1</replaceable> はデフォルト値のコンテナ名の LV の代わりに <filename>lvname1</filename> という名前の LV を作成します。
+            <replaceable>--vgname vgname1</replaceable> は、デフォルト値である <filename>lxc</filename> という volume group の代わりに <filename>vgname1</filename> という名前の volume group 内に LV を作成します。
+            <replaceable>--thinpool thinpool1</replaceable> は、デフォルトである <filename>lxc</filename> のという名前のプールの代わりに <filename>thinpool1</filename> という名前のプール内にシンプロビジョニングされたボリュームとして LV を作成します。
+            <replaceable>--fstype FSTYPE</replaceable> は LV 上のファイルシステムをデフォルト値である ext4 の代わりに FSTYPE で指定したもので作成します。
+            <replaceable>--fssize SIZE</replaceable> はデフォルト値である 1G の代わりに SIZE で指定したサイズで LV を作成します。
 	  </para>
 	  <para>
             <!--
 	    If backingstore is 'best', then lxc will try, in order, btrfs,
 	    zfs, lvm, and finally a directory backing store.
             -->
-            backingstore が 'best' の時，lxc は btrfs, zfs, lvm, dir の順に試行します．
+            backingstore が 'best' の時、lxc は btrfs, zfs, lvm, dir の順に試行します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -218,8 +218,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    the template, you can run
 	    <command>lxc-create -t TEMPLATE -h</command>.
             -->
-            これは <replaceable>template-options</replaceable> で指定したものをオプションとしてテンプレートへ渡します．
-            テンプレートでサポートされているオプションを調べるには，<command>lxc-create -t TEMPLATE -h</command> というコマンドが使えます．
+            これは <replaceable>template-options</replaceable> で指定したものをオプションとしてテンプレートへ渡します。
+            テンプレートでサポートされているオプションを調べるには、<command>lxc-create -t TEMPLATE -h</command> というコマンドが使えます。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -245,8 +245,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    the <command>lxc-ls</command> command to list the
 	    available containers on the system.
             -->
-            メッセージの通り，コンテナを作成しようとしたけれども，同じ名前のコンテナが存在しています．
-            <command>lxc-ls</command> コマンドを使って，システム上に存在する利用可能なコンテナのリストが表示できます．
+            メッセージの通り、コンテナを作成しようとしたけれども、同じ名前のコンテナが存在しています。
+            <command>lxc-ls</command> コマンドを使って、システム上に存在する利用可能なコンテナのリストが表示できます。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-destroy.sgml.in
+++ b/doc/ja/lxc-destroy.sgml.in
@@ -68,7 +68,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-destroy</command> destroys the system object
       previously created by the <command>lxc-create</command> command.
       -->
-      <command>lxc-destroy</command> は，<command>lxc-create</command> で以前に作成したシステムオブジェクトを破壊します．
+      <command>lxc-destroy</command> は、<command>lxc-create</command> で以前に作成したシステムオブジェクトを破壊します。
     </para>
 
   </refsect1>
@@ -89,8 +89,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    not specified and the container is running, then
 	    <command>lxc-destroy</command> will be aborted.
             -->
-            コンテナが実行中の場合，まずコンテナを停止させます．
-            このオプションが指定されていない場合でコンテナが実行中の場合，<command>lxc-destroy</command> コマンドは実行を中断します．
+            コンテナが実行中の場合、まずコンテナを停止させます。
+            このオプションが指定されていない場合でコンテナが実行中の場合、<command>lxc-destroy</command> コマンドは実行を中断します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -102,7 +102,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    Use an alternate container path.  The default is @LXCPATH@.
             -->
-            コンテナパスを指定します．デフォルトは @LXCPATH@ です．
+            コンテナパスを指定します。デフォルトは @LXCPATH@ です。
 	  </para>
         </listitem>
       </varlistentry>
@@ -126,9 +126,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    destroyed.You can use the <command>lxc-ls</command>
 	    command to list the available containers on the system.
             -->
-            破壊するために指定したコンテナが見つかりません．
-            おそらくそのコンテナが存在しないのか，既に破壊された後なのでしょう．
-            <command>lxc-ls</command> コマンドを使って，システム上に存在するコンテナのリストを得ることができます．
+            破壊するために指定したコンテナが見つかりません。
+            おそらくそのコンテナが存在しないのか、既に破壊された後なのでしょう。
+            <command>lxc-ls</command> コマンドを使って、システム上に存在するコンテナのリストを得ることができます。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-device.sgml.in
+++ b/doc/ja/lxc-device.sgml.in
@@ -67,7 +67,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <!--
       <command>lxc-device</command> manages devices in running container.
       -->
-      <command>lxc-device</command> は実行中のコンテナのデバイスを管理します．
+      <command>lxc-device</command> は実行中のコンテナのデバイスを管理します。
     </para>
   </refsect1>
 
@@ -83,7 +83,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             The full command help message.
             -->
-            コマンドのヘルプを表示します．
+            コマンドのヘルプを表示します。
           </para>
         </listitem>
       </varlistentry>
@@ -111,7 +111,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             What action to perform. Only 'add' is supported at this point.
             -->
-            実行するアクション．現時点では 'add' のみ指定できます．
+            実行するアクション。現時点では 'add' のみ指定できます。
           </para>
         </listitem>
       </varlistentry>
@@ -127,8 +127,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             It can either be the path to a device under /dev or a network
             interface name.
             -->
-            コンテナに追加するデバイス．
-            /dev 以下のデバイスのパスかネットワークインターフェース名を指定できます．
+            コンテナに追加するデバイス。
+            /dev 以下のデバイスのパスかネットワークインターフェース名を指定できます。
           </para>
         </listitem>
       </varlistentry>
@@ -160,7 +160,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           Creates a /dev/video0 device in container p1 based on the matching
           device on the host.
           -->
-          コンテナ p1 内に，ホスト上でマッチするデバイスに基づいて /dev/video0 デバイスを作製します．
+          コンテナ p1 内に、ホスト上でマッチするデバイスに基づいて /dev/video0 デバイスを作製します。
         </para>
         </listitem>
       </varlistentry>
@@ -172,7 +172,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
            Moves eth0 from the host as eth1 in p1.
            -->
-          eth0 をホストから p1 内の eth1 に移動します．
+          eth0 をホストから p1 内の eth1 に移動します。
         </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-execute.sgml.in
+++ b/doc/ja/lxc-execute.sgml.in
@@ -71,7 +71,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <replaceable>command</replaceable> inside the container
       specified by <replaceable>name</replaceable>.
       -->
-      <command>lxc-execute</command> は指定した <replaceable>command</replaceable> を，<replaceable>name</replaceable> で指定したコンテナ内で実行します．
+      <command>lxc-execute</command> は指定した <replaceable>command</replaceable> を、<replaceable>name</replaceable> で指定したコンテナ内で実行します。
     </para>
     <para>
       <!--
@@ -81,15 +81,15 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       If no configuration is
       defined, the default isolation is used.
       -->
-      このコマンドは，lxc-create コマンドであらかじめ定義した設定，もしくはパラメータとして与えた設定ファイルを元にコンテナをセットアップします．
-      もし設定が定義されていない場合，デフォルトの隔離を使用します．
+      このコマンドは、lxc-create コマンドであらかじめ定義した設定、もしくはパラメータとして与えた設定ファイルを元にコンテナをセットアップします。
+      もし設定が定義されていない場合、デフォルトの隔離を使用します。
     </para>
     <para>
       <!--
       This command is mainly used when you want to quickly launch an
       application in an isolated environment.
       -->
-      このコマンドは主に，素早く単一のアプリケーションを隔離された環境で動作させたい時に使います．
+      このコマンドは主に、素早く単一のアプリケーションを隔離された環境で動作させたい時に使います。
     </para>
     <para>
       <!--
@@ -103,16 +103,16 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       container, <command>lxc-init</command> has the pid 1 and the
       first process of the application has the pid 2.
       -->
-      <command>lxc-execute</command> は，<command>lxc-init</command> を間にはさんで，コンテナ内で特定のコマンドを実行します．
-      lxc-init は，指定されたコマンドが実行された後は，そのコマンドの終了と，そのコマンドから生成された全てのプロセスの終了を待ちます (これにより，コンテナ内でデーモンのサポートが可能になります)．
-      言いかえると，コンテナ内では <command>lxc-init</command> が pid 1 となり，アプリケーションの最初のプロセスの pid が 2 となります．
+      <command>lxc-execute</command> は、<command>lxc-init</command> を間にはさんで、コンテナ内で特定のコマンドを実行します。
+      lxc-init は、指定されたコマンドが実行された後は、そのコマンドの終了と、そのコマンドから生成された全てのプロセスの終了を待ちます (これにより、コンテナ内でデーモンのサポートが可能になります)。
+      言いかえると、コンテナ内では <command>lxc-init</command> が pid 1 となり、アプリケーションの最初のプロセスの pid が 2 となります。
      </para>
      <para>
        <!--
       The above <command>lxc-init</command> is designed to forward received
       signals to the started command.
        -->
-       前述の <command>lxc-init</command> は，受け取ったシグナルを開始したコマンドに送るように設計されています．
+       前述の <command>lxc-init</command> は、受け取ったシグナルを開始したコマンドに送るように設計されています。
      </para>
   </refsect1>
 
@@ -130,7 +130,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Specify the configuration file to configure the virtualization
 	    and isolation functionalities for the container.
             -->
-            コンテナに設定したい仮想化および隔離機能の設定を行う設定ファイルを指定します．
+            コンテナに設定したい仮想化および隔離機能の設定を行う設定ファイルを指定します。
 	  </para>
 	  <para>
             <!--
@@ -138,7 +138,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	   already a configuration file present in the previously created
 	   container (via lxc-create).
             -->
-            もしコンテナ作成前に (lxc-create によって) あらかじめ設定ファイルが指定されている場合であっても，指定した設定ファイルが使われます．
+            もしコンテナ作成前に (lxc-create によって) あらかじめ設定ファイルが指定されている場合であっても、指定した設定ファイルが使われます。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -153,7 +153,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    variable <replaceable>KEY</replaceable>. This overrides any
 	    assignment done in <replaceable>config_file</replaceable>.
             -->
-            設定変数 <replaceable>KEY</replaceable> の値を <replaceable>VAL</replaceable> に設定します．この設定は <replaceable>config_file</replaceable> で設定された値を上書きします．
+            設定変数 <replaceable>KEY</replaceable> の値を <replaceable>VAL</replaceable> に設定します。この設定は <replaceable>config_file</replaceable> で設定された値を上書きします。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -166,8 +166,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    processing. Any arguments after the &#045;&#045; are treated as
 	    arguments to <replaceable>command</replaceable>.
             -->
-            オプション指定の最後の印で，それ以上のオプションの処理を止めます．
-            -- の後の引数は実行する <replaceable>command</replaceable> の引数として扱われます．
+            オプション指定の最後の印で、それ以上のオプションの処理を止めます。
+            -- の後の引数は実行する <replaceable>command</replaceable> の引数として扱われます。
 	  </para>
 	  <para>
             <!--
@@ -175,7 +175,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    to <replaceable>command</replaceable> and don't want
 	    <command>lxc-execute</command> to interpret them.
             -->
-            このオプションは，<replaceable>command</replaceable> にオプションを指定したいときに，<command>lxc-execute</command> がそのオプションを読み取ってほしくないときに役に立ちます．
+            このオプションは、<replaceable>command</replaceable> にオプションを指定したいときに、<command>lxc-execute</command> がそのオプションを読み取ってほしくないときに役に立ちます。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -200,7 +200,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    application. You should stop it before reuse this
 	    container or create a new one.
             -->
-            指定したコンテナが既にアプリケーションを実行中の場合．コンテナを再使用したり，新しく作成する前にコンテナを止める必要があります．
+            指定したコンテナが既にアプリケーションを実行中の場合。コンテナを再使用したり、新しく作成する前にコンテナを止める必要があります。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-freeze.sgml.in
+++ b/doc/ja/lxc-freeze.sgml.in
@@ -70,9 +70,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       command. This command is useful for batch managers to schedule a
       group of processes.
       -->
-      <command>lxc-freeze</command> は，コンテナ内部で実行中のプロセスを全て凍結します．
-      プロセスは <command>lxc-unfreeze</command> コマンドによって明示的に解凍されるまでブロックされます．
-      このコマンドはプロセスのグループをスケジューリングするバッチマネージャに便利なコマンドです．
+      <command>lxc-freeze</command> は、コンテナ内部で実行中のプロセスを全て凍結します。
+      プロセスは <command>lxc-unfreeze</command> コマンドによって明示的に解凍されるまでブロックされます。
+      このコマンドはプロセスのグループをスケジューリングするバッチマネージャに便利なコマンドです。
     </para>
 
   </refsect1>
@@ -92,7 +92,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    The specified container was not created before with
 	    the <command>lxc-create</command> command.
             -->
-            指定したコンテナが <command>lxc-create</command> で作成されておらず存在しません．
+            指定したコンテナが <command>lxc-create</command> で作成されておらず存在しません。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-info.sgml.in
+++ b/doc/ja/lxc-info.sgml.in
@@ -70,7 +70,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-info</command> queries and shows information about a
       container.
       -->
-      <command>lxc-info</command> は，コンテナに関する情報を問い合わせ，表示します．
+      <command>lxc-info</command> は、コンテナに関する情報を問い合わせ、表示します。
     </para>
   </refsect1>
 
@@ -88,7 +88,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             Print a configuration key from the container. This option
             may be given mulitple times to print out multiple key = value pairs.
             -->
-            コンテナの設定値を表示します．このオプションは複数の key = value のペアを表示したい場合には複数回指定することも可能です．
+            コンテナの設定値を表示します。このオプションは複数の key = value のペアを表示したい場合には複数回指定することも可能です。
           </para>
         </listitem>
       </varlistentry>
@@ -102,7 +102,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             Just print the container's state.
             -->
-            コンテナの状態のみを表示します．
+            コンテナの状態のみを表示します。
           </para>
         </listitem>
       </varlistentry>
@@ -116,7 +116,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             Just print the container's pid.
             -->
-            コンテナの pid を表示します．
+            コンテナの pid を表示します。
           </para>
         </listitem>
       </varlistentry>
@@ -130,7 +130,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             Just print the container's IP addresses.
             -->
-            コンテナの IP アドレスを表示します．．
+            コンテナの IP アドレスを表示します。。
           </para>
         </listitem>
       </varlistentry>
@@ -156,18 +156,18 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <manvolnum>5</manvolnum>
             </citerefentry>.
             -->
-            コンテナの統計情報を表示します．
-            パフォーマンスへの影響を考慮して，カーネルメモリの使用量は，カーネルメモリの制限値が設定されない限りはカウントされません．
-            もし，制限が設定されていない場合，<command>lxc-info</command> はカーネルメモリの使用量を 0 と表示します．制限は
+            コンテナの統計情報を表示します。
+            パフォーマンスへの影響を考慮して、カーネルメモリの使用量は、カーネルメモリの制限値が設定されない限りはカウントされません。
+            もし、制限が設定されていない場合、<command>lxc-info</command> はカーネルメモリの使用量を 0 と表示します。制限は
             <programlisting>
             lxc.cgroup.memory.kmem.limit_in_bytes = <replaceable>number</replaceable>
             </programlisting>
-            のように，コンテナの設定ファイルで指定することができます．詳しくは，
+            のように、コンテナの設定ファイルで指定することができます。詳しくは、
             <citerefentry>
               <refentrytitle>lxc.conf</refentrytitle>
               <manvolnum>5</manvolnum>
             </citerefentry>
-            を参照してください．
+            を参照してください。
           </para>
         </listitem>
       </varlistentry>
@@ -182,8 +182,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             Print the container's statistics in raw, non-humanized form. The
             default is to print statistics in humanized form.
             -->
-            コンテナの統計情報を人間が読みやすい形に加工しないでそのまま表示します．
-            デフォルトは人間が読みやすい形の統計情報を表示します．
+            コンテナの統計情報を人間が読みやすい形に加工しないでそのまま表示します。
+            デフォルトは人間が読みやすい形の統計情報を表示します。
           </para>
         </listitem>
       </varlistentry>
@@ -202,7 +202,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             Show information for foo.
             -->
-            foo という名前のコンテナの情報を表示します．
+            foo という名前のコンテナの情報を表示します。
           </para>
         </listitem>
       </varlistentry>
@@ -214,7 +214,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             Show information for all containers whose name starts with ubuntu.
             -->
-            ubuntu という文字列で始まる名前の全てのコンテナの情報を表示します．
+            ubuntu という文字列で始まる名前の全てのコンテナの情報を表示します。
           </para>
         </listitem>
       </varlistentry>
@@ -226,7 +226,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             prints the veth pair name of foo.
             -->
-            コンテナ foo の veth pair を表示します．
+            コンテナ foo の veth pair を表示します。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-ls.sgml.in
+++ b/doc/ja/lxc-ls.sgml.in
@@ -73,7 +73,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-ls</command> list the containers existing on the
       system.
       -->
-      <command>lxc-ls</command> はシステム上に存在するコンテナをリスト表示します．
+      <command>lxc-ls</command> はシステム上に存在するコンテナをリスト表示します。
     </para>
   </refsect1>
 
@@ -89,7 +89,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             Show one entry per line. (default when /dev/stdout isn't a tty)
             -->
-            1 行に 1 エントリ表示します．(/dev/stdout が tty でない場合のデフォルト)
+            1 行に 1 エントリ表示します。(/dev/stdout が tty でない場合のデフォルト)
           </para>
         </listitem>
       </varlistentry>
@@ -103,7 +103,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             List only active containers (same as &#045;&#045;frozen &#045;&#045;running).
             -->
-            アクティブなコンテナのみリスト表示します．(--frozen --running と同じです)
+            アクティブなコンテナのみリスト表示します。(--frozen --running と同じです)
 	  </para>
 	</listitem>
       </varlistentry>
@@ -117,7 +117,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             List only frozen containers.
             -->
-            凍結 (frozen) 状態のコンテナのみをリスト表示します．
+            凍結 (frozen) 状態のコンテナのみをリスト表示します。
           </para>
         </listitem>
       </varlistentry>
@@ -131,7 +131,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             List only running containers.
             -->
-            実行 (running) 状態のコンテナのみをリスト表示します．
+            実行 (running) 状態のコンテナのみをリスト表示します。
           </para>
         </listitem>
       </varlistentry>
@@ -145,7 +145,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             List only stopped containers.
             -->
-            停止状態のコンテナのみをリスト表示します．
+            停止状態のコンテナのみをリスト表示します。
           </para>
         </listitem>
       </varlistentry>
@@ -159,7 +159,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             Use a fancy, column-based output.
             -->
-            装飾付きのカラムベースの出力を使用します．
+            装飾付きのカラムベースの出力を使用します。
           </para>
         </listitem>
       </varlistentry>
@@ -175,8 +175,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             Valid values are: name, state, ipv4, ipv6 and pid
             Default is: name,state,ipv4,ipv6
             -->
-            装飾付き出力で表示するカラムのコンマ区切りのリスト．
-            有効な値は name,state,ipv4,ipv6,pid．
+            装飾付き出力で表示するカラムのコンマ区切りのリスト。
+            有効な値は name,state,ipv4,ipv6,pid。
             デフォルトは name,state,ipv4,ipv6
           </para>
         </listitem>
@@ -191,7 +191,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             Show nested containers.
             -->
-            ネストされたコンテナを表示します．
+            ネストされたコンテナを表示します。
           </para>
         </listitem>
       </varlistentry>
@@ -206,8 +206,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             The filter passed to <command>lxc-ls</command> will be
             applied to the container name. The format is a regular expression.
             -->
-            コンテナ名に対して適用する <command>lxc-ls</command> に与えるフィルタ．
-            フォーマットは正規表現です．
+            コンテナ名に対して適用する <command>lxc-ls</command> に与えるフィルタ。
+            フォーマットは正規表現です。
           </para>
         </listitem>
       </varlistentry>
@@ -227,8 +227,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           list all the containers, listing one per line along with its
           name, state, ipv4 and ipv6 addresses.
           -->
-          全てのコンテナをリスト表示します．
-          一行にはコンテナの名前，状態，IPv4 アドレス，IPv6 アドレスが表示されます．
+          全てのコンテナをリスト表示します。
+          一行にはコンテナの名前、状態、IPv4 アドレス、IPv6 アドレスが表示されます。
         </para>
         </listitem>
       </varlistentry>
@@ -240,7 +240,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  list active containers and display the list in one column.
           -->
-          稼働中のコンテナを一列にリスト表示します．
+          稼働中のコンテナを一列にリスト表示します。
 	</para>
 	</listitem>
       </varlistentry>

--- a/doc/ja/lxc-monitor.sgml.in
+++ b/doc/ja/lxc-monitor.sgml.in
@@ -73,10 +73,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <replaceable>name</replaceable> will default to '.*' which will
       monitor all containers in <command>lxcpath</command>.
       -->
-      <command>lxc-monitor</command> はコンテナの状態を監視します．
-      <replaceable>name</replaceable> をモニタ対象のコンテナを指定するために使うことも可能です．
-      これは posix2 準拠の正規表現であり，全てのコンテナの監視を行ったり，いくつかのコンテナの監視を行ったり，1 つだけのコンテナの監視を行ったりすることが可能です．
-      <replaceable>name</replaceable> を指定しない場合，デフォルトで '.*' となり，<command>lxcpath</command> 以下の全てのコンテナの監視を行います．
+      <command>lxc-monitor</command> はコンテナの状態を監視します。
+      <replaceable>name</replaceable> をモニタ対象のコンテナを指定するために使うことも可能です。
+      これは posix2 準拠の正規表現であり、全てのコンテナの監視を行ったり、いくつかのコンテナの監視を行ったり、1 つだけのコンテナの監視を行ったりすることが可能です。
+      <replaceable>name</replaceable> を指定しない場合、デフォルトで '.*' となり、<command>lxcpath</command> 以下の全てのコンテナの監視を行います。
     </para>
 
     <para>
@@ -86,8 +86,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       containers with the same name in multiple paths will be
       indistinguishable in the output.
       -->
-      1 つ以上のコンテナパスをモニタリングするために，複数回の <option>-P, --lxcpath</option>=PATH オプションを指定することが可能です．
-      しかし，複数のパスに同じ名前のコンテナが存在する場合は，出力の見分けがつかない事に注意が必要です．
+      1 つ以上のコンテナパスをモニタリングするために、複数回の <option>-P, --lxcpath</option>=PATH オプションを指定することが可能です。
+      しかし、複数のパスに同じ名前のコンテナが存在する場合は、出力の見分けがつかない事に注意が必要です。
     </para>
 
   </refsect1>
@@ -109,9 +109,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    normal 30 seconds for new clients. This is useful if you need to
 	    unmount the filesystem <command>lxcpath</command> is on.
             -->
-            指定したそれぞれの <command>lxcpath</command> に対する lxc-monitord デーモンを終了させる要求を行います．
-            lxc-monitord は通常は新しいクライアントを 30 秒待ちますが，このコマンドを受け取ると，クライアントがいなくなるとすぐに終了します．
-            このオプションは，<command>lxcpath</command> のファイルシステムをアンマウントする必要があるときに役に立ちます．
+            指定したそれぞれの <command>lxcpath</command> に対する lxc-monitord デーモンを終了させる要求を行います。
+            lxc-monitord は通常は新しいクライアントを 30 秒待ちますが、このコマンドを受け取ると、クライアントがいなくなるとすぐに終了します。
+            このオプションは、<command>lxcpath</command> のファイルシステムをアンマウントする必要があるときに役に立ちます。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -130,7 +130,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  will monitor the different states for container foo.
           -->
-          foo という名前のコンテナの様々な状態を監視します．
+          foo という名前のコンテナの様々な状態を監視します。
 	</para>
 	</listitem>
       </varlistentry>
@@ -142,7 +142,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  will monitor the different states for container foo and bar.
           -->
-          foo と bar という名前のコンテナの様々な状態を監視します．
+          foo と bar という名前のコンテナの様々な状態を監視します。
 	</para>
 	</listitem>
       </varlistentry>
@@ -155,7 +155,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  will monitor the different states for container with the
 	  name beginning with letter 'f' or 'b'.
           -->
-          'f' もしくは 'b' という文字で始まるコンテナの様々な状態を監視します．
+          'f' もしくは 'b' という文字で始まるコンテナの様々な状態を監視します。
 	</para>
 	</listitem>
       </varlistentry>
@@ -167,7 +167,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  will monitor the different states for all containers.
           -->
-          全てのコンテナの様々な状態を監視します．
+          全てのコンテナの様々な状態を監視します。
 	</para>
 	</listitem>
       </varlistentry>
@@ -188,7 +188,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    The specified container was not created before with
 	    the <command>lxc-create</command> command.
             -->
-            指定したコンテナが <command>lxc-create</command> で作成されておらず存在しません．
+            指定したコンテナが <command>lxc-create</command> で作成されておらず存在しません。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-snapshot.sgml.in
+++ b/doc/ja/lxc-snapshot.sgml.in
@@ -79,14 +79,14 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-snapshot</command> creates, lists, and restores
       container snapshots.
       -->
-      <command>lxc-snapshot</command> はコンテナのスナップショットの作製，スナップショットのリスト表示，スナップショットからのリストアを行います．
+      <command>lxc-snapshot</command> はコンテナのスナップショットの作製、スナップショットのリスト表示、スナップショットからのリストアを行います。
     </para>
     <para>
       <!--
     Snapshots are stored as snapshotted containers under a private configuration path.  For instance, if the container's configuration path is <filename>/var/lib/lxc</filename> and the container is <filename>c1</filename>, then the first snapshot will be stored as container <filename>snap0</filename> under configuration path <filename>/var/lib/lxcsnaps/c1</filename>.
     -->
-      スナップショットは，専用の設定されたパス以下にスナップショット化されたコンテナとして保存されます．
-      例えば，もしコンテナパスが <filename>/var/lib/lxc</filename> で，コンテナが <filename>c1</filename> である場合，最初に取得するスナップショットは，パス <filename>/var/lib/lxcsnaps/c1</filename> の下の <filename>snap0</filename> として保存されます．
+      スナップショットは、専用の設定されたパス以下にスナップショット化されたコンテナとして保存されます。
+      例えば、もしコンテナパスが <filename>/var/lib/lxc</filename> で、コンテナが <filename>c1</filename> である場合、最初に取得するスナップショットは、パス <filename>/var/lib/lxcsnaps/c1</filename> の下の <filename>snap0</filename> として保存されます。
     </para>
   </refsect1>
 
@@ -103,7 +103,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               Associate the comment in <replaceable>comment_file</replaceable> with the newly created snapshot.
               -->
-              新しく作製するスナップショットに <replaceable>comment_file</replaceable> ファイル内のコメントを関連付ける．
+              新しく作製するスナップショットに <replaceable>comment_file</replaceable> ファイル内のコメントを関連付ける。
             </para>
 	   </listitem>
 	  </varlistentry>
@@ -115,7 +115,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               List existing snapshots.
               -->
-              存在するスナップショットをリスト表示します．
+              存在するスナップショットをリスト表示します。
             </para>
 	   </listitem>
 	  </varlistentry>
@@ -127,7 +127,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               Show snapshot comments in the snapshots listings.
               -->
-              スナップショットのリスト表示でスナップショットに対するコメントを表示します．
+              スナップショットのリスト表示でスナップショットに対するコメントを表示します。
             </para>
 	   </listitem>
 	  </varlistentry>
@@ -139,8 +139,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               Restore the named snapshot, meaning a full new container is created which is a copy of the snapshot.
               -->
-              指定のスナップショットをリストアします．
-              これはスナップショットのコピーである完全に新しいコンテナが作製されるということです．
+              指定のスナップショットをリストアします。
+              これはスナップショットのコピーである完全に新しいコンテナが作製されるということです。
             </para>
 	   </listitem>
 	  </varlistentry>
@@ -152,9 +152,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
                   When restoring a snapshot, the last optional argument is the name to use for the restored container.  If no name is given, then the original container will be destroyed and the restored container will take its place.  Note that deleting the original snapshot is not possible in the case of aufs, overlayfs or zfs backed snapshots.
               -->
-              スナップショットをリストアする際，最後のオプション引数はリストアされたコンテナの名前として使用されます．
-              もし名前が与えられてない場合，元のコンテナが破壊され，リストアされるコンテナに置き換えられます．
-              スナップショット元を削除することは，aufs, overlayfs, zfs がバックエンドのスナップショットでは出来ないことに注意が必要です．
+              スナップショットをリストアする際、最後のオプション引数はリストアされたコンテナの名前として使用されます。
+              もし名前が与えられてない場合、元のコンテナが破壊され、リストアされるコンテナに置き換えられます。
+              スナップショット元を削除することは、aufs, overlayfs, zfs がバックエンドのスナップショットでは出来ないことに注意が必要です。
             </para>
 	   </listitem>
 	  </varlistentry>

--- a/doc/ja/lxc-start-ephemeral.sgml.in
+++ b/doc/ja/lxc-start-ephemeral.sgml.in
@@ -72,7 +72,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-start-ephemeral</command> start an ephemeral copy of an
       existing container.
       -->
-      <command>lxc-start-ephemeral</command> は，存在するコンテナの一時的なコピーからコンテナを起動します．
+      <command>lxc-start-ephemeral</command> は、存在するコンテナの一時的なコピーからコンテナを起動します。
     </para>
   </refsect1>
 
@@ -117,8 +117,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             Start the container in background and print the name and IP.
             This option can't be used if a command is passed.
             -->
-            コンテナをバックグラウンドで実行し，名前と IP アドレスを表示します．
-            このオプションはコマンドを実行させたいときには使用することはできません．
+            コンテナをバックグラウンドで実行し、名前と IP アドレスを表示します。
+            このオプションはコマンドを実行させたいときには使用することはできません。
           </para>
         </listitem>
       </varlistentry>
@@ -133,8 +133,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             Directory to bind mount into container.
             Can be passed multiple times.
             -->
-            コンテナ内にバインドマウントするためのディレクトリ．
-            複数回指定できます．
+            コンテナ内にバインドマウントするためのディレクトリ。
+            複数回指定できます。
           </para>
         </listitem>
       </varlistentry>
@@ -149,8 +149,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             The user to connect to the container as.
             Used when passing a command to lxc-start-ephemeral.
             -->
-            コンテナに接続するためのユーザ．
-            lxc-start-ephemeral にコマンドを指定するときに使います．
+            コンテナに接続するためのユーザ。
+            lxc-start-ephemeral にコマンドを指定するときに使います。
           </para>
         </listitem>
       </varlistentry>
@@ -164,7 +164,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
             Copy the provided SSH public key into the container.
             -->
-            コンテナ内にコピーする既存の SSH 公開鍵．
+            コンテナ内にコピーする既存の SSH 公開鍵。
           </para>
         </listitem>
       </varlistentry>
@@ -179,8 +179,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             Force a specific union file system.
             Can be one of: overlayfs aufs
             -->
-            指定した union ファイルシステムを使用します．
-            overlayfs か aufs のどちらかが使用できます．
+            指定した union ファイルシステムを使用します。
+            overlayfs か aufs のどちらかが使用できます。
           </para>
         </listitem>
       </varlistentry>
@@ -196,7 +196,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             With this option, you can lxc-stop and lxc-start the no longer so
             ephemeral container (it's still an overlay, but a persistent one).
             -->
-            tmpfs の代わりに永続的なバックエンドを使用します．このオプションを使うことにより，もはや一時的なコンテナではないので，lxc-stop や lxc-start を使用することができます (オーバーレイな状態ですが，永続的です)．
+            tmpfs の代わりに永続的なバックエンドを使用します。このオプションを使うことにより、もはや一時的なコンテナではないので、lxc-stop や lxc-start を使用することができます (オーバーレイな状態ですが、永続的です)。
           </para>
         </listitem>
       </varlistentry>
@@ -212,7 +212,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             This currently uses ssh (not attach) and is incompatible
             with daemon mode.
             -->
-            即座に指定したコマンドをコンテナ内で実行します．現時点では (attach ではなく) ssh を使用します．そしてデーモンモードと両方を指定することはできません．
+            即座に指定したコマンドをコンテナ内で実行します。現時点では (attach ではなく) ssh を使用します。そしてデーモンモードと両方を指定することはできません。
           </para>
         </listitem>
       </varlistentry>
@@ -241,8 +241,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           Simply start an ephemeral container and attach to the console.
           This container will be based on existing container "p1".
           -->
-          単に一時的なコンテナを開始させ，コンソールにアタッチします．
-          このコンテナは "p1" という既存のコンテナを基にします．
+          単に一時的なコンテナを開始させ、コンソールにアタッチします。
+          このコンテナは "p1" という既存のコンテナを基にします。
         </para>
         </listitem>
       </varlistentry>
@@ -255,7 +255,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           Start an ephemeral container based on p1 called p1-ephemeral and
           print its IP and name to the console instead of attaching.
           -->
-          p1 を基にした一時的なコンテナを開始し，コンソールにアタッチする代わりに IP アドレスと名前を表示します．
+          p1 を基にした一時的なコンテナを開始し、コンソールにアタッチする代わりに IP アドレスと名前を表示します。
         </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-start.sgml.in
+++ b/doc/ja/lxc-start.sgml.in
@@ -77,7 +77,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <replaceable>command</replaceable> inside the container
       specified by <replaceable>name</replaceable>.
       -->
-      <command>lxc-start</command> は <replaceable>command</replaceable> で指定されたコマンドを，<replaceable>name</replaceable> で指定されたコンテナ内で実行します．
+      <command>lxc-start</command> は <replaceable>command</replaceable> で指定されたコマンドを、<replaceable>name</replaceable> で指定されたコンテナ内で実行します。
     </para>
     <para>
       <!--
@@ -87,8 +87,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       If no configuration is
       defined, the default isolation is used.
       -->
-      このコマンドは，lxc-create コマンドもしくは設定ファイルのパラメータであらかじめ定義された設定に従ってコンテナをセットアップします．
-      もし設定が定義されていない場合は，デフォルトの隔離状態を使用します．
+      このコマンドは、lxc-create コマンドもしくは設定ファイルのパラメータであらかじめ定義された設定に従ってコンテナをセットアップします。
+      もし設定が定義されていない場合は、デフォルトの隔離状態を使用します。
     </para>
     <para>
       <!--
@@ -97,7 +97,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>"/sbin/init"</command> command to run a system
       container.
       -->
-      もし command が指定されない場合は，<command>lxc-start</command> はシステムコンテナを実行するためのコマンドとして，デフォルトで <command>"/sbin/init"</command> を使用します．
+      もし command が指定されない場合は、<command>lxc-start</command> はシステムコンテナを実行するためのコマンドとして、デフォルトで <command>"/sbin/init"</command> を使用します。
     </para>
 
   </refsect1>
@@ -119,9 +119,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    more tty, if an error occurs nothing will be displayed,
 	    the log file can be used to check the error.
             -->
-            コンテナをデーモンとして実行します．
-            コンテナはそれ以上の tty を持ちませんので，もしエラーが起きても何も表示されません．
-            エラーのチェックにはログファイルを使用することができます．
+            コンテナをデーモンとして実行します。
+            コンテナはそれ以上の tty を持ちませんので、もしエラーが起きても何も表示されません。
+            エラーのチェックにはログファイルを使用することができます。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -135,7 +135,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    Create a file with the process id.
             -->
-            プロセス ID を含むファイルを作製します．
+            プロセス ID を含むファイルを作製します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -150,7 +150,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Specify the configuration file to configure the virtualization
 	    and isolation functionalities for the container.
             -->
-            コンテナの仮想化，隔離機能の設定のための設定ファイルを指定します．
+            コンテナの仮想化、隔離機能の設定のための設定ファイルを指定します。
 	  </para>
 	  <para>
             <!--
@@ -158,7 +158,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	   already a configuration file present in the previously created
 	   container (via lxc-create).
            -->
-            (lxc-create 経由で) 前もってコンテナが作られた際の設定ファイルが既にあった場合でも，このオプションが指定された場合は，指定した設定ファイルが使用されます．
+            (lxc-create 経由で) 前もってコンテナが作られた際の設定ファイルが既にあった場合でも、このオプションが指定された場合は、指定した設定ファイルが使用されます。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -175,8 +175,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             /dev/tty8. If this option is not specified the current terminal
             will be used unless <option>-d</option> is specified.
             -->
-            コンテナのコンソールに使用するデバイスを指定します．例えば /dev/tty8 のように指定します．
-            このオプションが指定されない時は，<option>-d</option> が指定されない限りは，現在のターミナルを使用します．
+            コンテナのコンソールに使用するデバイスを指定します。例えば /dev/tty8 のように指定します。
+            このオプションが指定されない時は、<option>-d</option> が指定されない限りは、現在のターミナルを使用します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -191,7 +191,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    Specify a file to log the container's console output to.
             -->
-            コンテナのコンソール出力のログを出力するファイルを指定します．
+            コンテナのコンソール出力のログを出力するファイルを指定します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -207,8 +207,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    variable <replaceable>KEY</replaceable>. This overrides any
 	    assignment done in <replaceable>config_file</replaceable>.
             -->
-            設定変数 <replaceable>KEY</replaceable> に対する設定値として <replaceable>VAL</replaceable> を設定します．
-            この設定は，<replaceable>config_file</replaceable> で既に設定されている値も上書きします．
+            設定変数 <replaceable>KEY</replaceable> に対する設定値として <replaceable>VAL</replaceable> を設定します。
+            この設定は、<replaceable>config_file</replaceable> で既に設定されている値も上書きします。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -226,9 +226,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  failure instead. Note: <replaceable>&#045;&#045;daemon</replaceable> implies
 	  <replaceable>&#045;&#045;close-all-fds</replaceable>.
           -->
-            継承しているファイルディスクリプタが存在する場合，それをクローズします．
-            このオプションが指定されない場合，<command>lxc-start</command> の実行は失敗して終了します．
-            注意: <replaceable>--daemon</replaceable> オプションは，<replaceable>--close-all-fds</replaceable> オプションを指定しなくても指定している場合と同様の動きをします．
+            継承しているファイルディスクリプタが存在する場合、それをクローズします。
+            このオプションが指定されない場合、<command>lxc-start</command> の実行は失敗して終了します。
+            注意: <replaceable>--daemon</replaceable> オプションは、<replaceable>--close-all-fds</replaceable> オプションを指定しなくても指定している場合と同様の動きをします。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -247,9 +247,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    network configuration of the starting container is ignored
 	    and the up/down scripts won't be executed.
             -->
-            名前が <replaceable>name</replaceable> である，もしくは PID が <replaceable>pid</replaceable> であるコンテナとネットワーク名前空間を共有します．
-            ネットワーク名前空間は引き続き元の所有者が管理します．
-            開始するコンテナのネットワーク設定は無視され，up/down のスクリプトは実行されません．
+            名前が <replaceable>name</replaceable> である、もしくは PID が <replaceable>pid</replaceable> であるコンテナとネットワーク名前空間を共有します。
+            ネットワーク名前空間は引き続き元の所有者が管理します。
+            開始するコンテナのネットワーク設定は無視され、up/down のスクリプトは実行されません。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -265,7 +265,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    a <replaceable>name</replaceable> container or
 	    a <replaceable>pid</replaceable>.
             -->
-            名前が <replaceable>name</replaceable> である，もしくは PID が <replaceable>pid</replaceable> であるコンテナと IPC 名前空間を共有します．
+            名前が <replaceable>name</replaceable> である、もしくは PID が <replaceable>pid</replaceable> であるコンテナと IPC 名前空間を共有します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -283,8 +283,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    not set the hostname, but the container OS may do it
 	    anyway.
             -->
-            名前が <replaceable>name</replaceable> である，もしくは PID が <replaceable>pid</replaceable> であるコンテナと UTS 名前空間を共有します．
-            LXC は開始するときににはホスト名を設定しませんが，コンテナ内の OS が何らかの方法でホスト名を設定するかもしれません．
+            名前が <replaceable>name</replaceable> である、もしくは PID が <replaceable>pid</replaceable> であるコンテナと UTS 名前空間を共有します。
+            LXC は開始するときににはホスト名を設定しませんが、コンテナ内の OS が何らかの方法でホスト名を設定するかもしれません。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -309,8 +309,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    application. You should stop it before reuse this
 	    container or create a new one.
             -->
-            指定したコンテナは既に実行済みです．
-            このコンテナを使用する前に既に起動しているコンテナを停止するか，新しいものを作成する必要があります．
+            指定したコンテナは既に実行済みです。
+            このコンテナを使用する前に既に起動しているコンテナを停止するか、新しいものを作成する必要があります。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-stop.sgml.in
+++ b/doc/ja/lxc-stop.sgml.in
@@ -79,9 +79,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       60 seconds, it will be sent the <command>lxc.stopsignal</command>
       (defaults to SIGKILL) to force it to shut down.
       -->
-      <command>lxc-stop</command> は，リブート，クリーンシャットダウン，コンテナ内の全てのプロセスの kill のどれかを行います．
-      デフォルトでは，コンテナのクリーンなシャットダウンを <command>lxc.haltsignal</command> (デフォルトでは SIGPWR) をコンテナの init プロセスに送ることでリクエストし，コンテナの終了を 60 秒待ち，return します．
-      コンテナが 60 秒の間にクリーンに終了するのに失敗した場合，<command>lxc.stopsignal</command> (デフォルトでは SIGKILL) を送り，強制的にシャットダウンします．
+      <command>lxc-stop</command> は、リブート、クリーンシャットダウン、コンテナ内の全てのプロセスの kill のどれかを行います。
+      デフォルトでは、コンテナのクリーンなシャットダウンを <command>lxc.haltsignal</command> (デフォルトでは SIGPWR) をコンテナの init プロセスに送ることでリクエストし、コンテナの終了を 60 秒待ち、return します。
+      コンテナが 60 秒の間にクリーンに終了するのに失敗した場合、<command>lxc.stopsignal</command> (デフォルトでは SIGKILL) を送り、強制的にシャットダウンします。
     </para>
 
     <para>
@@ -94,9 +94,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <optional>-t TIMEOUT</optional> specifies the maximum amount of time
       to wait for the container to complete the shutdown or reboot.
       -->
-      <optional>-W</optional>, <optional>-r</optional>, <optional>-s</optional>, <optional>-k</optional>, <optional>--nokill</optional> オプションは実行する際のアクションを指定します．
-      <optional>-W</optional> は，指定したアクションの後に，<command>lxc-stop</command> は速やかに終了します．
-      一方，<optional>-t TIMEOUT</optional> はコンテナが完全にシャットダウンやリブートするのを待つ時間の最大値を設定します．
+      <optional>-W</optional>, <optional>-r</optional>, <optional>-s</optional>, <optional>-k</optional>, <optional>--nokill</optional> オプションは実行する際のアクションを指定します。
+      <optional>-W</optional> は、指定したアクションの後に、<command>lxc-stop</command> は速やかに終了します。
+      一方、<optional>-t TIMEOUT</optional> はコンテナが完全にシャットダウンやリブートするのを待つ時間の最大値を設定します。
     </para>
 
   </refsect1>
@@ -114,7 +114,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    Request a reboot of the container.
             -->
-            コンテナのリブートをリクエストします．
+            コンテナのリブートをリクエストします。
 	  </para>
 	</listitem>
 	</varlistentry>
@@ -130,8 +130,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         kill all tasks in the container.  This is the legacy
         <command>lxc-stop</command> behavior.
         -->
-           コンテナのクリーンシャットダウンをリクエストするのでなく，明確にコンテナ内の全てのタスクを kill します．
-            これは，以前の <command>lxc-stop</command> の動作です．
+           コンテナのクリーンシャットダウンをリクエストするのでなく、明確にコンテナ内の全てのタスクを kill します。
+            これは、以前の <command>lxc-stop</command> の動作です。
 	  </para>
 	</listitem>
     </varlistentry>
@@ -146,8 +146,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Only request a clean shutdown, do not kill the container tasks if the
 		clean shutdown fails.
               -->
-            クリーンなシャットダウンのみをリクエストします．
-            クリーンなシャットダウンに失敗した場合でも，コンテナのタスクを kill しません．
+            クリーンなシャットダウンのみをリクエストします。
+            クリーンなシャットダウンに失敗した場合でも、コンテナのタスクを kill しません。
 	  </para>
 	</listitem>
 	</varlistentry>
@@ -163,8 +163,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	only be used if <command>lxc-stop</command> is hanging due to a bad
 	system state.
               -->
-            このオプションはいかなる場合でも API の lxc のロックの使用を回避します．
-            システム状態が不良な場合に lxc-stop の応答がない状態の場合のみ使用すべきです．
+            このオプションはいかなる場合でも API の lxc のロックの使用を回避します。
+            システム状態が不良な場合に lxc-stop の応答がない状態の場合のみ使用すべきです。
 	  </para>
 	</listitem>
     </varlistentry>
@@ -179,7 +179,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Simply perform the requestion action (reboot, shutdown, or hard
 		kill) and exit.
               -->
-            リクエストされたアクション (reboot, shutdown, 強制的な kill) を実行するだけで (すぐに) 終了 (exit) します．
+            リクエストされたアクション (reboot, shutdown, 強制的な kill) を実行するだけで (すぐに) 終了 (exit) します。
 	  </para>
 	</listitem>
 	</varlistentry>
@@ -193,7 +193,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    Wait TIMEOUT seconds before hard-stopping the container.
               -->
-            コンテナの強制停止まで TIMEOUT 秒待ちます．
+            コンテナの強制停止まで TIMEOUT 秒待ちます。
 	  </para>
 	</listitem>
 	</varlistentry>
@@ -213,7 +213,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    The container was successfully stopped.
             -->
-            コンテナの停止が成功しました．
+            コンテナの停止が成功しました。
           </para>
         </listitem>
       </varlistentry>
@@ -225,7 +225,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    An error occurred while stopping the container.
             -->
-            コンテナの停止中にエラーが発生しました．
+            コンテナの停止中にエラーが発生しました。
           </para>
         </listitem>
       </varlistentry>
@@ -237,7 +237,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    The specified container exists but was not running.
             -->
-            指定のコンテナは存在しますが，実行中ではありません．
+            指定のコンテナは存在しますが、実行中ではありません。
           </para>
         </listitem>
       </varlistentry>
@@ -258,7 +258,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    The specified container was not created before with
 	    the <command>lxc-create</command> command.
             -->
-            指定したコンテナが <command>lxc-create</command> で作成されておらず存在しません．
+            指定したコンテナが <command>lxc-create</command> で作成されておらず存在しません。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-top.sgml.in
+++ b/doc/ja/lxc-top.sgml.in
@@ -68,8 +68,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       number of containers displayed, otherwise <command>lxc-top</command>
       will display as many containers as can fit in your terminal.
       -->
-      <command>lxc-top</command> はコンテナの統計情報を表示します．出力は <replaceable>delay</replaceable> 秒ごとに更新されます．
-      そして，<replaceable>sortby</replaceable> で指定した値に従ってソートされます．<replaceable>count</replaceable> を指定すると表示するコンテナ数を制限しますが，指定しなければ使用しているターミナルに合うようなコンテナ数で表示します．
+      <command>lxc-top</command> はコンテナの統計情報を表示します。出力は <replaceable>delay</replaceable> 秒ごとに更新されます。
+      そして、<replaceable>sortby</replaceable> で指定した値に従ってソートされます。<replaceable>count</replaceable> を指定すると表示するコンテナ数を制限しますが、指定しなければ使用しているターミナルに合うようなコンテナ数で表示します。
     </para>
   </refsect1>
 
@@ -87,7 +87,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             Limit the number of containers displayed to
             <replaceable>count</replaceable>.
             -->
-            表示するコンテナ数を <replaceable>count</replaceable> に制限します．
+            表示するコンテナ数を <replaceable>count</replaceable> に制限します。
           </para>
         </listitem>
       </varlistentry>
@@ -104,8 +104,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             rational number, for example 0.5 for a half second delay. The
             default is 3 seconds.
             -->
-            表示を更新する間隔を秒で指定します．有理数を指定することにより，1 秒以下を指定することも可能です．
-            例えば，1 秒の半分で更新を行うために 0.5 を指定します．デフォルトは 3 秒です．
+            表示を更新する間隔を秒で指定します。有理数を指定することにより、1 秒以下を指定することも可能です。
+            例えば、1 秒の半分で更新を行うために 0.5 を指定します。デフォルトは 3 秒です。
           </para>
         </listitem>
       </varlistentry>
@@ -121,8 +121,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             the letters n,c,d,m,k to sort by name, cpu use, disk I/O, memory,
             or kernel memory use respectively. The default is 'n'.
             -->
-            名前，CPU 使用量，メモリ使用量でコンテナをソートします．<replaceable>sortby</replaceable> で指定する引数は n,c,d,m,k のどれかでなければなりません．
-            これはそれぞれ名前，CPU 使用量，disk I/O，メモリ使用量，カーネルメモリ使用量を表します．デフォルトは 'n' です．
+            名前、CPU 使用量、メモリ使用量でコンテナをソートします。<replaceable>sortby</replaceable> で指定する引数は n,c,d,m,k のどれかでなければなりません。
+            これはそれぞれ名前、CPU 使用量、disk I/O、メモリ使用量、カーネルメモリ使用量を表します。デフォルトは 'n' です。
           </para>
         </listitem>
       </varlistentry>
@@ -137,7 +137,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             ascending alphabetical order and values sort in descending
             amounts (ie. largest value first).
             -->
-            デフォルトのソート順を逆転させます．デフォルトでは，名前のソートはアルファベットの昇順，値のソートは量の降順 (最も大きい数が最初) です．
+            デフォルトのソート順を逆転させます。デフォルトでは、名前のソートはアルファベットの昇順、値のソートは量の降順 (最も大きい数が最初) です。
           </para>
         </listitem>
       </varlistentry>
@@ -154,7 +154,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
           <!--
           Display containers, updating every second, sorted by memory use.
           -->
-          コンテナを 1 秒ごとに更新し，メモリ使用量でソートして表示します．
+          コンテナを 1 秒ごとに更新し、メモリ使用量でソートして表示します。
         </para>
         </listitem>
       </varlistentry>
@@ -179,18 +179,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         <manvolnum>5</manvolnum>
       </citerefentry>.
       -->
-      パフォーマンスへの影響を考慮して，カーネルメモリの使用量は，カーネルメモリの制限値が設定されない限りはカウントされません．
-      もし，制限が設定されていない場合，<command>lxc-top</command> はカーネルメモリの使用量を 0 と表示します．
-      もし，カウントされているコンテナが存在しない場合，KMem カラムは表示されません．制限は
+      パフォーマンスへの影響を考慮して、カーネルメモリの使用量は、カーネルメモリの制限値が設定されない限りはカウントされません。
+      もし、制限が設定されていない場合、<command>lxc-top</command> はカーネルメモリの使用量を 0 と表示します。
+      もし、カウントされているコンテナが存在しない場合、KMem カラムは表示されません。制限は
       <programlisting>
       lxc.cgroup.memory.kmem.limit_in_bytes = <replaceable>number</replaceable>
       </programlisting>
-      のように，コンテナの設定ファイルで指定することができます．詳しくは，
+      のように、コンテナの設定ファイルで指定することができます。詳しくは、
       <citerefentry>
         <refentrytitle>lxc.conf</refentrytitle>
         <manvolnum>5</manvolnum>
       </citerefentry>
-      を参照してください．
+      を参照してください。
     </para>
   </refsect1>
 

--- a/doc/ja/lxc-unfreeze.sgml.in
+++ b/doc/ja/lxc-unfreeze.sgml.in
@@ -67,7 +67,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-unfreeze</command> will thaw all the processes
       previously frozen by the <command>lxc-freeze</command> command.
       -->
-      <command>lxc-unfreeze</command> は，先に <command>lxc-freeze</command> を使って凍結した全てのプロセスを解凍します．
+      <command>lxc-unfreeze</command> は、先に <command>lxc-freeze</command> を使って凍結した全てのプロセスを解凍します。
     </para>
 
   </refsect1>
@@ -87,7 +87,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    The specified container was not created before with
 	    the <command>lxc-create</command> command.
             -->
-            指定したコンテナが <command>lxc-create</command> で作成されておらず存在しません．
+            指定したコンテナが <command>lxc-create</command> で作成されておらず存在しません。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc-unshare.sgml.in
+++ b/doc/ja/lxc-unshare.sgml.in
@@ -77,10 +77,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       the new task with fresh namespaces.  Apart from testing kernel
       regressions this should make no difference.
       -->
-      <command>lxc-unshare</command> はクローンされた名前空間の組の中でタスクを実行するのに使います．
-      このコマンドは主にテスト目的で使います．
-      このような名前であるにもかかわらず，このコマンドは常に，新しい名前空間で新しいタスクを作成するために unshare ではなく clone を使います．
-      テスト中のカーネルの退行は別として，これで違いは生じないはずです．
+      <command>lxc-unshare</command> はクローンされた名前空間の組の中でタスクを実行するのに使います。
+      このコマンドは主にテスト目的で使います。
+      このような名前であるにもかかわらず、このコマンドは常に、新しい名前空間で新しいタスクを作成するために unshare ではなく clone を使います。
+      テスト中のカーネルの退行は別として、これで違いは生じないはずです。
     </para>
 
   </refsect1>
@@ -108,11 +108,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    container while retaining the other namespaces as those of the
 	    host.
             -->
-            アタッチする名前空間を，パイプでつなげたリストで指定します．
-            例えば <replaceable>NETWORK|IPC</replaceable> のようにです．
-            指定できる値は <replaceable>MOUNT</replaceable>，<replaceable>PID</replaceable>，<replaceable>UTSNAME</replaceable>，<replaceable>IPC</replaceable>，<replaceable>USER </replaceable>，<replaceable>NETWORK</replaceable> です．
-            これにより，プロセスのコンテキストを変更することができます．
-            例えば，コンテナのネットワーク名前空間だけを変更し，他の名前空間をホストのものと同じものに保ったままにするというようなことです．
+            アタッチする名前空間を、パイプでつなげたリストで指定します。
+            例えば <replaceable>NETWORK|IPC</replaceable> のようにです。
+            指定できる値は <replaceable>MOUNT</replaceable>、<replaceable>PID</replaceable>、<replaceable>UTSNAME</replaceable>、<replaceable>IPC</replaceable>、<replaceable>USER </replaceable>、<replaceable>NETWORK</replaceable> です。
+            これにより、プロセスのコンテキストを変更することができます。
+            例えば、コンテナのネットワーク名前空間だけを変更し、他の名前空間をホストのものと同じものに保ったままにするというようなことです。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -126,7 +126,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    Specify a user which the new task should become.
             -->
-            新しいタスクを実行するユーザを指定します．
+            新しいタスクを実行するユーザを指定します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -141,7 +141,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Set the hostname in the new container.  Only allowed if
 	    the UTSNAME namespace is set.
             -->
-            新しいコンテナ内でのホスト名を設定します．UTSNAME 名前空間を指定している時のみ有効です．
+            新しいコンテナ内でのホスト名を設定します。UTSNAME 名前空間を指定している時のみ有効です。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -158,7 +158,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    argument multiple times to move multiple interfaces into
 	    container.
             -->
-            指定したインターフェースをコンテナ内に移動させます．ネットワーク (NETWORK) 名前空間を指定している時のみ有効です．複数のインターフェースをコンテナに移動させるために複数回指定することも可能です．
+            指定したインターフェースをコンテナ内に移動させます。ネットワーク (NETWORK) 名前空間を指定している時のみ有効です。複数のインターフェースをコンテナに移動させるために複数回指定することも可能です。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -172,7 +172,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    Daemonize (do not wait for the container to exit before exiting)
             -->
-            デーモンにします (コマンドはコンテナの終了を待ちません)．
+            デーモンにします (コマンドはコンテナの終了を待ちません)。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -187,7 +187,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Mount default filesystems (/proc /dev/shm and /dev/mqueue)
 	    in the container.  Only allowed if MOUNT namespace is set.
             -->
-            コンテナ内でデフォルトのファイルシステム (/proc, /dev/shm, /dev/mqueue) をマウントします．マウント (MOUNT) 名前空間を指定している時のみ有効です．
+            コンテナ内でデフォルトのファイルシステム (/proc, /dev/shm, /dev/mqueue) をマウントします。マウント (MOUNT) 名前空間を指定している時のみ有効です。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -207,11 +207,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	If the hostname is changed in that shell, the change will not be
 	reflected on the host.
         -->
-        自身の UTS(hostname)名前空間でシェルを起動するには以下のように実行します．
+        自身の UTS(hostname)名前空間でシェルを起動するには以下のように実行します。
         <programlisting>
           lxc-unshare -s UTSNAME /bin/bash
         </programlisting>
-        もし，そのシェル上でホスト名を変更しても，その変更はホストには反映されません．
+        もし、そのシェル上でホスト名を変更しても、その変更はホストには反映されません。
       </para>
       <para>
         <!--
@@ -226,16 +226,16 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         </programlisting>
 	ps output will show there are no other processes in the namespace.
         -->
-        新しいネットワーク，pid，マウント名前空間でシェルを起動するには以下のように実行します．
+        新しいネットワーク、pid、マウント名前空間でシェルを起動するには以下のように実行します。
         <programlisting>
           lxc-unshare -s "NETWORK|PID|MOUNT" /bin/bash
         </programlisting>
-        その結果起動するシェルは pid が 1 となり，ネットワークインターフェースがないでしょう．
+        その結果起動するシェルは pid が 1 となり、ネットワークインターフェースがないでしょう。
         そのシェル上で /proc を再マウントした後
         <programlisting>
           mount -t proc proc /proc
         </programlisting>
-        ps の出力は，その名前空間内には他のプロセスが存在しない事を表示するでしょう．
+        ps の出力は、その名前空間内には他のプロセスが存在しない事を表示するでしょう。
       </para>
       <para>
         <!--
@@ -245,7 +245,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           lxc-unshare -s "NETWORK|PID|MOUNT|UTSNAME" -M -H slave -i veth1 /bin/bash
         </programlisting>
         -->
-        新しいネットワーク，PID，マウント，ホスト名 (UTS) 名前空間でシェルを起動するには，
+        新しいネットワーク、PID、マウント、ホスト名 (UTS) 名前空間でシェルを起動するには、
         <programlisting>
           lxc-unshare -s "NETWORK|PID|MOUNT|UTSNAME" -M -H slave -i veth1 /bin/bash
         </programlisting>
@@ -256,8 +256,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	/proc will have been remounted.  ps output will show there are
 	no other processes in the namespace.
         -->
-        起動したシェルは PID 1 を持ち，2 つのネットワークインターフェース (lo と veth1) を持ちます．
-        ホスト名は "slave" となり，/proc は再マウントされます．ps コマンドは，名前空間内には他のプロセスがない状態を表示するでしょう．
+        起動したシェルは PID 1 を持ち、2 つのネットワークインターフェース (lo と veth1) を持ちます。
+        ホスト名は "slave" となり、/proc は再マウントされます。ps コマンドは、名前空間内には他のプロセスがない状態を表示するでしょう。
       </para>
   </refsect1>
 

--- a/doc/ja/lxc-user-nic.sgml.in
+++ b/doc/ja/lxc-user-nic.sgml.in
@@ -48,7 +48,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <!--
       Create and attach a nic to another network namespace.
       -->
-      NIC を作成し，他のネットワーク名前空間に割り当てる
+      NIC を作成し、他のネットワーク名前空間に割り当てる
     </refpurpose>
   </refnamediv>
 
@@ -70,7 +70,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-user-nic</command> is a setuid-root program with which
       unprivileged users may create network interfaces for use by a lxc container.
       -->
-      <command>lxc-user-nic</command> は root に setuid されたプログラムで，lxc コンテナが使うネットワークインターフェースを，特権を持たないユーザが作成できます．
+      <command>lxc-user-nic</command> は root に setuid されたプログラムで、lxc コンテナが使うネットワークインターフェースを、特権を持たないユーザが作成できます。
     </para>
     <para>
       <!--
@@ -82,9 +82,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       user is privileged over the network namespace to which the interface
       will be attached.
       -->
-      このプログラムは，<filename>@LXC_USERNIC_CONF@</filename> という設定ファイルを参照して，呼び出したユーザが作成することができるインターフェースの数と，どのブリッジに接続するかを決定します．
-      また，ユーザが作成したインターフェースの数を <filename>@LXC_USERNIC_DB@</filename> を使ってチェックします．
-      これにより，呼び出したユーザが，インターフェースを割り当てるネットワーク名前空間上で特権を持つことが保証されます．
+      このプログラムは、<filename>@LXC_USERNIC_CONF@</filename> という設定ファイルを参照して、呼び出したユーザが作成することができるインターフェースの数と、どのブリッジに接続するかを決定します。
+      また、ユーザが作成したインターフェースの数を <filename>@LXC_USERNIC_DB@</filename> を使ってチェックします。
+      これにより、呼び出したユーザが、インターフェースを割り当てるネットワーク名前空間上で特権を持つことが保証されます。
     </para>
 
   </refsect1>
@@ -105,7 +105,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  The process id for the task to whose network namespace the interface
 	  should be attached.
               -->
-            インターフェースを割り当てたいネットワーク名前空間を持つタスクのプロセス ID．
+            インターフェースを割り当てたいネットワーク名前空間を持つタスクのプロセス ID。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -123,9 +123,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  to the specified bridge, while the other will be passed into
 	  the container.
               -->
-            割り当てるネットワークインターフェースのタイプ．現時点では，veth のみサポートされます．
-            このタイプを指定すると，それぞれがトンネルのエンドポイントとなる 2 つのインターフェースが作成されます．
-            一方のエンドポイントは指定したブリッジに接続され，もう一方はコンテナに割り当てられます．
+            割り当てるネットワークインターフェースのタイプ。現時点では、veth のみサポートされます。
+            このタイプを指定すると、それぞれがトンネルのエンドポイントとなる 2 つのインターフェースが作成されます。
+            一方のエンドポイントは指定したブリッジに接続され、もう一方はコンテナに割り当てられます。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -140,8 +140,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  The bridge to which to attach the network interface, for
 	  instance <filename>lxcbr0</filename>.
               -->
-            ネットワークインターフェースを接続するブリッジ．
-            例えば <filename>lxcbr0</filename> のように指定します．
+            ネットワークインターフェースを接続するブリッジ。
+            例えば <filename>lxcbr0</filename> のように指定します。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -156,8 +156,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  The desired interface name in the container.  This will be
 	  <filename>eth0</filename> if unspecified.
           -->
-            コンテナ内に作られるインターフェースの名前．
-            もし指定しない場合，<filename>eth0</filename> となります．
+            コンテナ内に作られるインターフェースの名前。
+            もし指定しない場合、<filename>eth0</filename> となります。
 	  </para>
 	</listitem>
       </varlistentry>

--- a/doc/ja/lxc-usernet.sgml.in
+++ b/doc/ja/lxc-usernet.sgml.in
@@ -60,7 +60,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       program <command>lxc-user-nic</command> places on network interfaces
       which an unprivileged user may create.
       -->
-      <filename>@LXC_USERNIC_CONF@</filename> は，非特権ユーザが作成する可能性のあるネットワークインターフェースを <command>lxc-user-nic</command> プログラムが割り当てる際の制限を制御します．
+      <filename>@LXC_USERNIC_CONF@</filename> は、非特権ユーザが作成する可能性のあるネットワークインターフェースを <command>lxc-user-nic</command> プログラムが割り当てる際の制限を制御します。
     </para>
 
     <refsect2>
@@ -69,7 +69,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         <!--
       This file consists of multiple entries, one per line, of the form:
           -->
-        このファイルは，一行が以下のような形式の複数のエントリを持つ行から構成されます．
+        このファイルは、一行が以下のような形式の複数のエントリを持つ行から構成されます。
       </para>
 
       <para>
@@ -79,7 +79,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         <!--
       Where
           -->
-        ここでそれぞれのエントリは以下のような意味を持ちます．
+        ここでそれぞれのエントリは以下のような意味を持ちます。
       </para>
 
       <variablelist>
@@ -108,7 +108,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      is the type of network interface being allowed.  Only veth
 	      is currently supported.
               -->
-              許可されるネットワークインターフェースのタイプ．現時点では veth のみサポートされます．
+              許可されるネットワークインターフェースのタイプ。現時点では veth のみサポートされます。
 	     </para>
 	  </listitem>
 	</varlistentry>
@@ -123,8 +123,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      is the bridge to which the network interfaces may be attached, for
 	      instance <filename>lxcbr0</filename>.
               -->
-              ネットワークインターフェースが接続されるブリッジ．
-              例えば <filename>lxcbr0</filename> のように指定します．
+              ネットワークインターフェースが接続されるブリッジ。
+              例えば <filename>lxcbr0</filename> のように指定します。
 	     </para>
 	  </listitem>
 	</varlistentry>
@@ -139,8 +139,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      is the number of network interfaces of the given type which the
 	      given user may attach to the given bridge, for instance <filename>2</filename>.
               -->
-              指定したユーザが，指定したブリッジに接続できる，指定した形式のネットワークインターフェースの数．
-              例えば <filename>2</filename> のように指定します．
+              指定したユーザが、指定したブリッジに接続できる、指定した形式のネットワークインターフェースの数。
+              例えば <filename>2</filename> のように指定します。
 	     </para>
 	  </listitem>
 	</varlistentry>

--- a/doc/ja/lxc-usernsexec.sgml.in
+++ b/doc/ja/lxc-usernsexec.sgml.in
@@ -68,7 +68,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-usernsexec</command> can be used to run a task as root
       in a new user namespace.
       -->
-      <command>lxc-usernsexec</command> は，新しいユーザ名前空間内で root としてタスクを実行するのに使います．
+      <command>lxc-usernsexec</command> は、新しいユーザ名前空間内で root としてタスクを実行するのに使います。
     </para>
 
   </refsect1>
@@ -93,9 +93,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  first userid as seen on the host;  and finally the number of
 	  ids to be mapped.
               -->
-            ユーザ名前空間内で使うための uid のマッピング．マッピングは，コロンで分けられた 4 つの値から構成されます．
-            最初の文字は 'u', 'g', 'b' のどれかで，マッピングが UID, GID, UID と GID の両方のうちのどれに関するものなのかを指定します．
-            次はユーザ名前空間内の最初の ID を指定します．その次はホスト上での最初の ID を指定します．最後はマッピングされる ID の数を指定します．
+            ユーザ名前空間内で使うための uid のマッピング。マッピングは、コロンで分けられた 4 つの値から構成されます。
+            最初の文字は 'u', 'g', 'b' のどれかで、マッピングが UID, GID, UID と GID の両方のうちのどれに関するものなのかを指定します。
+            次はユーザ名前空間内の最初の ID を指定します。その次はホスト上での最初の ID を指定します。最後はマッピングされる ID の数を指定します。
 	  </para>
 	  <para>
             <!--
@@ -104,7 +104,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  by /etc/subuid and /etc/subgid will be mapped to the
 	  uids and gids starting at 0 in the container.
               -->
-            複数回のマッピングを指定することも可能です．もしマッピングを指定しない場合，デフォルトでは /etc/subuid, /etc/subgid で許可された全ての範囲の UID, GID が，コンテナ内の 0 から始まる UID, GID にマッピングされます．
+            複数回のマッピングを指定することも可能です。もしマッピングを指定しない場合、デフォルトでは /etc/subuid, /etc/subgid で許可された全ての範囲の UID, GID が、コンテナ内の 0 から始まる UID, GID にマッピングされます。
 	  </para>
 	  <para>
             <!--
@@ -112,7 +112,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  to setuid and setgid to 0 in the namespace.  Therefore uid 0 in
 	  the namespace must be mapped.
               -->
-            <replaceable>lxc-usernsexec</replaceable> は，常に名前空間内の 0 に setuid, setgid しようとしますので，名前空間内の UID 0 は必ずマッピングしなければいけないことに注意してください．
+            <replaceable>lxc-usernsexec</replaceable> は、常に名前空間内の 0 に setuid, setgid しようとしますので、名前空間内の UID 0 は必ずマッピングしなければいけないことに注意してください。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -136,15 +136,15 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  lxc-usernsexec &#045;&#045; /bin/bash
         </programlisting>
         -->
-        割り当てられた subuid の全てをコンテナ内にマッピングしてシェルを起動するには，
+        割り当てられた subuid の全てをコンテナ内にマッピングしてシェルを起動するには、
         <programlisting>
 	  lxc-usernsexec
         </programlisting>
-        のようにしてください．<replaceable>/bin/sh</replaceable> とは違うシェルを起動する場合，
+        のようにしてください。<replaceable>/bin/sh</replaceable> とは違うシェルを起動する場合、
         <programlisting>
 	  lxc-usernsexec -- /bin/bash
         </programlisting>
-        のようにしてください．
+        のようにしてください。
       </para>
       <para>
         <!--
@@ -158,12 +158,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	into the namespace, you are allowed to change the file ownership, which
 	you could not do on the host using a simple chown.
         -->
-        あなたの UID が 1000 で，コンテナ内の root を 190000 にマッピングする場合で，あなたの所有するファイルをコンテナ内の root に chown したい場合は，以下のように実行します．
+        あなたの UID が 1000 で、コンテナ内の root を 190000 にマッピングする場合で、あなたの所有するファイルをコンテナ内の root に chown したい場合は、以下のように実行します。
         <programlisting>
 	  lxc-usernsexec -m b:0:1000:1 -m b:1:190000:1 -- /bin/chown 1:1 $file
         </programlisting>
-        これはあなたの UID をユーザ名前空間の root に，190000 を uid 1 にマッピングしています．
-        ユーザ名前空間内の root は，名前空間内の全ての ID に対して特権があるため，ホスト上で単純に chown を使えない場合でも，あなたはファイルのオーナーを変更する事が可能です．
+        これはあなたの UID をユーザ名前空間の root に、190000 を uid 1 にマッピングしています。
+        ユーザ名前空間内の root は、名前空間内の全ての ID に対して特権があるため、ホスト上で単純に chown を使えない場合でも、あなたはファイルのオーナーを変更する事が可能です。
       </para>
   </refsect1>
 

--- a/doc/ja/lxc-wait.sgml.in
+++ b/doc/ja/lxc-wait.sgml.in
@@ -67,8 +67,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-wait</command> waits for a specific container state
       before exiting, this is useful for scripting.
       -->
-      <command>lxc-wait</command> は，コンテナが指定した状態になるのを待って終了します．
-      スクリプトで使用するときに役に立ちます．
+      <command>lxc-wait</command> は、コンテナが指定した状態になるのを待って終了します。
+      スクリプトで使用するときに役に立ちます。
     </para>
   </refsect1>
 
@@ -86,8 +86,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    Specify the container state(s) to wait for. The container
 	    states can be ORed to specify several states.
             -->
-            待つ対象のコンテナの状態を指定します．
-            コンテナの状態として，いくつかの状態を OR で指定することが可能です．
+            待つ対象のコンテナの状態を指定します。
+            コンテナの状態として、いくつかの状態を OR で指定することが可能です。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -101,7 +101,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <!--
 	    Wait timeout seconds for desired state to be reached.
             -->
-            期待した状態になるまで timeout 秒待ちます．
+            期待した状態になるまで timeout 秒待ちます。
 	  </para>
 	</listitem>
       </varlistentry>
@@ -122,7 +122,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  exits when 'RUNNING' is reached.
           -->
-          状態が 'RUNNING' になった時点で終了します．
+          状態が 'RUNNING' になった時点で終了します。
 	</para>
 	</listitem>
       </varlistentry>
@@ -134,7 +134,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
 	  exits when 'RUNNING' or 'STOPPED' state is reached.
           -->
-          状態が 'RUNNING' もしくは 'STOPPED' になった時点で終了します．
+          状態が 'RUNNING' もしくは 'STOPPED' になった時点で終了します。
 	</para>
 	</listitem>
       </varlistentry>
@@ -155,7 +155,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	    The specified container was not created before with
 	    the <command>lxc-create</command> command.
             -->
-            指定したコンテナが <command>lxc-create</command> で作成されておらず存在しません．
+            指定したコンテナが <command>lxc-create</command> で作成されておらず存在しません。
           </para>
         </listitem>
       </varlistentry>

--- a/doc/ja/lxc.conf.sgml.in
+++ b/doc/ja/lxc.conf.sgml.in
@@ -59,7 +59,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       LXC configuration is split in two parts. Container configuration
       and system configuration.
       -->
-      LXC の設定は 2 つのパートに分かれます．コンテナの設定とシステムの設定です．
+      LXC の設定は 2 つのパートに分かれます。コンテナの設定とシステムの設定です。
     </para>
 
     <refsect2>
@@ -70,7 +70,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <filename>config</filename> stored in the container's
           directory.
           -->
-        コンテナの設定は，コンテナのディレクトリ内の <filename>config</filename> に設定します．
+        コンテナの設定は、コンテナのディレクトリ内の <filename>config</filename> に設定します。
       </para>
 
       <para>
@@ -80,7 +80,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           as extra default keys coming from the
           <filename>default.conf</filename> file.
           -->
-        必要最小限の設定は，コンテナの作成時に選択したテンプレートの推奨するデフォルトと，<filename>default.conf</filename> ファイルに記載されているデフォルトに追加する設定から生成されます．
+        必要最小限の設定は、コンテナの作成時に選択したテンプレートの推奨するデフォルトと、<filename>default.conf</filename> ファイルに記載されているデフォルトに追加する設定から生成されます。
       </para>
 
       <para>
@@ -90,8 +90,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           unprivileged containers at
           <filename>~/.config/lxc/default.conf</filename>.
           -->
-        <filename>default.conf</filename> ファイルは <filename>@LXC_DEFAULT_CONFIG@</filename> に置かれます．
-        非特権コンテナの場合には <filename>~/.config/lxc/default.conf</filename> を使用します．
+        <filename>default.conf</filename> ファイルは <filename>@LXC_DEFAULT_CONFIG@</filename> に置かれます。
+        非特権コンテナの場合には <filename>~/.config/lxc/default.conf</filename> を使用します。
       </para>
 
       <para>
@@ -102,7 +102,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <manvolnum>5</manvolnum>
           </citerefentry>
           -->
-        このファイルの書式は以下を参照してください．
+        このファイルの書式は以下を参照してください。
         <citerefentry>
           <refentrytitle><command>lxc.container.conf</command></refentrytitle>
           <manvolnum>5</manvolnum>
@@ -119,7 +119,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <filename>~/.config/lxc/lxc.conf</filename> for unprivileged
           containers.
           -->
-        システムの設定には <filename>@LXC_GLOBAL_CONF@</filename> を使用します．非特権コンテナの場合は <filename>~/.config/lxc/lxc.conf</filename> を使用します．
+        システムの設定には <filename>@LXC_GLOBAL_CONF@</filename> を使用します。非特権コンテナの場合は <filename>~/.config/lxc/lxc.conf</filename> を使用します。
       </para>
 
       <para>
@@ -127,7 +127,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           This configuration file is used to set values such as default
           lookup paths and storage backend settings for LXC.
           -->
-        この設定ファイルは LXC のデフォルトパスやストレージバックエンドの設定のような値を設定する時に使用します．
+        この設定ファイルは LXC のデフォルトパスやストレージバックエンドの設定のような値を設定する時に使用します。
       </para>
 
       <para>
@@ -138,7 +138,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <manvolnum>5</manvolnum>
           </citerefentry>
           -->
-        このファイルの書式は以下を参照してください．
+        このファイルの書式は以下を参照してください。
         <citerefentry>
           <refentrytitle><command>lxc.system.conf</command></refentrytitle>
           <manvolnum>5</manvolnum>

--- a/doc/ja/lxc.container.conf.sgml.in
+++ b/doc/ja/lxc.container.conf.sgml.in
@@ -68,12 +68,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       specified, a new network stack is created for the container and
       the container can no longer use the network of its ancestor.
       -->
-      linux コンテナ (<command>lxc</command>) は，常に使用する前に作成されます．
-      コンテナは，プロセスがコンテナを使う時に仮想化/隔離するシステムリソースのセットを定義することによって作成します．
-      デフォルトでは，pid, sysv ipc, マウントポイントが仮想化され，隔離されます．
-      他のシステムリソースは，設定ファイルで明確に定義されない限りは，コンテナをまたいで共有されます．
-      例えば，もしネットワークが設定されていなければ，コンテナを作成する側とコンテナでネットワークを共有します．
-      しかし，ネットワークが指定されれば，新しいネットワークスタックがコンテナ用に作成され，コンテナは作成元の環境のネットワークを使いません．
+      linux コンテナ (<command>lxc</command>) は、常に使用する前に作成されます。
+      コンテナは、プロセスがコンテナを使う時に仮想化/隔離するシステムリソースのセットを定義することによって作成します。
+      デフォルトでは、pid, sysv ipc, マウントポイントが仮想化され、隔離されます。
+      他のシステムリソースは、設定ファイルで明確に定義されない限りは、コンテナをまたいで共有されます。
+      例えば、もしネットワークが設定されていなければ、コンテナを作成する側とコンテナでネットワークを共有します。
+      しかし、ネットワークが指定されれば、新しいネットワークスタックがコンテナ用に作成され、コンテナは作成元の環境のネットワークを使いません。
     </para>
 
     <para>
@@ -83,8 +83,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       network, the mount points, the root file system, the user namespace,
       and the control groups are supported.
       -->
-      設定ファイルは，コンテナに割り当てられる様々なシステムリソースを定義します．
-      現時点では，utsname，ネットワーク，マウントポイント，root ファイルシステム，ユーザ名前空間，control groups がサポートされます．
+      設定ファイルは、コンテナに割り当てられる様々なシステムリソースを定義します。
+      現時点では、utsname、ネットワーク、マウントポイント、root ファイルシステム、ユーザ名前空間、control groups がサポートされます。
     </para>
 
     <para>
@@ -93,8 +93,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       = value</command> fitting in one line. The '#' character means
       the line is a comment.
       -->
-      設定ファイルのオプション一つを，<command>key = value</command> の形で一行で表します．
-      '#' は，その行はコメントであることを示します．
+      設定ファイルのオプション一つを、<command>key = value</command> の形で一行で表します。
+      '#' は、その行はコメントであることを示します。
     </para>
 
     <refsect2>
@@ -108,9 +108,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	containers.  Then, if the containers are moved to another host,
 	only one file may need to be updated.
         -->
-        複数の関係するコンテナの管理を容易にするために，コンテナの設定ファイルに別のファイルをロードすることが可能です．
-        例えば，ネットワークの設定を，複数のコンテナから include させるように 1 つのファイルに定義することが可能です．
-        その場合，コンテナが他のホストに移動すると，そのファイルだけを更新する必要があるかもしれません．
+        複数の関係するコンテナの管理を容易にするために、コンテナの設定ファイルに別のファイルをロードすることが可能です。
+        例えば、ネットワークの設定を、複数のコンテナから include させるように 1 つのファイルに定義することが可能です。
+        その場合、コンテナが他のホストに移動すると、そのファイルだけを更新する必要があるかもしれません。
       </para>
 
       <variablelist>
@@ -124,8 +124,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Specify the file to be included.  The included file must be
 	      in the same valid lxc configuration file format.
               -->
-              include させたいファイルを指定します．
-              include するファイルは，lxc 設定ファイルのフォーマットとして有効でなければいけません．
+              include させたいファイルを指定します。
+              include するファイルは、lxc 設定ファイルのフォーマットとして有効でなければいけません。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -142,9 +142,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	which rely on the architecture to do some work like
 	downloading the packages.
         -->
-        コンテナに対してアーキテクチャを設定することが可能です．
-        例えば，64 ビットのホスト上で 32 ビットのバイナリを動かすために 32 ビットアーキテクチャを設定することが可能です．
-        この設定を行うことにより，パッケージのダウンロードを行うなどの作業のうち，アーキテクチャ名に依存するような作業を行うコンテナスクリプトの修正を行います．
+        コンテナに対してアーキテクチャを設定することが可能です。
+        例えば、64 ビットのホスト上で 32 ビットのバイナリを動かすために 32 ビットアーキテクチャを設定することが可能です。
+        この設定を行うことにより、パッケージのダウンロードを行うなどの作業のうち、アーキテクチャ名に依存するような作業を行うコンテナスクリプトの修正を行います。
       </para>
 
       <variablelist>
@@ -157,7 +157,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
 	      Specify the architecture for the container.
               -->
-              コンテナに設定するアーキテクチャを指定します．
+              コンテナに設定するアーキテクチャを指定します。
 	    </para>
 	    <para>
               <!--
@@ -167,7 +167,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      <option>x86_64</option>,
 	      <option>amd64</option>
               -->
-              有効なオプションは以下です．
+              有効なオプションは以下です。
 	      <option>x86</option>,
 	      <option>i686</option>,
 	      <option>x86_64</option>,
@@ -188,9 +188,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	without changing the one from the system. That makes the
 	hostname private for the container.
         -->
-        utsname セクションは，コンテナに設定されるホスト名を定義します．
-        コンテナは，システムのホスト名を変えることなく，自身のホスト名を持つ事が可能です．
-        このことにより，ホスト名はコンテナ専用となります．
+        utsname セクションは、コンテナに設定されるホスト名を定義します。
+        コンテナは、システムのホスト名を変えることなく、自身のホスト名を持つ事が可能です。
+        このことにより、ホスト名はコンテナ専用となります。
       </para>
       <variablelist>
 	<varlistentry>
@@ -202,7 +202,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
 	      specify the hostname for the container
               -->
-              コンテナのホスト名を指定します．
+              コンテナのホスト名を指定します。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -220,10 +220,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     fashion, e.g. SIGPWR, SIGRTMIN+14, SIGRTMAX-10 or plain number. The
     default signal is SIGPWR.
           -->
-        lxc-stop がコンテナをクリーンにシャットダウンするためにコンテナの init プロセスに送るシグナル名か番号を指定することができます．
-        init システムによって，クリーンなシャットダウンを行うために使うシグナルは異なります．
-        このオプションではシグナルとして kill(1) で使う形式を指定することができます．
-        例えば SIGKILL, SIGRTMIN+14, SIGRTMAX-10 のような形式，もしくは数字を指定します．デフォルトのシグナルは SIGPWR です．
+        lxc-stop がコンテナをクリーンにシャットダウンするためにコンテナの init プロセスに送るシグナル名か番号を指定することができます。
+        init システムによって、クリーンなシャットダウンを行うために使うシグナルは異なります。
+        このオプションではシグナルとして kill(1) で使う形式を指定することができます。
+        例えば SIGKILL, SIGRTMIN+14, SIGRTMAX-10 のような形式、もしくは数字を指定します。デフォルトのシグナルは SIGPWR です。
       </para>
       <variablelist>
     <varlistentry>
@@ -251,9 +251,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     kill(1) fashion, e.g. SIGKILL, SIGRTMIN+14, SIGRTMAX-10 or plain number.
     The default signal is SIGKILL.
     -->
-        lxc-stop がコンテナを強制的にシャットダウンするために送るシグナル名か番号を指定することができます．
-        このオプションではシグナルとして kill(1) で使う形式を指定することができます．
-        例えば SIGKILL, SIGRTMIN+14, SIGRTMAX-10 のような形式，もしくは数字を指定します．デフォルトのシグナルは SIGKILL です．
+        lxc-stop がコンテナを強制的にシャットダウンするために送るシグナル名か番号を指定することができます。
+        このオプションではシグナルとして kill(1) で使う形式を指定することができます。
+        例えば SIGKILL, SIGRTMIN+14, SIGRTMAX-10 のような形式、もしくは数字を指定します。デフォルトのシグナルは SIGKILL です。
       </para>
       <variablelist>
     <varlistentry>
@@ -265,7 +265,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
           specify the signal used to stop the container
           -->
-          コンテナを停止するのに使用するシグナルを指定します．
+          コンテナを停止するのに使用するシグナルを指定します。
         </para>
       </listitem>
     </varlistentry>
@@ -284,11 +284,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	in a container even if the system has only one physical
 	network interface.
         -->
-        ネットワークセクションは，コンテナ内でどのようにネットワークを仮想化するかを定義します．
-        ネットワークの仮想化はレイヤー 2 で作動します．
-        ネットワークの仮想化を使用するためには，コンテナのネットワークインターフェースを定義しなければなりません．
-        いくつかの仮想インターフェースをアサインすることができます．
-        そして，仮に物理ネットワークインターフェースが一つしかなくても，コンテナ内でいくつもの仮想インターフェースを使うことができます．
+        ネットワークセクションは、コンテナ内でどのようにネットワークを仮想化するかを定義します。
+        ネットワークの仮想化はレイヤー 2 で作動します。
+        ネットワークの仮想化を使用するためには、コンテナのネットワークインターフェースを定義しなければなりません。
+        いくつかの仮想インターフェースをアサインすることができます。
+        そして、仮に物理ネットワークインターフェースが一つしかなくても、コンテナ内でいくつもの仮想インターフェースを使うことができます。
       </para>
       <variablelist>
 	<varlistentry>
@@ -307,9 +307,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      network interfaces for one container. The different
 	      virtualization types can sbe:
               -->
-              コンテナがどの種類のネットワーク仮想化を使うかを指定します．
-              一つのネットワークの設定ごとに <option>lxc.network.type</option> フィールドを指定します．
-              このように，一つのコンテナに複数のネットワークインターフェースを割り当てることができるだけでなく，同じコンテナに対して複数のネットワーク仮想化の種類を指定することが出来ます．
+              コンテナがどの種類のネットワーク仮想化を使うかを指定します。
+              一つのネットワークの設定ごとに <option>lxc.network.type</option> フィールドを指定します。
+              このように、一つのコンテナに複数のネットワークインターフェースを割り当てることができるだけでなく、同じコンテナに対して複数のネットワーク仮想化の種類を指定することが出来ます。
               仮想化の種類は以下の値を取る事が出来ます:
 	    </para>
 
@@ -322,9 +322,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      init, 'halt' in a container (for instance) will shut down the
 	      host.
               -->
-              <option>none:</option> ホストのネットワーク名前空間を共有します．
-              これにより，ホストのネットワークデバイスをコンテナ内で使うことが可能になります．
-              もしコンテナもホストも init として upstart を使っている場合，(例えば) コンテナ内で 'halt' を実行すると，ホストがシャットダウンしてしまうことにもなります．
+              <option>none:</option> ホストのネットワーク名前空間を共有します。
+              これにより、ホストのネットワークデバイスをコンテナ内で使うことが可能になります。
+              もしコンテナもホストも init として upstart を使っている場合、(例えば) コンテナ内で 'halt' を実行すると、ホストがシャットダウンしてしまうことにもなります。
 	    </para>
 
 	    <para>
@@ -332,7 +332,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      <option>empty:</option> will create only the loopback
 	      interface.
               -->
-	      <option>empty:</option> ループバックインターフェースだけを作成します．
+	      <option>empty:</option> ループバックインターフェースだけを作成します。
 	    </para>
 
 	    <para>
@@ -354,12 +354,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      to set a specific name with
 	      the <option>lxc.network.veth.pair</option> option.
               -->
-              <option>veth:</option> 一方がコンテナに，もう一方が <option>lxc.network.link</option> で指定されるブリッジにアタッチされる，ピアネットワークデバイスを作成します．
-              もし，ブリッジが指定されていない場合，veth ペアデバイスは作成されますが，ブリッジにはアタッチされません．
-              ブリッジはシステムで事前に設定する必要があります．
-              さもなければ，<command>lxc</command> はコンテナ外のいかなる設定も扱うことはできないでしょう．
-              デフォルトでは，<command>lxc</command> はコンテナの外部に属するネットワークデバイスに対する名前を決定し，<command>lxc</command> はこの名前を使います．
-              しかし，もしこの名前を自分で指定したい場合，<option>lxc.network.veth.pair</option> オプションを使って名前を設定し，lxc に対して指定をすることができます．
+              <option>veth:</option> 一方がコンテナに、もう一方が <option>lxc.network.link</option> で指定されるブリッジにアタッチされる、ピアネットワークデバイスを作成します。
+              もし、ブリッジが指定されていない場合、veth ペアデバイスは作成されますが、ブリッジにはアタッチされません。
+              ブリッジはシステムで事前に設定する必要があります。
+              さもなければ、<command>lxc</command> はコンテナ外のいかなる設定も扱うことはできないでしょう。
+              デフォルトでは、<command>lxc</command> はコンテナの外部に属するネットワークデバイスに対する名前を決定し、<command>lxc</command> はこの名前を使います。
+              しかし、もしこの名前を自分で指定したい場合、<option>lxc.network.veth.pair</option> オプションを使って名前を設定し、lxc に対して指定をすることができます。
 	    </para>
 
 	    <para>
@@ -370,8 +370,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      the container. The vlan identifier is specified with the
 	      option <option>lxc.network.vlan.id</option>.
               -->
-              <option>vlan:</option> vlan インターフェースは <option>lxc.network.link</option> で指定されたインターフェースとリンクし，コンテナに割り当てられます．
-              vlan の指定は <option>lxc.network.vlan.id</option> オプションで指定します．
+              <option>vlan:</option> vlan インターフェースは <option>lxc.network.link</option> で指定されたインターフェースとリンクし、コンテナに割り当てられます。
+              vlan の指定は <option>lxc.network.vlan.id</option> オプションで指定します。
 	    </para>
 
 	    <para>
@@ -403,18 +403,18 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      the MAC addresses, the macvlan bridge mode does not
 	      require learning or STP like the bridge module does.
               -->
-              <option>macvlan:</option> macvlan インターフェースは <option>lxc.network.link</option> により指定されるインターフェースとリンクし，コンテナに割り当てられます．
-              <option>lxc.network.macvlan.mode</option> でモードを指定すると，その macvlan の指定を，同じ上位デバイスで異なる macvlan の間の通信をする時に使います．
-              受け入れられたモードが <option>private</option> であれば，デバイスは同じ上位デバイスの他のデバイスとの通信を行いません (デフォルト)．
-              新しい仮想イーサネットポート集約モード (Virtual Ethernet Port Aggregator (VEPA)) である <option>vepa</option> は，隣接したポートが，ソースとデスティネーションの両方が macvlan ポートに対してローカルであるフレームを全て返すと仮定します．
-              すなわち，ブリッジが reflective relay として設定されているということです．
-              上位デバイスから入ってくるブロードキャストフレームは，VEPA モードである全ての macvlan インターフェースに送りつけられます．
-              ローカルのフレームはローカルには配送されません．
-              <option>bridge</option> の指定は，同じポートの異なる macvlan インターフェースの間のシンプルなブリッジとして動作します．
-              あるインターフェースから他のインターフェースへのフレームは，直接配送され，外部には送出されません．
-              ブロードキャストフレームは，全ての他のブリッジと外部のインターフェースに対して送られます．
-              しかし，reflective relay からフレームが返ってきたときは，再度それを配送することはしません．
-              全ての MAC アドレスを知っているので，ブリッジモジュールのように，macvlan ブリッジモードは学習や STP の必要はありません．
+              <option>macvlan:</option> macvlan インターフェースは <option>lxc.network.link</option> により指定されるインターフェースとリンクし、コンテナに割り当てられます。
+              <option>lxc.network.macvlan.mode</option> でモードを指定すると、その macvlan の指定を、同じ上位デバイスで異なる macvlan の間の通信をする時に使います。
+              受け入れられたモードが <option>private</option> であれば、デバイスは同じ上位デバイスの他のデバイスとの通信を行いません (デフォルト)。
+              新しい仮想イーサネットポート集約モード (Virtual Ethernet Port Aggregator (VEPA)) である <option>vepa</option> は、隣接したポートが、ソースとデスティネーションの両方が macvlan ポートに対してローカルであるフレームを全て返すと仮定します。
+              すなわち、ブリッジが reflective relay として設定されているということです。
+              上位デバイスから入ってくるブロードキャストフレームは、VEPA モードである全ての macvlan インターフェースに送りつけられます。
+              ローカルのフレームはローカルには配送されません。
+              <option>bridge</option> の指定は、同じポートの異なる macvlan インターフェースの間のシンプルなブリッジとして動作します。
+              あるインターフェースから他のインターフェースへのフレームは、直接配送され、外部には送出されません。
+              ブロードキャストフレームは、全ての他のブリッジと外部のインターフェースに対して送られます。
+              しかし、reflective relay からフレームが返ってきたときは、再度それを配送することはしません。
+              全ての MAC アドレスを知っているので、ブリッジモジュールのように、macvlan ブリッジモードは学習や STP の必要はありません。
 	    </para>
 
 	    <para>
@@ -423,7 +423,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      specified by the <option>lxc.network.link</option> is
 	      assigned to the container.
               -->
-              <option>phys:</option> <option>lxc.network.link</option> で指定された，すでに存在しているインターフェースがコンテナに割り当てられます．
+              <option>phys:</option> <option>lxc.network.link</option> で指定された、すでに存在しているインターフェースがコンテナに割り当てられます。
 	    </para>
 	  </listitem>
 	  </varlistentry>
@@ -438,14 +438,14 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      specify an action to do for the
 	      network.
               -->
-              ネットワークに対して行うアクションを指定します．
+              ネットワークに対して行うアクションを指定します。
 	    </para>
 
 	    <para>
               <!--
               <option>up:</option> activates the interface.
               -->
-              <option>up:</option> インターフェースを起動させます．
+              <option>up:</option> インターフェースを起動させます。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -460,7 +460,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      specify the interface to be used for real network
 	      traffic.
               -->
-              実際のネットワークトラフィックに使うインターフェースを指定します．
+              実際のネットワークトラフィックに使うインターフェースを指定します。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -474,7 +474,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
 	      specify the maximum transfer unit for this interface.
               -->
-              インターフェースに対する MTU を指定します．
+              インターフェースに対する MTU を指定します。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -492,8 +492,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      eg. eth0, this option will rename the interface in the
 	      container.
               -->
-              インターフェース名は動的に割り当てられます．
-              しかし，もしコンテナが使用する設定ファイルが一般的な名前を使用するために，他の特定の名前が必要であれば (例えば eth0 など)，コンテナ内のインターフェースは，このオプションで指定した名前にリネームされます．
+              インターフェース名は動的に割り当てられます。
+              しかし、もしコンテナが使用する設定ファイルが一般的な名前を使用するために、他の特定の名前が必要であれば (例えば eth0 など)、コンテナ内のインターフェースは、このオプションで指定した名前にリネームされます。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -512,10 +512,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Any "x" in address will be replaced by random value,
 	      this allows setting hwaddr templates.
               -->
-              仮想インターフェースの MAC アドレスは，デフォルトでは動的に割り当てられます．
-              しかし，MAC アドレスの衝突や，リンクローカルIPv6 アドレスを常に同じにした場合などは，このオプションが必要です．
-              アドレス中の "x" という文字は，ランダムな値に置き換えられます．
-              これによりテンプレートに hwaddr を設定することが可能になります．
+              仮想インターフェースの MAC アドレスは、デフォルトでは動的に割り当てられます。
+              しかし、MAC アドレスの衝突や、リンクローカルIPv6 アドレスを常に同じにした場合などは、このオプションが必要です。
+              アドレス中の "x" という文字は、ランダムな値に置き換えられます。
+              これによりテンプレートに hwaddr を設定することが可能になります。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -534,10 +534,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      specified on the same line, right after the ipv4
 	      address.
               -->
-              仮想インターフェースに割り当てる ipv4 アドレスを指定します．
-              複数行により複数の ipv4 アドレスを指定します．
-              このアドレスは x.y.z.t/m というフォーマットで指定します．
-              例えば，192.168.1.123/24．ブロードキャストアドレスも同じ行の ipv4 アドレスのすぐ後で指定しなくてはなりません．
+              仮想インターフェースに割り当てる ipv4 アドレスを指定します。
+              複数行により複数の ipv4 アドレスを指定します。
+              このアドレスは x.y.z.t/m というフォーマットで指定します。
+              例えば、192.168.1.123/24。ブロードキャストアドレスも同じ行の ipv4 アドレスのすぐ後で指定しなくてはなりません。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -561,13 +561,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      using the <option>veth</option> and
 	      <option>macvlan</option> network types.
               -->
-              コンテナでゲートウェイとして使う IPv4 アドレスを指定します．
-              アドレスは x.y.z.t というフォーマットです．
-              例えば，192.168.1.123．
+              コンテナでゲートウェイとして使う IPv4 アドレスを指定します。
+              アドレスは x.y.z.t というフォーマットです。
+              例えば、192.168.1.123。
 
-              <option>auto</option> という特別な値を記述する事も可能です．
-              これは (<option>lxc.network.link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し，それをゲートウェイに使うという意味になります．
-              <option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります．
+              <option>auto</option> という特別な値を記述する事も可能です。
+              これは (<option>lxc.network.link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し、それをゲートウェイに使うという意味になります。
+              <option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -585,10 +585,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      The address is in format x::y/m,
 	      eg. 2003:db8:1:0:214:1234:fe0b:3596/64
               -->
-              仮想インターフェースに割り当てる ipv6 アドレスを指定します．
-              複数行により複数の ipv6 アドレスを指定します．
-              このアドレスは x::y/m というフォーマットで指定します．
-              例えば，2003:db8:1:0:214:1234:fe0b:3596/64．
+              仮想インターフェースに割り当てる ipv6 アドレスを指定します。
+              複数行により複数の ipv6 アドレスを指定します。
+              このアドレスは x::y/m というフォーマットで指定します。
+              例えば、2003:db8:1:0:214:1234:fe0b:3596/64。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -612,12 +612,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      using the <option>veth</option> and
 	      <option>macvlan</option> network types.
               -->
-              コンテナでゲートウェイとして使う IPv6 アドレスを指定します．
-              アドレスは x::y というフォーマットです．例えば，2003:db8:1:0::1．
+              コンテナでゲートウェイとして使う IPv6 アドレスを指定します。
+              アドレスは x::y というフォーマットです。例えば、2003:db8:1:0::1。
 
-              <option>auto</option> という特別な値を記述する事も可能です．
-              これは (<option>lxc.network.link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し，それをゲートウェイに使うという意味になります．
-              <option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります．
+              <option>auto</option> という特別な値を記述する事も可能です。
+              これは (<option>lxc.network.link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し、それをゲートウェイに使うという意味になります。
+              <option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -640,11 +640,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      type, other arguments may be passed:
 	      veth/macvlan/phys. And finally (host-sided) device name.
               -->
-              ホスト側から使われる，ネットワークの作成と設定が済んだ後に実行するスクリプトを指定します．
-              以下の引数がスクリプトに渡されます: コンテナ名，設定セクション名(net)．
-              その後の引数はスクリプトのフックで使われる設定セクションに依存します．
-              以下がネットワークシステムによって使われます: 実行コンテキスト (up)，ネットワークのタイプ (empty/veth/macvlan/phys)
-              ネットワークのタイプによっては，更に別の引数が渡されるかもしれません: veth/macvlan/phys の場合 (ホスト側の) デバイス名
+              ホスト側から使われる、ネットワークの作成と設定が済んだ後に実行するスクリプトを指定します。
+              以下の引数がスクリプトに渡されます: コンテナ名、設定セクション名(net)。
+              その後の引数はスクリプトのフックで使われる設定セクションに依存します。
+              以下がネットワークシステムによって使われます: 実行コンテキスト (up)、ネットワークのタイプ (empty/veth/macvlan/phys)
+              ネットワークのタイプによっては、更に別の引数が渡されるかもしれません: veth/macvlan/phys の場合 (ホスト側の) デバイス名
             </para>
 	    <para>
               <!--
@@ -652,9 +652,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Standard error is not logged, but can be captured by the
 	      hook redirecting its standard error to standard output.
               -->
-              スクリプトからの標準出力は debug レベルでロギングされます．
-              標準エラー出力はロギングされません．
-              しかし，フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です．
+              スクリプトからの標準出力は debug レベルでロギングされます。
+              標準エラー出力はロギングされません。
+              しかし、フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -677,11 +677,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      type, other arguments may be passed:
 	      veth/macvlan/phys. And finally (host-sided) device name.
               -->
-              ホスト側から使われる，ネットワークを破壊する前に実行するスクリプトを指定します．
-              以下の引数がスクリプトに渡されます: コンテナ名，設定セクション名(net)．
-              その後の引数はスクリプトのフックで使われる設定セクションに依存します．
-              以下がネットワークシステムによって使われます: 実行コンテキスト (up)，ネットワークのタイプ (empty/veth/macvlan/phys)．
-              ネットワークのタイプによっては，更に別の引数が渡されるかもしれません: veth/macvlan/phys．そして最後に (ホスト側の) デバイス名が渡されます．
+              ホスト側から使われる、ネットワークを破壊する前に実行するスクリプトを指定します。
+              以下の引数がスクリプトに渡されます: コンテナ名、設定セクション名(net)。
+              その後の引数はスクリプトのフックで使われる設定セクションに依存します。
+              以下がネットワークシステムによって使われます: 実行コンテキスト (up)、ネットワークのタイプ (empty/veth/macvlan/phys)。
+              ネットワークのタイプによっては、更に別の引数が渡されるかもしれません: veth/macvlan/phys。そして最後に (ホスト側の) デバイス名が渡されます。
             </para>
 	    <para>
               <!--
@@ -689,9 +689,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Standard error is not logged, but can be captured by the
 	      hook redirecting its standard error to standard output.
               -->
-              スクリプトからの標準出力は debug レベルでロギングされます．
-              標準エラー出力はロギングされません．
-              しかし，フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です．
+              スクリプトからの標準出力は debug レベルでロギングされます。
+              標準エラー出力はロギングされません。
+              しかし、フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -706,7 +706,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	For stricter isolation the container can have its own private
 	instance of the pseudo tty.
         -->
-        さらに厳しい隔離のために，コンテナは自身のプライベートな pseudo tty (擬似端末) を持つことが可能です．
+        さらに厳しい隔離のために、コンテナは自身のプライベートな pseudo tty (擬似端末) を持つことが可能です。
       </para>
       <variablelist>
 	<varlistentry>
@@ -721,8 +721,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               the maximum number of pseudo ttys allowed for a pts
               instance (this limitation is not implemented yet).
               -->
-              もし設定された場合，コンテナは新しい psuedo tty インスタンスを持ち，それを自身のプライベートとします．
-              この値は pts インスタンスに許可される pseudo tty の最大数を指定します (この制限はまだ実装されていません)．
+              もし設定された場合、コンテナは新しい psuedo tty インスタンスを持ち、それを自身のプライベートとします。
+              この値は pts インスタンスに許可される pseudo tty の最大数を指定します (この制限はまだ実装されていません)。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -737,7 +737,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	inittab file is setup to use the console, you may want to specify
 	where the output of this console goes.
         -->
-        コンテナでルートファイルシステムを持つように設定されており，inittab ファイルでコンソールの使用が設定されている場合，このコンソールの出力がどこになされるのかを指定したいと思うでしょう．
+        コンテナでルートファイルシステムを持つように設定されており、inittab ファイルでコンソールの使用が設定されている場合、このコンソールの出力がどこになされるのかを指定したいと思うでしょう。
       </para>
       <variablelist>
 	<varlistentry>
@@ -753,8 +753,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      console device file where the application can write, the
 	      messages will fall in the host.
               -->
-              コンソールの出力が書かれるファイルのパスを指定します．'none' というキーワードは，単純にコンソールを無効にします．
-              この設定は，アプリケーションが書き込む事ができるコンソールデバイスファイルが rootfs に存在する場合，メッセージがホスト側に出力されるので危険です．
+              コンソールの出力が書かれるファイルのパスを指定します。'none' というキーワードは、単純にコンソールを無効にします。
+              この設定は、アプリケーションが書き込む事ができるコンソールデバイスファイルが rootfs に存在する場合、メッセージがホスト側に出力されるので危険です。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -774,10 +774,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	respawn indefinitely giving annoying messages on the console or in
 	<filename>/var/log/messages</filename>.
         -->
-        このオプションはコンテナが root ファイルシステムを持つように設定されており，inittab ファイルで tty 上に getty の起動が設定されている場合に役に立ちます．
-        このオプションはコンテナで利用できる tty の数を指定します．
-        inittab ファイルに設定する getty の数は，このオプションの指定する tty の数より大きくしてはいけません．
-        さもなければ，超過した分の getty セッションはコンソールか /var/log/messages にうっとうしいメッセージを生死を表示しながら，永久に生死を繰り返すでしょう．
+        このオプションはコンテナが root ファイルシステムを持つように設定されており、inittab ファイルで tty 上に getty の起動が設定されている場合に役に立ちます。
+        このオプションはコンテナで利用できる tty の数を指定します。
+        inittab ファイルに設定する getty の数は、このオプションの指定する tty の数より大きくしてはいけません。
+        さもなければ、超過した分の getty セッションはコンソールか /var/log/messages にうっとうしいメッセージを生死を表示しながら、永久に生死を繰り返すでしょう。
       </para>
       <variablelist>
 	<varlistentry>
@@ -790,7 +790,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Specify the number of tty to make available to the
 	      container.
               -->
-              コンテナに作成出来る tty の数を指定します．
+              コンテナに作成出来る tty の数を指定します。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -812,13 +812,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	A package upgrade can then succeed as it is able to remove and replace
 	the symbolic links.
         -->
-        LXC のコンソールはホストによって作られ，コンテナ内で要求されたデバイスに bind マウントされた Unix98 PTY 経由で提供されます．
-        デフォルトでは <filename>/dev/console</filename> と <filename>/dev/ttyN</filename> に bind マウントされます．
-        これはゲスト内でのパッケージのアップグレードを妨げる可能性があります．
-        なので <filename>/dev</filename> 以下のディレクトリを指定することができます．
-        LXC はこのディレクトリ以下にファイルを作成し，これらのファイルを bind マウントします．
-        そして，これらの (作成された) ファイルは <filename>/dev/console</filename> と <filename>/dev/ttyN</filename> にシンボリックリンクされます．
-        シンボリックリンクを消去したり置き換えたりすることは可能ですから，パッケージのアップグレードは成功します．
+        LXC のコンソールはホストによって作られ、コンテナ内で要求されたデバイスに bind マウントされた Unix98 PTY 経由で提供されます。
+        デフォルトでは <filename>/dev/console</filename> と <filename>/dev/ttyN</filename> に bind マウントされます。
+        これはゲスト内でのパッケージのアップグレードを妨げる可能性があります。
+        なので <filename>/dev</filename> 以下のディレクトリを指定することができます。
+        LXC はこのディレクトリ以下にファイルを作成し、これらのファイルを bind マウントします。
+        そして、これらの (作成された) ファイルは <filename>/dev/console</filename> と <filename>/dev/ttyN</filename> にシンボリックリンクされます。
+        シンボリックリンクを消去したり置き換えたりすることは可能ですから、パッケージのアップグレードは成功します。
       </para>
       <variablelist>
 	<varlistentry>
@@ -831,7 +831,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Specify a directory under <filename>/dev</filename>
 	      under which to create the container console devices.
               -->
-              コンテナのコンソールデバイスを作成するための <filename>/dev</filename> 以下のディレクトリを指定します．
+              コンテナのコンソールデバイスを作成するための <filename>/dev</filename> 以下のディレクトリを指定します。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -854,12 +854,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         devices in the containers /dev directory may be created through the
         use of the <option>lxc.hook.autodev</option> hook.
         -->
-        デフォルトでは，lxc はコンテナの <filename>/dev</filename> 以下に fd, stdin, stdout, stderr のシンボリックリンクを作成しますが，自動的にはデバイスノードのエントリは作成しません．
-        これは，コンテナの rootfs で必要な設定を行えるようにするものです．
-        lxc.autodev が 1 に設定されている場合，コンテナの rootfs をマウントした後，LXC は新しい tmpfs を <filename>/dev</filename> 以下にマウントします (100k 制限の)．
-        そして初期デバイスの最小限のセットを作成します．
-        これは，"systemd" ベースの "init" 環境のコンテナを起動する時に通常必要ですが，他の環境の場合はオプショナルなものです．
-        コンテナの /dev ディレクトリ内の追加デバイスは <option>lxc.hook.autodev</option> フックを使用して作成されます．
+        デフォルトでは、lxc はコンテナの <filename>/dev</filename> 以下に fd, stdin, stdout, stderr のシンボリックリンクを作成しますが、自動的にはデバイスノードのエントリは作成しません。
+        これは、コンテナの rootfs で必要な設定を行えるようにするものです。
+        lxc.autodev が 1 に設定されている場合、コンテナの rootfs をマウントした後、LXC は新しい tmpfs を <filename>/dev</filename> 以下にマウントします (100k 制限の)。
+        そして初期デバイスの最小限のセットを作成します。
+        これは、"systemd" ベースの "init" 環境のコンテナを起動する時に通常必要ですが、他の環境の場合はオプショナルなものです。
+        コンテナの /dev ディレクトリ内の追加デバイスは <option>lxc.hook.autodev</option> フックを使用して作成されます。
       </para>
       <variablelist>
 	<varlistentry>
@@ -872,7 +872,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Set this to 1 to have LXC mount and populate a minimal
 	      <filename>/dev</filename> when starting the container.
               -->
-              コンテナの起動時に LXC が /dev をマウントして，最小限の /dev を作成しているようにするには，これを 1 に設定してください．
+              コンテナの起動時に LXC が /dev をマウントして、最小限の /dev を作成しているようにするには、これを 1 に設定してください。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -885,7 +885,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         <!--
       Enable creating /dev/kmsg as symlink to /dev/console.  This defaults to 1.
       -->
-        /dev/kmsg の /dev/console へのシンボリックリンクとしての作成を有効にします．デフォルトは 1 です．
+        /dev/kmsg の /dev/console へのシンボリックリンクとしての作成を有効にします。デフォルトは 1 です。
       </para>
       <variablelist>
     <varlistentry>
@@ -897,7 +897,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <!--
           Set this to 0 to disable /dev/kmsg symlinking.
           -->
-          /dev/kmsg のシンボリックリンクを無効にするには 0 を設定してください．
+          /dev/kmsg のシンボリックリンクを無効にするには 0 を設定してください。
         </para>
       </listitem>
     </varlistentry>
@@ -914,9 +914,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	container. This is useful to mount /etc, /var or /home for
 	examples.
         -->
-        マウントポイントセクションは，マウントするための区別された場所を指定します．
-        これらのマウントポイントは，コンテナだけに見え，コンテナ外で実行されるプロセスから見えることはありません．
-        例えば，/etc や /var や /home をマウントするときに役に立つでしょう．
+        マウントポイントセクションは、マウントするための区別された場所を指定します。
+        これらのマウントポイントは、コンテナだけに見え、コンテナ外で実行されるプロセスから見えることはありません。
+        例えば、/etc や /var や /home をマウントするときに役に立つでしょう。
       </para>
       <variablelist>
 	<varlistentry>
@@ -943,14 +943,14 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               </citerefentry>
               but must be explicitly specified.
               -->
-              マウントに関する情報が書かれた <filename>fstab</filename> フォーマットのファイルの場所を指定します．
-              rootfs がイメージファイルやブロックデバイスで，fstab ファイルがこの rootfs 内のどこかをマウントするために使われる場合，rootfs のマウントポイントのパスはデフォルトパスである <filename>@LXCROOTFSMOUNT@</filename> か，もしくは <option>lxc.rootfs.mount</option> が指定されている場合は，その値を前に付ける必要があります．
-              ファイルシステムがイメージファイルやブロックデバイスからマウントされている場合，3 つ目のフィールド (fs_vfstype) は
+              マウントに関する情報が書かれた <filename>fstab</filename> フォーマットのファイルの場所を指定します。
+              rootfs がイメージファイルやブロックデバイスで、fstab ファイルがこの rootfs 内のどこかをマウントするために使われる場合、rootfs のマウントポイントのパスはデフォルトパスである <filename>@LXCROOTFSMOUNT@</filename> か、もしくは <option>lxc.rootfs.mount</option> が指定されている場合は、その値を前に付ける必要があります。
+              ファイルシステムがイメージファイルやブロックデバイスからマウントされている場合、3 つ目のフィールド (fs_vfstype) は
               <citerefentry>
 		<refentrytitle>mount</refentrytitle>
                 <manvolnum>8</manvolnum>
               </citerefentry>
-              のように auto を指定することはできず，明確に指定しなければいけません．
+              のように auto を指定することはできず、明確に指定しなければいけません。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -965,7 +965,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      specify a mount point corresponding to a line in the
 	      fstab format.
               -->
-              fstab フォーマットの一行と同じフォーマットのマウントポイントの指定をします．
+              fstab フォーマットの一行と同じフォーマットのマウントポイントの指定をします。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -981,8 +981,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      automatically mounted. This may dramatically simplify
 	      the configuration. The file systems are:
               -->
-              標準のカーネルファイルシステムで自動的にマウントするものを指定します．
-              これは劇的に設定を容易にする可能性があります．
+              標準のカーネルファイルシステムで自動的にマウントするものを指定します。
+              これは劇的に設定を容易にする可能性があります。
 	    </para>
 	    <itemizedlist>
 	      <listitem>
@@ -997,8 +997,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
                   <option>proc:mixed</option> (or <option>proc</option>):
-                  <filename>/proc</filename> を読み書き可能でマウントします．
-                  ただし，<filename>/proc/sys</filename> と <filename>/proc/sysrq-trigger</filename> は，セキュリティとコンテナの隔離の目的でリードオンリーで再マウントされます．
+                  <filename>/proc</filename> を読み書き可能でマウントします。
+                  ただし、<filename>/proc/sys</filename> と <filename>/proc/sysrq-trigger</filename> は、セキュリティとコンテナの隔離の目的でリードオンリーで再マウントされます。
                 </para>
 	      </listitem>
 	      <listitem>
@@ -1010,7 +1010,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>proc:rw</option>:
-                  <filename>/proc</filename> を読み書き可能でマウントします．
+                  <filename>/proc</filename> を読み書き可能でマウントします。
                 </para>
 	      </listitem>
 	      <listitem>
@@ -1023,7 +1023,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
                   <option>sys:ro</option> (or <option>sys</option>):
-                  <filename>/sys</filename> を，セキュリティとコンテナの隔離の目的でリードオンリーでマウントします．
+                  <filename>/sys</filename> を、セキュリティとコンテナの隔離の目的でリードオンリーでマウントします。
                 </para>
 	      </listitem>
 	      <listitem>
@@ -1035,7 +1035,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>sys:rw</option>:
-                  <filename>/sys</filename> を読み書き可能でマウントします．
+                  <filename>/sys</filename> を読み書き可能でマウントします。
                 </para>
 	      </listitem>
 	      <listitem>
@@ -1055,8 +1055,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>cgroup:mixed</option> (or <option>cgroup</option>):
-                  <filename>/sys/fs/cgroup</filename> を tmpfs でマウントし，そのコンテナの追加が行われた全ての階層構造に対するディレクトリを作製し，その cgroup の名前でその中にサブディレクトリを作製し，そのコンテナ自身の cgroup をそのディレクトリにバインドマウントします．
-                  コンテナは自身の cgroup ディレクトリに書き込みが可能ですが，親ディレクトリはリードオンリーで再マウントされているため書き込めません．
+                  <filename>/sys/fs/cgroup</filename> を tmpfs でマウントし、そのコンテナの追加が行われた全ての階層構造に対するディレクトリを作製し、その cgroup の名前でその中にサブディレクトリを作製し、そのコンテナ自身の cgroup をそのディレクトリにバインドマウントします。
+                  コンテナは自身の cgroup ディレクトリに書き込みが可能ですが、親ディレクトリはリードオンリーで再マウントされているため書き込めません。
                 </para>
 	      </listitem>
 	      <listitem>
@@ -1069,7 +1069,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>cgroup:ro</option>:
-                  <option>cgroup:mixed</option> と同様にマウントされますが，全てリードオンリーでマウントされます．
+                  <option>cgroup:mixed</option> と同様にマウントされますが、全てリードオンリーでマウントされます。
                 </para>
 	      </listitem>
 	      <listitem>
@@ -1085,9 +1085,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>cgroup:rw</option>:
-                  <option>cgroup:mixed</option> と同様にマウントされますが，全て読み書き可能でマウントされます．
-                  コンテナ自身の cgroup に至るまでのパスも書き込み可能になることに注意が必要ですが，cgroup ファイルシステムにはならず，
-                  <filename>/sys/fs/cgroup</filename> の tmpfs の一部分になるでしょう．
+                  <option>cgroup:mixed</option> と同様にマウントされますが、全て読み書き可能でマウントされます。
+                  コンテナ自身の cgroup に至るまでのパスも書き込み可能になることに注意が必要ですが、cgroup ファイルシステムにはならず、
+                  <filename>/sys/fs/cgroup</filename> の tmpfs の一部分になるでしょう。
                 </para>
 	      </listitem>
 	      <listitem>
@@ -1113,9 +1113,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>cgroup-full:mixed</option> (or <option>cgroup-full</option>):
-                  <filename>/sys/fs/cgroup</filename> を tmpfs でマウントし，そのコンテナの追加が行われた全ての階層構造に対するディレクトリを作製し，ホストからコンテナまでの階層構造を全てバインドマウントし，コンテナ自身の cgroup を除いてリードオンリーにします．
-                  <option>cgroup</option> と比べると，コンテナ自身の cgroup に至るまでの全てのパスが tmpfs の下層のシンプルなディレクトリとなり，コンテナ自身の cgroup の外ではリードオンリーになりますが，<filename>/sys/fs/cgroup/$hierarchy</filename> はホストの全ての cgroup 階層構造を含みます．
-                  これにより，コンテナにはかなりの情報が漏洩します．
+                  <filename>/sys/fs/cgroup</filename> を tmpfs でマウントし、そのコンテナの追加が行われた全ての階層構造に対するディレクトリを作製し、ホストからコンテナまでの階層構造を全てバインドマウントし、コンテナ自身の cgroup を除いてリードオンリーにします。
+                  <option>cgroup</option> と比べると、コンテナ自身の cgroup に至るまでの全てのパスが tmpfs の下層のシンプルなディレクトリとなり、コンテナ自身の cgroup の外ではリードオンリーになりますが、<filename>/sys/fs/cgroup/$hierarchy</filename> はホストの全ての cgroup 階層構造を含みます。
+                  これにより、コンテナにはかなりの情報が漏洩します。
                 </para>
 	      </listitem>
 	      <listitem>
@@ -1128,7 +1128,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>cgroup-full:ro</option>:
-                  <option>cgroup-full:mixed</option> と同様にマウントされますが，全てリードオンリーでマウントされます．
+                  <option>cgroup-full:mixed</option> と同様にマウントされますが、全てリードオンリーでマウントされます。
                 </para>
 	      </listitem>
 	      <listitem>
@@ -1145,8 +1145,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
                 -->
                 <para>
 	          <option>cgroup-full:rw</option>:
-	          <option>cgroup-full:mixed</option>と同様にマウントされますが，全て読み書き可能でマウントされます．
-                  この場合，コンテナは自身の cgroup から脱出する可能性があることに注意してください (コンテナが CAP_SYS_ADMIN を持ち，自身で cgroup ファイルシステムをマウント可能なら，いずれにせよそのようにするかもしれないことにも注意してください)．
+	          <option>cgroup-full:mixed</option>と同様にマウントされますが、全て読み書き可能でマウントされます。
+                  この場合、コンテナは自身の cgroup から脱出する可能性があることに注意してください (コンテナが CAP_SYS_ADMIN を持ち、自身で cgroup ファイルシステムをマウント可能なら、いずれにせよそのようにするかもしれないことにも注意してください)。
                 </para>
 	      </listitem>
 	    </itemizedlist>
@@ -1173,7 +1173,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	The root file system of the container can be different than that
 	of the host system.
         -->
-        コンテナのルートファイルシステムは，ホストのルートファイルシステムと異なるようにすることも可能です．
+        コンテナのルートファイルシステムは、ホストのルートファイルシステムと異なるようにすることも可能です。
       </para>
       <variablelist>
 	<varlistentry>
@@ -1188,9 +1188,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      specified, the container shares its root file system
 	      with the host.
               -->
-              コンテナのルートファイルシステムになるディレクトリを指定します．
-              この値はイメージファイル，ディレクトリ，ブロックデバイスのどれかを取ることができます．
-              もし指定されない場合，コンテナはホストとルートファイルシステムを共有します．
+              コンテナのルートファイルシステムになるディレクトリを指定します。
+              この値はイメージファイル、ディレクトリ、ブロックデバイスのどれかを取ることができます。
+              もし指定されない場合、コンテナはホストとルートファイルシステムを共有します。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1211,13 +1211,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      syscall.  Any directory suffices, the default should
 	      generally work.
               -->
-              root ファイルシステムの変更の前に，<option>lxc.rootfs</option> を再帰的にどこにバインドするのかを指定します．これは
+              root ファイルシステムの変更の前に、<option>lxc.rootfs</option> を再帰的にどこにバインドするのかを指定します。これは
 	      <citerefentry>
 		<refentrytitle><command>pivot_root</command></refentrytitle>
 		<manvolnum>8</manvolnum>
 	      </citerefentry>
-              システムコールが確実に成功する事を保証します．
-              どんなディレクトリでも良く，デフォルトでも通常は動くはずです．
+              システムコールが確実に成功する事を保証します。
+              どんなディレクトリでも良く、デフォルトでも通常は動くはずです。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1231,7 +1231,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
 	      extra mount options to use when mounting the rootfs.
               -->
-              rootfs をマウントするときに追加したいマウントオプション．
+              rootfs をマウントするときに追加したいマウントオプション。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1249,9 +1249,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      It is created if necessary, and also removed after
 	      unmounting everything from it during container setup.
               -->
-              元の root ファイルシステムを，<option>lxc.rootfs</option> 以下のどこに移動させるかを <option>lxc.rootfs</option> からの相対パスで指定します．
-              デフォルトは <filename>mnt</filename> です．
-              これはもし必要であれば作成され，そしてコンテナのセットアップの間，全てアンマウントされた後で消去されます．
+              元の root ファイルシステムを、<option>lxc.rootfs</option> 以下のどこに移動させるかを <option>lxc.rootfs</option> からの相対パスで指定します。
+              デフォルトは <filename>mnt</filename> です。
+              これはもし必要であれば作成され、そしてコンテナのセットアップの間、全てアンマウントされた後で消去されます。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1269,9 +1269,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	started, but has the advantage of permitting any future
 	subsystem.
         -->
-        CONTROL GROUP セクションは，(lxc とは) 別のサブシステムの設定を含みます．
-        <command>lxc</command> は，このサブシステム名の正しさはチェックしません．
-        実行時のエラーを検出するのに不便ですが，別の将来のサブシステムをサポート出来るという有利な点もあります．
+        CONTROL GROUP セクションは、(lxc とは) 別のサブシステムの設定を含みます。
+        <command>lxc</command> は、このサブシステム名の正しさはチェックしません。
+        実行時のエラーを検出するのに不便ですが、別の将来のサブシステムをサポート出来るという有利な点もあります。
       </para>
       <variablelist>
 	<varlistentry>
@@ -1289,9 +1289,9 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      container is started,
 	      eg. <option>lxc.cgroup.cpuset.cpus</option>
               -->
-              設定する control group の値を指定します．
-              サブシステム名は，control group のそのままの名前です．
-              許される名前や値の書式は LXC が指示することはなく，コンテナが実行された時に実行されている Linux カーネルの機能に依存します．
+              設定する control group の値を指定します。
+              サブシステム名は、control group のそのままの名前です。
+              許される名前や値の書式は LXC が指示することはなく、コンテナが実行された時に実行されている Linux カーネルの機能に依存します。
               例えば <option>lxc.cgroup.cpuset.cpus</option>
 	    </para>
 	  </listitem>
@@ -1306,7 +1306,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	The capabilities can be dropped in the container if this one
 	is run as root.
         -->
-        コンテナが root 権限で実行されていても，コンテナ内ではケーパビリティ (capabilities) を削除する事は可能です．
+        コンテナが root 権限で実行されていても、コンテナ内ではケーパビリティ (capabilities) を削除する事は可能です。
       </para>
       <variablelist>
 	<varlistentry>
@@ -1327,11 +1327,11 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 		<manvolnum>7</manvolnum>
 	      </citerefentry>,
               -->
-              コンテナ内で削除するケーパビリティ (capability) を指定します．
-              一行でスペース区切りで複数のケーパビリティを指定することも可能です．
-              指定は，"CAP_" というプレフィックスなしで，小文字でケーパビリティを指定します．
-              例えば，CAP_SYS_MODULE というケーパビリティは sys_module と指定する必要があります．
-              詳しくは以下を参照してください．
+              コンテナ内で削除するケーパビリティ (capability) を指定します。
+              一行でスペース区切りで複数のケーパビリティを指定することも可能です。
+              指定は、"CAP_" というプレフィックスなしで、小文字でケーパビリティを指定します。
+              例えば、CAP_SYS_MODULE というケーパビリティは sys_module と指定する必要があります。
+              詳しくは以下を参照してください。
 	      <citerefentry>
 		<refentrytitle><command>capabilities</command></refentrytitle>
 		<manvolnum>7</manvolnum>
@@ -1349,8 +1349,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Specify the capability to be kept in the container. All other
 	      capabilities will be dropped.
               -->
-              コンテナ内で維持するケーパビリティを指定します．
-              指定した以外の全てのケーパビリティはドロップされます．
+              コンテナ内で維持するケーパビリティを指定します。
+              指定した以外の全てのケーパビリティはドロップされます。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1366,8 +1366,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	container should be run can be specified in the container
 	configuration.  The default is <command>lxc-container-default</command>.
         -->
-        lxc が apparmor サポートでコンパイルされ，インストールされている場合で，ホストで apparmor が有効な場合，コンテナが従って動くべき apparmor プロファイルは，コンテナの設定で指定することが可能です．
-        デフォルトは <command>lxc-container-default</command> です．
+        lxc が apparmor サポートでコンパイルされ、インストールされている場合で、ホストで apparmor が有効な場合、コンテナが従って動くべき apparmor プロファイルは、コンテナの設定で指定することが可能です。
+        デフォルトは <command>lxc-container-default</command> です。
       </para>
       <variablelist>
 	<varlistentry>
@@ -1381,8 +1381,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      be run.  To specify that the container should be unconfined,
 	      use
               -->
-              コンテナが従うべき apparmor プロファイルを指定します．
-              コンテナが apparmor による制限を受けないように設定するには，以下のように設定します．
+              コンテナが従うべき apparmor プロファイルを指定します。
+              コンテナが apparmor による制限を受けないように設定するには、以下のように設定します。
 	    </para>
 	      <programlisting>lxc.aa_profile = unconfined</programlisting>
 	  </listitem>
@@ -1400,8 +1400,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	configuration.  The default is <command>unconfined_t</command>,
 	which means that lxc will not attempt to change contexts.
         -->
-        lxc が SELinux サポートでコンパイルされ，インストールされている場合で，ホストで SELinux が有効な場合，コンテナが従って動くべき SELinux コンテキストは，コンテナの設定で指定することが可能です．
-        デフォルトは <command>unconfined_t</command> であり，これは lxc がコンテキストを変えないという意味になります．
+        lxc が SELinux サポートでコンパイルされ、インストールされている場合で、ホストで SELinux が有効な場合、コンテナが従って動くべき SELinux コンテキストは、コンテナの設定で指定することが可能です。
+        デフォルトは <command>unconfined_t</command> であり、これは lxc がコンテキストを変えないという意味になります。
       </para>
       <variablelist>
 	<varlistentry>
@@ -1414,7 +1414,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	      Specify the SELinux context under which the container should
 	      be run or <command>unconfined_t</command>. For example
               -->
-              コンテナが従うべき SELinux コンテキストを指定するか，<command>unconfined_t</command> を指定します．例えば以下のように設定します．
+              コンテナが従うべき SELinux コンテキストを指定するか、<command>unconfined_t</command> を指定します。例えば以下のように設定します。
 	    </para>
 	    <programlisting>lxc.se_context = unconfined_u:unconfined_r:lxc_t:s0-s0:c0.c1023</programlisting>
 	  </listitem>
@@ -1432,8 +1432,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	on the first line, a policy type on the second line, followed
 	by the configuration.
         -->
-        コンテナは，起動時に seccomp プロファイルをロードすることで，利用可能なシステムコールを減らして起動することが可能です．
-        seccomp の設定ファイルは，1 行目がバージョン番号，2 行目がポリシーのタイプで始まる必要があり，その後に設定を書きます．
+        コンテナは、起動時に seccomp プロファイルをロードすることで、利用可能なシステムコールを減らして起動することが可能です。
+        seccomp の設定ファイルは、1 行目がバージョン番号、2 行目がポリシーのタイプで始まる必要があり、その後に設定を書きます。
       </para>
       <para>
         <!--
@@ -1443,8 +1443,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	sycall number per line.  Each syscall number is whitelisted,
 	while every unlisted number is blacklisted for use in the container
         -->
-        現時点では，バージョン番号は 1 と 2 をサポートしています．バージョン 1 では，ポリシーはシンプルなホワイトリストですので，2 行目は "whitelist" でなければなりません．
-        そして残りの行には 1 行に 1 つずつ，システムコール番号を書きます．各行のシステムコール番号がホワイトリスト化され，リストにない番号は，そのコンテナではブラックリストに入ります．
+        現時点では、バージョン番号は 1 と 2 をサポートしています。バージョン 1 では、ポリシーはシンプルなホワイトリストですので、2 行目は "whitelist" でなければなりません。
+        そして残りの行には 1 行に 1 つずつ、システムコール番号を書きます。各行のシステムコール番号がホワイトリスト化され、リストにない番号は、そのコンテナではブラックリストに入ります。
       </para>
 
       <para>
@@ -1453,7 +1453,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
        supports per-rule and per-policy default actions, and supports
        per-architecture system call resolution from textual names.
           -->
-        バージョン 2 では，ポリシーはブラックリストもしくはホワイトリストで表され，ルールごとのアクションと，ポリシーごとのデフォルトのアクションを設定できます．そして，アーキテクチャごとの設定と，テキストで書かれたシステムコール名での設定が可能です．
+        バージョン 2 では、ポリシーはブラックリストもしくはホワイトリストで表され、ルールごとのアクションと、ポリシーごとのデフォルトのアクションを設定できます。そして、アーキテクチャごとの設定と、テキストで書かれたシステムコール名での設定が可能です。
       </para>
       <para>
         <!--
@@ -1461,7 +1461,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
        allowed except for mknod, which will simply do nothing and
        return 0 (success), looks like:
        -->
-        以下にブラックリストのポリシーの例を示します．これは mknod 以外の全てのシステムコールが許可され，mknod が呼ばれると，何もせずに単に 0(成功) を返します．
+        以下にブラックリストのポリシーの例を示します。これは mknod 以外の全てのシステムコールが許可され、mknod が呼ばれると、何もせずに単に 0(成功) を返します。
       </para>
 <screen>
 2
@@ -1479,7 +1479,7 @@ mknod errno 0
 	      Specify a file containing the seccomp configuration to
 	      load before the container starts.
               -->
-              コンテナがスタートする前にロードする seccomp の設定を含むファイルを指定します．
+              コンテナがスタートする前にロードする seccomp の設定を含むファイルを指定します。
 	     </para>
 	  </listitem>
 	</varlistentry>
@@ -1499,11 +1499,11 @@ mknod errno 0
 	user and group ids 0 through 20,000 in the container to the
 	ids 200,000 through 220,000.
         -->
-        コンテナは，ユーザとグループの id のマッピングを持った専用のユーザ名前空間で起動することが可能です．
-        たとえば，コンテナ内のユーザ id 0 を，ホストのユーザ id 200000 にマッピングすることが可能です．
-        コンテナの root ユーザはコンテナ内では特権を持ちますが，ホストでは特権を持ちません．
-        通常は，システムコンテナは id の範囲を要求し，それをマッピングします．
-        例えば，コンテナ内のユーザとグループの id 0 から 20,000 を 200,000 から 220,000 にマッピングします．
+        コンテナは、ユーザとグループの id のマッピングを持った専用のユーザ名前空間で起動することが可能です。
+        たとえば、コンテナ内のユーザ id 0 を、ホストのユーザ id 200000 にマッピングすることが可能です。
+        コンテナの root ユーザはコンテナ内では特権を持ちますが、ホストでは特権を持ちません。
+        通常は、システムコンテナは id の範囲を要求し、それをマッピングします。
+        例えば、コンテナ内のユーザとグループの id 0 から 20,000 を 200,000 から 220,000 にマッピングします。
       </para>
       <variablelist>
 	<varlistentry>
@@ -1520,11 +1520,11 @@ mknod errno 0
 	      seen on the host.  Finally, a range indicating the number
 	      of consecutive ids to map.
               -->
-              4 つの値を記述する必要があります．
-              最初の文字は 'u' か 'g' のどちらかで，ユーザかグループの ID のどちらをマッピングするかを指定します．
-              次はコンテナのユーザ名前空間内に現れる最初のユーザ ID です．
-              その次は，そのユーザ ID のホスト上での値です．
-              最後は，ID のマッピングをいくつ連続して行うかの数を指定します．
+              4 つの値を記述する必要があります。
+              最初の文字は 'u' か 'g' のどちらかで、ユーザかグループの ID のどちらをマッピングするかを指定します。
+              次はコンテナのユーザ名前空間内に現れる最初のユーザ ID です。
+              その次は、そのユーザ ID のホスト上での値です。
+              最後は、ID のマッピングをいくつ連続して行うかの数を指定します。
 	     </para>
 	  </listitem>
 	</varlistentry>
@@ -1538,7 +1538,7 @@ mknod errno 0
         Container hooks are programs or scripts which can be executed
 	at various times in a container's lifetime.
         -->
-        コンテナのフックは，コンテナの存続期間の色々な場面で実行することのできるプログラムやスクリプトです．
+        コンテナのフックは、コンテナの存続期間の色々な場面で実行することのできるプログラムやスクリプトです。
       </para>
       <para>
         <!--
@@ -1562,20 +1562,20 @@ mknod errno 0
 	  <listitem><para> LXC_ROOTFS_PATH: this is the lxc.rootfs entry for the container.  Note this is likely not where the mounted rootfs is to be found, use LXC_ROOTFS_MOUNT for that. </para></listitem>
 	</itemizedlist>
         -->
-        コンテナのフックが実行されるとき，情報がコマンドライン引数と環境変数の両方を通して渡されます．引数は:
+        コンテナのフックが実行されるとき、情報がコマンドライン引数と環境変数の両方を通して渡されます。引数は:
 	<itemizedlist>
 	  <listitem><para>コンテナ名</para></listitem>
 	  <listitem><para>セクション (常に 'lxc')</para></listitem>
 	  <listitem><para>フックのタイプ ('clone' や 'pre-mount' など)</para></listitem>
-	  <listitem><para>追加の引数．clone フックの場合，lxc-clone に渡される追加の引数は，フックへの引数として追加されます．</para></listitem>
+	  <listitem><para>追加の引数。clone フックの場合、lxc-clone に渡される追加の引数は、フックへの引数として追加されます。</para></listitem>
 	</itemizedlist>
-        以下の環境変数がセットされます．
+        以下の環境変数がセットされます。
 	<itemizedlist>
 	  <listitem><para> LXC_NAME: コンテナ名</para></listitem>
 	  <listitem><para> LXC_ROOTFS_MOUNT: マウントされた root ファイルシステムへのパス</para></listitem>
 	  <listitem><para> LXC_CONFIG_FILE: コンテナの設定ファイルのパス </para></listitem>
-	  <listitem><para> LXC_SRC_NAME: clone フックの場合，元のコンテナの名前</para></listitem>
-	  <listitem><para> LXC_ROOTFS_PATH: コンテナの lxc.rootfs エントリ．これはマウントされた rootfs が存在する場所にはならないでしょう．それには LXC_ROOTFS_MOUNT を使用してください．</para></listitem>
+	  <listitem><para> LXC_SRC_NAME: clone フックの場合、元のコンテナの名前</para></listitem>
+	  <listitem><para> LXC_ROOTFS_PATH: コンテナの lxc.rootfs エントリ。これはマウントされた rootfs が存在する場所にはならないでしょう。それには LXC_ROOTFS_MOUNT を使用してください。</para></listitem>
         </itemizedlist>
       </para>
       <para>
@@ -1584,9 +1584,9 @@ mknod errno 0
         Standard error is not logged, but can be captured by the
         hook redirecting its standard error to standard output.
         -->
-        スクリプトからの標準出力は debug レベルでロギングされます．
-        標準エラー出力はロギングされません．
-        しかし，フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です．
+        スクリプトからの標準出力は debug レベルでロギングされます。
+        標準エラー出力はロギングされません。
+        しかし、フックの標準エラー出力を標準出力にリダイレクトすることにより保存することは可能です。
       </para>
       <variablelist>
 	<varlistentry>
@@ -1599,7 +1599,7 @@ mknod errno 0
 	      A hook to be run in the host's namespace before the
 	      container ttys, consoles, or mounts are up.
               -->
-              コンテナの tty，コンソールの作成，マウントが実行される前に，ホストの名前空間内で実行するフック．
+              コンテナの tty、コンソールの作成、マウントが実行される前に、ホストの名前空間内で実行するフック。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1619,11 +1619,11 @@ mknod errno 0
 	      mounts propagation), so they will be automatically cleaned up
 	      when the container shuts down.
               -->
-              コンテナのファイルシステムの名前空間で実行されますが，rootfs が設定される前に実行するフック．
-              これにより rootfs の操作が可能になります．
-              例えば，暗号化されたファイルシステムのマウントなどです．
-              このフック内でなされるマウントはホストには影響しません (mounts propagation を除いて)．
-              なので，それらはコンテナがシャットダウンする時に自動的にクリーンアップされます．
+              コンテナのファイルシステムの名前空間で実行されますが、rootfs が設定される前に実行するフック。
+              これにより rootfs の操作が可能になります。
+              例えば、暗号化されたファイルシステムのマウントなどです。
+              このフック内でなされるマウントはホストには影響しません (mounts propagation を除いて)。
+              なので、それらはコンテナがシャットダウンする時に自動的にクリーンアップされます。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1639,7 +1639,7 @@ mknod errno 0
 	      A hook to be run in the container's namespace after
 	      mounting has been done, but before the pivot_root.
               -->
-              マウントが完了した後ですが，pivot_root の前にコンテナの名前空間で実行されるフック．
+              マウントが完了した後ですが、pivot_root の前にコンテナの名前空間で実行されるフック。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1663,8 +1663,8 @@ mknod errno 0
 	      ${<option>LXC_ROOTFS_MOUNT</option>} environment
 	      variable available when the hook is run.
               -->
-              <option>lxc.autodev</option> == 1 が設定されている場合で，マウントが完了し，マウント時のフックも実行された後ですが，pivot_root の前にコンテナの名前空間で実行するフック．
-              このフックの目的は，systemd ベースのコンテナ向けの autodev オプションが設定されている時に，コンテナの /dev ディレクトリを設定するのを支援することです．コンテナの /dev ディレクトリは，このフックが実行される時有効な ${<option>LXC_ROOTFS_MOUNT</option>} 環境変数からの相対パスとなります．
+              <option>lxc.autodev</option> == 1 が設定されている場合で、マウントが完了し、マウント時のフックも実行された後ですが、pivot_root の前にコンテナの名前空間で実行するフック。
+              このフックの目的は、systemd ベースのコンテナ向けの autodev オプションが設定されている時に、コンテナの /dev ディレクトリを設定するのを支援することです。コンテナの /dev ディレクトリは、このフックが実行される時有効な ${<option>LXC_ROOTFS_MOUNT</option>} 環境変数からの相対パスとなります。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1681,8 +1681,8 @@ mknod errno 0
 	      before executing the container's init.  This requires the
 	      program to be available in the container.
               -->
-              コンテナの init が実行される直前にコンテナの名前空間で実行されるフック．
-              コンテナ内で利用可能なプログラムである必要があります．
+              コンテナの init が実行される直前にコンテナの名前空間で実行されるフック。
+              コンテナ内で利用可能なプログラムである必要があります。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1698,7 +1698,7 @@ mknod errno 0
 	      A hook to be run in the host's namespace after the
 	      container has been shut down.
               -->
-              コンテナがシャットダウンされた後にホストの名前空間で実行するフック．
+              コンテナがシャットダウンされた後にホストの名前空間で実行するフック。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1715,10 +1715,10 @@ mknod errno 0
 	      See <citerefentry><refentrytitle><command>lxc-clone</command></refentrytitle>
 	      <manvolnum>1</manvolnum></citerefentry> for more information.
               -->
-              コンテナが新しいコンテナにクローンされる際に実行されるフック．詳しくは
+              コンテナが新しいコンテナにクローンされる際に実行されるフック。詳しくは
               <citerefentry><refentrytitle><command>lxc-clone</command></refentrytitle>
               <manvolnum>1</manvolnum></citerefentry>
-              を参照してください．
+              を参照してください。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1735,9 +1735,9 @@ mknod errno 0
         contexts.  In particular, all paths are relative to the host system
         and, as such, not valid during the <option>lxc.hook.start</option> hook.
         -->
-        起動時のフックに設定情報を提供し，フックの機能を助けるための環境変数がいくつか利用可能です．
-        全ての変数が全てのコンテキストで利用可能なわけではありません．
-        具体的には，全てのパスはホストシステム上のパスであり，そのため，<option>lxc.hook.start</option> フックの時点では使用できません．
+        起動時のフックに設定情報を提供し、フックの機能を助けるための環境変数がいくつか利用可能です。
+        全ての変数が全てのコンテキストで利用可能なわけではありません。
+        具体的には、全てのパスはホストシステム上のパスであり、そのため、<option>lxc.hook.start</option> フックの時点では使用できません。
       </para>
       <variablelist>
 	<varlistentry>
@@ -1750,7 +1750,7 @@ mknod errno 0
 	      The LXC name of the container.  Useful for logging messages
 	      in common log environments.  [<option>-n</option>]
               -->
-              LXC コンテナの名前．共通のログ環境内でのログメッセージに使うときに便利です．[<option>-n</option>]
+              LXC コンテナの名前。共通のログ環境内でのログメッセージに使うときに便利です。[<option>-n</option>]
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1769,8 +1769,8 @@ mknod errno 0
 	      additional configuration information not otherwise made
 	      available.  [<option>-f</option>]
               -->
-              コンテナの設定ファイルのホスト上でのパス．
-              これは，他の方法では得られない追加の設定情報を見つけるために，コンテナに，元の，トップレベルの設定ファイルの位置を与えるものです． [<option>-f</option>]
+              コンテナの設定ファイルのホスト上でのパス。
+              これは、他の方法では得られない追加の設定情報を見つけるために、コンテナに、元の、トップレベルの設定ファイルの位置を与えるものです。 [<option>-f</option>]
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1786,7 +1786,7 @@ mknod errno 0
 	      The path to the console output of the container if not NULL.
 	      [<option>-c</option>] [<option>lxc.console</option>]
               -->
-              設定されている場合のコンテナのコンソール出力のパス．
+              設定されている場合のコンテナのコンソール出力のパス。
 	      [<option>-c</option>] [<option>lxc.console</option>]
 	    </para>
 	  </listitem>
@@ -1803,7 +1803,7 @@ mknod errno 0
 	      The path to the console log output of the container if not NULL.
 	      [<option>-L</option>]
               -->
-              設定されている場合のコンテナのコンソールログ出力のパス．
+              設定されている場合のコンテナのコンソールログ出力のパス。
 	      [<option>-L</option>]
 	    </para>
 	  </listitem>
@@ -1823,8 +1823,8 @@ mknod errno 0
 	      should be made for that instance.
 	      [<option>lxc.rootfs.mount</option>]
               -->
-              初期にコンテナがマウントされる場所．
-              これは，コンテナインスタンスが起動するためのコンテナの rootfs へのホスト上のパスであり，インスタンスのための移行が行われる場所です．
+              初期にコンテナがマウントされる場所。
+              これは、コンテナインスタンスが起動するためのコンテナの rootfs へのホスト上のパスであり、インスタンスのための移行が行われる場所です。
 	      [<option>lxc.rootfs.mount</option>]
 	    </para>
 	  </listitem>
@@ -1842,7 +1842,7 @@ mknod errno 0
 	      mounted to the rootfs.mount location.
 	      [<option>lxc.rootfs</option>]
               -->
-              rootfs.mount へマウントされるコンテナのルートへのホスト上のパスです．
+              rootfs.mount へマウントされるコンテナのルートへのホスト上のパスです。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1860,8 +1860,8 @@ mknod errno 0
       the container (with '.log' appended) either under the container path,
       or under @LOGPATH@.
       -->
-      ロギングはコンテナごとに設定することが可能です．
-      デフォルトでは，lxc パッケージのコンパイル条件に依存し，コンテナのスタートアップは ERROR レベルでのみロギングされ，コンテナのパス以下か，@LOGPATH@ 以下のどちらかにコンテナ名 (の後に '.log' が付与される) をもとにした名前でロギングされます．
+      ロギングはコンテナごとに設定することが可能です。
+      デフォルトでは、lxc パッケージのコンパイル条件に依存し、コンテナのスタートアップは ERROR レベルでのみロギングされ、コンテナのパス以下か、@LOGPATH@ 以下のどちらかにコンテナ名 (の後に '.log' が付与される) をもとにした名前でロギングされます。
     </para>
     <para>
       <!--
@@ -1870,8 +1870,8 @@ mknod errno 0
       that the configuration file entries can in turn be overridden by the
       command line options to <command>lxc-start</command>.
       -->
-      デフォルトのログレベルとログファイルは両方とも，コンテナの設定ファイル内で指定され，デフォルトの値を上書きします．
-      同様に，設定ファイルのエントリは <command>lxc-start</command> のコマンドラインオプションで上書きすることも可能です．
+      デフォルトのログレベルとログファイルは両方とも、コンテナの設定ファイル内で指定され、デフォルトの値を上書きします。
+      同様に、設定ファイルのエントリは <command>lxc-start</command> のコマンドラインオプションで上書きすることも可能です。
     </para>
       <variablelist>
 	<varlistentry>
@@ -1888,11 +1888,11 @@ mknod errno 0
 	    alert, and 8 = fatal.  If unspecified, the level defaults
 	    to 5 (error), so that only errors and above are logged.
             -->
-              ログを取得するレベル．
-              ログレベルは 0..8 の範囲の整数です．
-              数字が小さいほど冗長なデバッグを意味します．
-              具体的には，0 = trace, 1 = debug, 2 = info, 3 = notice, 4 = warn, 5 = error, 6 = critical, 7 = alert, and 8 = fatal です．
-              指定されない場合，レベルのデフォルトは 5 (error) で，それ以上のエラーがロギングされます．
+              ログを取得するレベル。
+              ログレベルは 0..8 の範囲の整数です。
+              数字が小さいほど冗長なデバッグを意味します。
+              具体的には、0 = trace, 1 = debug, 2 = info, 3 = notice, 4 = warn, 5 = error, 6 = critical, 7 = alert, and 8 = fatal です。
+              指定されない場合、レベルのデフォルトは 5 (error) で、それ以上のエラーがロギングされます。
 	    </para>
 	    <para>
               <!--
@@ -1900,7 +1900,7 @@ mknod errno 0
 	    network interface up or down script) is called, the script's
 	    standard output is logged at level 1, debug.
             -->
-              (フックスクリプトやネットワークインターフェースの起動，停止時のスクリプトのような) スクリプトが呼ばれた時，スクリプトの標準出力は level 1 の debug でロギングされます．
+              (フックスクリプトやネットワークインターフェースの起動、停止時のスクリプトのような) スクリプトが呼ばれた時、スクリプトの標準出力は level 1 の debug でロギングされます。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1913,7 +1913,7 @@ mknod errno 0
               <!--
 	    The file to which logging info should be written.
             -->
-              ログ情報を書き込むファイル．
+              ログ情報を書き込むファイル。
 	    </para>
 	  </listitem>
 	</varlistentry>
@@ -1928,8 +1928,8 @@ mknod errno 0
         auto-started and in what order. These options may be used by LXC tools
         directly or by external tooling provided by the distributions.
         -->
-      自動起動オプションでは，自動起動させるコンテナと順番の設定が可能です．
-      このオプションは LXC ツールが直接使用するか，ディストリビューションが提供する外部ツールが使用するかもしれません．
+      自動起動オプションでは、自動起動させるコンテナと順番の設定が可能です。
+      このオプションは LXC ツールが直接使用するか、ディストリビューションが提供する外部ツールが使用するかもしれません。
     </para>
 
     <variablelist>
@@ -1943,8 +1943,8 @@ mknod errno 0
               Whether the container should be auto-started.
               Valid values are 0 (off) and 1 (on).
               -->
-              コンテナを自動起動させるかどうかを設定します．
-              有効な値は 0(オフ) か 1(オン) です．
+              コンテナを自動起動させるかどうかを設定します。
+              有効な値は 0(オフ) か 1(オン) です。
             </para>
           </listitem>
         </varlistentry>
@@ -1958,7 +1958,7 @@ mknod errno 0
               How long to wait (in seconds) after the container is
               started before starting the next one.
               -->
-              コンテナを起動させた後，次のコンテナを起動させるまでにどれくらい (秒) 待つかを設定します．
+              コンテナを起動させた後、次のコンテナを起動させるまでにどれくらい (秒) 待つかを設定します。
             </para>
           </listitem>
         </varlistentry>
@@ -1972,7 +1972,7 @@ mknod errno 0
               An integer used to sort the containers when auto-starting
               a series of containers at once.
               -->
-              多数の自動起動させるコンテナがある場合のコンテナの起動順を決めるのに使う整数を指定します．
+              多数の自動起動させるコンテナがある場合のコンテナの起動順を決めるのに使う整数を指定します。
             </para>
           </listitem>
         </varlistentry>
@@ -1988,9 +1988,9 @@ mknod errno 0
               used (amongst other things) to start a series of related
               containers.
               -->
-              コンテナを追加したいコンテナグループ名を指定します．
-              (複数回使用される可能性のある) 複数の値を設定可能です．
-              設定されたグループは，関連する一連のコンテナを起動させるために使われます．
+              コンテナを追加したいコンテナグループ名を指定します。
+              (複数回使用される可能性のある) 複数の値を設定可能です。
+              設定されたグループは、関連する一連のコンテナを起動させるために使われます。
             </para>
           </listitem>
         </varlistentry>
@@ -2006,7 +2006,7 @@ mknod errno 0
 	In addition to the few examples given below, you will find
 	some other examples of configuration file in @DOCDIR@/examples
         -->
-        以下に紹介するいくつかの例に加えて，他の設定例が @DOCDIR@/examples にあります．
+        以下に紹介するいくつかの例に加えて、他の設定例が @DOCDIR@/examples にあります。
       </para>
     <refsect2>
       <title><!-- Network -->ネットワーク</title>
@@ -2018,8 +2018,8 @@ mknod errno 0
 	virtual network device visible in the container is renamed to
 	eth0.
         -->
-        この設定は，片方をブリッジである br0 と接続される veth ペアデバイスを使うコンテナを設定します (ブリッジは管理者によりあらかじめシステム上に設定済みである必要があります)．
-        仮想ネットワークデバイスは，コンテナ内では eth0 とリネームされます．
+        この設定は、片方をブリッジである br0 と接続される veth ペアデバイスを使うコンテナを設定します (ブリッジは管理者によりあらかじめシステム上に設定済みである必要があります)。
+        仮想ネットワークデバイスは、コンテナ内では eth0 とリネームされます。
       </para>
       <programlisting>
 	lxc.utsname = myhostname
@@ -2037,7 +2037,7 @@ mknod errno 0
       <title><!-- UID/GID mapping -->UID/GID のマッピング</title>
       <para><!-- This configuration will map both user and group ids in the
         range 0-9999 in the container to the ids 100000-109999 on the host. -->
-        この設定は，コンテナ内のユーザとグループ両方の id 0-9999 の範囲を，ホスト上の 100000-109999 へマッピングします．
+        この設定は、コンテナ内のユーザとグループ両方の id 0-9999 の範囲を、ホスト上の 100000-109999 へマッピングします。
       </para>
       <programlisting>
 	lxc.id_map = u 0 100000 10000
@@ -2052,10 +2052,10 @@ mknod errno 0
       the application, cpuset.cpus restricts usage of the defined cpu,
       cpus.share prioritize the control group, devices.allow makes
       usable the specified devices.-->
-        この設定は，アプリケーションのための control group をいくつか設定します．
-        cpuset.cpus は定義された cpu のみ使用できるように制限します．
-        cpus.share は，control group の (cpu) 優先度を指定します．
-        devices.allow は，特定のデバイスを使用可能にします．
+        この設定は、アプリケーションのための control group をいくつか設定します。
+        cpuset.cpus は定義された cpu のみ使用できるように制限します。
+        cpus.share は、control group の (cpu) 優先度を指定します。
+        devices.allow は、特定のデバイスを使用可能にします。
       </para>
       <programlisting>
 	lxc.cgroup.cpuset.cpus = 0,1
@@ -2072,7 +2072,7 @@ mknod errno 0
         <!-- This example show a complex configuration making a complex
       network stack, using the control groups, setting a new hostname,
       mounting some locations and a changing root file system. -->
-        この例は，control group を使って，複雑なネットワークスタックを作成し，新しいホスト名を指定し，いくつかの場所をマウントし，ルートファイルシステムを変更するような複雑な設定を示します．
+        この例は、control group を使って、複雑なネットワークスタックを作成し、新しいホスト名を指定し、いくつかの場所をマウントし、ルートファイルシステムを変更するような複雑な設定を示します。
       </para>
       <programlisting>
 	lxc.utsname = complex

--- a/doc/ja/lxc.sgml.in
+++ b/doc/ja/lxc.sgml.in
@@ -68,8 +68,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>@BINDIR@/lxc-execute -n foo -f
       @DOCDIR@/examples/lxc-macvlan.conf /bin/bash</command>
       -->
-      急いでいて，この man ページすら読みたくないという場合は，いいでしょう，
-      保証はないですが，あらかじめ準備されている設定テンプレートを使ったコンテナ内でシェルを動かすためのコマンドを紹介しましょう．
+      急いでいて、この man ページすら読みたくないという場合は、いいでしょう、
+      保証はないですが、あらかじめ準備されている設定テンプレートを使ったコンテナ内でシェルを動かすためのコマンドを紹介しましょう。
       <command>@BINDIR@/lxc-execute -n foo -f
       @DOCDIR@/examples/lxc-macvlan.conf /bin/bash</command>
     </para>
@@ -84,8 +84,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       through the control groups aka process containers and resource
       isolation through the namespaces.
       -->
-      コンテナ技術は，メインストリームの linux kernel で活発に開発が進んでいる技術です．
-      コンテナ技術は，process container という名前でも知られる control groups の機能を使って，リソース管理を提供し，名前空間を使って，リソースの隔離を提供します．
+      コンテナ技術は、メインストリームの linux kernel で活発に開発が進んでいる技術です。
+      コンテナ技術は、process container という名前でも知られる control groups の機能を使って、リソース管理を提供し、名前空間を使って、リソースの隔離を提供します。
     </para>
 
     <para>
@@ -95,8 +95,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       which provides full resource isolation and resource control for
       an applications or a system.
       -->
-      linux コンテナ (<command>lxc</command>) は，ユーザースペースのコンテナオブジェクトを提供するための新しい機能を使う事を目指しています．
-      この新しい機能とは，アプリケーションやシステムでの利用を目的とした，完全なリソースの隔離やリソースコントロールを提供する機能です．
+      linux コンテナ (<command>lxc</command>) は、ユーザースペースのコンテナオブジェクトを提供するための新しい機能を使う事を目指しています。
+      この新しい機能とは、アプリケーションやシステムでの利用を目的とした、完全なリソースの隔離やリソースコントロールを提供する機能です。
     </para>
 
     <para>
@@ -108,8 +108,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       manage a container with simple command lines and complete enough
       to be used for other purposes.
       -->
-      このプロジェクトの第一の目的は，コンテナプロジェクトに参加するカーネル開発者の作業を快適にすることと，特に新機能である Checkpoint/Restart 機能への取り組みを続ける事です．
-      <command>lxc</command> コマンドは，シンプルなコマンドでコンテナの管理を簡単に行えるように小さく，他の目的のために使うのに充分な機能を持っています．
+      このプロジェクトの第一の目的は、コンテナプロジェクトに参加するカーネル開発者の作業を快適にすることと、特に新機能である Checkpoint/Restart 機能への取り組みを続ける事です。
+      <command>lxc</command> コマンドは、シンプルなコマンドでコンテナの管理を簡単に行えるように小さく、他の目的のために使うのに充分な機能を持っています。
     </para>
   </refsect1>
 
@@ -123,8 +123,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       work with a restricted number of functionalities or will simply
       fail.
       -->
-      <command>lxc</command> は，カーネルが提供するいくつかの機能に依存しており，その機能がアクティブになっている必要があります．
-      機能が足りない場合は，<command>lxc</command> は，いくつかの機能が制限されるか，単純に動作が失敗します．
+      <command>lxc</command> は、カーネルが提供するいくつかの機能に依存しており、その機能がアクティブになっている必要があります。
+      機能が足りない場合は、<command>lxc</command> は、いくつかの機能が制限されるか、単純に動作が失敗します。
     </para>
 
     <para>
@@ -132,7 +132,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       The following list gives the kernel features to be enabled in
       the kernel to have the full features container:
       -->
-      以下のリストは，コンテナの全機能を有効にするために，カーネルで有効にする必要のある機能の一覧です．
+      以下のリストは、コンテナの全機能を有効にするために、カーネルで有効にする必要のある機能の一覧です。
     </para>
       <programlisting>
 	    * General setup
@@ -176,10 +176,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	The helper script <command>lxc-checkconfig</command> will give
 	you information about your kernel configuration.
 	-->
-	2.6.27 以上のバージョンが採用されているディストリビューションならば，<command>lxc</command> は動作するでしょう．
-        機能的には若干少ない形ですが，充分に楽しめるはずです．
-        2.6.29 カーネルであれば，<command>lxc</command> は完全に機能します．
-        ヘルパースクリプトの <command>lxc-checkconfig</command> を使って，あなたのカーネルの設定に関する情報を取得できるでしょう．
+	2.6.27 以上のバージョンが採用されているディストリビューションならば、<command>lxc</command> は動作するでしょう。
+        機能的には若干少ない形ですが、充分に楽しめるはずです。
+        2.6.29 カーネルであれば、<command>lxc</command> は完全に機能します。
+        ヘルパースクリプトの <command>lxc-checkconfig</command> を使って、あなたのカーネルの設定に関する情報を取得できるでしょう。
       </para>
 
       <para>
@@ -188,7 +188,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	configured with the file capabilities, otherwise you will need
 	to run the <command>lxc</command> commands as root.
 	-->
-	<command>lxc</command> を使う前に，システムがファイルに対するケーパビリティーをえられるように設定するか，もしくは <command>lxc</command> コマンドを root で実行する必要があるでしょう．
+	<command>lxc</command> を使う前に、システムがファイルに対するケーパビリティーをえられるように設定するか、もしくは <command>lxc</command> コマンドを root で実行する必要があるでしょう。
       </para>
 
       <para>
@@ -205,10 +205,10 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  <command>mount -t cgroup -ons,cpuset,freezer,devices
 	  lxc /cgroup4lxc</command>
 	 -->
-	control group は，どこにでもマウント可能です．
-        例えば，<command>mount -t cgroup cgroup /cgroup</command> のようにです．
+	control group は、どこにでもマウント可能です。
+        例えば、<command>mount -t cgroup cgroup /cgroup</command> のようにです。
 
-	もし，異なる場所で，異なるオプションでマウントされた別々の cgroup を持ち，一つの場所の <command>lxc</command> コマンドを使うための，特定の <command>lxc</command> のための専用の cgroup のマウントポイントを提供したければ，lxc という名前でマウントポイントにバインドすることが出来ます．例えば以下のようにです．
+	もし、異なる場所で、異なるオプションでマウントされた別々の cgroup を持ち、一つの場所の <command>lxc</command> コマンドを使うための、特定の <command>lxc</command> のための専用の cgroup のマウントポイントを提供したければ、lxc という名前でマウントポイントにバインドすることが出来ます。例えば以下のようにです。
 	  <command>mount -t cgroup lxc /cgroup4lxc</command> or
 	  <command>mount -t cgroup -ons,cpuset,freezer,devices
 	  lxc /cgroup4lxc</command>
@@ -223,7 +223,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       A container is an object isolating some resources of the host,
       for the application or system running in it.
       -->
-      コンテナは，コンテナ内で実行されているシステムやアプリケーションに対するホストのリソースのいくつかが，隔離されているオブジェクトです．
+      コンテナは、コンテナ内で実行されているシステムやアプリケーションに対するホストのリソースのいくつかが、隔離されているオブジェクトです。
     </para>
     <para>
       <!--
@@ -232,7 +232,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       initially created or passed as parameter of the starting
       commands.
       -->
-      アプリケーション／システムは，あらかじめ作成された設定もしくは開始コマンドのパラメータで指定された設定で，コンテナ内で実行されます．
+      アプリケーション／システムは、あらかじめ作成された設定もしくは開始コマンドのパラメータで指定された設定で、コンテナ内で実行されます。
     </para>
 
     <para>
@@ -259,13 +259,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       so you can still use your distro but with your
       own <filename>/etc</filename> and <filename>/home</filename>
       -->
-      アプリケーションを実行する前に，隔離したいリソースについて知っておくべきです．
-      デフォルトの設定では，pid，sysv ipc，マウントポイントが隔離されます．
-      コンテナ内でシンプルなシェルを実行したい場合で，特に rootfs を共有したい場合，基本的な設定が必要です．
-      もし，<command>sshd</command> のようなアプリケーションを実行したい場合，新しいネットワークスタックと，新しいホスト名を準備しなくてはなりません．
-      もし，同じファイル (<filename>/var/run/httpd.pid</filename> 等) の衝突を避けたい場合，空の <filename>/var/run/</filename> を再度マウントしなければなりません．
-      どんな場合でも，衝突を避けたい場合，コンテナ専用の rootfs を指定することができます．
-      rootfs はディレクトリツリーとなる事も可能で，前もって元の rootfs を bind マウントし，しかし，自身の <filename>/etc</filename> や <filename>/home</filename>を使って．自身のディストリビューションを使うことが可能です．
+      アプリケーションを実行する前に、隔離したいリソースについて知っておくべきです。
+      デフォルトの設定では、pid、sysv ipc、マウントポイントが隔離されます。
+      コンテナ内でシンプルなシェルを実行したい場合で、特に rootfs を共有したい場合、基本的な設定が必要です。
+      もし、<command>sshd</command> のようなアプリケーションを実行したい場合、新しいネットワークスタックと、新しいホスト名を準備しなくてはなりません。
+      もし、同じファイル (<filename>/var/run/httpd.pid</filename> 等) の衝突を避けたい場合、空の <filename>/var/run/</filename> を再度マウントしなければなりません。
+      どんな場合でも、衝突を避けたい場合、コンテナ専用の rootfs を指定することができます。
+      rootfs はディレクトリツリーとなる事も可能で、前もって元の rootfs を bind マウントし、しかし、自身の <filename>/etc</filename> や <filename>/home</filename>を使って。自身のディストリビューションを使うことが可能です。
     </para>
     <para>
       <!--
@@ -308,7 +308,7 @@ rootfs
 	/sbin /home/root/sshd/rootfs/sbin none ro,bind 0 0
       </programlisting>
       -->
-	ここで，<command>sshd</command> のためのディレクトリツリーのサンプルを示しましょう．
+	ここで、<command>sshd</command> のためのディレクトリツリーのサンプルを示しましょう。
       <programlisting>	
 [root@lxc sshd]$ tree -d rootfs
 	
@@ -336,7 +336,7 @@ rootfs
         `-- sshd
       </programlisting>
 
-      そして，それに対応するマウントポイントのファイルは以下のようになります．
+      そして、それに対応するマウントポイントのファイルは以下のようになります。
       <programlisting>
 	[root@lxc sshd]$ cat fstab
 
@@ -379,11 +379,11 @@ rootfs
 	/etc/resolv.conf /home/root/debian/rootfs/etc/resolv.conf none bind 0 0
       </programlisting>
       -->
-      コンテナ内でシステムを実行するのは，逆説的ではありますが，アプリケーションを実行するよりも簡単です．
-      それは，隔離するリソースについて考える必要がないからで，全てを隔離する必要があるからです．
-      他のリソースは，コンテナが設定を行うので，設定なしで隔離されるように指定されます．
-      例えば，IPv4 アドレスはコンテナの init スクリプトでシステムによってセットアップされるでしょう．
-      以下に，(システムを実行するときの) マウントポイントファイルを示します．
+      コンテナ内でシステムを実行するのは、逆説的ではありますが、アプリケーションを実行するよりも簡単です。
+      それは、隔離するリソースについて考える必要がないからで、全てを隔離する必要があるからです。
+      他のリソースは、コンテナが設定を行うので、設定なしで隔離されるように指定されます。
+      例えば、IPv4 アドレスはコンテナの init スクリプトでシステムによってセットアップされるでしょう。
+      以下に、(システムを実行するときの) マウントポイントファイルを示します。
 
       <programlisting>
 	[root@lxc debian]$ cat fstab
@@ -392,8 +392,8 @@ rootfs
 	/dev/pts /home/root/debian/rootfs/dev/pts  none bind 0 0
       </programlisting>
 
-      設定を手助けするために，コンテナに更なる情報を追加することも可能です．
-      例えば，ホスト上に存在する resolv.conf ファイルをコンテナからアクセス可能にするには，以下のようにします．
+      設定を手助けするために、コンテナに更なる情報を追加することも可能です。
+      例えば、ホスト上に存在する resolv.conf ファイルをコンテナからアクセス可能にするには、以下のようにします。
 
       <programlisting>
 	/etc/resolv.conf /home/root/debian/rootfs/etc/resolv.conf none bind 0 0
@@ -409,16 +409,16 @@ rootfs
 	starting and running. When the last process running inside the
 	container exits, the container is stopped.
 	-->
-	コンテナが作成されるとき，コンテナは設定情報を含みます．
-        プロセスが生成されるとき，コンテナは開始し，実行されるでしょう．
-        コンテナ内で実行されている最後のプロセスが終了したとき，コンテナは停止します．
+	コンテナが作成されるとき、コンテナは設定情報を含みます。
+        プロセスが生成されるとき、コンテナは開始し、実行されるでしょう。
+        コンテナ内で実行されている最後のプロセスが終了したとき、コンテナは停止します。
       </para>
       <para>
 	<!--
 	In case of failure when the container is initialized, it will
 	pass through the aborting state.
 	-->
-	コンテナの初期化時の失敗の場合は，(以下の図の) 中断の状態を通ります．
+	コンテナの初期化時の失敗の場合は、(以下の図の) 中断の状態を通ります。
       </para>
 
       <programlisting>
@@ -463,7 +463,7 @@ rootfs
       </citerefentry>
       -->
       </para>
-	コンテナは設定ファイル経由で設定します．設定の書式は以下で説明しています．
+	コンテナは設定ファイル経由で設定します。設定の書式は以下で説明しています。
       <citerefentry>
 	<refentrytitle><filename>lxc.conf</filename></refentrytitle>
 	<manvolnum>5</manvolnum>
@@ -488,10 +488,10 @@ rootfs
 	  lxc-destroy -n foo
 	</programlisting>
 	-->
-	持続性のコンテナオブジェクトは <command>lxc-create</command> コマンドで作成することができます．
-        コマンドにはコンテナ名をパラメータとして，オプションで設定ファイルとテンプレートを指定します．
-        ここで指定する名前は，他のコマンドからこのコンテナを参照する際に使います．
-        <command>lxc-destroy</command> コマンドはコンテナオブジェクトを破壊します．
+	持続性のコンテナオブジェクトは <command>lxc-create</command> コマンドで作成することができます。
+        コマンドにはコンテナ名をパラメータとして、オプションで設定ファイルとテンプレートを指定します。
+        ここで指定する名前は、他のコマンドからこのコンテナを参照する際に使います。
+        <command>lxc-destroy</command> コマンドはコンテナオブジェクトを破壊します。
 	<programlisting>
 	  lxc-create -n foo
 	  lxc-destroy -n foo
@@ -508,8 +508,8 @@ rootfs
 	The container can be directly started with a
 	configuration file as parameter.
         -->
-          コンテナを開始する前にコンテナオブジェクトを作成する必要はありません．
-          コンテナを設定ファイルのパラメータで指定して直接開始することができます．
+          コンテナを開始する前にコンテナオブジェクトを作成する必要はありません。
+          コンテナを設定ファイルのパラメータで指定して直接開始することができます。
 	</para>
     </refsect2>
 
@@ -530,11 +530,11 @@ rootfs
       but if needed the <command>lxc-stop</command> command can
       be used to kill the still running application.
       -->
-        コンテナが作成されると，アプリケーションもしくはシステムとして実行することができます．
-        このために使用するのが <command>lxc-execute</command> と <command>lxc-start</command> コマンドです．
-        アプリケーションが開始する前にコンテナが作成されなかった場合，コンテナはコマンドへ与えるパラメータを取得するのに設定ファイルを使うでしょう．
-        もし，このようなパラメータもない場合は，デフォルトで指定されている通りに隔離されます．
-        アプリケーションが終了した場合，コンテナも停止しますが，実行中のアプリケーションを停止するには <command>lxc-stop</command> を使用する必要があります．
+        コンテナが作成されると、アプリケーションもしくはシステムとして実行することができます。
+        このために使用するのが <command>lxc-execute</command> と <command>lxc-start</command> コマンドです。
+        アプリケーションが開始する前にコンテナが作成されなかった場合、コンテナはコマンドへ与えるパラメータを取得するのに設定ファイルを使うでしょう。
+        もし、このようなパラメータもない場合は、デフォルトで指定されている通りに隔離されます。
+        アプリケーションが終了した場合、コンテナも停止しますが、実行中のアプリケーションを停止するには <command>lxc-stop</command> を使用する必要があります。
       </para>
 
       <para>
@@ -547,8 +547,8 @@ rootfs
 	  lxc-start -n foo [-f config] [/bin/bash]
 	</programlisting>
         -->
-        コンテナ内のアプリケーションの実行は，正確にはシステムとして実行するのとは異なります．
-        そのような理由で，コンテナ内でアプリケーションを実行するためのコマンドには，2 種類の違ったものがあります．
+        コンテナ内のアプリケーションの実行は、正確にはシステムとして実行するのとは異なります。
+        そのような理由で、コンテナ内でアプリケーションを実行するためのコマンドには、2 種類の違ったものがあります。
         <programlisting>
 	  lxc-execute -n foo [-f config] /bin/bash
 	  lxc-start -n foo [-f config] [/bin/bash]
@@ -567,9 +567,9 @@ rootfs
 	container, <command>lxc-init</command> has the pid 1 and the
 	first process of the application has the pid 2.
         -->
-        <command>lxc-execute</command> コマンドは，<command>lxc-init</command> プロセス経由で，コンテナ内で特定のコマンドを実行します．
-        lxc-init はコマンドを実行した後，(コンテナ内でのデーモンの実行をサポートするために) 実行したコマンドと生成された全てのプロセスが終了するのを待ちます．
-        言いかえると，コンテナ内では <command>lxc-init</command> は pid 1 を持ち，アプリケーションの最初のプロセスは pid 2 をもちます．
+        <command>lxc-execute</command> コマンドは、<command>lxc-init</command> プロセス経由で、コンテナ内で特定のコマンドを実行します。
+        lxc-init はコマンドを実行した後、(コンテナ内でのデーモンの実行をサポートするために) 実行したコマンドと生成された全てのプロセスが終了するのを待ちます。
+        言いかえると、コンテナ内では <command>lxc-init</command> は pid 1 を持ち、アプリケーションの最初のプロセスは pid 2 をもちます。
       </para>
 
       <para>
@@ -580,9 +580,9 @@ rootfs
 	specified <command>lxc-start</command> will
 	run <filename>/sbin/init</filename>.
         -->
-        <command>lxc-start</command> コマンドは，コンテナ内の特定のコマンドを直接実行します．
-        最初のプロセスの pid が 1 となります．
-        もし，実行するコマンドが指定されない場合は，<command>lxc-start</command> は <filename>/sbin/init</filename> を実行します．
+        <command>lxc-start</command> コマンドは、コンテナ内の特定のコマンドを直接実行します。
+        最初のプロセスの pid が 1 となります。
+        もし、実行するコマンドが指定されない場合は、<command>lxc-start</command> は <filename>/sbin/init</filename> を実行します。
       </para>
 
       <para>
@@ -591,7 +591,7 @@ rootfs
 	an application and <command>lxc-start</command> is better suited for
 	running a system.
         -->
-        まとめると，<command>lxc-execute</command> はアプリケーションを実行するためのコマンドであり，<command>lxc-start</command> はシステムを実行するのにより適したコマンドです．
+        まとめると、<command>lxc-execute</command> はアプリケーションを実行するためのコマンドであり、<command>lxc-start</command> はシステムを実行するのにより適したコマンドです。
       </para>
 
       <para>
@@ -604,7 +604,7 @@ rootfs
 	  lxc-stop -n foo
 	</programlisting>
         -->
-        もしアプリケーションの反応がなくなった場合や，アクセスできなくなった場合，自分で終了することができない場合は，荒っぽいですが，<command>lxc-stop</command> コマンドがコンテナ内の全てのプロセスを容赦なく停止させてくれるでしょう．
+        もしアプリケーションの反応がなくなった場合や、アクセスできなくなった場合、自分で終了することができない場合は、荒っぽいですが、<command>lxc-stop</command> コマンドがコンテナ内の全てのプロセスを容赦なく停止させてくれるでしょう。
       </para>
     </refsect2>
 
@@ -621,9 +621,9 @@ rootfs
 	  lxc-console -n foo -t 3
 	</programlisting>
         -->
-        コンテナが tty を持つように設定されているならば，tty を通してコンテナにアクセスすることができます．
-        それは以下のコマンドが使う tty がコンテナで利用可能に設定されているか次第です．
-        tty が失われたとき，再度のログインなしでその tty に再接続することが可能です．
+        コンテナが tty を持つように設定されているならば、tty を通してコンテナにアクセスすることができます。
+        それは以下のコマンドが使う tty がコンテナで利用可能に設定されているか次第です。
+        tty が失われたとき、再度のログインなしでその tty に再接続することが可能です。
 	<programlisting>
 	  lxc-console -n foo -t 3
 	</programlisting>
@@ -648,18 +648,18 @@ rootfs
 
 	will resume them.
         -->
-        ジョブスケジューリングなどで，コンテナに属する全てのプロセスを停止する事が役に立つときがあります．
+        ジョブスケジューリングなどで、コンテナに属する全てのプロセスを停止する事が役に立つときがあります。
         コマンド
 	<programlisting>
 	  lxc-freeze -n foo
 	</programlisting>
-        は，全てのプロセスを中断不可能な状態に置きます．そして，
+        は、全てのプロセスを中断不可能な状態に置きます。そして、
 
 	<programlisting>
 	  lxc-unfreeze -n foo
 	</programlisting>
 
-        その全てのプロセスを再開します．
+        その全てのプロセスを再開します。
       </para>
 
       <para>
@@ -667,7 +667,7 @@ rootfs
 	This feature is enabled if the cgroup freezer is enabled in the
 	kernel.
         -->
-        この機能は，カーネルで cgroup freezer 機能が有効になっている場合に使用可能です．
+        この機能は、カーネルで cgroup freezer 機能が有効になっている場合に使用可能です。
       </para>
     </refsect2>
 
@@ -685,8 +685,8 @@ rootfs
 	  lxc-info -n foo
 	</programlisting>
         -->
-        多数のコンテナが存在する場合，それらが実行されたり破壊されたりすること，何が実行されていて，特定のコンテナ内で実行されている pid が何であるかをフォローするのは大変です．
-        このような時には，以下のようなコマンドが役に立つかもしれません．
+        多数のコンテナが存在する場合、それらが実行されたり破壊されたりすること、何が実行されていて、特定のコンテナ内で実行されている pid が何であるかをフォローするのは大変です。
+        このような時には、以下のようなコマンドが役に立つかもしれません。
 	<programlisting>
 	  lxc-ls
 	  lxc-info -n foo
@@ -697,7 +697,7 @@ rootfs
 	<command>lxc-ls</command> lists the containers of the
 	system.
         -->
-        <command>lxc-ls</command> は，システムのコンテナを一覧します．
+        <command>lxc-ls</command> は、システムのコンテナを一覧します。
       </para>
 
       <para>
@@ -705,7 +705,7 @@ rootfs
 	<command>lxc-info</command> gives information for a specific
 	container.
         -->
-        <command>lxc-info</command> は，指定したコンテナに関する情報を取得します．
+        <command>lxc-info</command> は、指定したコンテナに関する情報を取得します。
       </para>
 
       <para>
@@ -718,7 +718,7 @@ rootfs
 	  done
 	</programlisting>
         -->
-        ここで，以上のコマンドを組み合わせて，どのようにしたら全てのコンテナのリストと，それぞれの状態が得られるかの例を示します．
+        ここで、以上のコマンドを組み合わせて、どのようにしたら全てのコンテナのリストと、それぞれの状態が得られるかの例を示します。
 	<programlisting>
 	  for i in $(lxc-ls -1); do
 	    lxc-info -n $i
@@ -736,8 +736,8 @@ rootfs
       for example to monitor it or just to wait for a specific
       state in a script.
         -->
-        時々，コンテナの状態を追跡することが出来ると便利な事があります．
-        例えば，状態をモニタリングしたり，スクリプト内で特定の状態を待ったりするような場合です．
+        時々、コンテナの状態を追跡することが出来ると便利な事があります。
+        例えば、状態をモニタリングしたり、スクリプト内で特定の状態を待ったりするような場合です。
       </para>
 
       <para>
@@ -754,16 +754,16 @@ rootfs
 	</programlisting>
 	will monitor all the containers.
         -->
-        <command>lxc-monitor</command> コマンドは，一つもしくはいくつかのコンテナをモニタリングします．
-        このコマンドのパラメータは，正規表現を受け付けます．例えば
+        <command>lxc-monitor</command> コマンドは、一つもしくはいくつかのコンテナをモニタリングします。
+        このコマンドのパラメータは、正規表現を受け付けます。例えば
 	<programlisting>
 	  lxc-monitor -n "foo|bar"
 	</programlisting>
-        は 'foo' と 'bar' という名前のコンテナの状態をモニタリングします．そして，
+        は 'foo' と 'bar' という名前のコンテナの状態をモニタリングします。そして、
 	<programlisting>
 	  lxc-monitor -n ".*"
 	</programlisting>
-        は全てのコンテナの状態をモニタリングします．
+        は全てのコンテナの状態をモニタリングします。
       </para>
       <para>
         <!--
@@ -776,7 +776,7 @@ rootfs
 	  'foo' changed state to [STOPPED]
 	</programlisting>
         -->
-        コンテナ 'foo' が開始され，いくつか処理を行い，終了した場合，出力は以下のようになります．
+        コンテナ 'foo' が開始され、いくつか処理を行い、終了した場合、出力は以下のようになります。
 	<programlisting>
 	  'foo' changed state to [STARTING]
 	  'foo' changed state to [RUNNING]
@@ -810,10 +810,10 @@ rootfs
 ]]>
 	</programlisting>
         -->
-        <command>lxc-wait</command> コマンドは指定した状態を待って，終了します．
-        これは，コンテナの開始や終了に同期したいスクリプトで役に立ちます．
-        パラメータは，異なった状態の論理和 (OR) を指定します．
-        以下の例は，バックグラウンドで実行されたコンテナをどのようにして待つかを示します．
+        <command>lxc-wait</command> コマンドは指定した状態を待って、終了します。
+        これは、コンテナの開始や終了に同期したいスクリプトで役に立ちます。
+        パラメータは、異なった状態の論理和 (OR) を指定します。
+        以下の例は、バックグラウンドで実行されたコンテナをどのようにして待つかを示します。
 
 	<programlisting>
 <![CDATA[
@@ -845,9 +845,9 @@ rootfs
 	with it. The control group properties can be read and modified
 	when the container is running by using the lxc-cgroup command.
         -->
-        コンテナは control group と結合しています．
-        コンテナが開始すると control group が生成され，それと結びつけられます．
-        control group のプロパティは，lxc-cgroup コマンドを使って，コンテナが実行中に読み取ったり，変更したりすることができます．
+        コンテナは control group と結合しています。
+        コンテナが開始すると control group が生成され、それと結びつけられます。
+        control group のプロパティは、lxc-cgroup コマンドを使って、コンテナが実行中に読み取ったり、変更したりすることができます。
       </para>
       <para>
         <!--
@@ -857,9 +857,9 @@ rootfs
 	command won't do any syntax checking on the subsystem name, if
 	the subsystem name does not exists, the command will fail.
         -->
-        <command>lxc-cgroup</command> コマンドは，コンテナと結びつけられている control group サブシステムを設定したり，取得したりするのに使います．
-        サブシステム名の指定はユーザが行ない，このコマンドはサブシステム名の文法チェックは一切行ないません．
-        もし，指定したサブシステム名が存在しない場合は，コマンドの実行は失敗します．
+        <command>lxc-cgroup</command> コマンドは、コンテナと結びつけられている control group サブシステムを設定したり、取得したりするのに使います。
+        サブシステム名の指定はユーザが行ない、このコマンドはサブシステム名の文法チェックは一切行ないません。
+        もし、指定したサブシステム名が存在しない場合は、コマンドの実行は失敗します。
       </para>
       <para>
         <!--
@@ -875,11 +875,11 @@ rootfs
 	<programlisting>
 	  lxc-cgroup -n foo cpuset.cpus
 	</programlisting>
-        は，このサブシステムの内容を表示します．
+        は、このサブシステムの内容を表示します。
 	<programlisting>
 	  lxc-cgroup -n foo cpu.shares 512
 	</programlisting>
-        は，このサブシステムに指定した値を設定します．
+        は、このサブシステムに指定した値を設定します。
       </para>
     </refsect2>
   </refsect1>
@@ -892,9 +892,9 @@ rootfs
     command syntax and the API can change. The version 1.0.0 will be
     the frozen version.
       -->
-      <command>lxc</command> はまだ開発中です．
-      従って，コマンドの文法や API は変更される可能性があります．
-      バージョン 1.0.0 がそれらを凍結するバージョンとなるでしょう．
+      <command>lxc</command> はまだ開発中です。
+      従って、コマンドの文法や API は変更される可能性があります。
+      バージョン 1.0.0 がそれらを凍結するバージョンとなるでしょう。
     </para>
   </refsect1>
 

--- a/doc/ja/lxc.system.conf.sgml.in
+++ b/doc/ja/lxc.system.conf.sgml.in
@@ -61,8 +61,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <filename>~/.config/lxc/lxc.conf</filename> for unprivileged
       containers.
       -->
-      システム設定ファイルは <filename>@LXC_GLOBAL_CONF@</filename> を使用します．
-      非特権コンテナの場合には <filename>~/.config/lxc/lxc.conf</filename> を使用します．
+      システム設定ファイルは <filename>@LXC_GLOBAL_CONF@</filename> を使用します。
+      非特権コンテナの場合には <filename>~/.config/lxc/lxc.conf</filename> を使用します。
     </para>
 
     <para>
@@ -70,7 +70,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       This configuration file is used to set values such as default
       lookup paths and storage backend settings for LXC.
       -->
-      この設定ファイルは LXC のデフォルトパスやストレージバックエンドの設定のような値を設定する時に使用します．
+      この設定ファイルは LXC のデフォルトパスやストレージバックエンドの設定のような値を設定する時に使用します。
     </para>
 
     <refsect2>
@@ -86,7 +86,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               The location in which all containers are stored.
               -->
-              全てのコンテナが保存される場所．
+              全てのコンテナが保存される場所。
             </para>
           </listitem>
         </varlistentry>
@@ -99,7 +99,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               The path to the default container configuration.
               -->
-              コンテナのデフォルト設定ファイルのパス．
+              コンテナのデフォルト設定ファイルのパス。
             </para>
           </listitem>
         </varlistentry>
@@ -119,7 +119,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               Comma separated list of cgroup controllers to setup.
               -->
-              使用する cgroup コントローラのコンマ区切りのリスト．
+              使用する cgroup コントローラのコンマ区切りのリスト。
             </para>
           </listitem>
         </varlistentry>
@@ -132,7 +132,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               Format string used to generate the cgroup path (e.g. lxc/%n).
               -->
-              コンテナ用の cgroup を生成する際に使うフォーマット文字列 (例. lxc/%n)．
+              コンテナ用の cgroup を生成する際に使うフォーマット文字列 (例. lxc/%n)。
             </para>
           </listitem>
         </varlistentry>
@@ -152,7 +152,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               Default LVM volume group name.
               -->
-              デフォルトの LVM の volume group 名．
+              デフォルトの LVM の volume group 名。
             </para>
           </listitem>
         </varlistentry>
@@ -165,7 +165,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               Default LVM thin pool name.
               -->
-              デフォルトの LVM の thin pool 名．
+              デフォルトの LVM の thin pool 名。
             </para>
           </listitem>
         </varlistentry>
@@ -185,7 +185,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <!--
               Default ZFS root name.
               -->
-              デフォルトの ZFS root 名．
+              デフォルトの ZFS root 名。
             </para>
           </listitem>
         </varlistentry>


### PR DESCRIPTION
This only converts punctuation marks from FULLWIDTH COMMA/FULL STOP to
IDEOGRAPHIC COMMA/FULL STOP in Japanese man pages. The contents of man
pages do not change at all.

Signed-off-by: KATOH Yasufumi karma@jazz.email.ne.jp
