### PR TITLE
Make lxc-checkconfig work with kernel versions > 3

### DIFF
--- a/src/lxc/lxc-checkconfig.in
+++ b/src/lxc/lxc-checkconfig.in
@@ -24,7 +24,7 @@ is_enabled() {
     if [ $RES -eq 0 ]; then
         $SETCOLOR_SUCCESS && echo "enabled" && $SETCOLOR_NORMAL
     else
-        if [ ! -z "$mandatory" -a "$mandatory" = yes ]; then
+        if [ ! -z "$mandatory" ] && [ "$mandatory" = yes ]; then
             $SETCOLOR_FAILURE && echo "required" && $SETCOLOR_NORMAL
         else
             $SETCOLOR_WARNING && echo "missing" && $SETCOLOR_NORMAL
@@ -100,7 +100,7 @@ echo -n "Cgroup device: " && is_enabled CONFIG_CGROUP_DEVICE
 echo -n "Cgroup sched: " && is_enabled CONFIG_CGROUP_SCHED
 echo -n "Cgroup cpu account: " && is_enabled CONFIG_CGROUP_CPUACCT
 echo -n "Cgroup memory controller: "
-if [ $KVER_MAJOR -ge 3 -a $KVER_MINOR -ge 6 ]; then
+if ([ $KVER_MAJOR -ge 3 ] && [ $KVER_MINOR -ge 6 ]) || ([ $KVER_MAJOR -gt 3 ]); then
     is_enabled CONFIG_MEMCG
 else
     is_enabled CONFIG_CGROUP_MEM_RES_CTLR


### PR DESCRIPTION
(1) Add test for kernel version greater 3.
(2) Use && and || instead of -a and -o as suggested in
    http://www.unix.com/man-page/posix/1p/test/.

lxc-checkconfig will currently report "missing" on "Cgroup memory controller"
for kernel versions greater 3. This happens because the script, before checking
for the corresponding memory variable in the kernel config, currently will test
whether we have a major kernel version greater- or equal to 3 and a minor kernel
version greater- or equal to 6. This adds an additional test whether we have a
major kernel version greater than 3.

Signed-off-by: Christian Brauner <christianvanbrauner@gmail.com>