### PR TITLE
Update english man for lxc-snapshot and lxc-clone

### DIFF
--- a/doc/lxc-clone.sgml.in
+++ b/doc/lxc-clone.sgml.in
@@ -50,32 +50,23 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
   <refsynopsisdiv>
     <cmdsynopsis>
       <command>lxc-clone</command>
-      <arg choice="opt">-s </arg>
-      <arg choice="opt">-K </arg>
-      <arg choice="opt">-M </arg>
-      <arg choice="opt">-H </arg>
-      <arg choice="opt">-B <replaceable>backingstore</replaceable></arg>
-      <arg choice="opt">-L <replaceable>fssize</replaceable></arg>
-      <arg choice="opt">-p <replaceable>lxcpath</replaceable></arg>
-      <arg choice="opt">-P <replaceable>newlxcpath</replaceable></arg>
-      <arg choice="opt">-R </arg>
-      <arg choice="req">-o <replaceable>orig</replaceable></arg>
-      <arg choice="req">-n <replaceable>new</replaceable></arg>
+      <arg choice="opt">-n, --name <replaceable>name</replaceable></arg>
+      <arg choice="opt">-N, --newname <replaceable>newname</replaceable></arg>
+      <arg choice="opt">-p, --newpath <replaceable>newpath</replaceable></arg>
+      <arg choice="opt">-s, --snapshot <replaceable>snapshot</replaceable></arg>
+      <arg choice="opt">-B, --backingstorage <replaceable>backingstorage</replaceable></arg>
+      <arg choice="opt">-L, --fssize <replaceable>fssize</replaceable></arg>
+      <arg choice="opt">-K, --keepname <replaceable>keepname</replaceable></arg>
+      <arg choice="opt">-M, --keepmac <replaceable>keepmac</replaceable></arg>
       <arg choice="opt">-- hook arguments</arg>
     </cmdsynopsis>
     <cmdsynopsis>
       <command>lxc-clone</command>
-      <arg choice="opt">-s </arg>
-      <arg choice="opt">-K </arg>
-      <arg choice="opt">-M </arg>
-      <arg choice="opt">-H </arg>
-      <arg choice="opt">-B <replaceable>backingstore</replaceable></arg>
-      <arg choice="opt">-L <replaceable>fssize</replaceable></arg>
-      <arg choice="opt">-p <replaceable>lxcpath</replaceable></arg>
-      <arg choice="opt">-P <replaceable>newlxcpath</replaceable></arg>
-      <arg choice="opt">-R </arg>
-      <arg choice="req">orig</arg>
-      <arg choice="req">new</arg>
+      <arg choice="opt">-n, --name <replaceable>name</replaceable></arg>
+      <arg choice="opt">-N, --newname <replaceable>newname</replaceable></arg>
+      <arg choice="opt">-R, --rename <replaceable>rename</replaceable></arg>
+      <arg choice="opt">-K, --keepname <replaceable>keepname</replaceable></arg>
+      <arg choice="opt">-M, --keepmac <replaceable>keepmac</replaceable></arg>
       <arg choice="opt">-- hook arguments</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -85,12 +76,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
     <para>
       <command>lxc-clone</command> Creates a new container as a clone of an existing
-      container.  Two types of clones are supported: copy and snapshot.  A copy
-      clone copies the root filessytem from the original container to the new.  A
+      container. Two types of clones are supported: copy and snapshot. A copy
+      clone copies the root filessytem from the original container to the new. A
       snapshot filesystem uses the backing store's snapshot functionality to create
-      a very small copy-on-write snapshot of the original container.  Snapshot
-      clones require the new container backing store to support snapshotting.  Currently
-      this includes only aufs, btrfs, lvm, overlayfs and zfs.  LVM devices do not support
+      a very small copy-on-write snapshot of the original container. Snapshot
+      clones require the new container backing store to support snapshotting. Currently
+      this includes only aufs, btrfs, lvm, overlayfs and zfs. LVM devices do not support
       snapshots of snapshots.
     </para>
 
@@ -98,14 +89,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       The backing store of the new container will be the same type as the
       original container, with one exception, overlay containers.
       aufs and overlayfs snapshots can be created of directory backed
