### PR TITLE
update path of tty.conf

### DIFF
--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -350,7 +350,7 @@ EOF
     # prevent mingetty from calling vhangup(2) since it fails with userns.
     # Same issue as oracle template: prevent mingetty from calling vhangup(2)
     # commit 2e83f7201c5d402478b9849f0a85c62d5b9f1589.
-    sed -i 's|mingetty|mingetty --nohangup|' $container_rootfs/etc/init/tty.conf
+    sed -i 's|mingetty|mingetty --nohangup|' $rootfs_path/etc/init/tty.conf
 
     if [ ${root_display_password} = "yes" ]
     then


### PR DESCRIPTION
$container_rootfs may not be used so 'sed' will try to patch "/etc/init/tty.conf". It must not be correct.

Signed-off-by: Teruo Oshida <teruo.oshida@miraclelinux.com>
