### PR TITLE
macvlan: add 'passthru' mode v1.1

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -325,16 +325,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               <option>lxc.network.macvlan.mode</option> specifies the
               mode the macvlan will use to communicate between
               different macvlan on the same upper device. The accepted
-              modes are <option>private</option>, the device never
-              communicates with any other device on the same upper_dev (default),
-              <option>vepa</option>, the new Virtual Ethernet Port
+              modes are <option>private</option>, <option>vepa</option>,
+              <option>bridge</option> and <option>passthru</option>.
+	      In <option>private</option> mode, the device never
+              communicates with any other device on the same upper_dev (default).
+              In <option>vepa</option> mode, the new Virtual Ethernet Port
               Aggregator (VEPA) mode, it assumes that the adjacent
               bridge returns all frames where both source and
               destination are local to the macvlan port, i.e. the
               bridge is set up as a reflective relay.  Broadcast
               frames coming in from the upper_dev get flooded to all
               macvlan interfaces in VEPA mode, local frames are not
-              delivered locally, or <option>bridge</option>, it
+              delivered locally. In <option>bridge</option> mode, it
               provides the behavior of a simple bridge between
               different macvlan interfaces on the same port. Frames
               from one interface to another one get delivered directly
@@ -343,7 +345,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               interface, but when they come back from a reflective
               relay, we don't deliver them again.  Since we know all
               the MAC addresses, the macvlan bridge mode does not
-              require learning or STP like the bridge module does.
+              require learning or STP like the bridge module does. In
+              <option>passthru</option> mode, all frames received by
+              the physical interface are forwarded to the macvlan
+              interface. Only one macvlan interface in <option>passthru</option>
+              mode is possible for one physical interface.
             </para>
 
             <para>

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -100,7 +100,7 @@ struct ifla_vlan {
 };
 
 struct ifla_macvlan {
-	int mode; /* private, vepa, bridge */
+	int mode; /* private, vepa, bridge, passthru */
 };
 
 union netdev_p {

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -517,6 +517,10 @@ static int network_ifname(char **valuep, const char *value)
 #  define MACVLAN_MODE_BRIDGE 4
 #endif
 
+#ifndef MACVLAN_MODE_PASSTHRU
+#  define MACVLAN_MODE_PASSTHRU 8
+#endif
+
 static int macvlan_mode(int *valuep, const char *value)
 {
 	struct mc_mode {
@@ -526,6 +530,7 @@ static int macvlan_mode(int *valuep, const char *value)
 		{ "private", MACVLAN_MODE_PRIVATE },
 		{ "vepa", MACVLAN_MODE_VEPA },
 		{ "bridge", MACVLAN_MODE_BRIDGE },
+		{ "passthru", MACVLAN_MODE_PASSTHRU },
 	};
 
 	int i;
@@ -2286,6 +2291,7 @@ static int lxc_get_item_nic(struct lxc_conf *c, char *retv, int inlen,
 			case MACVLAN_MODE_PRIVATE: mode = "private"; break;
 			case MACVLAN_MODE_VEPA: mode = "vepa"; break;
 			case MACVLAN_MODE_BRIDGE: mode = "bridge"; break;
+			case MACVLAN_MODE_PASSTHRU: mode = "passthru"; break;
 			default: mode = "(invalid)"; break;
 			}
 			strprint(retv, inlen, "%s", mode);


### PR DESCRIPTION
A rebase of #506 with the addition of a commit for man page update.