### PR TITLE
Deletion of unnecessary checks before some function calls

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -108,8 +108,7 @@ static struct lxc_proc_context_info *lxc_proc_get_context_info(pid_t pid)
 		}
 	}
 
-	if (line)
-		free(line);
+	free(line);
 	fclose(proc_file);
 
 	if (!found) {
@@ -129,8 +128,7 @@ out_error:
 
 static void lxc_proc_put_context_info(struct lxc_proc_context_info *ctx)
 {
-	if (ctx->lsm_label)
-		free(ctx->lsm_label);
+	free(ctx->lsm_label);
 	if (ctx->container)
 		lxc_container_put(ctx->container);
 	free(ctx);
@@ -444,8 +442,7 @@ static char *lxc_attach_getpwshell(uid_t uid)
 			}
 			if (!token)
 				continue;
-			if (result)
-				free(result);
+			free(result);
 			result = strdup(token);
 
 			/* sanity check that there are no fields after that */

--- a/src/lxc/bdev.c
+++ b/src/lxc/bdev.c
@@ -1439,8 +1439,7 @@ out:
 		close(fddst);
 	if (fd != -1)
 		close(fd);
-	if (newfull)
-		free(newfull);
+	free(newfull);
 	return ret;
 }
 
@@ -3119,12 +3118,9 @@ static const size_t numbdevs = sizeof(bdevs) / sizeof(struct bdev_type);
 
 void bdev_put(struct bdev *bdev)
 {
-	if (bdev->mntopts)
-		free(bdev->mntopts);
-	if (bdev->src)
-		free(bdev->src);
-	if (bdev->dest)
-		free(bdev->dest);
+	free(bdev->mntopts);
+	free(bdev->src);
+	free(bdev->dest);
 	free(bdev);
 }
 

--- a/src/lxc/cgfs.c
+++ b/src/lxc/cgfs.c
@@ -2187,8 +2187,7 @@ static bool do_init_cpuset_file(struct cgroup_mount_point *mp,
 		SYSERROR("failed writing %s", childfile);
 
 out:
-	if (parentfile)
-		free(parentfile);
+	free(parentfile);
 	free(childfile);
 	return ok;
 }
@@ -2248,8 +2247,7 @@ static void cgfs_destroy(void *hdata)
 
 	if (!d)
 		return;
-	if (d->name)
-		free(d->name);
+	free(d->name);
 	if (d->info)
 		lxc_cgroup_process_info_free_and_remove(d->info);
 	if (d->meta)

--- a/src/lxc/cgfs.c
+++ b/src/lxc/cgfs.c
@@ -2248,10 +2248,8 @@ static void cgfs_destroy(void *hdata)
 	if (!d)
 		return;
 	free(d->name);
-	if (d->info)
-		lxc_cgroup_process_info_free_and_remove(d->info);
-	if (d->meta)
-		lxc_cgroup_put_meta(d->meta);
+	lxc_cgroup_process_info_free_and_remove(d->info);
+	lxc_cgroup_put_meta(d->meta);
 	free(d);
 }
 

--- a/src/lxc/cgmanager.c
+++ b/src/lxc/cgmanager.c
@@ -577,8 +577,7 @@ static void cgm_destroy(void *hdata)
 		cgm_remove_cgroup(slist[i], d->cgroup_path);
 
 	free(d->name);
-	if (d->cgroup_path)
-		free(d->cgroup_path);
+	free(d->cgroup_path);
 	free(d);
 	cgm_dbus_disconnect();
 }

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2639,10 +2639,9 @@ static int instantiate_veth(struct lxc_handler *handler, struct lxc_netdev *netd
 
 out_delete:
 	lxc_netdev_delete_by_name(veth1);
-	if (!netdev->priv.veth_attr.pair && veth1)
+	if (!netdev->priv.veth_attr.pair)
 		free(veth1);
-	if(veth2)
-		free(veth2);
+	free(veth2);
 	return -1;
 }
 
