### PR TITLE
lxc-debian: support systemd as PID 1

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -183,6 +183,34 @@ install_packages()
     fi
 }
 
+configure_debian_systemd()
+{
+    rootfs=$1
+    init="$(chroot ${rootfs} dpkg-query --search /sbin/init | cut -d : -f 1)"
+    if [ "$init" != "systemd-sysv" ]; then
+       # systemd is not PID 1
+       return
+    fi
+
+    # This function has been copied and adapted from lxc-fedora
+    rm -f ${rootfs}/etc/systemd/system/default.target
+    touch ${rootfs}/etc/fstab
+    chroot ${rootfs} ln -s /dev/null /etc/systemd/system/udev.service
+    chroot ${rootfs} ln -s /lib/systemd/system/multi-user.target /etc/systemd/system/default.target
+    # Make systemd honor SIGPWR
+    chroot ${rootfs} ln -s /lib/systemd/system/halt.target /etc/systemd/system/sigpwr.target
+    sed -e 's/^ConditionPathExists=/# ConditionPathExists=/' \
+        -e 's/After=dev-%i.device/After=/' \
+        < ${rootfs}/lib/systemd/system/getty\@.service \
+        > ${rootfs}/etc/systemd/system/getty\@.service
+    # Setup getty service on the 4 ttys we are going to allow in the
+    # default config.  Number should match lxc.tty
+    ( cd ${rootfs}/etc/systemd/system/getty.target.wants
+        for i in 1 2 3 4 ; do ln -sf ../getty\@.service getty@tty${i}.service; done )
+
+    return 0
+}
+
 cleanup()
 {
     rm -rf $cache/partial-$release-$arch
@@ -521,6 +549,8 @@ if [ $? -ne 0 ]; then
     echo "failed to configure debian for a container"
     exit 1
 fi
+
+configure_debian_systemd $rootfs
 
 copy_configuration $path $rootfs $name $arch
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Containers with systemd need a somewhat special setup, which I borrowed
and adaptec from lxc-fedora. These changes are required so that Debian 8
(jessie) containers work properly, and are a no-op for previous Debian
versions.

Signed-off-by: Antonio Terceiro terceiro@debian.org
