### PR TITLE
apparmor: Fix slave bind mounts

### DIFF
--- a/config/apparmor/abstractions/start-container
+++ b/config/apparmor/abstractions/start-container
@@ -13,7 +13,7 @@
   mount -> /usr/lib/lxc/{**,},
   mount fstype=devpts -> /dev/pts/,
   mount options=bind /dev/pts/ptmx/ -> /dev/ptmx/,
-  mount options=(rw, slave) -> /,
+  mount options=(rw, make-slave) -> **,
   mount fstype=debugfs,
   # allow pre-mount hooks to stage mounts under /var/lib/lxc/<container>/
   mount -> /var/lib/lxc/{**,},


### PR DESCRIPTION
The permission to make a mount "slave" is spelt "make-slave", not "slave", see
https://launchpad.net/bugs/1401619. Also, we need to make all mounts slave, not
just the root dir.

https://launchpad.net/bugs/1350947