### PR TITLE
fix download template when /tmp is mounted separately (tmpfs or noexec)

### DIFF
--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -298,7 +298,7 @@ fi
 # Trap all exit signals
 trap cleanup EXIT HUP INT TERM
 
-if ! mount| awk '{print $3}' |grep ^/tmp &>/dev/null; then
+if ! mount |awk '{print $3}' |grep ^/tmp &>/dev/null; then
     if ! type mktemp >/dev/null 2>&1; then
         DOWNLOAD_TEMP=/tmp/lxc-download.$$
         mkdir -p $DOWNLOAD_TEMP

--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -298,11 +298,15 @@ fi
 # Trap all exit signals
 trap cleanup EXIT HUP INT TERM
 
-if ! type mktemp >/dev/null 2>&1; then
-    DOWNLOAD_TEMP=/tmp/lxc-download.$$
-    mkdir -p $DOWNLOAD_TEMP
-else
-    DOWNLOAD_TEMP=$(mktemp -d)
+if ! mount| awk '{print $3}' |grep ^/tmp &>/dev/null; then
+    if ! type mktemp >/dev/null 2>&1; then
+        DOWNLOAD_TEMP=/tmp/lxc-download.$$
+        mkdir -p $DOWNLOAD_TEMP
+    else
+         DOWNLOAD_TEMP=$(mktemp -d)
+    fi
+else # /tmp may be mounted in tmpfs or noexec
+    DOWNLOAD_TEMP=$(mktemp -d -p $LXC_PATH)
 fi
 
 # Simply list images


### PR DESCRIPTION
If `/tmp` is mounted on a partition smaller than the image size (such as tmpfs or a small partition mounted noexec) - the download template hangs.

Signed-off-by:  Stuart Cardall <developer@it-offshore.co.uk>