### PR TITLE
lxc-ubuntu-cloud: support passing vendor-data

### DIFF
--- a/hooks/ubuntu-cloud-prep
+++ b/hooks/ubuntu-cloud-prep
@@ -31,13 +31,14 @@ Usage: ${0##*/} [options] root-dir
   [ -L | --nolocales ]:    Do not copy host's locales into container
   [ -S | --auth-key ]:     ssh public key file for datasource [ds]
   [ -u | --userdata ]:     user-data file for cloud-init [ds]
+  [ -V | --vendordata ]:   vendor-data file for cloud-init [ds]
 
 EOF
 }
 
 prep() {
     local short_opts="Chi:L:S:u:v"
-    local long_opts="auth-key:,cloud,help,hostid:,name:,nolocales:,create-etc-init,userdata:,verbose"
+    local long_opts="auth-key:,cloud,help,hostid:,name:,nolocales:,create-etc-init,userdata:,vendordata:,verbose"
     local getopt_out getopt_ret
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@" 2>/dev/null) ||
@@ -49,7 +50,7 @@ prep() {
     fi
 
     local cur="" next=""
-    local userdata="" hostid="" authkey="" locales=1 cloud=0
+    local vendordata="" userdata="" hostid="" authkey="" locales=1 cloud=0
     local create_etc_init=0 name="ubuntucloud-lxc"
 
     while [ $# -ne 0 ]; do
@@ -65,6 +66,10 @@ prep() {
                 [ -f "$next" ] ||
                     { error "--auth-key: '$next' not a file"; return 1; }
                 authkey="$next";;
+            -V|--vendordata)
+                [ -f "$next" ] ||
+                    { error "--vendordata: '$next' not a file"; return 1; }
+                vendordata="$next";;
             -u|--userdata)
                 [ -f "$next" ] ||
                     { error "--userdata: '$next' not a file"; return 1; }
@@ -156,6 +161,13 @@ prep() {
             error "failed to write user-data write to '$seed_d/user-data'";
             return 1;
         }
+
+        if [ -n "$vendordata" ]; then
+            cp "$vendordata" "$seed_d/vendor-data" || {
+                error "failed copy vendordata to $seed_d/vendor-data";
+                return 1;
+            }
+        fi
     fi
 
 }

--- a/templates/lxc-ubuntu-cloud.in
+++ b/templates/lxc-ubuntu-cloud.in
@@ -146,7 +146,7 @@ EOF
     return 0
 }
 
-options=$(getopt -o a:hp:r:n:Fi:CLS:T:ds:u: -l arch:,help,rootfs:,path:,release:,name:,flush-cache,hostid:,auth-key:,cloud,no_locales,tarball:,debug,stream:,userdata:,mapped-uid:,mapped-gid: -- "$@")
+options=$(getopt -o a:hp:r:n:Fi:CLS:T:ds:u: -l arch:,help,rootfs:,path:,release:,name:,flush-cache,hostid:,auth-key:,cloud,no_locales,tarball:,debug,stream:,userdata:,vendordata:,mapped-uid:,mapped-gid: -- "$@")
 if [ $? -ne 0 ]; then
     usage $(basename $0)
     exit 1
@@ -213,6 +213,7 @@ do
     -L|--no?locales)   cloneargs[${#cloneargs[@]}]="--no-locales"; shift 1;;
     -i|--hostid)       cloneargs[${#cloneargs[@]}]="--hostid=$2"; shift 2;;
     -u|--userdata)     cloneargs[${#cloneargs[@]}]="--userdata=$2"; shift 2;;
+    -V|--vendordata)   cloneargs[${#cloneargs[@]}]="--vendordata=$2"; shift 2;;
     -C|--cloud)        cloneargs[${#cloneargs[@]}]="--cloud"; shift 1;;
     -S|--auth-key)     cloneargs[${#cloneargs[@]}]="--auth-key=$2"; shift 2;;
     --mapped-uid)      mapped_uid=$2; shift 2;;


### PR DESCRIPTION
vendor-data is supported in Ubuntu cloud images in trusty and later.
This allows the user to pass it in on create or clone.

Signed-off-by: Scott Moser <smoser@ubuntu.com>