@@ -3156,8 +3155,7 @@ int lxc_map_ids(struct lxc_list *idmap, pid_t pid)
 			break;
 	}
 
-	if (buf)
-		free(buf);
+	free(buf);
 	return ret;
 }
 
@@ -3599,8 +3597,7 @@ void remount_all_slave(void)
 		}
 	}
 	fclose(f);
-	if (line)
-		free(line);
+	free(line);
 }
 
 void lxc_execute_bind_init(struct lxc_conf *conf)
@@ -3886,22 +3883,15 @@ static void lxc_remove_nic(struct lxc_list *it)
 
 	lxc_list_del(it);
 
-	if (netdev->link)
-		free(netdev->link);
-	if (netdev->name)
-		free(netdev->name);
-	if (netdev->type == LXC_NET_VETH && netdev->priv.veth_attr.pair)
+	free(netdev->link);
+	free(netdev->name);
+	if (netdev->type == LXC_NET_VETH)
 		free(netdev->priv.veth_attr.pair);
-	if (netdev->upscript)
-		free(netdev->upscript);
-	if (netdev->hwaddr)
-		free(netdev->hwaddr);
-	if (netdev->mtu)
-		free(netdev->mtu);
-	if (netdev->ipv4_gateway)
-		free(netdev->ipv4_gateway);
-	if (netdev->ipv6_gateway)
-		free(netdev->ipv6_gateway);
+	free(netdev->upscript);
+	free(netdev->hwaddr);
+	free(netdev->mtu);
+	free(netdev->ipv4_gateway);
+	free(netdev->ipv6_gateway);
 	lxc_list_for_each_safe(it2, &netdev->ipv4, next) {
 		lxc_list_del(it2);
 		free(it2->elem);
@@ -3964,40 +3954,26 @@ int lxc_clear_nic(struct lxc_conf *c, const char *key)
 			free(it2);
 		}
 	} else if (strcmp(p1, ".link") == 0) {
-		if (netdev->link) {
-			free(netdev->link);
-			netdev->link = NULL;
-		}
+		free(netdev->link);
+		netdev->link = NULL;
 	} else if (strcmp(p1, ".name") == 0) {
-		if (netdev->name) {
-			free(netdev->name);
-			netdev->name = NULL;
-		}
+		free(netdev->name);
+		netdev->name = NULL;
 	} else if (strcmp(p1, ".script.up") == 0) {
-		if (netdev->upscript) {
-			free(netdev->upscript);
-			netdev->upscript = NULL;
-		}
+		free(netdev->upscript);
+		netdev->upscript = NULL;
 	} else if (strcmp(p1, ".hwaddr") == 0) {
-		if (netdev->hwaddr) {
-			free(netdev->hwaddr);
-			netdev->hwaddr = NULL;
-		}
+		free(netdev->hwaddr);
+		netdev->hwaddr = NULL;
 	} else if (strcmp(p1, ".mtu") == 0) {
-		if (netdev->mtu) {
-			free(netdev->mtu);
-			netdev->mtu = NULL;
-		}
+		free(netdev->mtu);
+		netdev->mtu = NULL;
 	} else if (strcmp(p1, ".ipv4.gateway") == 0) {
-		if (netdev->ipv4_gateway) {
-			free(netdev->ipv4_gateway);
-			netdev->ipv4_gateway = NULL;
-		}
+		free(netdev->ipv4_gateway);
+		netdev->ipv4_gateway = NULL;
 	} else if (strcmp(p1, ".ipv6.gateway") == 0) {
-		if (netdev->ipv6_gateway) {
-			free(netdev->ipv6_gateway);
-			netdev->ipv6_gateway = NULL;
-		}
+		free(netdev->ipv6_gateway);
+		netdev->ipv6_gateway = NULL;
 	}
 		else return -1;
 
