### PR TITLE
check for NULL pointers before calling setenv()

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2174,16 +2174,16 @@ static bool container_destroy(struct lxc_container *c)
 
 	if (conf && !lxc_list_empty(&conf->hooks[LXCHOOK_DESTROY])) {
 		/* Start of environment variable setup for hooks */
-		if (setenv("LXC_NAME", c->name, 1)) {
+		if (c->name && setenv("LXC_NAME", c->name, 1)) {
 			SYSERROR("failed to set environment variable for container name");
 		}
-		if (setenv("LXC_CONFIG_FILE", conf->rcfile, 1)) {
+		if (conf->rcfile && setenv("LXC_CONFIG_FILE", conf->rcfile, 1)) {
 			SYSERROR("failed to set environment variable for config path");
 		}
-		if (setenv("LXC_ROOTFS_MOUNT", conf->rootfs.mount, 1)) {
+		if (conf->rootfs.mount && setenv("LXC_ROOTFS_MOUNT", conf->rootfs.mount, 1)) {
 			SYSERROR("failed to set environment variable for rootfs mount");
 		}
-		if (setenv("LXC_ROOTFS_PATH", conf->rootfs.path, 1)) {
+		if (conf->rootfs.path && setenv("LXC_ROOTFS_PATH", conf->rootfs.path, 1)) {
 			SYSERROR("failed to set environment variable for rootfs mount");
 		}
 		if (conf->console.path && setenv("LXC_CONSOLE", conf->console.path, 1)) {
@@ -2743,19 +2743,19 @@ static int clone_update_rootfs(struct clone_update_data *data)
 
 	if (!lxc_list_empty(&conf->hooks[LXCHOOK_CLONE])) {
 		/* Start of environment variable setup for hooks */
-		if (setenv("LXC_SRC_NAME", c0->name, 1)) {
+		if (c0->name && setenv("LXC_SRC_NAME", c0->name, 1)) {
 			SYSERROR("failed to set environment variable for source container name");
 		}
-		if (setenv("LXC_NAME", c->name, 1)) {
+		if (c->name && setenv("LXC_NAME", c->name, 1)) {
 			SYSERROR("failed to set environment variable for container name");
 		}
-		if (setenv("LXC_CONFIG_FILE", conf->rcfile, 1)) {
+		if (conf->rcfile && setenv("LXC_CONFIG_FILE", conf->rcfile, 1)) {
 			SYSERROR("failed to set environment variable for config path");
 		}
-		if (setenv("LXC_ROOTFS_MOUNT", bdev->dest, 1)) {
+		if (bdev->dest && setenv("LXC_ROOTFS_MOUNT", bdev->dest, 1)) {
 			SYSERROR("failed to set environment variable for rootfs mount");
 		}
-		if (setenv("LXC_ROOTFS_PATH", conf->rootfs.path, 1)) {
+		if (conf->rootfs.path && setenv("LXC_ROOTFS_PATH", conf->rootfs.path, 1)) {
 			SYSERROR("failed to set environment variable for rootfs mount");
 		}
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -406,16 +406,16 @@ struct lxc_handler *lxc_init(const char *name, struct lxc_conf *conf, const char
 	}
 
 	/* Start of environment variable setup for hooks */
-	if (setenv("LXC_NAME", name, 1)) {
+	if (name && setenv("LXC_NAME", name, 1)) {
 		SYSERROR("failed to set environment variable for container name");
 	}
-	if (setenv("LXC_CONFIG_FILE", conf->rcfile, 1)) {
+	if (conf->rcfile && setenv("LXC_CONFIG_FILE", conf->rcfile, 1)) {
 		SYSERROR("failed to set environment variable for config path");
 	}
-	if (setenv("LXC_ROOTFS_MOUNT", conf->rootfs.mount, 1)) {
+	if (conf->rootfs.mount && setenv("LXC_ROOTFS_MOUNT", conf->rootfs.mount, 1)) {
 		SYSERROR("failed to set environment variable for rootfs mount");
 	}
-	if (setenv("LXC_ROOTFS_PATH", conf->rootfs.path, 1)) {
+	if (conf->rootfs.path && setenv("LXC_ROOTFS_PATH", conf->rootfs.path, 1)) {
 		SYSERROR("failed to set environment variable for rootfs mount");
 	}
 	if (conf->console.path && setenv("LXC_CONSOLE", conf->console.path, 1)) {


### PR DESCRIPTION
Latest glibc release actually honours calling setenv with a NULL
pointer by causing SIGSEGV but checking pointers before submitting
to any system function is a good idea anyway.

Signed-off-by: Robert Schiele <rschiele@gmail.com>