### PR TITLE
Ssh container: send hostname to dhcp server

### DIFF
--- a/templates/lxc-sshd.in
+++ b/templates/lxc-sshd.in
@@ -229,7 +229,7 @@ if [ $0 = "/sbin/init" ]; then
         touch /etc/fstab
         rm -f /dhclient.conf
         cat > /dhclient.conf << EOF
-send host-name "<hostname>";
+send host-name = gethostname();
 EOF
         ifconfig eth0 up
         dhclient eth0 -cf /dhclient.conf


### PR DESCRIPTION
Send container's hostname to dhcp server when getting ip address.

Signed-off-by: Nikolay Martynov mar.kolya@gmail.com
