### PR TITLE
Report container exit status to monitord

### DIFF
--- a/src/lxc/lxc_monitor.c
+++ b/src/lxc/lxc_monitor.c
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #include <regex.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <errno.h>
 
 #include "lxc.h"
@@ -171,6 +172,10 @@ int main(int argc, char *argv[])
 		case lxc_msg_state:
 			printf("'%s' changed state to [%s]\n",
 			       msg.name, lxc_state2str(msg.value));
+			break;
+		case lxc_msg_exit_code:
+			printf("'%s' exited with status [%d]\n",
+			       msg.name, WEXITSTATUS(msg.value));
 			break;
 		default:
 			/* ignore garbage */

--- a/src/lxc/monitor.c
+++ b/src/lxc/monitor.c
@@ -131,6 +131,16 @@ void lxc_monitor_send_state(const char *name, lxc_state_t state, const char *lxc
 	lxc_monitor_fifo_send(&msg, lxcpath);
 }
 
+void lxc_monitor_send_exit_code(const char *name, int exit_code, const char *lxcpath)
+{
+	struct lxc_msg msg = { .type = lxc_msg_exit_code,
+			       .value = exit_code };
+	strncpy(msg.name, name, sizeof(msg.name));
+	msg.name[sizeof(msg.name) - 1] = 0;
+
+	lxc_monitor_fifo_send(&msg, lxcpath);
+}
+
 
 /* routines used by monitor subscribers (lxc-monitor) */
 int lxc_monitor_close(int fd)

--- a/src/lxc/monitor.h
+++ b/src/lxc/monitor.h
@@ -32,6 +32,7 @@
 typedef enum {
 	lxc_msg_state,
 	lxc_msg_priority,
+	lxc_msg_exit_code,
 } lxc_msg_type_t;
 
 struct lxc_msg {
@@ -45,6 +46,8 @@ extern int lxc_monitor_sock_name(const char *lxcpath, struct sockaddr_un *addr);
 extern int lxc_monitor_fifo_name(const char *lxcpath, char *fifo_path,
 				 size_t fifo_path_sz, int do_mkdirp);
 extern void lxc_monitor_send_state(const char *name, lxc_state_t state,
+			    const char *lxcpath);
+extern void lxc_monitor_send_exit_code(const char *name, int exit_code,
 			    const char *lxcpath);
 extern int lxc_monitord_spawn(const char *lxcpath);
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1139,6 +1139,7 @@ int __lxc_start(const char *name, struct lxc_conf *conf,
 		handler->pinfd = -1;
 	}
 
+	lxc_monitor_send_exit_code(name, status, handler->lxcpath);
 	err =  lxc_error_set_and_log(handler->pid, status);
 out_fini:
 	lxc_delete_network(handler);


### PR DESCRIPTION
When managing containers, I need to take action based on container exit status. For instance, if it exited abnormally (status != 0), it may be interesting to respawn it automatically. Or, when invoking `lxc-stop` I want to know if it terminated gracefully (ie on `SIGTERM`) or on `SIGKILL` after a timeout.

This pull request adds a new message type `lxc_msg_exit_code,` to preserve ABI and sends the raw status code as returned by `waitpid` so that listening application may want to apply `WEXITSTATUS` before. This is what `lxc-monitor` does.
