### PR TITLE
Add SIGPWR support to lxc_init

### DIFF
--- a/src/lxc/lxc_init.c
+++ b/src/lxc/lxc_init.c
@@ -209,6 +209,7 @@ int main(int argc, char *argv[])
 		case 0:
 			break;
 
+		case SIGPWR:
 		case SIGTERM:
 			if (!shutdown) {
 				shutdown = 1;


### PR DESCRIPTION
This patch adds SIGPWR support to lxc_init.
This helps to properly shutdown lxc_init based containers.

Signed-off-by: Nikolay Martynov mar.kolya@gmail.com
