### PR TITLE
macvlan: add 'passthru' mode

### DIFF
--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -100,7 +100,7 @@ struct ifla_vlan {
 };
 
 struct ifla_macvlan {
-	int mode; /* private, vepa, bridge */
+	int mode; /* private, vepa, bridge, passthru */
 };
 
 union netdev_p {

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -517,6 +517,10 @@ static int network_ifname(char **valuep, const char *value)
 #  define MACVLAN_MODE_BRIDGE 4
 #endif
 
+#ifndef MACVLAN_MODE_PASSTHRU
+#  define MACVLAN_MODE_PASSTHRU 8
+#endif
+
 static int macvlan_mode(int *valuep, const char *value)
 {
 	struct mc_mode {
@@ -526,6 +530,7 @@ static int macvlan_mode(int *valuep, const char *value)
 		{ "private", MACVLAN_MODE_PRIVATE },
 		{ "vepa", MACVLAN_MODE_VEPA },
 		{ "bridge", MACVLAN_MODE_BRIDGE },
+		{ "passthru", MACVLAN_MODE_PASSTHRU },
 	};
 
 	int i;
@@ -2286,6 +2291,7 @@ static int lxc_get_item_nic(struct lxc_conf *c, char *retv, int inlen,
 			case MACVLAN_MODE_PRIVATE: mode = "private"; break;
 			case MACVLAN_MODE_VEPA: mode = "vepa"; break;
 			case MACVLAN_MODE_BRIDGE: mode = "bridge"; break;
+			case MACVLAN_MODE_PASSTHRU: mode = "passthru"; break;
 			default: mode = "(invalid)"; break;
 			}
 			strprint(retv, inlen, "%s", mode);


### PR DESCRIPTION
In setup where we want to sniff with an IDS from inside a container
we can use the 'passthru' mode of macvlan. This was not accessible
from the config and this patch fixes the issue.

Signed-off-by: Eric Leblond <eric@regit.org>