### PR TITLE
Include hostname in DHCP requests

### DIFF
--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -253,6 +253,7 @@ HOSTNAME=${UTSNAME}
 NM_CONTROLLED=no
 TYPE=Ethernet
 MTU=${MTU}
+DHCP_HOSTNAME=$name
 EOF
 
     # set the hostname


### PR DESCRIPTION
With the current old CentOS template, dnsmasq was not able to resolve the hostname of an lxc container after it had been created. This minor change rectifies that.
