### PR TITLE
Debian template: randomized root password

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -157,8 +157,9 @@ EOF
         echo "Timezone in container is not configured. Adjust it manually."
     fi
 
-    echo "root:root" | chroot $rootfs chpasswd
-    echo "Root password is 'root', please change !"
+    root_password=$(mktemp -u Root-${name}-XXXXXX)
+    echo "root:${root_password}" | chroot $rootfs chpasswd
+    echo "Root password is '${root_password}', please change !"
 
     return 0
 }


### PR DESCRIPTION
By default, the Debian template sets root's password to 'root' during the build of a new container.  This commit sets a randomized password based on a six-character random string and the container's name.

At the end of the LXC build, the output looks like this:

    $ lxc-create -n debian-test -t debian
    --- SNIPPED OUTPUT ---
    Root password is 'Root-debian-test-U2wgIi', please change !