### PR TITLE
lxc-start-ephemeral: Parse passwd directly

### DIFF
--- a/src/lxc/lxc-start-ephemeral.in
+++ b/src/lxc/lxc-start-ephemeral.in
@@ -29,7 +29,6 @@ import argparse
 import gettext
 import lxc
 import os
-import pwd
 import sys
 import subprocess
 import tempfile
@@ -363,12 +362,17 @@ if os.path.exists("/proc/self/ns/pid"):
             if args.user:
                 username = args.user
 
-            user = pwd.getpwnam(username)
-            os.setgid(user.pw_gid)
-            os.initgroups(user.pw_name, user.pw_gid)
-            os.setuid(user.pw_uid)
-            os.chdir(user.pw_dir)
-            os.environ['HOME'] = user.pw_dir
+            line = subprocess.check_output(
+                ["getent", "passwd", username],
+                universal_newlines=True).rstrip("\n")
+            _, _, pw_uid, pw_gid, _, pw_dir, _ = line.split(":", 6)
+            pw_uid = int(pw_uid)
+            pw_gid = int(pw_gid)
+            os.setgid(pw_gid)
+            os.initgroups(username, pw_gid)
+            os.setuid(pw_uid)
+            os.chdir(pw_dir)
+            os.environ['HOME'] = pw_dir
         except:
             print(_("Unable to switch to user: %s" % username))
             sys.exit(1)


### PR DESCRIPTION
On Ubuntu 15.04, lxc-start-ephemeral's call to pwd.getpwnam always
fails.  While I haven't been able to prove it or track down an exact
cause, I strongly suspect that glibc does not guarantee that you can
call NSS functions after a context switch without re-execing.  (Running
"id root" in a subprocess from the same point works fine.)

It's safer to use getent to extract the relevant line from the passwd
file and parse it directly.

Signed-off-by: Colin Watson <cjwatson@ubuntu.com>