@@ -4183,36 +4159,22 @@ void lxc_conf_free(struct lxc_conf *conf)
 {
 	if (!conf)
 		return;
-	if (conf->console.log_path)
-		free(conf->console.log_path);
-	if (conf->console.path)
-		free(conf->console.path);
-	if (conf->rootfs.mount)
-		free(conf->rootfs.mount);
-	if (conf->rootfs.options)
-		free(conf->rootfs.options);
-	if (conf->rootfs.path)
-		free(conf->rootfs.path);
-	if (conf->rootfs.pivot)
-		free(conf->rootfs.pivot);
-	if (conf->logfile)
-		free(conf->logfile);
-	if (conf->utsname)
-		free(conf->utsname);
-	if (conf->ttydir)
-		free(conf->ttydir);
-	if (conf->fstab)
-		free(conf->fstab);
-	if (conf->rcfile)
-		free(conf->rcfile);
-	if (conf->init_cmd)
-		free(conf->init_cmd);
+	free(conf->console.log_path);
+	free(conf->console.path);
+	free(conf->rootfs.mount);
+	free(conf->rootfs.options);
+	free(conf->rootfs.path);
+	free(conf->rootfs.pivot);
+	free(conf->logfile);
+	free(conf->utsname);
+	free(conf->ttydir);
+	free(conf->fstab);
+	free(conf->rcfile);
+	free(conf->init_cmd);
 	free(conf->unexpanded_config);
 	lxc_clear_config_network(conf);
-	if (conf->lsm_aa_profile)
-		free(conf->lsm_aa_profile);
-	if (conf->lsm_se_context)
-		free(conf->lsm_se_context);
+	free(conf->lsm_aa_profile);
+	free(conf->lsm_se_context);
 	lxc_seccomp_free(conf);
 	lxc_clear_config_caps(conf);
 	lxc_clear_config_keepcaps(conf);
@@ -4486,8 +4448,7 @@ void suggest_default_idmap(void)
 	}
 	fclose(f);
 
-	if (line)
-		free(line);
+	free(line);
 
 	if (!urange || !grange) {
 		ERROR("You do not have subuids or subgids allocated");

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -241,8 +241,7 @@ static int config_string_item(char **conf_item, const char *value)
 	char *new_value;
 
 	if (!value || strlen(value) == 0) {
-		if (*conf_item)
-			free(*conf_item);
+		free(*conf_item);
 		*conf_item = NULL;
 		return 0;
 	}
@@ -253,8 +252,7 @@ static int config_string_item(char **conf_item, const char *value)
 		return -1;
 	}
 
-	if (*conf_item)
-		free(*conf_item);
+	free(*conf_item);
 	*conf_item = new_value;
 	return 0;
 }
@@ -1120,7 +1118,7 @@ static int config_environment(const char *key, const char *value,
 	return 0;
 
 freak_out:
-	if (list_item) free(list_item);
+	free(list_item);
 
 	return -1;
 }
