### PR TITLE
Caps are getting lost when cloning an LXC.

### DIFF
--- a/src/lxc/bdev.c
+++ b/src/lxc/bdev.c
@@ -98,7 +98,7 @@ static int do_rsync(const char *src, const char *dest)
 	s[l-2] = '/';
 	s[l-1] = '\0';
 
-	execlp("rsync", "rsync", "-aH", s, dest, (char *)NULL);
+	execlp("rsync", "rsync", "-aHX", s, dest, (char *)NULL);
 	exit(1);
 }
 


### PR DESCRIPTION
Adding the -X parameter to rsync copies the extended attributes. This allows things like ping to continue to be used by a non-privilged user in Debian at least.