### PR TITLE
Test dpkg for multiarch support in lxc-debian template

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -379,13 +379,9 @@ EOF
 
     # If the container isn't running a native architecture, setup multiarch
     if [ "${arch}" != "${hostarch}" ]; then
-        mkdir -p ${rootfs}/etc/dpkg/dpkg.cfg.d
-        echo "foreign-architecture ${hostarch}" > ${rootfs}/etc/dpkg/dpkg.cfg.d/lxc-multiarch
-        
         # Test if dpkg supports multiarch
-	if chroot $rootfs dpkg -l dpkg 2>&1 | grep -q "unknown option 'foreign-architecture'"; then
-	    echo "dpkg does not support multiarch: removing multiarch configuration file"
-            rm ${rootfs}/etc/dpkg/dpkg.cfg.d/lxc-multiarch
+        if ! chroot $rootfs dpkg --print-foreign-architecture 2>&1; then
+            chroot $rootfs dpkg --add-architecture ${hostarch}
         fi
     fi
 

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -381,6 +381,12 @@ EOF
     if [ "${arch}" != "${hostarch}" ]; then
         mkdir -p ${rootfs}/etc/dpkg/dpkg.cfg.d
         echo "foreign-architecture ${hostarch}" > ${rootfs}/etc/dpkg/dpkg.cfg.d/lxc-multiarch
+        
+        # Test if dpkg supports multiarch
+	if chroot $rootfs dpkg -l dpkg 2>&1 | grep -q "unknown option 'foreign-architecture'"; then
+	    echo "dpkg does not support multiarch: removing multiarch configuration file"
+            rm ${rootfs}/etc/dpkg/dpkg.cfg.d/lxc-multiarch
+        fi
     fi
 
     # Write a new sources.list containing both native and multiarch entries


### PR DESCRIPTION
Signed-off-by: David Noyes <david.j.noyes@gmail.com>

A fix for the lxc-debian template when creating 32-bit containers: Test if dpkg supports the multiarch foreign-architecture flag.

Issue raised in lxc/lxc/#616

