### PR TITLE
Ensure /dev/pts directory exists on pts setup

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1605,6 +1605,13 @@ static int setup_pts(int pts)
 		return -1;
 	}
 
+	if (mkdir("/dev/pts", 0755)) {
+		if ( errno != EEXIST ) {
+		    SYSERROR("failed to create '/dev/pts'");
+		    return -1;
+		}
+	}
+
 	if (mount("devpts", "/dev/pts", "devpts", MS_MGC_VAL,
 		  "newinstance,ptmxmode=0666,mode=0620,gid=5")) {
 		SYSERROR("failed to mount a new instance of '/dev/pts'");


### PR DESCRIPTION
When `lxc.autodev = 0` and empty tmpfs is mounted on `/dev` via `lxc.mount.entry` and private pts are requested, we need to ensure '/dev/pts' exists before attempting to mount devpts on it or container start will fail.