@@ -1331,15 +1329,12 @@ static int config_cgroup(const char *key, const char *value,
 	return 0;
 
 out:
-	if (cglist)
-		free(cglist);
+	free(cglist);
 
 	if (cgelem) {
-		if (cgelem->subsystem)
-			free(cgelem->subsystem);
+		free(cgelem->subsystem);
 
-		if (cgelem->value)
-			free(cgelem->value);
+		free(cgelem->value);
 
 		free(cgelem);
 	}
@@ -1399,8 +1394,7 @@ static int config_idmap(const char *key, const char *value, struct lxc_conf *lxc
 	return 0;
 
 out:
-	if (idmaplist)
-		free(idmaplist);
+	free(idmaplist);
 
 	if (idmap) {
 		free(idmap);
@@ -1796,8 +1790,7 @@ static int config_utsname(const char *key, const char *value,
 	}
 
 	strcpy(utsname->nodename, value);
-	if (lxc_conf->utsname)
-		free(lxc_conf->utsname);
+	free(lxc_conf->utsname);
 	lxc_conf->utsname = utsname;
 
 	return 0;

--- a/src/lxc/lsm/apparmor.c
+++ b/src/lxc/lsm/apparmor.c
@@ -95,8 +95,7 @@ again:
 	f = fopen(path, "r");
 	if (!f) {
 		SYSERROR("opening %s", path);
-		if (buf)
-			free(buf);
+		free(buf);
 		return NULL;
 	}
 	sz += 1024;
@@ -133,8 +132,7 @@ static int apparmor_am_unconfined(void)
 	int ret = 0;
 	if (!p || strcmp(p, "unconfined") == 0)
 		ret = 1;
-	if (p)
-		free(p);
+	free(p);
 	return ret;
 }
 

--- a/src/lxc/lxc_autostart.c
+++ b/src/lxc/lxc_autostart.c
@@ -500,8 +500,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if ( c_groups_lists )
-		free(c_groups_lists);
+	free(c_groups_lists);
 
 	if ( cmd_groups_list ) {
 		toss_list( cmd_groups_list );

--- a/src/lxc/lxc_autostart.c
+++ b/src/lxc/lxc_autostart.c
@@ -482,7 +482,7 @@ int main(int argc, char *argv[])
 			if ( lxc_container_put(c) > 0 ) {
 				containers[i] = NULL;
 			}
-			if ( c_groups_lists && c_groups_lists[i] ) {
+			if ( c_groups_lists ) {
 				toss_list(c_groups_lists[i]);
 				c_groups_lists[i] = NULL;
 			}
@@ -501,11 +501,7 @@ int main(int argc, char *argv[])
 	}
 
 	free(c_groups_lists);
-
-	if ( cmd_groups_list ) {
-		toss_list( cmd_groups_list );
-	}
-
+	toss_list( cmd_groups_list );
 	free(containers);
 
 	return 0;

--- a/src/lxc/lxc_snapshot.c
+++ b/src/lxc/lxc_snapshot.c
@@ -72,8 +72,7 @@ static void print_file(char *path)
 	while (getline(&line, &sz, f) != -1) {
 		printf("%s", line);
 	}
-	if (line)
-		free(line);
+	free(line);
 	fclose(f);
 }
 

--- a/src/lxc/lxc_start.c
+++ b/src/lxc/lxc_start.c
@@ -89,8 +89,7 @@ static int ensure_path(char **confpath, const char *path)
 	err = 0;
 
 err:
-	if (fullpath)
-		free(fullpath);
+	free(fullpath);
 	return err;
 }
 

--- a/src/lxc/lxc_top.c
+++ b/src/lxc/lxc_top.c
@@ -390,10 +390,8 @@ static void ct_free(void)
 			lxc_container_put(ct[i].c);
 			ct[i].c = NULL;
 		}
-		if (ct[i].stats) {
-			free(ct[i].stats);
-			ct[i].stats = NULL;
-		}
+		free(ct[i].stats);
+		ct[i].stats = NULL;
 	}
 }
 

--- a/src/lxc/lxc_user_nic.c
+++ b/src/lxc/lxc_user_nic.c
@@ -133,8 +133,7 @@ static int get_alloted(char *me, char *intype, char *link)
 		return n;
 	}
 	fclose(fin);
-	if (line)
-		free(line);
+	free(line);
 	return -1;
 }
 

--- a/src/lxc/lxc_usernsexec.c
+++ b/src/lxc/lxc_usernsexec.c
@@ -244,8 +244,7 @@ static int read_default_map(char *fnam, int which, char *username)
 		break;
 	}
 
-	if (line)
-		free(line);
+	free(line);
 	fclose(fin);
 	return 0;
 }

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -217,14 +217,10 @@ static void lxc_container_free(struct lxc_container *c)
 	if (!c)
 		return;
 
