### PR TITLE
Add Ceph RBD backingstore.

### DIFF
--- a/doc/lxc-create.sgml.in
+++ b/doc/lxc-create.sgml.in
@@ -126,7 +126,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 	</term>
 	<listitem>
 	  <para>
-	    'backingstore' is one of 'dir', 'lvm', 'loop', 'btrfs', 'zfs', or 'best'.  The
+	    'backingstore' is one of 'dir', 'lvm', 'loop', 'btrfs', 'zfs', 'rbd', or 'best'.  The
 	    default is 'dir', meaning that the container root filesystem
 	    will be a directory under <filename>@LXCPATH@/container/rootfs</filename>.
 	    This backing store type allows the optional
@@ -156,6 +156,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 	  </para>
 	  <para>
 	    If backingstore is 'loop', you can use <replaceable>--fstype FSTYPE</replaceable> and <replaceable>--fssize SIZE</replaceable> as 'lvm'. The default values for these options are the same as 'lvm'.
+	  </para>
+	  <para>
+	    If backingstore is 'rbd', then you will need to have a valid configuration in <filename>ceph.conf</filename> and a <filename>ceph.client.admin.keyring</filename> defined.
+	    You can specify the following options :
+	    <replaceable>--rbdname RBDNAME</replaceable> will create a blockdevice named RBDNAME rather than the default, which is the container name.
+	    <replaceable>--rbdpool POOL</replaceable> will create the blockdevice in the pool named POOL, rather than the default, which is 'lxc'.
 	  </para>
 	  <para>
 	    If backingstore is 'best', then lxc will try, in order, btrfs,

