### PR TITLE
Translate untranslated section titles in Japanese man pages

### DIFF
--- a/doc/ja/lxc-autostart.sgml.in
+++ b/doc/ja/lxc-autostart.sgml.in
@@ -327,7 +327,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     &seealso;
 
     <refsect1>
-        <title>Author</title>
+        <title><!-- Author -->作者</title>
         <para>Stéphane Graber <email>stgraber@ubuntu.com</email></para>
     </refsect1>
 </refentry>

--- a/doc/ja/lxc-config.sgml.in
+++ b/doc/ja/lxc-config.sgml.in
@@ -106,7 +106,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     &seealso;
 
     <refsect1>
-        <title>Author</title>
+        <title><!-- Author -->作者</title>
         <para>Stéphane Graber <email>stgraber@ubuntu.com</email></para>
     </refsect1>
 </refentry>

--- a/doc/ja/lxc-destroy.sgml.in
+++ b/doc/ja/lxc-destroy.sgml.in
@@ -61,7 +61,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   </refsynopsisdiv>
 
   <refsect1>
-    <title>Description</title>
+    <title><!-- Description -->説明</title>
 
     <para>
       <!--

--- a/doc/ja/lxc-snapshot.sgml.in
+++ b/doc/ja/lxc-snapshot.sgml.in
@@ -186,7 +186,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   &seealso;
 
   <refsect1>
-    <title>Author</title>
+    <title><!-- Author -->作者</title>
     <para>Serge Hallyn <email>serge.hallyn@ubuntu.com </email></para>
   </refsect1>
 

--- a/doc/ja/lxc-user-nic.sgml.in
+++ b/doc/ja/lxc-user-nic.sgml.in
@@ -190,7 +190,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
    </refsect1>
 
   <refsect1>
-    <title>Author</title>
+    <title><!-- Author -->作者</title>
     <para>Daniel Lezcano <email>daniel.lezcano@free.fr</email></para>
   </refsect1>
 

--- a/doc/ja/lxc-usernet.sgml.in
+++ b/doc/ja/lxc-usernet.sgml.in
@@ -164,7 +164,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   </refsect1>
 
   <refsect1>
-    <title>Author</title>
+    <title><!-- Author -->作者</title>
     <para>Daniel Lezcano <email>daniel.lezcano@free.fr</email></para>
   </refsect1>
 

--- a/doc/ja/lxc-usernsexec.sgml.in
+++ b/doc/ja/lxc-usernsexec.sgml.in
@@ -170,7 +170,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   &seealso;
 
   <refsect1>
-    <title>Author</title>
+    <title><!-- Author -->作者</title>
     <para>Serge Hallyn <email>serge.hallyn@ubuntu.com</email></para>
   </refsect1>
 

--- a/doc/ja/lxc.conf.sgml.in
+++ b/doc/ja/lxc.conf.sgml.in
@@ -170,7 +170,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   </refsect1>
 
   <refsect1>
-    <title>Author</title>
+    <title><!-- Author -->作者</title>
     <para>Stéphane Graber <email>stgraber@ubuntu.com</email></para>
   </refsect1>
 </refentry>

--- a/doc/ja/lxc.system.conf.sgml.in
+++ b/doc/ja/lxc.system.conf.sgml.in
@@ -220,7 +220,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
   &seealso;
 
   <refsect1>
-    <title>Author</title>
+    <title><!-- Author -->作者</title>
     <para>Stéphane Graber <email>stgraber@ubuntu.com</email></para>
   </refsect1>
 </refentry>


### PR DESCRIPTION
Some sections titles (eg. "Author") are not translated.
I change that words to Japanese word.