### PR TITLE
Update lxc-centos.in

### DIFF
--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -679,7 +679,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-arch=$(arch)
+arch=$(uname -m)
 eval set -- "$options"
 while true
 do

--- a/templates/lxc-fedora.in
+++ b/templates/lxc-fedora.in
@@ -1163,7 +1163,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-arch=$(arch)
+arch=$(uname -m)
 eval set -- "$options"
 while true
 do

--- a/templates/lxc-gentoo.in
+++ b/templates/lxc-gentoo.in
@@ -79,7 +79,7 @@ die()
 set_default_arch()
 {
     printf "### set_default_arch: default arch/variant autodetect...\n"
-    arch=$(arch)
+    arch=$(uname -m)
     if [[ $arch =~ i.86 ]]; then
         arch="x86"
         variant="x86"


### PR DESCRIPTION
The command "arch" is ironically not available under arch linux and it does the same as "uname -m".
