### PR TITLE
fix build on mpc85xx

### DIFF
--- a/src/lxc/monitor.c
+++ b/src/lxc/monitor.c
@@ -182,7 +182,7 @@ int lxc_monitor_sock_name(const char *lxcpath, struct sockaddr_un *addr) {
 int lxc_monitor_open(const char *lxcpath)
 {
 	struct sockaddr_un addr;
-	int fd,ret;
+	int fd,ret = 0;
 	int retry,backoff_ms[] = {10, 50, 100};
 	size_t len;
 


### PR DESCRIPTION
Initialize ret to 0 so compiler no longer complains about
monitor.c: In function 'lxc_monitor_open':
monitor.c:212:5: error: 'ret' may be used uninitialized in this function [-Werror=maybe-uninitialized]

https://github.com/openwrt/packages/issues/1356

Signed-off-by: Daniel Golle <daniel@makrotopia.org>