### PR TITLE
use correct lxc-init path in sshd template

### DIFF
--- a/templates/lxc-sshd.in
+++ b/templates/lxc-sshd.in
@@ -218,7 +218,7 @@ fi
 if [ $0 = "/sbin/init" ]; then
 
     PATH="$PATH:/bin:/sbin:/usr/sbin"
-    check_for_cmd @LXCINITDIR@/lxc/lxc-init
+    check_for_cmd @SBINDIR@/init.lxc
     check_for_cmd sshd
     sshd_path=$cmd_path
 
@@ -237,7 +237,7 @@ EOF
         ifconfig eth0 |grep inet
     fi
 
-    exec @LXCINITDIR@/lxc/lxc-init -- $sshd_path
+    exec @SBINDIR@/init.lxc -- $sshd_path
     exit 1
 fi
 


### PR DESCRIPTION
lxc-init got moved into SBINDIR/init.lxc recently.
This broke sshd template because path wasn't updated there.
This patch should fix this issue.

Signed-off-by: Nikolay Martynov mar.kolya@gmail.com
