### PR TITLE
Added a more reliable test for --releasever

### DIFF
--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -414,9 +414,9 @@ download_centos()
     # download a mini centos into a cache
     echo "Downloading centos minimal ..."
     if [ $(yum -h | grep 'releasever=RELEASEVER') ];then
-        YUM="yum --installroot $INSTALL_ROOT -y --nogpgcheck"
-    else
         YUM="yum --installroot $INSTALL_ROOT -y --nogpgcheck --releasever=$release"
+    else
+        YUM="yum --installroot $INSTALL_ROOT -y --nogpgcheck"
     fi
     PKG_LIST="yum initscripts passwd rsyslog vim-minimal openssh-server openssh-clients dhclient chkconfig rootfiles policycoreutils"
 

--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -413,7 +413,7 @@ download_centos()
 
     # download a mini centos into a cache
     echo "Downloading centos minimal ..."
-    if [ $release -le 5 ];then
+    if [ $(yum -h  | grep 'releasever=RELEASEVER') ];then
         YUM="yum --installroot $INSTALL_ROOT -y --nogpgcheck"
     else
         YUM="yum --installroot $INSTALL_ROOT -y --nogpgcheck --releasever=$release"

--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -413,7 +413,7 @@ download_centos()
 
     # download a mini centos into a cache
     echo "Downloading centos minimal ..."
-    if [ $(yum -h  | grep 'releasever=RELEASEVER') ];then
+    if [ $(yum -h | grep 'releasever=RELEASEVER') ];then
         YUM="yum --installroot $INSTALL_ROOT -y --nogpgcheck"
     else
         YUM="yum --installroot $INSTALL_ROOT -y --nogpgcheck --releasever=$release"


### PR DESCRIPTION
The current lxc-centos template dosen't support this use case:

    alexandrel@epsilon:~/work$ lxc-create -n c7.test01 -t centos -- -R 7
    Host CPE ID from /etc/os-release: 
    Checking cache download in /var/cache/lxc/centos/x86_64/7/rootfs ... 
    Downloading centos minimal ...
    Usage: yum [options] COMMAND

    List of Commands:

    check-update   Check for available package updates
    clean          Remove cached data
    deplist        List a package's dependencies
    downgrade      downgrade a package
    erase          Remove a package or packages from your system
    groupinfo      Display details about a package group
    groupinstall   Install the packages in a group on your system
    grouplist      List available package groups
    groupremove    Remove the packages in a group from your system
    help           Display a helpful usage message
    history        Display, or use, the transaction history
    info           Display details about a package or group of packages
    install        Install a package or packages on your system
    list           List a package or groups of packages
    localinstall   Install a local RPM
    makecache      Generate the metadata cache

The lxc-centos template is failing because the --releasever yum option was introduced in 3.2.29

    alexandrel@epsilon:~/work$ yum --version
    3.2.25

    alexandrel@epsilon:~/work$ cat /etc/*-release
    DISTRIB_ID=Ubuntu
    DISTRIB_RELEASE=12.04
    DISTRIB_CODENAME=precise
    DISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"
    NAME="Ubuntu"
    VERSION="12.04.5 LTS, Precise Pangolin"
    ID=ubuntu
    ID_LIKE=debian
    PRETTY_NAME="Ubuntu precise (12.04.5 LTS)"
    VERSION_ID="12.04"
