### PR TITLE
Adjustments to debian template for systemd

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -210,6 +210,7 @@ configure_debian_systemd()
     # This function has been copied and adapted from lxc-fedora
     rm -f ${rootfs}/etc/systemd/system/default.target
     touch ${rootfs}/etc/fstab
+    chroot ${rootfs} ln -s /dev/null /etc/systemd/system/udev.service
     chroot ${rootfs} ln -s /dev/null /etc/systemd/system/systemd-udevd.service
     chroot ${rootfs} ln -s /lib/systemd/system/multi-user.target /etc/systemd/system/default.target
     # Make systemd honor SIGPWR


### PR DESCRIPTION
Among the changes are:
- mask systemd-udevd.service in addition to udev.service (jessie name and wheezy name, respectively)
- try to configure as much of the systemd stuff as possible even when systemd is not installed, in anticipation for upgrades and init system switches
- use `update-rc.d disable` instead of `remove`, as the effects of remove are reset after the packages are updated and `defaults` is run

I do have a question: why is there no /dev/tty0 device when `lxc.autodev` is enabled? If there was, we could get rid of at least some of the ugly sed hack.
