### PR TITLE
Apparmor: allow hugetlbfs mounts everywhere

### DIFF
--- a/config/apparmor/abstractions/container-base
+++ b/config/apparmor/abstractions/container-base
@@ -15,6 +15,9 @@
   # allow tmpfs mounts everywhere
   mount fstype=tmpfs,
 
+  # allow hugetlbfs mounts everywhere
+  mount fstype=hugetlbfs,
+
   # allow mqueue mounts everywhere
   mount fstype=mqueue,
 

--- a/config/apparmor/abstractions/container-base.in
+++ b/config/apparmor/abstractions/container-base.in
@@ -15,6 +15,9 @@
   # allow tmpfs mounts everywhere
   mount fstype=tmpfs,
 
+  # allow hugetlbfs mounts everywhere
+  mount fstype=hugetlbfs,
+
   # allow mqueue mounts everywhere
   mount fstype=mqueue,
 


### PR DESCRIPTION
I needed this to make Archlinux happy (systemd tries to mount hugetlbfs on to /dev/hugepages at boot), although I don't really know much about hugetlbfs or if this introduces any unnecessary risks.