--- a/src/lxc/arguments.h
+++ b/src/lxc/arguments.h
@@ -86,6 +86,7 @@ struct lxc_arguments {
 	char *fstype;
 	uint64_t fssize;
 	char *lvname, *vgname, *thinpool;
+	char *rbdname, *rbdpool;
 	char *zfsroot, *lowerdir, *dir;
 
 	/* lxc-execute */

--- a/src/lxc/bdev.c
+++ b/src/lxc/bdev.c
@@ -1323,7 +1323,7 @@ static int rbd_create(struct bdev *bdev, const char *dest, const char *n,
 	if (!(bdev->dest = strdup(dest)))
 		return -1;
 
-	if (mkdir_p(bdev->dest, 0755) < 0) {
+	if (mkdir_p(bdev->dest, 0755) < 0 && errno != EEXIST) {
 		ERROR("Error creating %s", bdev->dest);
 		return -1;
 	}

--- a/src/lxc/bdev.c
+++ b/src/lxc/bdev.c
@@ -1245,7 +1245,7 @@ static int rbd_destroy(struct bdev *orig)
 	if ((pid = fork()) < 0)
 		return -1;
 	if (!pid) {
-		rbdfullname = alloca(strlen(orig->src) - 9);
+		rbdfullname = alloca(strlen(orig->src) - 8);
 		strcpy( rbdfullname, &orig->src[9] );
 		execlp("rbd", "rbd", "rm" , rbdfullname, NULL);
 		exit(1);

--- a/src/lxc/bdev.c
+++ b/src/lxc/bdev.c
@@ -1181,6 +1181,168 @@ static const struct bdev_ops lvm_ops = {
 	.can_backup = false,
 };
 
+
+/*
+ *   CEPH RBD ops
+ */
+
+static int rbd_detect(const char *path)
+{
+	if ( memcmp(path, "/dev/rbd/", 9) == 0)
+		return 1;
+	return 0;
+}
+
+static int rbd_mount(struct bdev *bdev)
+{
+	if (strcmp(bdev->type, "rbd"))
+		return -22;
+	if (!bdev->src || !bdev->dest)
+		return -22;
+
+	if ( !file_exists(bdev->src) ) {
+		// if blkdev does not exist it should be mapped, because it is not persistent on reboot
+		ERROR("Block device %s is not mapped.", bdev->src);
+		return -1;
+	}
+
+	return mount_unknown_fs(bdev->src, bdev->dest, bdev->mntopts);
+}
+
+static int rbd_umount(struct bdev *bdev)
+{
+	if (strcmp(bdev->type, "rbd"))
+		return -22;
+	if (!bdev->src || !bdev->dest)
+		return -22;
+	return umount(bdev->dest);
+}
+
+static int rbd_clonepaths(struct bdev *orig, struct bdev *new, const char *oldname,
+		const char *cname, const char *oldpath, const char *lxcpath, int snap,
+		uint64_t newsize, struct lxc_conf *conf)
+{
+	ERROR("rbd clonepaths not implemented");
+	return -1;
+}
+
+static int rbd_destroy(struct bdev *orig)
+{
+	pid_t pid;
+	char *rbdfullname;
+
+	if ( file_exists(orig->src) ) {
+		if ((pid = fork()) < 0)
+			return -1;
+		if (!pid) {
+			execlp("rbd", "rbd", "unmap" , orig->src, NULL);
+			exit(1);
+		}
+		if (wait_for_pid(pid) < 0)
+			return -1;
+	}
+
+	if ((pid = fork()) < 0)
+		return -1;
+	if (!pid) {
+		rbdfullname = alloca(strlen(orig->src) - 9);
+		strcpy( rbdfullname, &orig->src[9] );
+		execlp("rbd", "rbd", "rm" , rbdfullname, NULL);
+		exit(1);
+	}
+	return wait_for_pid(pid);
+
+}
+
+static int rbd_create(struct bdev *bdev, const char *dest, const char *n,
+			struct bdev_specs *specs)
+{
+	const char *rbdpool, *rbdname = n, *fstype;
+	uint64_t size;
+	int ret, len;
+	char sz[24];
+	pid_t pid;
+
+	if (!specs)
+		return -1;
+
+	rbdpool = specs->rbd.rbdpool;
+	if (!rbdpool)
+		rbdpool = lxc_global_config_value("lxc.bdev.rbd.rbdpool");
+
+	if (specs->rbd.rbdname)
+		rbdname = specs->rbd.rbdname;
+
+	/* source device /dev/rbd/lxc/ctn */
+	len = strlen(rbdpool) + strlen(rbdname) + 11;
+	bdev->src = malloc(len);
+	if (!bdev->src)
+		return -1;
+
+	ret = snprintf(bdev->src, len, "/dev/rbd/%s/%s", rbdpool, rbdname);
+	if (ret < 0 || ret >= len)
+		return -1;
+
+	// fssize is in bytes.
+	size = specs->fssize;
+	if (!size)
+		size = DEFAULT_FS_SIZE;
+
+	// in megabytes for rbd tool
+	ret = snprintf(sz, 24, "%"PRIu64, size / 1024 / 1024 );
+	if (ret < 0 || ret >= 24)
+		exit(1);
+
+	if ((pid = fork()) < 0)
+		return -1;
+	if (!pid) {
+		execlp("rbd", "rbd", "create" , "--pool", rbdpool, rbdname, "--size", sz, NULL);
+		exit(1);
+	}
+	if (wait_for_pid(pid) < 0)
+		return -1;
+
+	if ((pid = fork()) < 0)
+		return -1;
+	if (!pid) {
+		execlp("rbd", "rbd", "map", "--pool", rbdpool, rbdname, NULL);
+		exit(1);
+	}
+	if (wait_for_pid(pid) < 0)
+		return -1;
+
+	fstype = specs->fstype;
+	if (!fstype)
+		fstype = DEFAULT_FSTYPE;
+
+	if (do_mkfs(bdev->src, fstype) < 0) {
+		ERROR("Error creating filesystem type %s on %s", fstype,
+			bdev->src);
+		return -1;
+	}
+	if (!(bdev->dest = strdup(dest)))
+		return -1;
+
+	if (mkdir_p(bdev->dest, 0755) < 0) {
+		ERROR("Error creating %s", bdev->dest);
+		return -1;
+	}
+
+	return 0;
+}
+
+static const struct bdev_ops rbd_ops = {
+	.detect = &rbd_detect,
+	.mount = &rbd_mount,
+	.umount = &rbd_umount,
+	.clone_paths = &rbd_clonepaths,
+	.destroy = &rbd_destroy,
+	.create = &rbd_create,
+	.can_snapshot = false,
+	.can_backup = false,
+};
+
+
 /*
  * Return the full path of objid under dirid.  Let's say dirid is
  * /lxc/c1/rootfs, and objid is /lxc/c1/rootfs/a/b/c.  Then we will
@@ -3237,6 +3399,7 @@ static const struct bdev_ops nbd_ops = {
 static const struct bdev_type bdevs[] = {
 	{.name = "zfs", .ops = &zfs_ops,},
 	{.name = "lvm", .ops = &lvm_ops,},
+	{.name = "rbd", .ops = &rbd_ops,},
 	{.name = "btrfs", .ops = &btrfs_ops,},
 	{.name = "dir", .ops = &dir_ops,},
 	{.name = "aufs", .ops = &aufs_ops,},
@@ -3596,6 +3759,7 @@ err:
 static struct bdev * do_bdev_create(const char *dest, const char *type,
 			const char *cname, struct bdev_specs *specs)
 {
+
 	struct bdev *bdev = bdev_get(type);
 	if (!bdev) {
 		return NULL;
@@ -3616,7 +3780,7 @@ static struct bdev * do_bdev_create(const char *dest, const char *type,
  * for use.  Before completing, the caller will need to call the
  * umount operation and bdev_put().
  * @dest: the mountpoint (i.e. /var/lib/lxc/$name/rootfs)
- * @type: the bdevtype (dir, btrfs, zfs, etc)
+ * @type: the bdevtype (dir, btrfs, zfs, rbd, etc)
  * @cname: the container name
  * @specs: details about the backing store to create, like fstype
  */
@@ -3624,7 +3788,7 @@ struct bdev *bdev_create(const char *dest, const char *type,
 			const char *cname, struct bdev_specs *specs)
 {
 	struct bdev *bdev;
-	char *best_options[] = {"btrfs", "zfs", "lvm", "dir", NULL};
+	char *best_options[] = {"btrfs", "zfs", "lvm", "dir", "rbd", NULL};
 
 	if (!type)
 		return do_bdev_create(dest, "dir", cname, specs);

--- a/src/lxc/initutils.c
+++ b/src/lxc/initutils.c
@@ -87,6 +87,7 @@ const char *lxc_global_config_value(const char *option_name)
 		{ "lxc.bdev.lvm.vg",        DEFAULT_VG      },
 		{ "lxc.bdev.lvm.thin_pool", DEFAULT_THIN_POOL },
 		{ "lxc.bdev.zfs.root",      DEFAULT_ZFSROOT },
+		{ "lxc.bdev.rbd.rbdpool",   DEFAULT_RBDPOOL },
 		{ "lxc.lxcpath",            NULL            },
 		{ "lxc.default_config",     NULL            },
 		{ "lxc.cgroup.pattern",     NULL            },

--- a/src/lxc/initutils.h
+++ b/src/lxc/initutils.h
@@ -42,6 +42,7 @@
 #define DEFAULT_VG "lxc"
 #define DEFAULT_THIN_POOL "lxc"
 #define DEFAULT_ZFSROOT "lxc"
+#define DEFAULT_RBDPOOL "lxc"
 
 extern void lxc_setup_fs(void);
 extern const char *lxc_global_config_value(const char *option_name);

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -857,11 +857,11 @@ struct bdev_specs {
 		char *lv; /*!< LVM Logical Volume name */
 		char *thinpool; /*!< LVM thin pool to use, if any */
 	} lvm;
+	char *dir; /*!< Directory path */
 	struct {
 		char *rbdname; /*!< RBD image name */
 		char *rbdpool; /*!< Ceph pool name */
 	} rbd;
-	char *dir; /*!< Directory path */
 };
 
 /*!

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -857,6 +857,10 @@ struct bdev_specs {
 		char *lv; /*!< LVM Logical Volume name */
 		char *thinpool; /*!< LVM thin pool to use, if any */
 	} lvm;
+	struct {
+		char *rbdname; /*!< RBD image name */
+		char *rbdpool; /*!< Ceph pool name */
+	} rbd;
 	char *dir; /*!< Directory path */
 };
 


### PR DESCRIPTION
I propose to add the management of Rados Block Device (http://docs.ceph.com/docs/master/rbd/rbd/)
Currently managing snapshots is not implemented. And the rbd devices are not remap in /dev/* when physical host restart.
Do you have any suggestions?