### PR TITLE
Ubuntu template: randomized ubuntu user password

### DIFF
--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -699,12 +699,16 @@ else
     fi
 fi
 
+# Set defaults
 debug=0
 hostarch=$arch
 flushcache=0
 packages=""
 user="ubuntu"
-password="ubuntu"
+
+# The default password for the ubuntu user should be randomized if the user
+# building the LXC instance doesn't specify a password.
+password=$(mktemp -u ubuntu-XXXXXX)
 
 while true
 do


### PR DESCRIPTION
The Ubuntu template current uses a username/password combination of ubuntu/ubuntu if the user doesn't specify a password for the ubuntu user.  That user has sudo privileges and that could lead to a security issue if the instance is brought onto a hostile network in that configuration.

This fix sets a randomized password for the ubuntu user if it's not specified by the user building the LXC container.  The final output from the build looks like this with the change in place:

    ##
    # The default user is 'ubuntu' with password 'ubuntu-AEq0qV'!
    # Use the 'sudo' command to run tasks as root in the container.
    ##