### PR TITLE
Add apparmor profile for systemd-based containers

### DIFF
--- a/config/apparmor/Makefile.am
+++ b/config/apparmor/Makefile.am
@@ -9,6 +9,7 @@ EXTRA_DIST = \
 	profiles/lxc-default \
 	profiles/lxc-default-with-mounting \
 	profiles/lxc-default-with-nesting \
+	profiles/lxc-default-with-systemd \
 	usr.bin.lxc-start
 
 
@@ -22,6 +23,7 @@ install-apparmor:
 	$(INSTALL_DATA) profiles/lxc-default $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
 	$(INSTALL_DATA) profiles/lxc-default-with-mounting $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
 	$(INSTALL_DATA) profiles/lxc-default-with-nesting $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
+	$(INSTALL_DATA) profiles/lxc-default-with-systemd $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
 	$(INSTALL_DATA) lxc-containers $(DESTDIR)$(sysconfdir)/apparmor.d/
 	$(INSTALL_DATA) usr.bin.lxc-start $(DESTDIR)$(sysconfdir)/apparmor.d/
 

--- a/config/apparmor/profiles/lxc-default-with-systemd
+++ b/config/apparmor/profiles/lxc-default-with-systemd
@@ -1,0 +1,13 @@
+# Do not load this file.  Rather, load /etc/apparmor.d/lxc-containers, which
+# will source all profiles under /etc/apparmor.d/lxc
+
+profile lxc-container-default-with-systemd flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/lxc/container-base>
+
+  # the container may never be allowed to mount devpts.  If it does, it
+  # will remount the host's devpts.  We could allow it to do it with
+  # the newinstance option (but, right now, we don't).
+  deny mount fstype=devpts,
+  mount options=(none,name=systemd) fstype=cgroup -> /sys/fs/cgroup/systemd/,
+  mount options=(rw,bind),
+}


### PR DESCRIPTION
Add new apparmor profile, lxc-container-default-with-systemd,
which can be used to start systemd-based containers. Tested for
Fedora 20 and Opensuse 13.1 containers.

This was discussed on lxc-users list:
https://www.mail-archive.com/lxc-users@lists.linuxcontainers.org/msg00995.html
https://www.mail-archive.com/lxc-users@lists.linuxcontainers.org/msg01101.html

Fedora only needs cgroup/systemd mount, while opensuse also needs the bind mount capability.

Signed-off-by: Fajar A. Nugraha github@fajar.net
