### PR TITLE
 debootstrap failed when $GREP_OPTIONS color is set

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -32,6 +32,7 @@ done
 
 # Make sure the usual locations are in PATH
 export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
+export GREP_OPTIONS=""
 
 MIRROR=${MIRROR:-http://http.debian.net/debian}
 SECURITY_MIRROR=${SECURITY_MIRROR:-http://security.debian.org/}


### PR DESCRIPTION
 debootstrap failed when $GREP_OPTIONS color is set to "always", so we need to unset it in the template

Signed-off-by:  feng xiahou <xiahoufeng@yahoo.com>