-	if (c->configfile) {
-		free(c->configfile);
-		c->configfile = NULL;
-	}
-	if (c->error_string) {
-		free(c->error_string);
-		c->error_string = NULL;
-	}
+	free(c->configfile);
+	c->configfile = NULL;
+	free(c->error_string);
+	c->error_string = NULL;
 	if (c->slock) {
 		lxc_putlock(c->slock);
 		c->slock = NULL;
@@ -233,18 +229,14 @@ static void lxc_container_free(struct lxc_container *c)
 		lxc_putlock(c->privlock);
 		c->privlock = NULL;
 	}
-	if (c->name) {
-		free(c->name);
-		c->name = NULL;
-	}
+	free(c->name);
+	c->name = NULL;
 	if (c->lxc_conf) {
 		lxc_conf_free(c->lxc_conf);
 		c->lxc_conf = NULL;
 	}
-	if (c->config_path) {
-		free(c->config_path);
-		c->config_path = NULL;
-	}
+	free(c->config_path);
+	c->config_path = NULL;
 
 	free(c);
 }
@@ -961,8 +953,7 @@ static bool create_run_template(struct lxc_container *c, char *tpath, bool quiet
 				exit(1);
 			}
 		} else { // TODO come up with a better way here!
-			if (bdev->dest)
-				free(bdev->dest);
+			free(bdev->dest);
 			bdev->dest = strdup(bdev->src);
 		}
 
@@ -1390,8 +1381,7 @@ out:
 	if (!ret && c)
 		container_destroy(c);
 free_tpath:
-	if (tpath)
-		free(tpath);
+	free(tpath);
 	return ret;
 }
 
@@ -1964,8 +1954,8 @@ static void mod_all_rdeps(struct lxc_container *c, bool inc)
 		lxc_container_put(p);
 	}
 out:
-	if (lxcpath) free(lxcpath);
-	if (lxcname) free(lxcname);
+	free(lxcpath);
+	free(lxcname);
 	fclose(f);
 }
 
@@ -2210,8 +2200,7 @@ static bool set_config_filename(struct lxc_container *c)
 		return false;
 	}
 
-	if (c->configfile)
-		free(c->configfile);
+	free(c->configfile);
 	c->configfile = newpath;
 
 	return true;
@@ -2250,8 +2239,7 @@ static bool lxcapi_set_config_path(struct lxc_container *c, const char *path)
 		oldpath = NULL;
 	}
 err:
-	if (oldpath)
-		free(oldpath);
+	free(oldpath);
 	container_mem_unlock(c);
 	return b;
 }
@@ -2598,8 +2586,7 @@ static int clone_update_rootfs(struct clone_update_data *data)
 			return -1;
 		}
 	} else { // TODO come up with a better way
-		if (bdev->dest)
-			free(bdev->dest);
+		free(bdev->dest);
 		bdev->dest = strdup(bdev->src);
 	}
 
@@ -3038,14 +3025,10 @@ static int lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
 
 static void lxcsnap_free(struct lxc_snapshot *s)
 {
-	if (s->name)
-		free(s->name);
-	if (s->comment_pathname)
-		free(s->comment_pathname);
-	if (s->timestamp)
-		free(s->timestamp);
-	if (s->lxcpath)
-		free(s->lxcpath);
+	free(s->name);
+	free(s->comment_pathname);
+	free(s->timestamp);
+	free(s->lxcpath);
 }
 
 static char *get_snapcomment_path(char* snappath, char *name)
@@ -3811,10 +3794,8 @@ static bool dump_net_info(struct lxc_container *c, char *directory)
 
 		has_error = false;
 out:
-		if (veth)
-			free(veth);
-		if (bridge)
-			free(bridge);
+		free(veth);
+		free(bridge);
 		if (has_error)
 			return false;
 	}
@@ -4388,8 +4369,7 @@ free_ct_name:
 	}
 
 out:
-	if (line)
-		free(line);
+	free(line);
 
 	fclose(f);
 	return ret;
@@ -4461,16 +4441,13 @@ free_ct_list:
 	for (i = 0; i < ct_list_cnt; i++) {
 		lxc_container_put(ct_list[i]);
 	}
