### PR TITLE
overlayfs: support multiple lower layers

### DIFF
--- a/src/lxc/bdev.c
+++ b/src/lxc/bdev.c
@@ -2194,7 +2194,7 @@ static int overlayfs_mount(struct bdev *bdev)
 	strcpy(dup, bdev->src);
 	if (!(lower = strchr(dup, ':')))
 		return -22;
-	if (!(upper = strchr(++lower, ':')))
+	if (!(upper = strrchr(++lower, ':')))
 		return -22;
 	*upper = '\0';
 	upper++;


### PR DESCRIPTION
overlayfs supports multiple lower layers[1]. This change enables mounting these in lxc.

Example usage:

    lxc.rootfs = overlayfs:/foo:/bar:/baz

Will give an overlay mounted container root with /bar at the lowest layer and /baz at the highest.

  [1] https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt