### PR TITLE
Added support for groups in lxc-usernet

### DIFF
--- a/doc/lxc-usernet.sgml.in
+++ b/doc/lxc-usernet.sgml.in
@@ -63,6 +63,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <para>
       <command>user</command> <command>type</command> <command>bridge</command> <command>number</command>
       </para>
+      <para>or</para>
+      <para>
+      <command>@group</command> <command>type</command> <command>bridge</command> <command>number</command>
+      </para>
       <para>
       Where
       </para>
@@ -77,6 +81,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 	    <para>
 	      is the username to whom this entry applies.
 	     </para>
+	  </listitem>
+	</varlistentry>
+
+	<varlistentry>
+	  <term>
+	    <option>@group</option>
+	  </term>
+	  <listitem>
+	    <para>
+	      is the groupname to which this entry applies.
+	    </para>
 	  </listitem>
 	</varlistentry>
 
@@ -110,12 +125,22 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 	  </term>
 	  <listitem>
 	    <para>
-	      is the number of network interfaces of the given type which the
-	      given user may attach to the given bridge, for instance <filename>2</filename>.
+	      is the number or quota of network interfaces of the given type which the
+	      given user or group may attach to the given bridge, for instance <filename>2</filename>.
 	     </para>
 	  </listitem>
 	</varlistentry>
       </variablelist>
+
+      <para>
+        Since a user can be be specified both by username as well as one or 
+        more usergroups, it is possible that several configuration lines 
+        enable that user to create network interfaces. In such cases, any 
+        interfaces create are counted towards the quotas of the user or group 
+        in the order in which they appear in the file. If the quota of one 
+        line is full, the rest will be parsed until one is found or the end of 
+        the file.
+      </para>
     </refsect2>
 
   </refsect1>

--- a/doc/lxc-usernet.sgml.in
+++ b/doc/lxc-usernet.sgml.in
@@ -133,12 +133,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       </variablelist>
 
       <para>
-        Since a user can be be specified both by username as well as one or 
-        more usergroups, it is possible that several configuration lines 
-        enable that user to create network interfaces. In such cases, any 
-        interfaces create are counted towards the quotas of the user or group 
-        in the order in which they appear in the file. If the quota of one 
-        line is full, the rest will be parsed until one is found or the end of 
+        Since a user can be be specified both by username as well as one or
+        more usergroups, it is possible that several configuration lines
+        enable that user to create network interfaces. In such cases, any
+        interfaces create are counted towards the quotas of the user or group
+        in the order in which they appear in the file. If the quota of one
+        line is full, the rest will be parsed until one is found or the end of
         the file.
       </para>
     </refsect2>

--- a/src/lxc/lxc_user_nic.c
+++ b/src/lxc/lxc_user_nic.c
@@ -194,6 +194,7 @@ static struct alloted_s *append_alloted(struct alloted_s **head, char *name, int
 
 	if (head == NULL || name == NULL) {
 		// sanity check. parameters should not be null
+		fprintf(stderr, "NULL parameters to append_alloted not allowed\n");
 		return NULL;
 	}
 
@@ -201,6 +202,7 @@ static struct alloted_s *append_alloted(struct alloted_s **head, char *name, int
 
 	if (al == NULL) {
 		// unable to allocate memory to new struct
+		fprintf(stderr, "Out of memory in append_alloted\n");
 		return NULL;
 	}
 
@@ -294,8 +296,14 @@ static int get_alloted(char *me, char *intype, char *link, struct alloted_s **al
 		/* found the user or group with the appropriate settings, therefore finish the search.
 		 * what to do if there are more than one applicable lines? not specified in the docs.
 		 * since getline is implemented with realloc, we don't need to free line until exiting func.
+		 *
+		 * if append_alloted returns NULL, e.g. due to a malloc error, we set count to 0 and break the loop,
+		 * allowing cleanup and then exiting from main()
 		 */
-		append_alloted(alloted, name, n);
+		if (append_alloted(alloted, name, n) == NULL) {
+			count = 0;
+			break;
+		}
 		count += n;
 	}
 

--- a/src/lxc/lxc_user_nic.c
+++ b/src/lxc/lxc_user_nic.c
@@ -185,7 +185,7 @@ static struct alloted_s *append_alloted(struct alloted_s **head, char *name, int
 	struct alloted_s *cur, *al;
 
 	if (head == NULL || name == NULL) {
-	// sanity check. parameters should not be null
+		// sanity check. parameters should not be null
 		return NULL;
 	}
 

--- a/src/lxc/lxc_user_nic.c
+++ b/src/lxc/lxc_user_nic.c
@@ -106,6 +106,12 @@ static char **get_groupnames(void)
 	struct group *gr;
 
 	ngroups = getgroups(0, NULL);
+
+  if (ngroups == -1) {
+    fprintf(stderr, "Failed to get number of groups user belongs to\n");
+    return NULL;
+  }
+
 	group_ids = (gid_t *)malloc(sizeof(gid_t)*ngroups);
 	ret = getgroups(ngroups, group_ids);
 
@@ -139,7 +145,7 @@ static char **get_groupnames(void)
 				free(group_names[j]);
 			}
 			free(group_names);
-			return NULL;	
+			return NULL;
 		}
 	}
 
