### PR TITLE
fix buffer overflow in ifaddrs.c

### DIFF
--- a/src/include/ifaddrs.c
+++ b/src/include/ifaddrs.c
@@ -473,7 +473,9 @@ static void interpretAddr(struct nlmsghdr *p_hdr, struct ifaddrs **p_links, stru
         {
             l_mask[i] = 0xff;
         }
-        l_mask[i] = 0xff << (8 - (l_prefix % 8));
+        if (l_prefix % 8) {
+            l_mask[i] = 0xff << (8 - (l_prefix % 8));
+        }
 
         makeSockaddr(l_entry->ifa_addr->sa_family, (struct sockaddr *)l_addr, l_mask, l_maxPrefix / 8);
         l_entry->ifa_netmask = (struct sockaddr *)l_addr;


### PR DESCRIPTION
We encounter this issue when using lxc in android with bionic. This is the fix.

jenkins: ok to test

Signed-off-by: Tw <tw19881113@gmail.com>
