### PR TITLE
debootstrap now uses --variant=minbase

### DIFF
--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -331,7 +331,7 @@ download_ubuntu()
     arch=$2
     release=$3
 
-    packages_template=${packages_template:-"ssh,vim"}
+    packages_template=${packages_template:-"ssh,vim,sudo,isc-dhcp-client"}
 
     # Try to guess a list of langpacks to install
     langpacks="language-pack-en"
@@ -358,9 +358,9 @@ download_ubuntu()
     # download a mini ubuntu into a cache
     echo "Downloading ubuntu $release minimal ..."
     if [ -n "$(which qemu-debootstrap)" ]; then
-        qemu-debootstrap --verbose --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch $MIRROR
+        qemu-debootstrap --verbose --variant=minbase --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch $MIRROR
     else
-        debootstrap --verbose --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch $MIRROR
+        debootstrap --verbose --variant=minbase --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch $MIRROR
     fi
 
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
Added --variant=minbase to the debootstrap command which results in fewer packages being installed by default: 141 now vs the 287 before.

Added sudo and isc-dhcp-client packages so that the container starts correctly and networking works out of the box.

Signed-off-by: Vaidas Kascėnas <vaidas@kascenas.lt>