@@ -156,12 +162,12 @@ static char **get_groupnames(void)
  	struct alloted_s *next;
  };
 
-static struct alloted_s *append_alloted(struct alloted_s **head, char *name, int n) 
+static struct alloted_s *append_alloted(struct alloted_s **head, char *name, int n)
 {
 	struct alloted_s *cur, *al;
 
 	if (head == NULL || name == NULL) {
-	// sanity check. parameters should not be null
+    // sanity check. parameters should not be null
 		return NULL;
 	}
 
@@ -242,14 +248,16 @@ static int get_alloted(char *me, char *intype, char *link, struct alloted_s **al
 		if (strcmp(link, br) != 0)
 			continue;
 
+    /* found the user with the appropriate settings, therefore finish the search.
+     * what to do if there are more than one applicable lines? not specified in the docs.
+     * since getline is implemented with realloc, we don't need to free line until exiting func.
+     */
 		append_alloted(alloted, me, n);
 		count += n;
-		break; // found the user with the appropriate settings, therefore finish the search.
-		// what to do if there are more than one applicable lines? not specified in the docs.
-		// since getline is implemented with realloc, we don't need to free line until exiting func.
+		break;
 	}
 
-    // now parse any possible groups specified
+  // now parse any possible groups specified
 	groups = get_groupnames();
 	if (groups != NULL) {
 
@@ -302,7 +310,7 @@ static char *get_eow(char *s, char *e)
 static char *find_line(char *p, char *e, char *u, char *t, char *l)
 {
 	char *p1, *p2, *ret;
-	
+
 	while (p<e  && (p1 = get_eol(p, e)) < e) {
 		ret = p;
 		if (*p == '#')
@@ -576,7 +584,7 @@ static bool get_nic_if_avail(int fd, struct alloted_s *names, int pid, char *int
 		owner = NULL;
 		for (n=names; n!=NULL; n=n->next) {
 			count = count_entries(buf, len, n->name, intype, br);
- 		
+
 			if (count >= n->allowed)
 				continue;
 

--- a/src/lxc/lxc_user_nic.c
+++ b/src/lxc/lxc_user_nic.c
@@ -281,7 +281,7 @@ static int get_alloted(char *me, char *intype, char *link, struct alloted_s **al
 		 * what to do if there are more than one applicable lines? not specified in the docs.
 		 * since getline is implemented with realloc, we don't need to free line until exiting func.
 		 */
-		append_alloted(alloted, me, n);
+		append_alloted(alloted, name, n);
 		count += n;
 		break;
 	}


### PR DESCRIPTION
#513 
lxc-user-nic will now check which groups the calling user are a member of and will match them to any lines in lxc-usernet that starts with '@'. Since the user can potentially be a member of several groups specified, all of them are checked. Quotas are checked first based on user name, secondly based on user group, in the order they are specified in lxc-usernet.

It is not yet ready to be merged, the docs and usage instructions will at least need to be updated, but I would appreciate feedback first.

@stgraber 