### PR TITLE
lxc-gentoo: handle date in stage3 pointer correctly

### DIFF
--- a/templates/lxc-gentoo.in
+++ b/templates/lxc-gentoo.in
@@ -166,7 +166,7 @@ cache_stage3()
         printf " => Got: %s\n" "${stage3_latest_tarball}"
 
         printf "Downloading/untarring the actual stage3 tarball...\n"
-        wget -O - "${stage3_baseurl}/${stage3_latest_tarball}" \
+        wget -O - "${stage3_baseurl}/${stage3_latest_tarball% *}" \
             | tar -xjpf - --numeric-owner -C "${partialfs}" \
             || die 6 "Error: unable to fetch or untar\n"
         printf " => extracted to: %s\n" "${partialfs}"


### PR DESCRIPTION
The stage3 pointer text file contains two fields: the tarball path and date. Strip date to obtain the URI.