### PR TITLE
improve "lxc-create -t debian -h" help text, add --keep option, fix option parsing

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -225,8 +225,12 @@ configure_debian_systemd()
 
 cleanup()
 {
-    rm -rf $cache/partial-$release-$arch
-    rm -rf $cache/rootfs-$release-$arch
+    if [ -z "$keep_cache" ]; then
+        rm -rf $cache/partial-$release-$arch
+        rm -rf $cache/rootfs-$release-$arch
+    else
+        echo "kept the cache"
+    fi
 }
 
 download_debian()
@@ -441,7 +445,7 @@ Template specific options can be passed to lxc-create after a '--' like this:
 
   lxc-create --name=NAME [-lxc-create-options] -- [-template-options]
 
-Usage: $1 -h|--help -p|--path=<path> [-c|--clean] [-a|--arch=<arch>] [-r|--release=<release>]
+Usage: $1 -h|--help -p|--path=<path> [-c|--clean] [-k|--keep] [-a|--arch=<arch>] [-r|--release=<release>]
                                      [--mirror=<mirror>] [--security-mirror=<security mirror>]
                                      [--package=<package_name1,package_name2,...>]
 
@@ -461,6 +465,7 @@ Options :
   --packages=PACKAGE_NAME1,PACKAGE_NAME2,...
                          List of additional packages to install. Comma separated, without space.
   -c, --clean            only clean up the cache and terminate
+  -k, --keep             don't clean up the cache on termination
 
 Environment variables:
 
@@ -473,7 +478,7 @@ EOF
     return 0
 }
 
-options=$(getopt -o hp:n:a:r:c -l arch:,clean,help,mirror:,name:,packages:,path:,release:,rootfs:,security-mirror: -- "$@")
+options=$(getopt -o hp:n:a:r:ck -l arch:,clean,keep,help,mirror:,name:,packages:,path:,release:,rootfs:,security-mirror: -- "$@")
 if [ $? -ne 0 ]; then
         usage $(basename $0)
         exit 1
@@ -494,6 +499,8 @@ else
 fi
 hostarch=$arch
 
+keep_cache=
+
 while true
 do
     case "$1" in
@@ -502,7 +509,8 @@ do
 
         -a|--arch)            arch=$2; shift 2;;
         -c|--clean)           clean=$2; shift 1;;
-           --mirror)          MIRROR=$2; shift 2;;
+        -k|--keep)            keep_cache=1; shift 1;;
+        --mirror)             MIRROR=$2; shift 2;;
         -n|--name)            name=$2; shift 2;;
            --packages)        packages=$2; shift 2;;
         -p|--path)            path=$2; shift 2;;

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -508,7 +508,7 @@ do
            --)                shift 1; break ;;
 
         -a|--arch)            arch=$2; shift 2;;
-        -c|--clean)           clean=$2; shift 1;;
+        -c|--clean)           clean=1; shift 1;;
         -k|--keep)            keep_cache=1; shift 1;;
         --mirror)             MIRROR=$2; shift 2;;
         -n|--name)            name=$2; shift 2;;

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -437,12 +437,38 @@ clean()
 usage()
 {
     cat <<EOF
-$1 -h|--help -p|--path=<path> [-a|--arch] [-c|--clean] [--mirror=<mirror>] [-r|--release=<release>] [--security-mirror=<security mirror>]
-arch: the container architecture (e.g. amd64): defaults to host arch
-release: the debian release (e.g. wheezy): defaults to current stable
-mirror: debain mirror to use during installation
-security mirror: debain mirror to use for security updates
-packages: list of packages to add comma separated
+Template specific options can be passed to lxc-create after a '--' like this:
+
+  lxc-create --name=NAME [-lxc-create-options] -- [-template-options]
+
+Usage: $1 -h|--help -p|--path=<path> [-c|--clean] [-a|--arch=<arch>] [-r|--release=<release>]
+                                     [--mirror=<mirror>] [--security-mirror=<security mirror>]
+                                     [--package=<package_name1,package_name2,...>]
+
+Options :
+
+  -h, --help             print this help text
+  -p, --path=PATH        directory where config and rootfs of this VM will be kept
+  -a, --arch=ARCH        The container architecture. Can be one of: i686, x86_64,
+                         amd64, armhf, armel, powerpc. Defaults to host arch.
+  -r, --release=RELEASE  Debian release. Can be one of: squeeze, wheezy, jessie, sid.
+                         Defaults to current stable.
+  --mirror=MIRROR        Debian mirror to use during installation. Overrides the MIRROR
+                         environment variable (see below).
+  --security-mirror=SECURITY_MIRROR
+                         Debian mirror to use for security updates. Overrides the
+                         SECURITY_MIRROR environment variable (see below).
+  --packages=PACKAGE_NAME1,PACKAGE_NAME2,...
+                         List of additional packages to install. Comma separated, without space.
+  -c, --clean            only clean up the cache and terminate
+
+Environment variables:
+
+  MIRROR                 The Debian package mirror to use. See also the --mirror switch above.
+                         Defaults to '$MIRROR'
+  SECURITY_MIRROR        The Debian package security mirror to use. See also the --security-mirror switch above.
+                         Defaults to '$SECURITY_MIRROR'
+
 EOF
     return 0
 }


### PR DESCRIPTION
Unfortunately Github can't create pull requests one on top of the other. So here are the descriptions of my commits, each on top of the previous, implementing a different thing:

72c0e81:

- document environment variables
- add missing --packages switch to command line
- describe how to pass template options to lxc-create (since lxc-create -h doesn't tell you)
- render help text in the same pretty format as lxc-create does

bb120e2:

- allow to keep the cache of the downloaded packages
- With this option, the user doesn't have to download all the required packages over and over again, when the download fails half way through for some reason, or when he wants to lxc-create another VM.

843aebc:

- fix option assignment. AFAIK it was broken. See commit text.
 
Please pull, thanks.

Signed-off-by: Tomáš Pospíšek <tpo_deb@sourcepole.ch>