### PR TITLE
lxc-top: print new line after flush terminal

### DIFF
--- a/src/lxc/lxc_top.c
+++ b/src/lxc/lxc_top.c
@@ -114,7 +114,7 @@ Options :\n\
 static void stdin_tios_restore(void)
 {
 	tcsetattr(0, TCSAFLUSH, &oldtios);
-        fprinf(stderr, "\n");
+        fprintf(stderr, "\n");
 }
 
 static int stdin_tios_setup(void)

--- a/src/lxc/lxc_top.c
+++ b/src/lxc/lxc_top.c
@@ -114,7 +114,7 @@ Options :\n\
 static void stdin_tios_restore(void)
 {
 	tcsetattr(0, TCSAFLUSH, &oldtios);
-        fprintf(stderr, "\n");
+	fprintf(stderr, "\n");
 }
 
 static int stdin_tios_setup(void)

--- a/src/lxc/lxc_top.c
+++ b/src/lxc/lxc_top.c
@@ -114,6 +114,7 @@ Options :\n\
 static void stdin_tios_restore(void)
 {
 	tcsetattr(0, TCSAFLUSH, &oldtios);
+        fprinf(stderr, "\n");
 }
 
 static int stdin_tios_setup(void)


### PR DESCRIPTION
I think this is a common feature for top-like programs.

Signed-off-by: feng xiahou xiahoufeng@yahoo.com