### PR TITLE
gentoo.common.conf improvements

### DIFF
--- a/config/templates/gentoo.common.conf.in
+++ b/config/templates/gentoo.common.conf.in
@@ -24,3 +24,7 @@ lxc.cgroup.devices.allow = c 10:232 rwm
 
 # /dev/ is created by template
 lxc.autodev = 0
+
+# /dev/shm need to be mounted as tmpfs. It's needed by python (bug #496328)
+# and possibly other packages.
+lxc.mount.entry = none dev/shm tmpfs rw,nosuid,nodev

--- a/config/templates/gentoo.common.conf.in
+++ b/config/templates/gentoo.common.conf.in
@@ -21,3 +21,6 @@ lxc.cgroup.devices.allow = c 10:232 rwm
 ## To use loop devices, copy the following line to the container's
 ## configuration file (uncommented).
 #lxc.cgroup.devices.allow = b 7:* rwm
+
+# /dev/ is created by template
+lxc.autodev = 0


### PR DESCRIPTION
Hi,

A couple of patches in order to support /dev/shm as tmpfs which is needed for building python in a Gentoo LXC. This will make the Gentoo LXC more useful for developer (and users) who use it to build and test Gentoo ebuilds.