-	if (ct_list)
-		free(ct_list);
+	free(ct_list);
 
 free_active_name:
 	for (i = 0; i < active_cnt; i++) {
-		if (active_name[i])
-			free(active_name[i]);
+		free(active_name[i]);
 	}
-	if (active_name)
-		free(active_name);
+	free(active_name);
 
 free_ct_name:
 	for (i = 0; i < ct_cnt; i++) {

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -1378,7 +1378,7 @@ out_unlock:
 	if (partial_fd >= 0)
 		remove_partial(c, partial_fd);
 out:
-	if (!ret && c)
+	if (!ret)
 		container_destroy(c);
 free_tpath:
 	free(tpath);

--- a/src/lxc/lxclock.c
+++ b/src/lxc/lxclock.c
@@ -323,10 +323,8 @@ void lxc_putlock(struct lxc_lock *l)
 			close(l->u.f.fd);
 			l->u.f.fd = -1;
 		}
-		if (l->u.f.fname) {
-			free(l->u.f.fname);
-			l->u.f.fname = NULL;
-		}
+		free(l->u.f.fname);
+		l->u.f.fname = NULL;
 		break;
 	}
 	free(l);

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -176,8 +176,7 @@ static char * is_wlan(const char *ifname)
 	return physname;
 
 bad:
-	if (physname)
-		free(physname);
+	free(physname);
 	return NULL;
 }
 

--- a/src/lxc/parse.c
+++ b/src/lxc/parse.c
@@ -59,8 +59,7 @@ int lxc_file_for_each_line(const char *file, lxc_file_cb callback, void *data)
 		}
 	}
 
-	if (line)
-		free(line);
+	free(line);
 	fclose(f);
 	return err;
 }

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -564,10 +564,8 @@ int lxc_seccomp_load(struct lxc_conf *conf)
 }
 
 void lxc_seccomp_free(struct lxc_conf *conf) {
-	if (conf->seccomp) {
-		free(conf->seccomp);
-		conf->seccomp = NULL;
-	}
+	free(conf->seccomp);
+	conf->seccomp = NULL;
 #if HAVE_SCMP_FILTER_CTX
 	if (conf->seccomp_ctx) {
 		seccomp_release(conf->seccomp_ctx);

--- a/src/python-lxc/lxc.c
+++ b/src/python-lxc/lxc.c
@@ -237,8 +237,7 @@ void lxc_attach_free_options(lxc_attach_options_t *options)
     int i;
     if (!options)
         return;
-    if (options->initial_cwd)
-        free(options->initial_cwd);
+    free(options->initial_cwd);
     if (options->extra_env_vars) {
         for (i = 0; options->extra_env_vars[i]; i++)
             free(options->extra_env_vars[i]);


### PR DESCRIPTION
* [The function "free"](http://stackoverflow.com/questions/18775608/free-a-null-pointer-anyway-or-check-first "Free a null pointer anyway or check first?") is documented in the way that no action shall occur for a passed null pointer. Redundant safety checks can be avoided.
* The following functions perform also input parameter validation.
  * [container_destroy](https://github.com/lxc/lxc/blob/d2cf4c378588cc1d497fe8b2ba3f835d6b03fe38/src/lxc/lxccontainer.c#L2062 "Destroy a container.")
  * [lxc_cgroup_process_info_free_and_remove](https://github.com/lxc/lxc/blob/ec64264d78d4ed608553842ce9e1f07eeab2a032/src/lxc/cgfs.c#L1186 "Free process membership information and remove control groups.")
  * [lxc_cgroup_put_meta](https://github.com/lxc/lxc/blob/ec64264d78d4ed608553842ce9e1f07eeab2a032/src/lxc/cgfs.c#L598 "Put meta.")
  * [toss_list](https://github.com/lxc/lxc/blob/67c660d0aaff5f2854a55da936fe6cd82510494f/src/lxc/lxc_autostart.c#L310 "Toss a list.")

  It is therefore not needed that a function caller repeats a corresponding check.