### PR TITLE
templates: lxc-opensuse, use rpm to determine build version

### DIFF
--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -422,7 +422,8 @@ if [ -z "$path" ]; then
 fi
 
 if grep -q Harlequin /etc/os-release || grep -q Tumbleweed /etc/os-release ; then
-    if [[ "$(zypper info build|awk -F "[- ]" '/Version/ {print $2}')" -lt "20141120" ]] ; then
+    BVER=`rpm -q --qf '%{version}\n' build`
+    if [ $? -ne 0 -o "$BVER" -lt "20141120" ]; then
 	echo "Building openSUSE containers with your version of the build package is broken. Please install the update to version 20141120 or newer."
 	exit 1
     fi


### PR DESCRIPTION
zypper info's output is not usable for several reasons:
* it is localized -- there is no "Version: " in my output
* it shows results both from the repo and local system

So use plain rpm to determine whether build is installed and if proper
version is in place.

Signed-off-by: Jiri Slaby <jslaby@suse.cz>