### PR TITLE
Allow veth that is not attached to a bridge on unprivileged container

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2979,6 +2979,7 @@ static int unpriv_assign_nic(struct lxc_netdev *netdev, pid_t pid)
 	int bytes, pipefd[2];
 	char *token, *saveptr = NULL;
 	char buffer[MAX_BUFFER_SIZE];
+	char netdev_link[IFNAMSIZ+1];
 
 	if (netdev->type != LXC_NET_VETH) {
 		ERROR("nic type %d not support for unprivileged use",
@@ -3008,7 +3009,12 @@ static int unpriv_assign_nic(struct lxc_netdev *netdev, pid_t pid)
 
 		// Call lxc-user-nic pid type bridge
 		char pidstr[20];
-		char *args[] = {LXC_USERNIC_PATH, pidstr, "veth", netdev->link, netdev->name, NULL };
+		if (netdev->link) {
+			strncpy(netdev_link, netdev->link, IFNAMSIZ);
+		} else {
+			strncpy(netdev_link, "none", IFNAMSIZ);
+		}
+		char *args[] = {LXC_USERNIC_PATH, pidstr, "veth", netdev_link, netdev->name, NULL };
 		snprintf(pidstr, 19, "%lu", (unsigned long) pid);
 		pidstr[19] = '\0';
 		execvp(args[0], args);


### PR DESCRIPTION
This PR is a follow up to https://www.mail-archive.com/lxc-users@lists.linuxcontainers.org/msg02624.html

Short summary, I suggest the following enhancement steps for unprivileged containers to allow veth networking with proxyarp/non-bridge setup:

1. Allow empty lxc.network.link with lxc.network.type = veth for unprivileged container, so that user can create a veth interface not attached to any bridge
2. Allow custom veth name on the host side
3. Allow static IP address definition on container config file

This PR only implements (1)

Tested on top of current master on ubuntu 14.04.2 host and container. I use this setup

```
$ cat /etc/lxc/lxc-usernet
# USERNAME TYPE BRIDGE COUNT
user veth lxcbr0 2
user veth none 2

$ grep link ~/.local/share/lxc/u1/config
#lxc.network.link = lxcbr0
```

with lxc.network.link commented-out, ``lxc-user-nic`` will be called with ``none`` as bridge, and a veth interface will be created that is not attached to any bridge.

veth count quota works, normal ``lxc.network.link = lxcbr0`` setup also still works.

Signed-off-by: Fajar A. Nugraha <github@fajar.net>