### PR TITLE
startpar should be disabled in debian wheezy!

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -365,6 +365,11 @@ post_process()
     local hostarch="$1"; shift
     local packages="$*"
 
+    # Parallel concurrent booting (using startpar) should be disabled in debian wheezy!
+    if [[ 'x'$release == 'xwheezy' ]]; then
+        touch $rootfs/etc/init.d/.legacy-bootordering
+    fi
+
     # Disable service startup
     cat > ${rootfs}/usr/sbin/policy-rc.d << EOF
 #!/bin/sh

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -400,7 +400,7 @@ EOF
 
     # Re-enable service startup
     rm ${rootfs}/usr/sbin/policy-rc.d
-    
+
     # reconfigure locales
     if [ -z "$LANG" ]; then
         cat >> $rootfs/etc/locale.gen << EOF


### PR DESCRIPTION
Parallel concurrent booting (using startpar) should be disabled in debian wheezy!

Signed-off-by: feng xiahou <xiahoufeng@yahoo.com>