### PR TITLE
Add support for specified UID/GID for lxc-execute in a private user namespace 

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -247,6 +247,39 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
     </refsect2>
 
     <refsect2>
+      <title>Init ID</title>
+      <para>
+        Sets the UID/GID to use for the init system, and subsequent command, executed by lxc-execute.
+
+        These options are only used when lxc-execute is started in a private user namespace.
+
+        Defaults to: UID(0), GID(0)
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <option>lxc.init_uid</option>
+          </term>
+          <listitem>
+            <para>
+              UID to use within a private user namesapce for init.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <option>lxc.init_gid</option>
+          </term>
+          <listitem>
+            <para>
+              GID to use within a private user namesapce for init.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </refsect2>
+
+    <refsect2>
       <title>Network</title>
       <para>
         The network section defines how the network is virtualized in

--- a/src/lxc/arguments.h
+++ b/src/lxc/arguments.h
@@ -88,6 +88,10 @@ struct lxc_arguments {
 	char *lvname, *vgname, *thinpool;
 	char *zfsroot, *lowerdir, *dir;
 
+	/* lxc-execute */
+	uid_t uid;
+	gid_t gid;
+
 	/* auto-start */
 	int all;
 	int ignore_auto;

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2604,6 +2604,11 @@ struct lxc_conf *lxc_conf_init(void)
 	for (i = 0; i < LXC_NS_MAX; i++)
 		new->inherit_ns_fd[i] = -1;
 
+	/* if running in a new user namespace, init and COMMAND
+	 * default to running as UID/GID 0 when using lxc-execute */
+	new->init_uid = 0;
+	new->init_gid = 0;
+
 	return new;
 }
 

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2604,9 +2604,6 @@ struct lxc_conf *lxc_conf_init(void)
 	for (i = 0; i < LXC_NS_MAX; i++)
 		new->inherit_ns_fd[i] = -1;
 
-	new->parent_uid = getuid();
-	new->parent_gid = getgid();
-
 	return new;
 }
 

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2604,6 +2604,9 @@ struct lxc_conf *lxc_conf_init(void)
 	for (i = 0; i < LXC_NS_MAX; i++)
 		new->inherit_ns_fd[i] = -1;
 
