### PR TITLE
Typo in help text.

### DIFF
--- a/src/lxc/lxc_autostart.c
+++ b/src/lxc/lxc_autostart.c
@@ -64,7 +64,7 @@ static struct lxc_arguments my_args = {
 	.progname = "lxc-autostart",
 	.help     = "\
 \n\
-lxc-autostart managed auto-started containers\n\
+lxc-autostart manages auto-started containers\n\
 \n\
 Options:\n\
   -k, --kill        kill the containers instead of starting them\n\


### PR DESCRIPTION
"lxc-autostart managed auto-started containers" - past tense is a misnomer.