### PR TITLE
templates/lxc-gentoo.in: Fix stage3 autodetection code

### DIFF
--- a/templates/lxc-gentoo.in
+++ b/templates/lxc-gentoo.in
@@ -160,7 +160,8 @@ cache_stage3()
         printf "Determining path to latest Gentoo %s (%s) stage3 archive...\n" "${arch}" "${variant}"
         printf " => downloading and processing %s\n" "${stage3_pointer}"
 
-        local stage3_latest_tarball=$(wget -q -O - "${stage3_pointer}" | tail -n1 ) \
+        local stage3_latest_tarball=$(wget -q -O - "${stage3_pointer}" | \
+			tail -n1 | cut -d " " -f 1) \
             || die 6 "Error: unable to fetch\n"
 
         printf " => Got: %s\n" "${stage3_latest_tarball}"


### PR DESCRIPTION
The latest-stage3-$variant.txt files list both the tarball name
and the released date but we only need to pass the stage3 tarball
name to the subsequent wget command otherwise we end up with 404
errors.

Signed-off-by: Markos Chandras <hwoarang@gentoo.org>