### PR TITLE
Improve the lxc-copy Japanese manpage

### DIFF
--- a/doc/ja/lxc-copy.sgml.in
+++ b/doc/ja/lxc-copy.sgml.in
@@ -144,7 +144,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     When <replaceable>-e</replaceable> is specified and no newname is given via
     <replaceable>-N</replaceable> a random name for the snapshot will be chosen.
     -->
-      <replaceable>-e</replaceable> を指定した場合で、<replaceable>-N</replaceable> で newname としてコンテナの名前を指定しない場合は、スナップショットの名前はランダムで命名されます。
+      <replaceable>-e</replaceable> を指定した場合で、<replaceable>-N</replaceable> でコンテナの名前を指定しない場合は、スナップショットの名前はランダムで命名されます。
     </para>
 
     <para>


### PR DESCRIPTION
Signed-off-by: Hiroaki Nakamura <hnakamur@gmail.com>

This PR improves the lxc-copy Japanese manpage created in 842948e4162d89ffce0e8cd292702598d736489a.

This change is agreed by @tenforward at
https://twitter.com/ten_forward/status/672806121011154946