### PR TITLE
fix '--log-priority' --> '--logpriority' in main

### DIFF
--- a/src/lxc/lxc_start.c
+++ b/src/lxc/lxc_start.c
@@ -338,7 +338,7 @@ int main(int argc, char *argv[])
 		if (my_args.daemonize)
 			ERROR("To get more details, run the container in foreground mode.");
 		ERROR("Additional information can be obtained by setting the "
-		      "--logfile and --log-priority options.");
+		      "--logfile and --logpriority options.");
 		err = c->error_num;
 		lxc_container_put(c);
 		return err;


### PR DESCRIPTION
Trivial fix in `int main()` error handler. This helps spare 20s (non scientific benchmark) when troubleshooting a container.
