### PR TITLE
Add -P lxcpath and --version to lxc-ls manpage

### DIFF
--- a/doc/ja/lxc-ls.sgml.in
+++ b/doc/ja/lxc-ls.sgml.in
@@ -55,6 +55,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     <cmdsynopsis>
       <command>lxc-ls</command>
       <arg choice="opt">-1</arg>
+      <arg choice="opt">-P <replaceable>lxcpath</replaceable></arg>
       <arg choice="opt">--active</arg>
       <arg choice="opt">--frozen</arg>
       <arg choice="opt">--running</arg>
@@ -64,6 +65,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <arg choice="opt">-g <replaceable>groups</replaceable></arg>
       <arg choice="opt">--nesting</arg>
       <arg choice="opt">filter</arg>
+      <arg choice="opt">--version</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/ko/lxc-ls.sgml.in
+++ b/doc/ko/lxc-ls.sgml.in
@@ -55,6 +55,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
     <cmdsynopsis>
       <command>lxc-ls</command>
       <arg choice="opt">-1</arg>
+      <arg choice="opt">-P <replaceable>lxcpath</replaceable></arg>
       <arg choice="opt">--active</arg>
       <arg choice="opt">--frozen</arg>
       <arg choice="opt">--running</arg>
@@ -64,6 +65,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
       <arg choice="opt">-g <replaceable>groups</replaceable></arg>
       <arg choice="opt">--nesting</arg>
       <arg choice="opt">filter</arg>
+      <arg choice="opt">--version</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/lxc-ls.sgml.in
+++ b/doc/lxc-ls.sgml.in
@@ -50,6 +50,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
     <cmdsynopsis>
       <command>lxc-ls</command>
       <arg choice="opt">-1</arg>
+      <arg choice="opt">-P <replaceable>lxcpath</replaceable></arg>
       <arg choice="opt">--active</arg>
       <arg choice="opt">--frozen</arg>
       <arg choice="opt">--running</arg>
@@ -59,6 +60,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <arg choice="opt">-g <replaceable>groups</replaceable></arg>
       <arg choice="opt">--nesting</arg>
       <arg choice="opt">filter</arg>
+      <arg choice="opt">--version</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 


### PR DESCRIPTION
lxc-ls takes -P lxcpath and --version as arguments but it did not specify these
options on the manpages.