-      containers.  This can be requested by using (for overlayfs) the
+      containers. This can be requested by using (for overlayfs) the
       <replaceable>-B overlayfs</replaceable> arguments.
     </para>
 
     <para>
-      The names of the original and new container can be given (in that order)
-      after all options, or can be specified with the
-      <replaceable>-o</replaceable> and <replaceable>-n</replaceable> options,
+      The names of the original and new container must be given with the
+      <replaceable>-n</replaceable> and <replaceable>-N</replaceable> options,
       respectively.
     </para>
 
@@ -119,11 +109,77 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
       <varlistentry>
 	<term>
+	  <option>-N, --newname <replaceable>newname</replaceable></option>
+	</term>
+	<listitem>
+	  <para>
+	    The newname of the cloned container.
+	  </para>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+	<term>
+	  <option>-p, --newpath <replaceable>newpath</replaceable></option>
+	</term>
+	<listitem>
+	  <para>
+	    The lxcpath for the new container. By default the same lxcpath
+	    as the original will be used. Note that with btrfs snapshots,
+	    changing lxcpaths may not be possible, as subvolume snapshots
+	    must be in the same btrfs filesystem.
+	  </para>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+	<term>
+	  <option>-R, --rename</option>
+	</term>
+	<listitem>
+	  <para>
+	    Rename an existing container.
+	    <replaceable>orig</replaceable> is renamed <replaceable>new</replaceable>.
+	  </para>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+	<term>
 	  <option>-s, --snapshot</option>
 	</term>
 	<listitem>
 	  <para>
 	    The new container's rootfs will be a snapshot of the original. This option can be specified when the backing store is LVM, btrfs or zfs, and must be specified when you want to snapshot using aufs or overlayfs.
+	  </para>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+	<term>
+	  <option>-B, --backingstore <replaceable>backingstore</replaceable></option>
+	</term>
+	<listitem>
+	  <para>
+	    Select a different backing store for the new container.  By
+	    default the same as the original container's is used.  Note that
+	    currently changing the backingstore is only supported for
+	    aufs and overlayfs snapshots of directory backed containers.  Valid
+	    backing stores include dir (directory), aufs, btrfs, lvm, zfs, loop
+	    and overlayfs.
+	  </para>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+	<term>
+	  <option>-L, --fssize <replaceable>fssize</replaceable></option>
+	</term>
+	<listitem>
+	  <para>
+	    In the case of a block device backed container, a size for the new
+	    block device.  By default, the new device will be made the
+	    same size as the original.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -152,108 +208,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 	</listitem>
       </varlistentry>
 
-      <varlistentry>
-	<term>
-	  <option>-H, --copyhooks</option>
-	</term>
-	<listitem>
-	  <para>
-	    Copy all mount hooks into the new container's directory, and
-	    update any lxcpaths and container names as needed.
-	  </para>
-	</listitem>
-      </varlistentry>
-
-      <varlistentry>
-	<term>
-	  <option>-L, --fssize <replaceable>fssize</replaceable></option>
-	</term>
-	<listitem>
-	  <para>
-	    In the case of a block device backed container, a size for the new
-	    block device.  By default, the new device will be made the
-	    same size as the original.
-	  </para>
-	</listitem>
-      </varlistentry>
-
-      <varlistentry>
-	<term>
-	  <option>-p, --lxcpath <replaceable>lxcpath</replaceable></option>
-	</term>
-	<listitem>
-	  <para>
-	    The lxcpath of the original container.  By default, the system
-	    wide configured lxcpath will be used.
-	  </para>
-	</listitem>
-      </varlistentry>
-
-      <varlistentry>
-	<term>
-	  <option>-P, --newpath <replaceable>newlxcpath</replaceable></option>
-	</term>
-	<listitem>
-	  <para>
-	    The lxcpath for the new container.  By default the same lxcpath
-	    as the original will be used.  Note that with btrfs snapshots,
-	    changing lxcpaths may not be possible, as subvolume snapshots
-	    must be in the same btrfs filesystem.
-	  </para>
-	</listitem>
-      </varlistentry>
-
-      <varlistentry>
-	<term>
-	  <option>-B, --backingstore <replaceable>backingstore</replaceable></option>
-	</term>
-	<listitem>
-	  <para>
-	    Select a different backing store for the new container.  By
-	    default the same as the original container's is used.  Note that
-	    currently changing the backingstore is only supported for
-	    aufs and overlayfs snapshots of directory backed containers.  Valid
-	    backing stores include dir (directory), aufs, btrfs, lvm, zfs, loop
-	    and overlayfs.
-	  </para>
-	</listitem>
-      </varlistentry>
-
-      <varlistentry>
-	<term>
-	  <option>-R, --rename</option>
-	</term>
-	<listitem>
-	  <para>
-	    Rename an existing container.
-	    <replaceable>orig</replaceable> is renamed <replaceable>new</replaceable>.
-	  </para>
-	</listitem>
-      </varlistentry>
-
-      <varlistentry>
-	<term>
-	  <option>-o, --orig <replaceable>orig</replaceable></option>
-	</term>
-	<listitem>
-	  <para>
-	    The name of the original container to clone.
-	  </para>
-	</listitem>
-      </varlistentry>
-
-      <varlistentry>
-	<term>
-	  <option>-n, --new <replaceable>new</replaceable></option>
-	</term>
-	<listitem>
-	  <para>
-	    The name of the new container to create.
-	  </para>
-	</listitem>
-      </varlistentry>
-
-
     </variablelist>
 
   </refsect1>
