### PR TITLE
Include network prefix when ipv4/ipv6 keys are queried

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -2210,7 +2210,7 @@ static int lxc_get_item_nic(struct lxc_conf *c, char *retv, int inlen,
 			struct lxc_inetdev *i = it2->elem;
 			char buf[INET_ADDRSTRLEN];
 			inet_ntop(AF_INET, &i->addr, buf, sizeof(buf));
-			strprint(retv, inlen, "%s\n", buf);
+			strprint(retv, inlen, "%s/%d\n", buf, i->prefix);
 		}
 	} else if (strcmp(p1, "ipv6_gateway") == 0) {
 		if (netdev->ipv6_gateway_auto) {
@@ -2226,7 +2226,7 @@ static int lxc_get_item_nic(struct lxc_conf *c, char *retv, int inlen,
 			struct lxc_inet6dev *i = it2->elem;
 			char buf[INET6_ADDRSTRLEN];
 			inet_ntop(AF_INET6, &i->addr, buf, sizeof(buf));
-			strprint(retv, inlen, "%s\n", buf);
+			strprint(retv, inlen, "%s/%d\n", buf, i->prefix);
 		}
 	}
 	return fulllen;


### PR DESCRIPTION
In reference to the issue #331 here is a small modification to add network prefix to both, ipv4 and ipv6 keys. It's been tested against ruby-lxc and seems to work as expected.

Please, let me know if there's anything else that should be done or if there's a better way for doing it.
