### PR TITLE
Tear down network devices during container halt

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1222,7 +1222,12 @@ int __lxc_start(const char *name, struct lxc_conf *conf,
 		}
         }
 
+	DEBUG("Pushing physical nics back to host namespace");
 	lxc_rename_phys_nics_on_shutdown(netnsfd, handler->conf);
+
+	DEBUG("Tearing down virtual network devices used by container");
+	lxc_delete_network(handler);
+
 	if (netnsfd >= 0)
 		close(netnsfd);
 


### PR DESCRIPTION
On very busy systems, some virtual network devices won't be destroyed after a
container halts.  This patch uses the lxc_delete_network() method to ensure
that network devices attached to the container are destroyed when the
container halts.

Without the patch, some virtual network devices are left over on the system
and must be removed with `ip link del <device>`.  This caused containers
with lxc.network.veth.pair to not be able to start.  For containers using
randomly generated virtual network device names, the old devices will hang
around on the bridge with their original MAC address.

Signed-off-by: Major Hayden <major@mhtx.net>