### PR TITLE
templates: gentoo.common: Add /dev/shm tmpfs mount entry

### DIFF
--- a/config/templates/gentoo.common.conf.in
+++ b/config/templates/gentoo.common.conf.in
@@ -21,3 +21,7 @@ lxc.cgroup.devices.allow = c 10:232 rwm
 ## To use loop devices, copy the following line to the container's
 ## configuration file (uncommented).
 #lxc.cgroup.devices.allow = b 7:* rwm
+
+# /dev/shm needs to be mounted as tmpfs. It's needed by python (bug #496328)
+# and possibly other packages.
+lxc.mount.entry = none dev/shm tmpfs rw,nosuid,nodev,create=dir


### PR DESCRIPTION
/dev/shm needs to be mounted as tmpfs. It's needed by python
and possibly other packages.

Signed-off-by: Markos Chandras <hwoarang@gentoo.org>