### PR TITLE
autostart: Fix bug with containers being started in reverse order

### DIFF
--- a/src/lxc/lxc_autostart.c
+++ b/src/lxc/lxc_autostart.c
@@ -304,7 +304,7 @@ static int cmporder(const void *p1, const void *p2) {
 	if (c1_order == c2_order)
 		return strcmp(c1->name, c2->name);
 	else
-		return (c1_order - c2_order) * -1;
+		return (c1_order - c2_order);
 }
 
 static int toss_list( struct lxc_list *c_groups_list ) {


### PR DESCRIPTION
Original pull request closed, because it was mistakenly made by using master branch instead of bugfix/*-named one.
https://github.com/lxc/lxc/pull/461

-------[ Original text ]--------------------------------------
As configuration parameter is called lxc.start.ORDER, one expects that container with order setting "1" will start before container with order setting set to "2", but this is not the case. Containers start in reverse order. If that is the desired behaviour, then I believe "order" should be called "priority" or something similar.

Anyway, I looked into src/lxc/lxc_autostart.c, and found this:

In main() there is this code:
qsort(&containers[0], count, sizeof(struct lxc_container *), cmporder);

In cmporder() the last comparison looks like this:
return (c1_order - c2_order) * -1;

qsort() sorts elements from lower to higher value, using callback cmporder(). Therefore cmporder() should return negative value if container c1 should be started before c2. That "* -1" achieves exactly the oposite result, as it causes containers to be sorted in descending order regarding to their order setting.

This pull request fixes the behaviour. See mailing list for additional discussion about multi-container operation ordering.
