### PR TITLE
Fixed mismatch on ipvX gateway

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4287,12 +4287,12 @@ int lxc_clear_nic(struct lxc_conf *c, const char *key)
 			free(netdev->mtu);
 			netdev->mtu = NULL;
 		}
-	} else if (strcmp(p1, ".ipv4_gateway") == 0) {
+	} else if (strcmp(p1, ".ipv4.gateway") == 0) {
 		if (netdev->ipv4_gateway) {
 			free(netdev->ipv4_gateway);
 			netdev->ipv4_gateway = NULL;
 		}
-	} else if (strcmp(p1, ".ipv6_gateway") == 0) {
+	} else if (strcmp(p1, ".ipv6.gateway") == 0) {
 		if (netdev->ipv6_gateway) {
 			free(netdev->ipv6_gateway);
 			netdev->ipv6_gateway = NULL;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -452,9 +452,9 @@ extern int lxc_list_nicconfigs(struct lxc_conf *c, const char *key,
 		strprint(retv, inlen, "hwaddr\n");
 		strprint(retv, inlen, "mtu\n");
 		strprint(retv, inlen, "ipv6\n");
-		strprint(retv, inlen, "ipv6_gateway\n");
+		strprint(retv, inlen, "ipv6.gateway\n");
 		strprint(retv, inlen, "ipv4\n");
-		strprint(retv, inlen, "ipv4_gateway\n");
+		strprint(retv, inlen, "ipv4.gateway\n");
 	}
 	switch(netdev->type) {
 	case LXC_NET_VETH:
@@ -2127,7 +2127,7 @@ static int lxc_get_auto_mounts(struct lxc_conf *c, char *retv, int inlen)
 /*
  * lxc.network.0.XXX, where XXX can be: name, type, link, flags, type,
  * macvlan.mode, veth.pair, vlan, ipv4, ipv6, script.up, hwaddr, mtu,
- * ipv4_gateway, ipv6_gateway.  ipvX_gateway can return 'auto' instead
+ * ipv4.gateway, ipv6.gateway.  ipvX.gateway can return 'auto' instead
  * of an address.  ipv4 and ipv6 return lists (newline-separated).
  * things like veth.pair return '' if invalid (i.e. if called for vlan
  * type).
@@ -2196,7 +2196,7 @@ static int lxc_get_item_nic(struct lxc_conf *c, char *retv, int inlen,
 		if (netdev->type == LXC_NET_VLAN) {
 			strprint(retv, inlen, "%d", netdev->priv.vlan_attr.vid);
 		}
-	} else if (strcmp(p1, "ipv4_gateway") == 0) {
+	} else if (strcmp(p1, "ipv4.gateway") == 0) {
 		if (netdev->ipv4_gateway_auto) {
 			strprint(retv, inlen, "auto");
 		} else if (netdev->ipv4_gateway) {
@@ -2212,7 +2212,7 @@ static int lxc_get_item_nic(struct lxc_conf *c, char *retv, int inlen,
 			inet_ntop(AF_INET, &i->addr, buf, sizeof(buf));
 			strprint(retv, inlen, "%s/%d\n", buf, i->prefix);
 		}
-	} else if (strcmp(p1, "ipv6_gateway") == 0) {
+	} else if (strcmp(p1, "ipv6.gateway") == 0) {
 		if (netdev->ipv6_gateway_auto) {
 			strprint(retv, inlen, "auto");
 		} else if (netdev->ipv6_gateway) {

--- a/src/tests/get_item.c
+++ b/src/tests/get_item.c
@@ -237,6 +237,30 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
+	if (!c->set_config_item(c, "lxc.network.ipv4.gateway", "10.2.3.254")) {
+		fprintf(stderr, "%d: failed to set ipv4.gateway\n", __LINE__);
+		ret = 1;
+		goto out;
+	}
+
+	ret = c->get_config_item(c, "lxc.network.0.ipv4.gateway", v2, 255);
+	if (ret <= 0) {
+		fprintf(stderr, "%d: lxc.network.0.ipv4.gateway returned %d\n", __LINE__, ret);
+		ret = 1;
+		goto out;
+	}
+	if (!c->clear_config_item(c, "lxc.network.0.ipv4.gateway")) {
+		fprintf(stderr, "%d: failed clearing ipv4.gateway\n", __LINE__);
+		ret = 1;
+		goto out;
+	}
+	ret = c->get_config_item(c, "lxc.network.0.ipv4.gateway", v2, 255);
+	if (ret != 0) {
+		fprintf(stderr, "%d: after clearing ipv4.gateway get_item(lxc.network.0.ipv4.gateway returned %d\n", __LINE__, ret);
+		ret = 1;
+		goto out;
+	}
+
 	ret = c->get_config_item(c, "lxc.network.0.link", v2, 255);
 	if (ret < 0) {
 		fprintf(stderr, "%d: get_config_item returned %d\n", __LINE__, ret);


### PR DESCRIPTION
Fixes a mismatch for configuring/retrieving gateway, two different keys were needed, `lxc.network.index.ipv4.gateway` and `lxc.network.index.ipv4_gateway`, respectively. Applying the patch, only the first is used for both operations.

Also added some tests for it (copied the existing ones for ipv4 and modified).

Let me know if there's anything else that should be done.

Thanks.
