### PR TITLE
Mark unmodified strings as const in public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+
+===
+Please note: This is a working copy of LXC used for patches.
+If you need the real upstream, please see:
+https://linuxcontainers.org/
+===
+
 Please see the COPYING file for details on copying and usage.
 Please refer to the INSTALL file for instructions on how to build.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 
 ===
 Please note: This is a working copy of LXC used for patches.
-If you need the real upstream, please see:
-https://linuxcontainers.org/
+If you need the real upstream, please see: https://linuxcontainers.org/
 ===
 
 Please see the COPYING file for details on copying and usage.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 ===
+
 Please note: This is a working copy of LXC used for patches.
 If you need the real upstream, please see: https://linuxcontainers.org/
+
 ===
 
 Please see the COPYING file for details on copying and usage.

--- a/src/lua-lxc/core.c
+++ b/src/lua-lxc/core.c
@@ -120,7 +120,7 @@ static int container_create(lua_State *L)
     struct lxc_container *c = lua_unboxpointer(L, 1, CONTAINER_TYPENAME);
     char *template_name = strdupa(luaL_checkstring(L, 2));
     int argc = lua_gettop(L);
-    char **argv;
+    const char **argv;
     int i;
 
     argv = alloca((argc+1) * sizeof(char *));
@@ -145,7 +145,7 @@ static int container_start(lua_State *L)
 {
     struct lxc_container *c = lua_unboxpointer(L, 1, CONTAINER_TYPENAME);
     int argc = lua_gettop(L);
-    char **argv = NULL;
+    const char **argv = NULL;
     int i,j;
     int useinit = 0;
 

--- a/src/lxc/arguments.c
+++ b/src/lxc/arguments.c
@@ -225,7 +225,7 @@ extern int lxc_arguments_parse(struct lxc_arguments *args,
 	/*
 	 * Reclaim the remaining command arguments
 	 */
-	args->argv = &argv[optind];
+	args->argv = (const char**) &argv[optind];
 	args->argc = argc - optind;
 
 	/* If no lxcpaths were given, use default */

--- a/src/lxc/arguments.h
+++ b/src/lxc/arguments.h
@@ -95,7 +95,7 @@ struct lxc_arguments {
 	char *groups;
 
 	/* remaining arguments */
-	char *const *argv;
+	const char *const *argv;
 	int argc;
 
 	/* private arguments */

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -345,7 +345,7 @@ static int lxc_attach_drop_privs(struct lxc_proc_context_info *ctx)
 	return 0;
 }
 
-static int lxc_attach_set_environment(enum lxc_attach_env_policy_t policy, char** extra_env, char** extra_keep)
+static int lxc_attach_set_environment(enum lxc_attach_env_policy_t policy, const char** extra_env, const char** extra_keep)
 {
 	if (policy == LXC_ATTACH_CLEAR_ENV) {
 		char **extra_keep_store = NULL;
@@ -697,7 +697,7 @@ int lxc_attach(const char* name, const char* lxcpath, lxc_attach_exec_t exec_fun
 	pid_t init_pid, pid, attached_pid, expected;
 	struct lxc_proc_context_info *init_ctx;
 	char* cwd;
-	char* new_cwd;
+	const char* new_cwd;
 	int ipc_sockets[2];
 	int procfd;
 	signed long personality;
@@ -1191,7 +1191,7 @@ int lxc_attach_run_command(void* payload)
 {
 	lxc_attach_command_t* cmd = (lxc_attach_command_t*)payload;
 
-	execvp(cmd->program, cmd->argv);
+	execvp(cmd->program, (char**) cmd->argv); // The execvp() signature requires argv to be non-const, but the POSIX standard ensures that the function will not modify the strings, so we are safe with that cast
 	SYSERROR("failed to exec '%s'", cmd->program);
 	return -1;
 }

--- a/src/lxc/attach_options.h
+++ b/src/lxc/attach_options.h
@@ -90,7 +90,7 @@ typedef struct lxc_attach_options_t {
 	 * If the current directory does not exist in the container, the
 	 * root directory will be used instead because of kernel defaults.
 	 */
-	char* initial_cwd;
+	const char* initial_cwd;
 
 	/*! The user-id to run as.
 	 *
@@ -110,12 +110,12 @@ typedef struct lxc_attach_options_t {
 	lxc_attach_env_policy_t env_policy;
 
 	/*! Extra environment variables to set in the container environment */
-	char** extra_env_vars;
+	const char * * extra_env_vars;
 
 	/*! Names of environment variables in existing environment to retain
 	 * in container environment.
 	 */
-	char** extra_keep_env;
+	const char** extra_keep_env;
 
 	/**@{*/
 	/*! File descriptors for stdin, stdout and stderr,
@@ -150,8 +150,8 @@ typedef struct lxc_attach_options_t {
  * Representation of a command to run in a container.
  */
 typedef struct lxc_attach_command_t {
-	char* program; /*!< The program to run (passed to execvp) */
-	char** argv;   /*!< The argv pointer of that program, including the program itself in argv[0] */
+	const char* program; /*!< The program to run (passed to execvp) */
+	const char** argv;   /*!< The argv pointer of that program, including the program itself in argv[0] */
 } lxc_attach_command_t;
 
 /*!

--- a/src/lxc/execute.c
+++ b/src/lxc/execute.c
@@ -35,7 +35,7 @@
 lxc_log_define(lxc_execute, lxc_start);
 
 struct execute_args {
-	char *const *argv;
+	const char *const *argv;
 	int quiet;
 };
 
@@ -43,7 +43,7 @@ static int execute_start(struct lxc_handler *handler, void* data)
 {
 	int j, i = 0;
 	struct execute_args *my_args = data;
-	char **argv;
+	const char **argv;
 	int argc = 0, argc_add;
 	char *initpath;
 
@@ -89,7 +89,7 @@ static int execute_start(struct lxc_handler *handler, void* data)
 
 	NOTICE("exec'ing '%s'", my_args->argv[0]);
 
-	execvp(argv[0], argv);
+	execvp(argv[0], (char **)argv); // The execvp() signature requires argv to be non-const, but the POSIX standard ensures that the function will not modify the strings, so we are safe with that cast
 	SYSERROR("failed to exec %s", argv[0]);
 	free(initpath);
 out2:
@@ -110,7 +110,7 @@ static struct lxc_operations execute_start_ops = {
 	.post_start = execute_post_start
 };
 
-int lxc_execute(const char *name, char *const argv[], int quiet,
+int lxc_execute(const char *name, const char *const argv[], int quiet,
 		struct lxc_conf *conf, const char *lxcpath, bool backgrounded)
 {
 	struct execute_args args = {

--- a/src/lxc/lxc.h
+++ b/src/lxc/lxc.h
@@ -51,7 +51,7 @@ struct lxc_arguments;
  * @backgrounded : whether or not the container is daemonized
  * Returns 0 on success, < 0 otherwise
  */
-extern int lxc_start(const char *name, char *const argv[], struct lxc_conf *conf,
+extern int lxc_start(const char *name, const char *const argv[], struct lxc_conf *conf,
 		     const char *lxcpath, bool backgrounded);
 
 /*
@@ -63,7 +63,7 @@ extern int lxc_start(const char *name, char *const argv[], struct lxc_conf *conf
  * @backgrounded : whether or not the container is daemonized
  * Returns 0 on success, < 0 otherwise
  */
-extern int lxc_execute(const char *name, char *const argv[], int quiet,
+extern int lxc_execute(const char *name, const char *const argv[], int quiet,
 		       struct lxc_conf *conf, const char *lxcpath,
 		       bool backgrounded);
 

--- a/src/lxc/lxc_attach.c
+++ b/src/lxc/lxc_attach.c
@@ -217,12 +217,12 @@ int main(int argc, char *argv[])
 	attach_options.namespaces = namespace_flags;
 	attach_options.personality = new_personality;
 	attach_options.env_policy = env_policy;
-	attach_options.extra_env_vars = extra_env;
-	attach_options.extra_keep_env = extra_keep;
+	attach_options.extra_env_vars = (const char **) extra_env;
+	attach_options.extra_keep_env = (const char **) extra_keep;
 
 	if (my_args.argc) {
 		command.program = my_args.argv[0];
-		command.argv = (char**)my_args.argv;
+		command.argv = (const char**) my_args.argv;
 		ret = lxc_attach(my_args.name, my_args.lxcpath[0], lxc_attach_run_command, &command, &attach_options, &pid);
 	} else {
 		ret = lxc_attach(my_args.name, my_args.lxcpath[0], lxc_attach_run_shell, NULL, &attach_options, &pid);

--- a/src/lxc/lxc_cgroup.c
+++ b/src/lxc/lxc_cgroup.c
@@ -64,7 +64,7 @@ Options :\n\
 
 int main(int argc, char *argv[])
 {
-	char *state_object = NULL, *value = NULL;
+	const char *state_object = NULL, *value = NULL;
 	struct lxc_container *c;
 
 	if (lxc_arguments_parse(&my_args, argc, argv))

--- a/src/lxc/lxc_create.c
+++ b/src/lxc/lxc_create.c
@@ -270,7 +270,7 @@ int main(int argc, char *argv[])
 		my_args.bdevtype = NULL;
 	if (my_args.quiet)
 		flags = LXC_CREATE_QUIET;
-	if (!c->create(c, my_args.template, my_args.bdevtype, &spec, flags, &argv[optind])) {
+	if (!c->create(c, my_args.template, my_args.bdevtype, &spec, flags, (const char **) &argv[optind])) {
 		ERROR("Error creating container %s", c->name);
 		lxc_container_put(c);
 		exit(1);

--- a/src/lxc/lxc_device.c
+++ b/src/lxc/lxc_device.c
@@ -100,7 +100,7 @@ static bool is_interface(const char* dev_name, pid_t pid)
 int main(int argc, char *argv[])
 {
 	struct lxc_container *c;
-	char *cmd, *dev_name, *dst_name;
+	const char *cmd, *dev_name, *dst_name;
 	int ret = 1;
 
 	if (geteuid() != 0) {

--- a/src/lxc/lxc_execute.c
+++ b/src/lxc/lxc_execute.c
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
 	if (lxc_config_define_load(&defines, conf))
 		return 1;
 
-	ret = lxc_execute(my_args.name, my_args.argv, my_args.quiet, conf, my_args.lxcpath[0], false);
+	ret = lxc_execute(my_args.name, (const char**) my_args.argv, my_args.quiet, conf, my_args.lxcpath[0], false);
 
 	lxc_conf_free(conf);
 

--- a/src/lxc/lxc_snapshot.c
+++ b/src/lxc/lxc_snapshot.c
@@ -35,7 +35,7 @@
 
 lxc_log_define(lxc_snapshot_ui, lxc);
 
-static char *newname;
+static const char *newname;
 static char *snapshot;
 
 #define DO_SNAP 0

--- a/src/lxc/lxc_start.c
+++ b/src/lxc/lxc_start.c
@@ -205,9 +205,9 @@ int main(int argc, char *argv[])
 {
 	int err = 1;
 	struct lxc_conf *conf;
-	char *const *args;
+	const char *const *args;
 	char *rcfile = NULL;
-	char *const default_args[] = {
+	const char *const default_args[] = {
 		"/sbin/init",
 		NULL,
 	};

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -189,7 +189,7 @@ struct lxc_container {
 	 *
 	 * \return \c true on success, else \c false.
 	 */
-	bool (*start)(struct lxc_container *c, int useinit, char * const argv[]);
+	bool (*start)(struct lxc_container *c, int useinit, const char * const argv[]);
 
 	/*!
 	 * \brief Start the container (list variant).
@@ -313,7 +313,7 @@ struct lxc_container {
 	 * \return \c true on success, else \c false.
 	 */
 	bool (*create)(struct lxc_container *c, const char *t, const char *bdevtype,
-			struct bdev_specs *specs, int flags, char *const argv[]);
+			struct bdev_specs *specs, int flags, const char *const argv[]);
 
 	/*!
 	 * \brief Create a container (list variant).

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1237,7 +1237,7 @@ out_abort:
 }
 
 struct start_args {
-	char *const *argv;
+	const char *const *argv;
 };
 
 static int start(struct lxc_handler *handler, void* data)
@@ -1246,7 +1246,7 @@ static int start(struct lxc_handler *handler, void* data)
 
 	NOTICE("exec'ing '%s'", arg->argv[0]);
 
-	execvp(arg->argv[0], arg->argv);
+	execvp(arg->argv[0], (char**) arg->argv);
 	SYSERROR("failed to exec %s", arg->argv[0]);
 	return 0;
 }
@@ -1264,7 +1264,7 @@ static struct lxc_operations start_ops = {
 	.post_start = post_start
 };
 
-int lxc_start(const char *name, char *const argv[], struct lxc_conf *conf,
+int lxc_start(const char *name, const char *const argv[], struct lxc_conf *conf,
 	      const char *lxcpath, bool backgrounded)
 {
 	struct start_args start_arg = {

--- a/src/tests/attach.c
+++ b/src/tests/attach.c
@@ -124,7 +124,7 @@ static int test_attach_lsm_cmd(struct lxc_container *ct)
 	int pipefd[2];
 	char result[1024];
 	char *space;
-	char *argv[] = {"cat", "/proc/self/attr/current", NULL};
+	const char *argv[] = {"cat", "/proc/self/attr/current", NULL};
 	lxc_attach_command_t command = {"cat", argv};
 	lxc_attach_options_t attach_options = LXC_ATTACH_OPTIONS_DEFAULT;
 
@@ -237,7 +237,7 @@ static int test_attach_cmd(struct lxc_container *ct)
 {
 	int ret;
 	pid_t pid;
-	char *argv[] = {"cmp", "-s", "/sbin/init", "/bin/busybox", NULL};
+	const char *argv[] = {"cmp", "-s", "/sbin/init", "/bin/busybox", NULL};
 	lxc_attach_command_t command = {"cmp", argv};
 	lxc_attach_options_t attach_options = LXC_ATTACH_OPTIONS_DEFAULT;
 


### PR DESCRIPTION
That commit fixes the public API in such a way that strings which are not modified by the LXC library are marked as const. Currently, users of the library typically need to cast pointers to constant strings into pointers to modifiable strings, in order to be able to call the LXC functions, which is something that should be avoided as much as possible.
