### PR TITLE
attach: use _exit() instead of exit() in the intermediate child process

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -575,7 +575,7 @@ struct attach_clone_payload {
 static int attach_child_main(void* data);
 
 /* help the optimizer along if it doesn't know that exit always exits */
-#define rexit(c)  do { int __c = (c); exit(__c); return __c; } while(0)
+#define rexit(c)  do { int __c = (c); _exit(__c); return __c; } while(0)
 
 /* define default options if no options are supplied by the user */
 static lxc_attach_options_t attach_static_default_options = LXC_ATTACH_OPTIONS_DEFAULT;


### PR DESCRIPTION
I ran into this issue while using lxc_attach in a native node.js addon: For some reason, the intermediate process created by lxc_attach could not be reaped by the parent process (waitpid reported no child processes). This causes the IPC communication between the attached process and the initial thread to fail, since the initial thread jumps to the cleanup block. (Error reported was "error using IPC to receive notification from initial process (0)")

As far as I can tell, the problem is that the call to exit() in the intermediate process causes cleanup handlers set by node.js or V8 (Google's javascript engine upon which node.js is based) to be run, which mess with the child process so it can't be reaped any more. 

This change prevents any on_exit() and atexit() functions registered by the parent process from being run in the forked intermediate process.

Here is a workaround for anyone who runs into this same issue: Forking and registering an on_exit() function that calls _exit() will prevent any previously registered on_exit()/atexit() functions from being called.

```c
void exitnow(int status, void *) {
    _exit(status);
}

int main() {
    lxc_container *c;

    /* ... */

    if (fork() == 0) {
        on_exit(exitnow, NULL);
        c->attach(c, /* ... */);
    }

    return 0;
}
```
