### PR TITLE
lxc-ubuntu: fix btrfs subvolumes when rootfs == realrootfs

### DIFF
--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -47,16 +47,19 @@ if [ -r /etc/default/lxc ]; then
 fi
 
 # Check if given path is in a btrfs partition
-is_btrfs() {
+is_btrfs()
+{
     [ -e $1 -a $(stat -f -c '%T' $1) = "btrfs" ]
 }
 
 # Check if given path is the root of a btrfs subvolume
-is_btrfs_subvolume() {
+is_btrfs_subvolume()
+{
     [ -d $1 -a $(stat -f -c '%T' $1) = "btrfs" -a $(stat -c '%i' $1) -eq 256 ]
 }
 
-try_mksubvolume() {
+try_mksubvolume()
+{
     path=$1
     [ -d $path ] && return 0
     mkdir -p $(dirname $path)
@@ -67,7 +70,8 @@ try_mksubvolume() {
     fi
 }
 
-try_rmsubvolume() {
+try_rmsubvolume()
+{
     path=$1
     [ -d $path ] || return 0
     if is_btrfs_subvolume $path; then


### PR DESCRIPTION
An update to my previous patch adding btrfs subvolume support to the Ubuntu template. It fixes the case where lxc-create would not create a bind-mount of the rootfs.

I also updated the coding style of the functions I added to match the rest of the file.
