### PR TITLE
Destroy on signal

### DIFF
--- a/src/lxc/bdev.c
+++ b/src/lxc/bdev.c
@@ -3614,3 +3614,21 @@ bool rootfs_is_blockdev(struct lxc_conf *conf)
 		return true;
 	return false;
 }
+
+bool bdev_destroy(struct lxc_conf *conf)
+{
+	struct bdev *r;
+	bool ret = false;
+
+	r = bdev_init(conf, conf->rootfs.path, conf->rootfs.mount, NULL);
+	if (!r)
+		return ret;
+
+	if (r->ops->destroy(r) < 0)
+		return ret;
+	bdev_put(r);
+
+	ret = true;
+	return ret;
+}
+

--- a/src/lxc/bdev.h
+++ b/src/lxc/bdev.h
@@ -123,6 +123,7 @@ struct bdev *bdev_copy(struct lxc_container *c0, const char *cname,
 struct bdev *bdev_create(const char *dest, const char *type,
 			const char *cname, struct bdev_specs *specs);
 void bdev_put(struct bdev *bdev);
+bool bdev_destroy(struct lxc_conf *conf);
 
 /*
  * these are really for qemu-nbd support, as container shutdown

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -370,6 +370,9 @@ struct lxc_conf {
 	 * should run under when using lxc-execute */
 	uid_t init_uid;
 	gid_t init_gid;
+
+	/* indicator if the container will be destroyed on shutdown */
+	int ephemeral;
 };
 
 #ifdef HAVE_TLS

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -108,6 +108,8 @@ static int config_environment(const char *, const char *, struct lxc_conf *);
 static int config_init_cmd(const char *, const char *, struct lxc_conf *);
 static int config_init_uid(const char *, const char *, struct lxc_conf *);
 static int config_init_gid(const char *, const char *, struct lxc_conf *);
