### PR TITLE
Fix instantiation of multiple vlan interfaces with same id

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2979,13 +2979,14 @@ static int instantiate_vlan(struct lxc_handler *handler, struct lxc_netdev *netd
 {
 	char peer[IFNAMSIZ];
 	int err;
+	static uint16_t vlan_cntr = 0;
 
 	if (!netdev->link) {
 		ERROR("no link specified for vlan netdev");
 		return -1;
 	}
 
-	err = snprintf(peer, sizeof(peer), "vlan%d", netdev->priv.vlan_attr.vid);
+	err = snprintf(peer, sizeof(peer), "vlan%d-%d", netdev->priv.vlan_attr.vid, vlan_cntr++);
 	if (err >= sizeof(peer)) {
 		ERROR("peer name too long");
 		return -1;


### PR DESCRIPTION
Container fail to start with configs (as shown below) where the same
vlan id is used for several type=vlan container interfaces.
Then, during the instantiation of the vlan interfaces, an error occurs
because the lxc code tries to assign the same temporary name to both
of them before it is bound into the container.

> lxc.network.type      = vlan
> lxc.network.flags     = up
> lxc.network.link      = eth1
> lxc.network.vlan.id   = 3842
> lxc.network.name      = iso0
>
> lxc.network.type      = vlan
> lxc.network.flags     = up
> lxc.network.link      = eth2
> lxc.network.vlan.id   = 3842
> lxc.network.name      = iso1

Signed-off-by: Axel Neumann <neumann@cgws.de>