### PR TITLE
Call /lib/apparmor/profile-load directly instead of the wrapper

### DIFF
--- a/config/init/systemd/lxc-apparmor-load
+++ b/config/init/systemd/lxc-apparmor-load
@@ -6,9 +6,9 @@ set -eu
 # don't load profiles if mount mediation is not supported
 SYSF=/sys/kernel/security/apparmor/features/mount/mask
 if [ -f $SYSF ]; then
-	if [ -x /lib/init/apparmor-profile-load ]; then
-		/lib/init/apparmor-profile-load usr.bin.lxc-start
-		/lib/init/apparmor-profile-load lxc-containers
+	if [ -x /lib/apparmor/profile-load ]; then
+		/lib/apparmor/profile-load usr.bin.lxc-start
+		/lib/apparmor/profile-load lxc-containers
 	fi
 fi
 

--- a/config/init/upstart/lxc.conf
+++ b/config/init/upstart/lxc.conf
@@ -36,9 +36,9 @@ pre-start script
 	# don't load profiles if mount mediation is not supported
 	SYSF=/sys/kernel/security/apparmor/features/mount/mask
 	if [ -f $SYSF ]; then
-		if [ -x /lib/init/apparmor-profile-load ]; then
-			/lib/init/apparmor-profile-load usr.bin.lxc-start
-			/lib/init/apparmor-profile-load lxc-containers
+		if [ -x /lib/apparmor/profile-load ]; then
+			/lib/apparmor/profile-load usr.bin.lxc-start
+			/lib/apparmor/profile-load lxc-containers
 		fi
 	fi
 


### PR DESCRIPTION
AppArmor ships /lib/apparmor/profile-load. /lib/init/apparmor-profile-load is
merely a wrapper which calls the former, so just call it directly to avoid the
dependency on the wrapper.

LP: #1432683