### PR TITLE
Change lxc-clone to use 'rsync -aH' instead of just 'rsync -a'

### DIFF
--- a/src/lxc/bdev.c
+++ b/src/lxc/bdev.c
@@ -94,7 +94,7 @@ static int do_rsync(const char *src, const char *dest)
 	s[l-2] = '/';
 	s[l-1] = '\0';
 
-	execlp("rsync", "rsync", "-a", s, dest, (char *)NULL);
+	execlp("rsync", "rsync", "-aH", s, dest, (char *)NULL);
 	exit(1);
 }
 


### PR DESCRIPTION
Fix for Launchpad Bug #1441307. 

(I am not sure how to build this changed branch into a Debian/Ubuntu package, so I have not been able to test it. Guidance on that would be nice!)

Signed-off-by: Erik B. Andersen <erik.b.andersen@gmail.com>