### PR TITLE
arch template: Fix systemd-sysctl service

### DIFF
--- a/templates/lxc-archlinux.in
+++ b/templates/lxc-archlinux.in
@@ -103,6 +103,10 @@ sed -e 's/^ConditionPathExists=/# ConditionPathExists=/' \
     -e 's/After=dev-%i.device/After=/' \
     < /lib/systemd/system/getty\@.service \
     > /etc/systemd/system/getty\@.service
+# fix systemd-sysctl service
+sed -e 's/^ConditionPathIsReadWrite=\/proc\/sys\/$/ConditionPathIsReadWrite=\/proc\/sys\/net\//' \
+    -e 's/^ExecStart=\/usr\/lib\/systemd\/systemd-sysctl$/ExecStart=\/usr\/lib\/systemd\/systemd-sysctl --prefix net/' \
+    -i /usr/lib/systemd/system/systemd-sysctl.service
 # initialize pacman keyring
 pacman-key --init
 pacman-key --populate archlinux


### PR DESCRIPTION
The systemd-sysctl service includes condition that `/proc/sys/` has to be read-write.
In lxc only `/proc/sys/net/` is read-write which causes the condition to fail and service not to run.
This patch changes the check to `/proc/sys/net/` and makes the service apply only rules that are in `net` tree.