### PR TITLE
python-lxc: Call PyOS_AfterFork after attaching to a container

### DIFF
--- a/src/python-lxc/lxc.c
+++ b/src/python-lxc/lxc.c
@@ -117,6 +117,12 @@ struct lxc_attach_python_payload {
 
 static int lxc_attach_python_exec(void* _payload)
 {
+    /* This function is the first one to be called after attaching to a
+     * container. As lxc_attach() calls fork() PyOS_AfterFork should be called
+     * in the new process if the Python interpreter will continue to be used.
+     */
+    PyOS_AfterFork();
+
     struct lxc_attach_python_payload *payload =
         (struct lxc_attach_python_payload *)_payload;
     PyObject *result = PyObject_CallFunctionObjArgs(payload->fn,


### PR DESCRIPTION
As `lxc_attach()` calls `fork()` `PyOS_AfterFork` should be called in the new process if the Python interpreter will continue to be used.

This fixes the issue we had with multithreaded Python program that attaches to a container with `lxc.attach_run_command` and hangs infinitely.

`Container_attach_and_possibly_wait()` calls `self->container->attach()`:
https://github.com/lxc/lxc/blob/master/src/python-lxc/lxc.c#L637

The latter is implemented via `lxc_attach()` that calls `fork()`:
https://github.com/lxc/lxc/blob/master/src/lxc/attach.c#L814

`PyOS_AfterFork` should be called in the new process if the Python interpreter will continue to be used:
https://docs.python.org/3/c-api/sys.html?highlight=fork#c.PyOS_AfterFork

In the multithreaded Python program the thread that does not own the GIL just before `fork()` may ask to drop the GIL with `SET_GIL_DROP_REQUEST` that sets `gil_drop_request` atomic variable:
https://github.com/python/cpython/blob/1fe0fd9feb6a4472a9a1b186502eb9c0b2366326/Python/ceval_gil.h#L200

After forking `gil_drop_request` will be set, but only the main thread (that called `fork()`) will exist. When this thread will drop the GIL it will wait on condition variable infinitely as there're no threads to signal on successful switching:
https://github.com/python/cpython/blob/1fe0fd9feb6a4472a9a1b186502eb9c0b2366326/Python/ceval_gil.h#L200