@@ -265,15 +219,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       specified, then the specified hooks will be called for the new container.  The
       first 3 arguments passed to the clone hook will be the container name, a section
       ('lxc'), and the hook type ('clone').  Extra arguments passed
-      <command>lxc-clone</command> will be passed to the hook program starting at
-      argument 4.  The <filename>LXC_ROOTFS_MOUNT</filename> environment variable gives
-      the path under which the container's root filesystem is mounted.  The
-      configuration file pathname is stored in <filename>LXC_CONFIG_FILE</filename>, the
-      new container name in <filename>LXC_NAME</filename>, the old container name in
-      <filename>LXC_SRC_NAME</filename>, and the path or device on which
-      the rootfs is located is in <filename>LXC_ROOTFS_PATH</filename>.
+      <command>lxc-clone</command> will be passed to the hook program.  The
+      <filename>LXC_ROOTFS_MOUNT</filename> environment variable gives the path
+      under which the container's root filesystem is mounted.  The configuration
+      file pathname is stored in <filename>LXC_CONFIG_FILE</filename>, the new
+      container name in <filename>LXC_NAME</filename>, the old container name in
+      <filename>LXC_SRC_NAME</filename>, and the path or device on which the
+      rootfs is located is in <filename>LXC_ROOTFS_PATH</filename>.
     </para>
   </refsect1>
+
+  &commonoptions;
 
   &seealso;
 

--- a/doc/lxc-snapshot.sgml.in
+++ b/doc/lxc-snapshot.sgml.in
@@ -67,7 +67,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <command>lxc-snapshot</command>
       <arg choice="req">-n, --name <replaceable>name</replaceable></arg>
       <arg choice="req">-r, -restore <replaceable>snapshot-name</replaceable></arg>
-      <arg choice="opt"> <replaceable> newname</replaceable></arg>
+      <arg choice="opt">-N, --newname <replaceable> newname</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -127,9 +127,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 	  </varlistentry>
 
 	  <varlistentry>
-	    <term> <option>newname</option> </term>
+	    <term> <option>-N, --newname</option> </term>
 	   <listitem>
-	    <para> When restoring a snapshot, the last optional argument is the name to use for the restored container.  If no name is given, then the original container will be destroyed and the restored container will take its place.  Note that deleting the original snapshot is not possible in the case of aufs, overlayfs or zfs backed snapshots.</para>
+	    <para> When restoring a snapshot, the last argument is the name to use for the restored container.  If the newname is identical to the original name of the container, then the original container will be destroyed and the restored container will take its place. Note that deleting the original snapshot is not possible in the case of aufs, overlayfs or zfs backed snapshots.</para>
 	   </listitem>
 	  </varlistentry>
 


### PR DESCRIPTION
- Recent changes in lxc-snapshot and lxc-clone require a rewrite of the manpages
  for both executables. The Japanese and Korean manpages are not affected by
  this commit and should be addressed by a competent speaker. 

Signed-off-by: Christian Brauner <christianvanbrauner@gmail.com>