### PR TITLE
lxc-checkconfig: remove zgrep dependency

### DIFF
--- a/src/lxc/lxc-checkconfig.in
+++ b/src/lxc/lxc-checkconfig.in
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-# Allow environment variables to override grep and config
+# Allow environment variables to override config
 : ${CONFIG:=/proc/config.gz}
-: ${GREP:=zgrep}
 : ${MODNAME:=configs}
+
+CAT="cat"
 
 SETCOLOR_SUCCESS="printf \\033[1;32m"
 SETCOLOR_FAILURE="printf \\033[1;31m"
@@ -11,7 +12,7 @@ SETCOLOR_WARNING="printf \\033[1;33m"
 SETCOLOR_NORMAL="printf \\033[0;39m"
 
 is_set() {
-    $GREP "$1=[y|m]" $CONFIG > /dev/null
+    $CAT $CONFIG | grep "$1=[y|m]" > /dev/null
     return $?
 }
 
@@ -45,7 +46,6 @@ if [ ! -f $CONFIG ]; then
         # although scripts/extract-ikconfig could be used to extract contents without loading kernel module
         # http://svn.pld-linux.org/trac/svn/browser/geninitrd/trunk/geninitrd?rev=12696#L327
     fi
-    GREP=grep
     if [ ! -f $CONFIG ]; then
         echo "$(basename $0): unable to retrieve kernel configuration" >&2
         echo >&2
@@ -59,6 +59,10 @@ if [ ! -f $CONFIG ]; then
     else
         echo "Kernel configuration found at $CONFIG"
     fi
+fi
+
+if gunzip -tq < $CONFIG 2>/dev/null; then
+    CAT="zcat"
 fi
 
 echo "--- Namespaces ---"
@@ -78,13 +82,13 @@ print_cgroups() {
 }
 
 CGROUP_MNT_PATH=`print_cgroups cgroup /proc/self/mounts | head -n 1`
-KVER_MAJOR=$($GREP '^# Linux.*Kernel Configuration' $CONFIG | \
+KVER_MAJOR=$($CAT $CONFIG | grep '^# Linux.*Kernel Configuration' | \
     sed -r 's/.* ([0-9])\.[0-9]{1,2}\.[0-9]{1,3}.*/\1/')
 if [ "$KVER_MAJOR" = "2" ]; then
-KVER_MINOR=$($GREP '^# Linux.*Kernel Configuration' $CONFIG | \
+KVER_MINOR=$($CAT $CONFIG | grep '^# Linux.*Kernel Configuration' | \
     sed -r 's/.* 2.6.([0-9]{2}).*/\1/')
 else
-KVER_MINOR=$($GREP '^# Linux.*Kernel Configuration' $CONFIG | \
+KVER_MINOR=$($CAT $CONFIG | grep '^# Linux.*Kernel Configuration' | \
     sed -r 's/.* [0-9]\.([0-9]{1,3})\.[0-9]{1,3}.*/\1/')
 fi
 


### PR DESCRIPTION
zgrep is a script provided by the 'gzip' package, which may not be
installed on embedded systems etc which use busybox instead of the
standard full-featured utilities.

Signed-off-by: Andre McCurdy <armccurdy@gmail.com>