### PR TITLE
Enable fuse filesystems for containers

### DIFF
--- a/config/templates/common.conf.in
+++ b/config/templates/common.conf.in
@@ -45,6 +45,7 @@ lxc.cgroup.devices.allow = c 136:* rwm
 
 # Setup the default mounts
 lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed
+lxc.mount.entry = /sys/fs/fuse/connections sys/fs/fuse/connections none bind,optional 0 0
 
 # Blacklist some syscalls which are not safe in privileged
 # containers

--- a/config/templates/common.conf.in
+++ b/config/templates/common.conf.in
@@ -42,6 +42,8 @@ lxc.cgroup.devices.allow = c 1:8 rwm
 lxc.cgroup.devices.allow = c 1:9 rwm
 ### /dev/pts/*
 lxc.cgroup.devices.allow = c 136:* rwm
+### fuse
+lxc.cgroup.devices.allow = c 10:229 rwm
 
 # Setup the default mounts
 lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed

--- a/config/templates/debian.common.conf.in
+++ b/config/templates/debian.common.conf.in
@@ -4,9 +4,6 @@ lxc.include = @LXCTEMPLATECONFIG@/common.conf
 # Doesn't support consoles in /dev/lxc/
 lxc.devttydir =
 
-# Default mount entries
-lxc.mount.entry = /sys/fs/fuse/connections sys/fs/fuse/connections none bind,optional 0 0
-
 # When using LXC with apparmor, the container will be confined by default.
 # If you wish for it to instead run unconfined, copy the following line
 # (uncommented) to the container's configuration file.
@@ -24,8 +21,6 @@ lxc.mount.entry = /sys/fs/fuse/connections sys/fs/fuse/connections none bind,opt
 # Extra cgroup device access
 ## rtc
 lxc.cgroup.devices.allow = c 254:0 rm
-## fuse
-lxc.cgroup.devices.allow = c 10:229 rwm
 ## tun
 lxc.cgroup.devices.allow = c 10:200 rwm
 ## hpet

--- a/config/templates/gentoo.common.conf.in
+++ b/config/templates/gentoo.common.conf.in
@@ -12,8 +12,6 @@ lxc.devttydir =
 # Extra cgroup device access
 ## rtc
 lxc.cgroup.devices.allow = c 254:0 rm
-## fuse
-lxc.cgroup.devices.allow = c 10:229 rwm
 ## tun
 lxc.cgroup.devices.allow = c 10:200 rwm
 ## hpet

--- a/config/templates/openwrt.common.conf.in
+++ b/config/templates/openwrt.common.conf.in
@@ -34,8 +34,6 @@ lxc.cgroup.devices.allow = c 5:2 rwm
 lxc.cgroup.devices.allow = c 136:* rwm
 ## rtc
 lxc.cgroup.devices.allow = c 254:0 rm
-## fuse
-lxc.cgroup.devices.allow = c 10:229 rwm
 ## tun
 lxc.cgroup.devices.allow = c 10:200 rwm
 ## dev/tty0

--- a/config/templates/plamo.common.conf.in
+++ b/config/templates/plamo.common.conf.in
@@ -13,5 +13,3 @@ lxc.autodev = 0
 # Extra cgroup device access
 ## rtc
 lxc.cgroup.devices.allow = c 254:0 rm
-## fuse
-lxc.cgroup.devices.allow = c 10:229 rwm

--- a/config/templates/ubuntu.common.conf.in
+++ b/config/templates/ubuntu.common.conf.in
@@ -2,7 +2,6 @@
 lxc.include = @LXCTEMPLATECONFIG@/common.conf
 
 # Default mount entries
-lxc.mount.entry = /sys/fs/fuse/connections sys/fs/fuse/connections none bind,optional 0 0
 lxc.mount.entry = /sys/kernel/debug sys/kernel/debug none bind,optional 0 0
 lxc.mount.entry = /sys/kernel/security sys/kernel/security none bind,optional 0 0
 lxc.mount.entry = /sys/fs/pstore sys/fs/pstore none bind,optional 0 0
@@ -28,8 +27,6 @@ lxc.mount.entry = /sys/fs/pstore sys/fs/pstore none bind,optional 0 0
 # Extra cgroup device access
 ## rtc
 lxc.cgroup.devices.allow = c 254:0 rm
-## fuse
-lxc.cgroup.devices.allow = c 10:229 rwm
 ## tun
 lxc.cgroup.devices.allow = c 10:200 rwm
 ## hpet


### PR DESCRIPTION
This enables containers to run a fuse filesystems per default. The mount
is designed to be safe. Hence, it can be enabled per default in
common.conf. It will lead to a cleaner boot for some unprivileged
systemd-based containers.