### PR TITLE
Include source code repositories in Ubuntu template's sources.list

### DIFF
--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -248,14 +248,20 @@ EOF
     if [ -n "$3" ]; then
         cat >> "$1/etc/apt/sources.list" << EOF
 deb [arch=$2] $MIRROR ${release} main restricted universe multiverse
+deb-src [arch=$2] $MIRROR ${release} main restricted universe multiverse
 deb [arch=$2] $MIRROR ${release}-updates main restricted universe multiverse
+deb-src [arch=$2] $MIRROR ${release}-updates main restricted universe multiverse
 deb [arch=$2] $SECURITY_MIRROR ${release}-security main restricted universe multiverse
+deb-src [arch=$2] $SECURITY_MIRROR ${release}-security main restricted universe multiverse
 EOF
     else
         cat >> "$1/etc/apt/sources.list" << EOF
 deb $MIRROR ${release} main restricted universe multiverse
+deb-src $MIRROR ${release} main restricted universe multiverse
 deb $MIRROR ${release}-updates main restricted universe multiverse
+deb-src $MIRROR ${release}-updates main restricted universe multiverse
 deb $SECURITY_MIRROR ${release}-security main restricted universe multiverse
+deb-src $SECURITY_MIRROR ${release}-security main restricted universe multiverse
 EOF
     fi
 }


### PR DESCRIPTION
Without source code repositories, `sudo apt-get build-dep <package>`
doesn't work. Because the main use of Linux Containers is software
development (particularly building 32-bit software on a 64-bit host),
and because source code repositories are included in the real Ubuntu
sources.list, source code repositories should be included in the Ubuntu
LXC template as well.
