### PR TITLE
Improved error/logged messages when namespace clone fails.

### DIFF
--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -79,6 +79,7 @@ static int log_append_stderr(const struct lxc_log_appender *appender,
 static int log_append_logfile(const struct lxc_log_appender *appender,
 			      struct lxc_log_event *event)
 {
+	static char log_buffer_nl[] = "\n";
 	char buffer[LXC_LOG_BUFFER_SIZE];
 	int n;
 	int ms;
@@ -88,7 +89,9 @@ static int log_append_logfile(const struct lxc_log_appender *appender,
 
 	ms = event->timestamp.tv_usec / 1000;
 	n = snprintf(buffer, sizeof(buffer),
-		     "%15s %10ld.%03d %-8s %s - ",
+		     "%s%15s %10ld.%03d %-8s %s - ",
+		     event->priority >= LXC_LOG_PRIORITY_ERROR ?
+			&(log_buffer_nl[0]) : &(log_buffer_nl[1]),
 		     log_prefix,
 		     event->timestamp.tv_sec,
 		     ms,

--- a/src/lxc/namespace.c
+++ b/src/lxc/namespace.c
@@ -64,7 +64,7 @@ pid_t lxc_clone(int (*fn)(void *), void *arg, int flags)
 	ret = clone(do_clone, stack  + stack_size, flags | SIGCHLD, &clone_arg);
 #endif
 	if (ret < 0)
-		ERROR("failed to clone(0x%x): %s", flags, strerror(errno));
+		ERROR("failed to clone (%#x): %s", flags, strerror(errno));
 
 	return ret;
 }


### PR DESCRIPTION
- Insert additional newline before logged messages of ERROR or higher level (vastly improves readability).
- Add a WARN about unprivileged configurations lacking subid map configuration.
- Include flags when namespace clone fails.

Example output:

```
  lxc-start 1405048807.231 INFO     lxc_start_ui - using rcfile /home/lxc_user/.local/share/lxc/lxc_user/config
  lxc-start 1405048807.231 WARN     lxc_log - lxc_log_init called with log already initialized
  lxc-start 1405048807.231 INFO     lxc_lsm - LSM security driver nop
  lxc-start 1405048807.231 DEBUG    lxc_start - sigchild handler set
  lxc-start 1405048807.231 DEBUG    lxc_console - opening /dev/tty for console peer
  lxc-start 1405048807.231 DEBUG    lxc_console - using '/dev/tty' as console
  lxc-start 1405048807.231 DEBUG    lxc_console - 10610 got SIGWINCH fd 9
  lxc-start 1405048807.231 DEBUG    lxc_console - set winsz dstfd:6 cols:211 rows:48
  lxc-start 1405048807.231 INFO     lxc_start - 'lxc_user' is initialized
  lxc-start 1405048807.231 WARN     lxc_start - Running with euid of 40000 but not CLONE_NEWUSER, check your config files.

  lxc-start 1405048807.232 ERROR    lxc_start - failed to clone with flags 0x20000011 : CLONE_NEWUSER unset

  lxc-start 1405048807.232 ERROR    lxc_start - Operation not permitted - failed to clone
  lxc-start 1405048807.232 DEBUG    lxc_start - Dropping cap_sys_boot
  lxc-start 1405048807.232 INFO     lxc_cgroup - cgroup driver cgroupfs initing for lxc_user
  lxc-start 1405048807.232 INFO     lxc_start - failed to pin the container's rootfs

  lxc-start 1405048807.232 ERROR    lxc_namespace - failed to clone (0x6c020000): Operation not permitted

  lxc-start 1405048807.233 ERROR    lxc_start - Operation not permitted - failed to fork into a new namespace

  lxc-start 1405048807.233 ERROR    lxc_start - failed to spawn 'lxc_user'

  lxc-start 1405048807.233 ERROR    lxc_start_ui - The container failed to start.

  lxc-start 1405048807.233 ERROR    lxc_start_ui - Additional information can be obtained by setting the --logfile and --log-priority options.
```
