### PR TITLE
Fix Lua 5.3 compatibility code.

### DIFF
--- a/src/lua-lxc/core.c
+++ b/src/lua-lxc/core.c
@@ -39,7 +39,9 @@
 #endif
 
 #if LUA_VERSION_NUM >= 503
+#ifndef luaL_checkunsigned
 #define luaL_checkunsigned(L,n) ((lua_Unsigned)luaL_checkinteger(L,n))
+#endif
 #endif
 
 #ifdef NO_CHECK_UDATA


### PR DESCRIPTION
If Lua 5.3 is compiled with LUA_COMPAT_5_2 defined, the
luaL_checkunsigned compatibility macro is already defined
in lauxlib.h.

Signed-off-by: Thomas Moschny <thomas.moschny@gmx.de>