### PR TITLE
Fix error message when cannot find an lxc-init

### DIFF
--- a/src/lxc/execute.c
+++ b/src/lxc/execute.c
@@ -64,7 +64,7 @@ static int execute_start(struct lxc_handler *handler, void* data)
 
 	initpath = choose_init(NULL);
 	if (!initpath) {
-		ERROR("Failed to find an lxc-init");
+		ERROR("Failed to find an lxc-init or init.lxc");
 		goto out2;
 	}
 	argv[i++] = initpath;


### PR DESCRIPTION
lxc-init has been renamed init.lxc so adapt error message

Signed-off-by: Nicolas Cornu <ncornu@aldebaran.com>