### PR TITLE
Allow lxc_clear_config_item to clear idmaps.

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -2360,9 +2360,12 @@ int lxc_clear_config_item(struct lxc_conf *c, const char *key)
 		lxc_seccomp_free(c);
 		return 0;
 	}
-	else if (strncmp(key, "lxc.environment", 15) == 0)
+	else if (strncmp(key, "lxc.environment", 15) == 0) {
 		return lxc_clear_environment(c);
-
+	}
+	else if (strncmp(key, "lxc.id_map", 10) == 0) {
+		return lxc_clear_idmaps(c);
+	}
 	return -1;
 }
 


### PR DESCRIPTION
Ran into this when trying to automate stgraber's "GUI in containers" post -- where I need to clear the default id_map in order to replace it.

Let me know if I should post this patch to the list instead.. this is my first lxc patch.
