### PR TITLE
ubuntu template fails when keyring file is not installed - wrt issue #409

### DIFF
--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -355,16 +355,31 @@ download_ubuntu()
     choose_container_proxy $cache/partial-$arch/ $arch
     # download a mini ubuntu into a cache
     echo "Downloading ubuntu $release minimal ..."
-    if [ -n "$(which qemu-debootstrap)" ]; then
-        qemu-debootstrap --verbose --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch $MIRROR
-    else
-        debootstrap --verbose --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch $MIRROR
+	DEBOOTSTRAP=debootstrap
+    if which qemu-debootstrap >/dev/null 2>&1; then
+		DEBOOTSTRAP=qemu-debootstrap
     fi
+	# debootstrap defaults to debian if this file is missing
+	if [ -r /usr/share/keyrings/ubuntu-archive-keyring.gpg ]; then
+		$DEBOOTSTRAP --verbose --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch
+		DEBOOTSTRAP_RETURN=$?
+	else
+		case $arch in
+			amd64|i386)
+				DEBOOTSTRAP_MIRROR=${MIRROR:-http://archive.ubuntu.com/ubuntu}
+				;;
+			*)
+				DEBOOTSTRAP_MIRROR=${MIRROR:-http://ports.ubuntu.com/ubuntu-ports}
+				;;
+		esac
+		$DEBOOTSTRAP --verbose --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch $DEBOOTSTRAP_MIRROR
+		DEBOOTSTRAP_RETURN=$?
+	fi
 
-    if [ $? -ne 0 ]; then
-        echo "Failed to download the rootfs, aborting."
-            return 1
-    fi
+	if [ $DEBOOTSTRAP_RETURN -ne 0 ]; then
+		echo "Failed to download the rootfs, aborting."
+		return 1
+	fi
 
     # Serge isn't sure whether we should avoid doing this when
     # $release == `distro-info -d`

--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -364,15 +364,14 @@ download_ubuntu()
 		$DEBOOTSTRAP --verbose --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch
 		DEBOOTSTRAP_RETURN=$?
 	else
-		case $arch in
-			amd64|i386)
-				DEBOOTSTRAP_MIRROR=${MIRROR:-http://archive.ubuntu.com/ubuntu}
-				;;
-			*)
-				DEBOOTSTRAP_MIRROR=${MIRROR:-http://ports.ubuntu.com/ubuntu-ports}
-				;;
-		esac
-		$DEBOOTSTRAP --verbose --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch $DEBOOTSTRAP_MIRROR
+		# download the ubuntu-archive-keyring.gpg file to /var/cache/lxc/keyrings
+		if [ ! -e "$LOCALSTATEDIR/cache/lxc/keyrings"/ubuntu-archive-keyring.gpg ]; then
+			mkdir -p "$LOCALSTATEDIR/cache/lxc/keyrings"
+			wget --directory-prefix="$LOCALSTATEDIR/cache/lxc/keyrings" http://archive.ubuntu.com/ubuntu/pool/main/u/ubuntu-keyring/ubuntu-keyring_2012.05.19.tar.gz
+			tar xf "$LOCALSTATEDIR/cache/lxc/keyrings"/ubuntu-keyring_2012.05.19.tar.gz -C "$LOCALSTATEDIR/cache/lxc/keyrings" --strip-components=2 ubuntu-keyring-2012.05.19/keyrings/ubuntu-archive-keyring.gpg
+		fi
+		# use downloaded keyring file with debootstrap
+		$DEBOOTSTRAP --keyring="$LOCALSTATEDIR/cache/lxc/keyrings"/ubuntu-archive-keyring.gpg --verbose --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch
 		DEBOOTSTRAP_RETURN=$?
 	fi
 


### PR DESCRIPTION
Please see issue #409 - these are the possible solutions that I proposed there.
Proposal 1 is in commit 1, proposal 2 in commit 2.

Other minor changes:
- `which qemu-debootstrap` is not quiet

- echo "Failed to download the rootfs, aborting."
Was shown depending on the previous if, not on result of debootstrap. (`set -e` prevents it from being displayed anyways ...)