### PR TITLE
Use POSIX-compliant function names in bash completion

### DIFF
--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -11,7 +11,7 @@ have lxc-start && {
         COMPREPLY=( $( compgen -W "$(ls @LXCTEMPLATEDIR@/ | sed -e 's|^lxc-||' )" "$cur" ) )
     }
 
-    _lxc-generic-n() {
+    _lxc_generic_n() {
         local cur prev
 
         COMPREPLY=()
@@ -27,7 +27,7 @@ have lxc-start && {
         return 1
     }
 
-    _lxc-generic-ns() {
+    _lxc_generic_ns() {
         local cur prev
 
         COMPREPLY=()
@@ -48,7 +48,7 @@ have lxc-start && {
         return 1
     }
 
-    _lxc-generic-t() {
+    _lxc_generic_t() {
         local cur prev
 
         COMPREPLY=()
@@ -64,7 +64,7 @@ have lxc-start && {
         return 1
     }
 
-    _lxc-generic-o() {
+    _lxc_generic_o() {
         local cur prev
 
         COMPREPLY=()
@@ -80,24 +80,24 @@ have lxc-start && {
         return 1
     }
 
-    complete -o default -F _lxc-generic-n lxc-attach
-    complete -o default -F _lxc-generic-n lxc-cgroup
-    complete -o default -F _lxc-generic-n lxc-console
-    complete -o default -F _lxc-generic-n lxc-destroy
-    complete -o default -F _lxc-generic-n lxc-device
-    complete -o default -F _lxc-generic-n lxc-execute
-    complete -o default -F _lxc-generic-n lxc-freeze
-    complete -o default -F _lxc-generic-n lxc-info
-    complete -o default -F _lxc-generic-n lxc-monitor
-    complete -o default -F _lxc-generic-n lxc-snapshot
-    complete -o default -F _lxc-generic-n lxc-start
-    complete -o default -F _lxc-generic-n lxc-stop
-    complete -o default -F _lxc-generic-n lxc-unfreeze
+    complete -o default -F _lxc_generic_n lxc-attach
+    complete -o default -F _lxc_generic_n lxc-cgroup
+    complete -o default -F _lxc_generic_n lxc-console
+    complete -o default -F _lxc_generic_n lxc-destroy
+    complete -o default -F _lxc_generic_n lxc-device
+    complete -o default -F _lxc_generic_n lxc-execute
+    complete -o default -F _lxc_generic_n lxc-freeze
+    complete -o default -F _lxc_generic_n lxc-info
+    complete -o default -F _lxc_generic_n lxc-monitor
+    complete -o default -F _lxc_generic_n lxc-snapshot
+    complete -o default -F _lxc_generic_n lxc-start
+    complete -o default -F _lxc_generic_n lxc-stop
+    complete -o default -F _lxc_generic_n lxc-unfreeze
 
-    complete -o default -F _lxc-generic-ns lxc-wait
+    complete -o default -F _lxc_generic_ns lxc-wait
 
-    complete -o default -F _lxc-generic-t lxc-create
+    complete -o default -F _lxc_generic_t lxc-create
 
-    complete -o default -F _lxc-generic-o lxc-clone
-    complete -o default -F _lxc-generic-o lxc-start-ephemeral
+    complete -o default -F _lxc_generic_o lxc-clone
+    complete -o default -F _lxc_generic_o lxc-start-ephemeral
 }


### PR DESCRIPTION
When running in posix mode (for example, because it was invoked as `sh`, or with the --posix option), bash rejects the function names previously used because they contain hyphens, which are not legal POSIX names, and exits immediately.

This is a particularly serious problem on a system in which the following three conditions hold:

1. The `sh` executable is provided by bash, e. g. via a symlink
2. Gnome Display Manager is used to launch X sessions
3. Bash completion is loaded in the (system or user) profile file instead of in the bashrc file

In that case, GDM's Xsession script (run with `sh`, i. e., bash in posix mode) sources the profile files, thus causing the shell to load the bash completion files. Upon encountering the non-POSIX-compliant function names, bash would then exit, immediately ending the X session.

Fixes #521.

---

Commit signed with my [PGP key](https://lucaswerkmeister.de/lucaswerkmeister-public.asc), which was signed by [CAcert](https://www.cacert.org/), verifying my identity.

The first line of the commit is a bit over 50 characters; let me know if you want me to rephrase that.