### PR TITLE
fix busybox unpriv

### DIFF
--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -73,9 +73,8 @@ $rootfs/usr/lib64"
 
     # minimal devices needed for busybox
     if [ $in_userns -eq 1 ]; then
-        for dev in tty console tty0 tty1 tty5 ram0 null urandom; do
-            touch $rootfs/dev/$dev
-            echo "/dev/$dev dev/$dev    none bind 0 0" >> $path/fstab
+        for dev in tty console tty0 tty1 ram0 null urandom; do
+            echo "/dev/$dev dev/$dev    none bind,optional,create=file 0 0" >> $path/fstab
         done
     else
         mknod -m 666 tty c 5 0       || res=1


### PR DESCRIPTION
1. tty5 is not needed
2. the devices should be optional in case they didn't exist in the
host / parent-container
3. switch from 'touch $rootfs/dev/$dev' to using create=file in the
mount entry.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>