+	new->parent_uid = getuid();
+	new->parent_gid = getgid();
+
 	return new;
 }
 

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -366,7 +366,8 @@ struct lxc_conf {
 	/* init command */
 	char *init_cmd;
 
-	/* the UID/GID that COMMAND for lxc-execute should run under */
+	/* if running in a new user namespace, the UID/GID that COMMAND for
+	 * lxc-execute should run under */
 	uid_t init_uid;
 	gid_t init_gid;
 };

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -366,8 +366,8 @@ struct lxc_conf {
 	/* init command */
 	char *init_cmd;
 
-	/* if running in a new user namespace, the UID/GID that COMMAND for
-	 * lxc-execute should run under */
+	/* if running in a new user namespace, the UID/GID that init and COMMAND
+	 * should run under when using lxc-execute */
 	uid_t init_uid;
 	gid_t init_gid;
 };

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -365,6 +365,10 @@ struct lxc_conf {
 
 	/* init command */
 	char *init_cmd;
+
+	/* The UID/GID of the process creating the container */
+	uid_t parent_uid;
+	gid_t parent_gid;
 };
 
 #ifdef HAVE_TLS

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -366,9 +366,9 @@ struct lxc_conf {
 	/* init command */
 	char *init_cmd;
 
-	/* The UID/GID of the process creating the container */
-	uid_t parent_uid;
-	gid_t parent_gid;
+	/* the UID/GID that COMMAND for lxc-execute should run under */
+	uid_t init_uid;
+	gid_t init_gid;
 };
 
 #ifdef HAVE_TLS

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -2510,6 +2510,10 @@ int lxc_get_config_item(struct lxc_conf *c, const char *key, char *retv,
 		return lxc_get_item_environment(c, retv, inlen);
 	else if (strcmp(key, "lxc.init_cmd") == 0)
 		v = c->init_cmd;
+	else if (strcmp(key, "lxc.init_uid") == 0)
+		return lxc_get_conf_int(c, retv, inlen, c->init_uid);
+	else if (strcmp(key, "lxc.init_gid") == 0)
+		return lxc_get_conf_int(c, retv, inlen, c->init_gid);
 	else return -1;
 
 	if (!v)

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -104,6 +104,8 @@ static int config_start(const char *, const char *, struct lxc_conf *);
 static int config_group(const char *, const char *, struct lxc_conf *);
 static int config_environment(const char *, const char *, struct lxc_conf *);
 static int config_init_cmd(const char *, const char *, struct lxc_conf *);
+static int config_init_uid(const char *, const char *, struct lxc_conf *);
+static int config_init_gid(const char *, const char *, struct lxc_conf *);
 
 static struct lxc_config_t config[] = {
 
@@ -168,6 +170,8 @@ static struct lxc_config_t config[] = {
 	{ "lxc.group",                config_group                },
 	{ "lxc.environment",          config_environment          },
 	{ "lxc.init_cmd",             config_init_cmd             },
+	{ "lxc.init_uid",             config_init_uid             },
+	{ "lxc.init_gid",             config_init_gid             },
 };
 
 struct signame {
@@ -1034,11 +1038,25 @@ static int config_init_cmd(const char *key, const char *value,
 	return config_path_item(&lxc_conf->init_cmd, value);
 }
 
+static int config_init_uid(const char *key, const char *value,
+				 struct lxc_conf *lxc_conf)
+{
+	lxc_conf->init_uid = atoi(value);
+	return 0;
+}
+
+static int config_init_gid(const char *key, const char *value,
+				 struct lxc_conf *lxc_conf)
+{
+	lxc_conf->init_gid = atoi(value);
+	return 0;
+}
+
 static int config_hook(const char *key, const char *value,
 				 struct lxc_conf *lxc_conf)
 {
 	char *copy;
-	
+
 	if (!value || strlen(value) == 0)
 		return lxc_clear_hooks(lxc_conf, key);
 

--- a/src/lxc/lxc_execute.c
+++ b/src/lxc/lxc_execute.c
@@ -59,7 +59,9 @@ static int my_parser(struct lxc_arguments* args, int c, char* arg)
 {
 	switch (c) {
 	case 'f': args->rcfile = arg; break;
-	case 's': return lxc_config_define_add(&defines, arg);
+	case 's': return lxc_config_define_add(&defines, arg); break;
+	case 'u': args->uid = atoi(arg); break;
+	case 'g': args->gid = atoi(arg);
 	}
 	return 0;
 }
@@ -67,6 +69,8 @@ static int my_parser(struct lxc_arguments* args, int c, char* arg)
 static const struct option my_longopts[] = {
 	{"rcfile", required_argument, 0, 'f'},
 	{"define", required_argument, 0, 's'},
+	{"uid", required_argument, 0, 'u'},
+	{"gid", required_argument, 0, 'g'},
 	LXC_COMMON_OPTIONS
 };
 
@@ -81,7 +85,9 @@ and execs COMMAND into this container.\n\
 Options :\n\
   -n, --name=NAME      NAME for name of the container\n\
   -f, --rcfile=FILE    Load configuration file FILE\n\
-  -s, --define KEY=VAL Assign VAL to configuration variable KEY\n",
+  -s, --define KEY=VAL Assign VAL to configuration variable KEY\n\
+  -u, --uid=UID Execute COMMAND with UID inside the container\n\
+  -g, --gid=GID Execute COMMAND with GID inside the container\n",
 	.options  = my_longopts,
 	.parser   = my_parser,
 	.checker  = my_checker,
@@ -138,6 +144,12 @@ int main(int argc, char *argv[])
 
 	if (lxc_config_define_load(&defines, conf))
 		return 1;
+
+	if (my_args.uid)
+		conf->init_uid = my_args.uid;
+
+	if (my_args.gid)
+		conf->init_gid = my_args.gid;
 
 	ret = lxc_execute(my_args.name, my_args.argv, my_args.quiet, conf, my_args.lxcpath[0], false);
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -664,8 +664,9 @@ static int do_start(void *data)
 
 	/*
 	 * if we are in a new user namespace, become root there to have
-	 * privilege over our namespace. We don't become root for lxc-execute, as
-	 * the intent is to execute a command as the original user.
+	 * privilege over our namespace. When using lxc-execute we default to root,
+	 * but this can be overriden using the lxc.init_uid and lxc.init_gid
+	 * configuration options.
 	 */
 	if (!lxc_list_empty(&handler->conf->id_map)) {
 		gid_t new_gid = 0;

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -667,13 +667,15 @@ static int do_start(void *data)
 	 * privilege over our namespace. We don't become root for lxc-execute, as
 	 * the intent is to execute a command as the original user.
 	 */
-	if (!handler->conf->is_execute && !lxc_list_empty(&handler->conf->id_map)) {
-		NOTICE("switching to gid/uid 0 in new user namespace");
-		if (setgid(0)) {
+	if (!lxc_list_empty(&handler->conf->id_map)) {
+		gid_t new_gid = handler->conf->is_execute ? handler->conf->parent_gid : 0;
+		gid_t new_uid = handler->conf->is_execute ? handler->conf->parent_uid : 0;
+		NOTICE("switching to gid/uid %d/%d in new user namespace", new_gid, new_uid);
+		if (setgid(new_gid)) {
 			SYSERROR("setgid");
 			goto out_warn_father;
 		}
-		if (setuid(0)) {
+		if (setuid(new_uid)) {
 			SYSERROR("setuid");
 			goto out_warn_father;
 		}

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -664,9 +664,10 @@ static int do_start(void *data)
 
 	/*
 	 * if we are in a new user namespace, become root there to have
-	 * privilege over our namespace
+	 * privilege over our namespace. We don't become root for lxc-execute, as
+	 * the intent is to execute a command as the original user.
 	 */
-	if (!lxc_list_empty(&handler->conf->id_map)) {
+	if (!handler->conf->is_execute && !lxc_list_empty(&handler->conf->id_map)) {
 		NOTICE("switching to gid/uid 0 in new user namespace");
 		if (setgid(0)) {
 			SYSERROR("setgid");

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -668,8 +668,14 @@ static int do_start(void *data)
 	 * the intent is to execute a command as the original user.
 	 */
 	if (!lxc_list_empty(&handler->conf->id_map)) {
-		gid_t new_gid = handler->conf->is_execute ? handler->conf->parent_gid : 0;
-		gid_t new_uid = handler->conf->is_execute ? handler->conf->parent_uid : 0;
+		gid_t new_gid = 0;
+		if (handler->conf->is_execute && handler->conf->init_gid)
+			new_gid = handler->conf->init_gid;
+
+		uid_t new_uid = 0;
+		if (handler->conf->is_execute && handler->conf->init_uid)
+			new_uid = handler->conf->init_uid;
+
 		NOTICE("switching to gid/uid %d/%d in new user namespace", new_gid, new_uid);
 		if (setgid(new_gid)) {
 			SYSERROR("setgid");

--- a/src/tests/get_item.c
+++ b/src/tests/get_item.c
@@ -88,6 +88,32 @@ int main(int argc, char *argv[])
 	}
 	printf("lxc.arch returned %d %s\n", ret, v2);
 
+	if (!c->set_config_item(c, "lxc.init_uid", "100")) {
+		fprintf(stderr, "%d: failed to set init_uid\n", __LINE__);
+		ret = 1;
+		goto out;
+	}
+	ret = c->get_config_item(c, "lxc.init_uid", v2, 255);
+	if (ret < 0) {
+		fprintf(stderr, "%d: get_config_item(lxc.init_uid) returned %d\n", __LINE__, ret);
+		ret = 1;
+		goto out;
+	}
+	printf("lxc.init_uid returned %d %s\n", ret, v2);
+
+	if (!c->set_config_item(c, "lxc.init_gid", "100")) {
+		fprintf(stderr, "%d: failed to set init_gid\n", __LINE__);
+		ret = 1;
+		goto out;
+	}
+	ret = c->get_config_item(c, "lxc.init_gid", v2, 255);
+	if (ret < 0) {
+		fprintf(stderr, "%d: get_config_item(lxc.init_gid) returned %d\n", __LINE__, ret);
+		ret = 1;
+		goto out;
+	}
+	printf("lxc.init_gid returned %d %s\n", ret, v2);
+
 #define HNAME "hostname1"
 	// demonstrate proper usage:
 	char *alloced;


### PR DESCRIPTION
In #417 some people noted that `lxc-execute` didn't work as expected when not running as root. The primary thing I noticed was that, no matter what, the process that was spawned was executed as container UID 0. This is a direct artifact of lxc assuming that, whatever container is launched, is started using "init" with UID 0. For lxc-start that makes a ton of sense, as we are trying to simulate a full distribution and init always runs as root. But, for lxc-execute, we aren't really trying to launch a full system. We are only trying to launch a process in some sort of default containment. So, it doesn't make much sense for something like `lxc-execute whoami` to return `root` unless that user is actually running as root.

I'v modified the "always become root" logic to check to see whether we are being executed via lxc-execute or not. If we are, then we don't become root. This doesn't make `lxc-execute` work 100% the way I would hope, but it does seem much closer. 

For example, with this change, I still can't do something like:

```
ptoomey3@ubuntu:/mnt/hgfs/lxc/lxc$ lxc-execute -n foobar  whoami
lxc-execute: start.c: must_drop_cap_sys_boot: 568 failed to clone (0x20000011): Operation not permitted
lxc-execute: namespace.c: lxc_clone: 67 failed to clone (0x6c020000): Operation not permitted
lxc-execute: start.c: lxc_spawn: 974 Operation not permitted - failed to fork into a new namespace
lxc-execute: start.c: __lxc_start: 1173 failed to spawn 'foobar' 
```

I'm not 100% sure what I would even hope the above would do, but crashing is probably not it :smile:. But, so long as we pass in a reasonable UID/GID remapping we can do this:

```
ptoomey3@ubuntu:/mnt/hgfs/lxc/lxc$ whoami
ptoomey3

ptoomey3@ubuntu:/mnt/hgfs/lxc/lxc$ cat ~/.config/lxc/default.conf
lxc.id_map = u 1000 1000 1
lxc.id_map = u 0 100000 1
lxc.id_map = g 1000 1000 1
lxc.id_map = g 0 100000 1

ptoomey3@ubuntu:/mnt/hgfs/lxc/lxc$ lxc-execute -n foobar -f ~/.config/lxc/default.conf whoami
init.lxc: initutils.c: mount_fs: 36 failed to mount /proc : Operation not permitted
init.lxc: initutils.c: mount_fs: 36 failed to mount /dev/shm : Operation not permitted
init.lxc: initutils.c: mount_fs: 36 failed to mount /dev/mqueue : Operation not permitted
ptoomey3
```

Before this patch, the above `whoami` would have returned `root` since the container was always switched to `root` for any unprivileged container.

So, while I'm not 100% sure this fixes all of #417, it does seem to at least allow unprivileged containers to execute a command as the original user. 

One last thing, as you can see, `mount_fs` seems to have a bit of an issue remounting when we don't switch our UID/GID to 0. This seems to be a non-fatal warning. So, I'd love it if someone with more LXC background could comment on the above warnings. Do they need to be "fixed" or can we simply add some logic to not attempt remounting for some situations?

/cc @sartrevan - since you opened the original `lxc-execute` issue. 