### PR TITLE
apparmor: Allow slave bind mounts

### DIFF
--- a/config/apparmor/abstractions/start-container
+++ b/config/apparmor/abstractions/start-container
@@ -13,6 +13,7 @@
   mount -> /usr/lib/lxc/{**,},
   mount fstype=devpts -> /dev/pts/,
   mount options=bind /dev/pts/ptmx/ -> /dev/ptmx/,
+  mount options=(rw, slave) -> /,
   mount fstype=debugfs,
   # allow pre-mount hooks to stage mounts under /var/lib/lxc/<container>/
   mount -> /var/lib/lxc/{**,},


### PR DESCRIPTION
This fixes the AppArmor policy for systems which configure shared subtree mounting by default (such as systemd). See https://launchpad.net/bugs/1325468 for details.
