### PR TITLE
Sort the cgroup memory settings before applying.

### DIFF
--- a/src/lxc/cgfs.c
+++ b/src/lxc/cgfs.c
@@ -1895,6 +1895,9 @@ static int do_setup_cgroup_limits(struct cgfs_data *d,
 		return 0;
 
 	sorted_cgroup_settings = sort_cgroup_settings(cgroup_settings);
+	if (!sorted_cgroup_settings) {
+		return -1;
+	}
 
 	lxc_list_for_each(iterator, sorted_cgroup_settings) {
 		cg = iterator->elem;

--- a/src/lxc/cgfs.c
+++ b/src/lxc/cgfs.c
@@ -1888,12 +1888,15 @@ static int do_setup_cgroup_limits(struct cgfs_data *d,
 {
 	struct lxc_list *iterator;
 	struct lxc_cgroup *cg;
+	struct lxc_list *sorted_cgroup_settings;
 	int ret = -1;
 
 	if (lxc_list_empty(cgroup_settings))
 		return 0;
 
-	lxc_list_for_each(iterator, cgroup_settings) {
+	sorted_cgroup_settings = sort_cgroup_settings(cgroup_settings);
+
+	lxc_list_for_each(iterator, sorted_cgroup_settings) {
 		cg = iterator->elem;
 
 		if (do_devices == !strncmp("devices", cg->subsystem, 7)) {
@@ -1916,6 +1919,10 @@ static int do_setup_cgroup_limits(struct cgfs_data *d,
 	ret = 0;
 	INFO("cgroup has been setup");
 out:
+	lxc_list_for_each(iterator, sorted_cgroup_settings) {
+		lxc_list_del(iterator);
+		free(iterator);
+	}
 	return ret;
 }
 

--- a/src/lxc/cgfs.c
+++ b/src/lxc/cgfs.c
@@ -1886,9 +1886,8 @@ static int do_cgroup_set(const char *cgroup_path, const char *sub_filename,
 static int do_setup_cgroup_limits(struct cgfs_data *d,
 			   struct lxc_list *cgroup_settings, bool do_devices)
 {
-	struct lxc_list *iterator;
+	struct lxc_list *iterator, *sorted_cgroup_settings, *next;
 	struct lxc_cgroup *cg;
-	struct lxc_list *sorted_cgroup_settings;
 	int ret = -1;
 
 	if (lxc_list_empty(cgroup_settings))
@@ -1922,10 +1921,11 @@ static int do_setup_cgroup_limits(struct cgfs_data *d,
 	ret = 0;
 	INFO("cgroup has been setup");
 out:
-	lxc_list_for_each(iterator, sorted_cgroup_settings) {
+	lxc_list_for_each_safe(iterator, sorted_cgroup_settings, next) {
 		lxc_list_del(iterator);
 		free(iterator);
 	}
+	free(sorted_cgroup_settings);
 	return ret;
 }
 

--- a/src/lxc/cgmanager.c
+++ b/src/lxc/cgmanager.c
@@ -1218,10 +1218,9 @@ static bool cgm_unfreeze(void *hdata)
 static bool cgm_setup_limits(void *hdata, struct lxc_list *cgroup_settings, bool do_devices)
 {
 	struct cgm_data *d = hdata;
-	struct lxc_list *iterator;
+	struct lxc_list *iterator, *sorted_cgroup_settings, *next;
 	struct lxc_cgroup *cg;
 	bool ret = false;
-	struct lxc_list *sorted_cgroup_settings;
 
 	if (lxc_list_empty(cgroup_settings))
 		return true;
@@ -1267,10 +1266,11 @@ static bool cgm_setup_limits(void *hdata, struct lxc_list *cgroup_settings, bool
 	ret = true;
 	INFO("cgroup limits have been setup");
 out:
-	lxc_list_for_each(iterator, sorted_cgroup_settings) {
+	lxc_list_for_each_safe(iterator, sorted_cgroup_settings, next) {
 		lxc_list_del(iterator);
 		free(iterator);
 	}
+	free(sorted_cgroup_settings);
 	cgm_dbus_disconnect();
 	return ret;
 }

--- a/src/lxc/cgmanager.c
+++ b/src/lxc/cgmanager.c
@@ -1221,6 +1221,7 @@ static bool cgm_setup_limits(void *hdata, struct lxc_list *cgroup_settings, bool
 	struct lxc_list *iterator;
 	struct lxc_cgroup *cg;
 	bool ret = false;
+	struct lxc_list *sorted_cgroup_settings;
 
 	if (lxc_list_empty(cgroup_settings))
 		return true;
@@ -1233,7 +1234,9 @@ static bool cgm_setup_limits(void *hdata, struct lxc_list *cgroup_settings, bool
 		return false;
 	}
 
-	lxc_list_for_each(iterator, cgroup_settings) {
+	sorted_cgroup_settings = sort_cgroup_settings(cgroup_settings);
+
+	lxc_list_for_each(iterator, sorted_cgroup_settings) {
 		char controller[100], *p;
 		cg = iterator->elem;
 		if (do_devices != !strncmp("devices", cg->subsystem, 7))
@@ -1261,6 +1264,10 @@ static bool cgm_setup_limits(void *hdata, struct lxc_list *cgroup_settings, bool
 	ret = true;
 	INFO("cgroup limits have been setup");
 out:
+	lxc_list_for_each(iterator, sorted_cgroup_settings) {
+		lxc_list_del(iterator);
+		free(iterator);
+	}
 	cgm_dbus_disconnect();
 	return ret;
 }

--- a/src/lxc/cgmanager.c
+++ b/src/lxc/cgmanager.c
@@ -1235,6 +1235,9 @@ static bool cgm_setup_limits(void *hdata, struct lxc_list *cgroup_settings, bool
 	}
 
 	sorted_cgroup_settings = sort_cgroup_settings(cgroup_settings);
+	if (!sorted_cgroup_settings) {
+		return false;
+	}
 
 	lxc_list_for_each(iterator, sorted_cgroup_settings) {
 		char controller[100], *p;

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4577,11 +4577,19 @@ struct lxc_list *sort_cgroup_settings(struct lxc_list* cgroup_settings)
 	struct lxc_list *item = NULL;
 
 	result = malloc(sizeof(*result));
+	if (!result) {
+		ERROR("failed to allocate memory to sort cgroup settings");
+		return NULL;
+	}
 	lxc_list_init(result);
 
 	/*Iterate over the cgroup settings and copy them to the output list*/
 	lxc_list_for_each(it, cgroup_settings) {
 		item = malloc(sizeof(*item));
+		if (!item) {
+			ERROR("failed to allocate memory to sort cgroup settings");
+			return NULL;
+		}
 		item->elem = it->elem;
 		cg = it->elem;
 		if (strcmp(cg->subsystem, "memory.memsw.limit_in_bytes") == 0) {

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -431,4 +431,5 @@ extern void tmp_proc_unmount(struct lxc_conf *lxc_conf);
 void remount_all_slave(void);
 extern void suggest_default_idmap(void);
 FILE *write_mount_file(struct lxc_list *mount);
+struct lxc_list *sort_cgroup_settings(struct lxc_list* cgroup_settings);
 #endif


### PR DESCRIPTION
Add a function to sort the cgroup settings before applying.
Currently, the function will put memory.memsw.limit_in_bytes after
memory.limit_in_bytes setting so the container will start
regardless of the order specified in the input. Fix #453

Signed-off-by: Kien Truong <duckientruong@gmail.com>