### PR TITLE
lxc-ls: use /usr/bin/env to find an appropriate python3 to run

### DIFF
--- a/config/apparmor/lxc-generate-aa-rules.py
+++ b/config/apparmor/lxc-generate-aa-rules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/src/lxc/lxc-ls.in
+++ b/src/lxc/lxc-ls.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # lxc-ls: List containers
 #

--- a/src/lxc/lxc-start-ephemeral.in
+++ b/src/lxc/lxc-start-ephemeral.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # lxc-start-ephemeral: Start a copy of a container using an overlay
 #

--- a/src/python-lxc/examples/api_test.py
+++ b/src/python-lxc/examples/api_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # api_test.py: Test/demo of the python3-lxc API
 #

--- a/src/python-lxc/examples/pyconsole-vte.py
+++ b/src/python-lxc/examples/pyconsole-vte.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # pyconsole-vte: Example program showing use of console functions
 #                in the lxc python binding

--- a/src/python-lxc/examples/pyconsole.py
+++ b/src/python-lxc/examples/pyconsole.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # pyconsole: Example program showing use of console functions
 #            in the lxc python binding

--- a/src/python-lxc/setup.py.in
+++ b/src/python-lxc/setup.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # python-lxc: Python bindings for LXC
 #


### PR DESCRIPTION
Previously, lxc-ls would fail on systems without a python3 in /usr/bin:

`-bash: /usr/local/bin/lxc-ls: /usr/bin/python3: bad interpreter: No such file or directory`

Use `env` instead in order to find an appropriate interpreter in $PATH.

Signed-off-by: Fox Wilson <2016fwilson@tjhsst.edu>