### PR TITLE
 Lxccreate: add a backing store type (bdevtype) to a python create function

### DIFF
--- a/src/python-lxc/lxc.c
+++ b/src/python-lxc/lxc.c
@@ -801,11 +801,11 @@ Container_create(Container *self, PyObject *args, PyObject *kwds)
     char** create_args = {NULL};
     PyObject *retval = NULL;
     PyObject *vargs = NULL;
+    char *bdevtype = NULL;
     int i = 0;
-    static char *kwlist[] = {"template", "flags", "args", NULL};
-
-    if (! PyArg_ParseTupleAndKeywords(args, kwds, "|siO", kwlist,
-                                      &template_name, &flags, &vargs))
+    static char *kwlist[] = {"template", "flags", "bdevtype", "args", NULL};
+    if (! PyArg_ParseTupleAndKeywords(args, kwds, "|sisO", kwlist,
+                                      &template_name, &flags, &bdevtype, &vargs))
         return NULL;
 
     if (vargs) {
@@ -821,7 +821,7 @@ Container_create(Container *self, PyObject *args, PyObject *kwds)
         }
     }
 
-    if (self->container->create(self->container, template_name, NULL, NULL,
+    if (self->container->create(self->container, template_name, bdevtype, NULL,
                                 flags, create_args))
         retval = Py_True;
     else

--- a/src/python-lxc/lxc/__init__.py
+++ b/src/python-lxc/lxc/__init__.py
@@ -205,7 +205,7 @@ class Container(_lxc.Container):
 
         return _lxc.Container.set_config_item(self, key, value)
 
-    def create(self, template=None, flags=0, args=()):
+    def create(self, template=None, flags=0, args=(), bdevtype=None):
         """
             Create a new rootfs for the container.
 
@@ -217,22 +217,19 @@ class Container(_lxc.Container):
             "args" (optional) is a tuple of arguments to pass to the
             template. It can also be provided as a dict.
         """
-
         if isinstance(args, dict):
-            template_args = []
+            tmp_args = []
             for item in args.items():
-                template_args.append("--%s" % item[0])
-                template_args.append("%s" % item[1])
-        else:
-            template_args = args
-
+                tmp_args.append("--%s" % item[0])
+                tmp_args.append("%s" % item[1])
+        template_args = {}
         if template:
-            return _lxc.Container.create(self, template=template,
-                                         flags=flags,
-                                         args=tuple(template_args))
-        else:
-            return _lxc.Container.create(self, flags=flags,
-                                         args=tuple(template_args))
+    	    template_args['template'] = template
+        template_args['flags'] = flags
+        template_args['args'] = tuple(tmp_args)
+        if bdevtype:
+            template_args['bdevtype'] = bdevtype
+        return _lxc.Container.create(self, **template_args)
 
     def clone(self, newname, config_path=None, flags=0, bdevtype=None,
               bdevdata=None, newsize=0, hookargs=()):


### PR DESCRIPTION
The main purpose of this commit is to add a backing store type (bdevtype) to a python create function (like lxc-create -B)

Signed-off-by: Bieliaievskyi Sergey magelan09@gmail.com