### PR TITLE
lxc/utils: bugfix freed pointer return value

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -376,6 +376,7 @@ const char *lxc_global_config_value(const char *option_name)
 				user_lxc_path = copy_global_config_value(p);
 				remove_trailing_slashes(user_lxc_path);
 				values[i] = user_lxc_path;
+				user_lxc_path = NULL;
 				goto out;
 			}
 


### PR DESCRIPTION
We allocate a pointer and save this address in a static variable. After
this we freed this pointer and return.

Here a cuttout of a valgrind report:

```
[...]
==11568== Invalid read of size 1
==11568==    at 0x4C2D524: strlen (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11568==    by 0x5961C9B: puts (in /usr/lib/libc-2.20.so)
==11568==    by 0x400890: main (lxc_config.c:73)
==11568==  Address 0x6933e21 is 1 bytes inside a block of size 32 free'd
==11568==    at 0x4C2B200: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11568==    by 0x4E654F2: lxc_global_config_value (utils.c:415)
==11568==    by 0x4E92177: lxc_get_global_config_item (lxccontainer.c:2287)
==11568==    by 0x400883: main (lxc_config.c:71)
[...]
```

Signed-off-by: Silvio Fricke silvio.fricke@gmail.com