+static int config_ephemeral(const char *key, const char *value,
+			    struct lxc_conf *lxc_conf);
 
 static struct lxc_config_t config[] = {
 
@@ -176,6 +178,7 @@ static struct lxc_config_t config[] = {
 	{ "lxc.init_cmd",             config_init_cmd             },
 	{ "lxc.init_uid",             config_init_uid             },
 	{ "lxc.init_gid",             config_init_gid             },
+	{ "lxc.ephemeral",            config_ephemeral            },
 };
 
 struct signame {
@@ -2490,6 +2493,8 @@ int lxc_get_config_item(struct lxc_conf *c, const char *key, char *retv,
 		return lxc_get_conf_int(c, retv, inlen, c->init_uid);
 	else if (strcmp(key, "lxc.init_gid") == 0)
 		return lxc_get_conf_int(c, retv, inlen, c->init_gid);
+	else if (strcmp(key, "lxc.ephemeral") == 0)
+		return lxc_get_conf_int(c, retv, inlen, c->ephemeral);
 	else return -1;
 
 	if (!v)
@@ -2759,3 +2764,14 @@ bool network_new_hwaddrs(struct lxc_conf *conf)
 	}
 	return true;
 }
+
+static int config_ephemeral(const char *key, const char *value,
+			    struct lxc_conf *lxc_conf)
+{
+	int v = atoi(value);
+
+	lxc_conf->ephemeral = v;
+
+	return 0;
+}
+

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -1984,7 +1984,6 @@ static bool mod_rdep(struct lxc_container *c0, struct lxc_container *c, bool inc
 	FILE *f1;
 	struct stat fbuf;
 	char *buf = NULL;
-	char *del;
 	char path[MAXPATHLEN];
 	char newpath[MAXPATHLEN];
 	int fd, ret, n = 0, v = 0;
@@ -2069,13 +2068,7 @@ static bool mod_rdep(struct lxc_container *c0, struct lxc_container *c, bool inc
 			}
 
 			len = strlen(newpath);
-
-			/* mmap()ed memory is only \0-terminated when it is not
-			 * a multiple of a pagesize. Hence, we'll use memmem(). */
-			if ((del = memmem(buf, fbuf.st_size, newpath, len))) {
-				/* remove container entry */
-				memmove(del, del + len, strlen(del) - len + 1);
-
+			if (lxc_delete_string_in_array(buf, fbuf.st_size, newpath, len)) {
 				munmap(buf, fbuf.st_size);
 
 				if (ftruncate(fd, fbuf.st_size - len) < 0) {

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2213,21 +2213,6 @@ static int lxc_rmdir_onedev_wrapper(void *data)
 	return lxc_rmdir_onedev(arg, "snaps");
 }
 
-static int do_bdev_destroy(struct lxc_conf *conf)
-{
-	struct bdev *r;
-	int ret = 0;
-
-	r = bdev_init(conf, conf->rootfs.path, conf->rootfs.mount, NULL);
-	if (!r)
-		return -1;
-
-	if (r->ops->destroy(r) < 0)
-		ret = -1;
-	bdev_put(r);
-	return ret;
-}
-
 static int bdev_destroy_wrapper(void *data)
 {
 	struct lxc_conf *conf = data;
@@ -2242,13 +2227,16 @@ static int bdev_destroy_wrapper(void *data)
 		ERROR("Failed to setuid to 0");
 		return -1;
 	}
-	return do_bdev_destroy(conf);
+	if (!bdev_destroy(conf))
+		return -1;
+	else
+		return 0;
 }
 
 static bool container_destroy(struct lxc_container *c)
 {
 	bool bret = false;
-	int ret;
+	int ret = 0;
 	struct lxc_conf *conf;
 
 	if (!c || !do_lxcapi_is_defined(c))
@@ -2301,13 +2289,18 @@ static bool container_destroy(struct lxc_container *c)
 	}
 
 	if (conf && conf->rootfs.path && conf->rootfs.mount) {
-		if (am_unpriv())
+		if (am_unpriv()) {
 			ret = userns_exec_1(conf, bdev_destroy_wrapper, conf);
-		else
-			ret = do_bdev_destroy(conf);
-		if (ret < 0) {
-			ERROR("Error destroying rootfs for %s", c->name);
-			goto out;
+			if (ret < 0) {
+				ERROR("Error destroying rootfs for %s", c->name);
+				goto out;
+			}
+		} else {
+			bret = bdev_destroy(conf);
+			if (!bret) {
+				ERROR("Error destroying rootfs for %s", c->name);
+				goto out;
+			}
 		}
 	}
 

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1466,3 +1466,17 @@ err:
 	close(fd);
 	return ret;
 }
+
+bool lxc_delete_string_in_array(char *haystack, size_t haystacklen,
+				const char *needle, size_t needlelen)
+{
+	char *del = NULL;
+	bool bret = false;
+
+	if ((del = memmem(haystack, haystacklen, needle, needlelen))) {
+		memmove(del, del + needlelen, strlen(del) - needlelen + 1);
+		bret = true;
+	}
+	return bret;
+}
+

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -243,6 +243,9 @@ extern char *lxc_append_paths(const char *first, const char *second);
 extern bool lxc_string_in_list(const char *needle, const char *haystack, char sep);
 extern char **lxc_string_split(const char *string, char sep);
 extern char **lxc_string_split_and_trim(const char *string, char sep);
+/* Delete a string from a non-null terminated buffer. */
+bool lxc_delete_string_in_array(char *haystack, size_t haystacklen,
+				const char *needle, size_t needlelen);
 
 /* some simple array manipulation utilities */
 typedef void (*lxc_free_fn)(void *);


### PR DESCRIPTION
These commits enable a container to be destroyed on shutdown by setting `lxc.ephemeral = 1` in its configuration file. This will allow us a consistent implementation of `lxc-copy = lxc-clone + lxc-start-ephemeral` without having to resort to hacks.

Small changes:

- `lxc_delete_string_in_array()` has beed added to `utils.c`. It replaces the manual method for deleting a container entry in `lxc_snapshots` files  in `mod_rdep()` in `lxccontainer.c`.
- static `do_bdev_destroy()` has been moved to `bdev.c` and `bdev.h` and made public because it will be reused in `start.c`.
- The "shutdown-handler" `lxc_fini()` has been modified to call the new static function `lxc_destroy_container_on_signal()` to destroy containers which have `lxc.ephemeral = 1` set in their config file. Currently only `overlayfs` and `aufs` backed containers can be destroyed in this way because this is so far the only case we care about (`lxc-start-ephemeral` part of `lxc-copy`) but the function works for all bdev types supported by lxc.