### PR TITLE
Return immediately in save_phys_nics if not run as root

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -856,7 +856,11 @@ out_warn_father:
 static int save_phys_nics(struct lxc_conf *conf)
 {
 	struct lxc_list *iterator;
+	int am_root = (getuid() == 0);
 
+	if (!am_root)
+		return 0;
+		
 	lxc_list_for_each(iterator, &conf->network) {
 		struct lxc_netdev *netdev = iterator->elem;
 


### PR DESCRIPTION
Physical nic is not instantiated in lxc_create_network. 
There will be a error message when shutting down the container, as the "saved" nic was not created.

Signed-off-by: Li Qiu <li.qiu@nomovok.com>