### PR TITLE
Reimplement lxc-ls in C

### DIFF
--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -215,6 +215,7 @@ bin_PROGRAMS = \
 	lxc-execute \
 	lxc-freeze \
 	lxc-info \
+	lxc-ls \
 	lxc-monitor \
 	lxc-snapshot \
 	lxc-start \
@@ -250,6 +251,7 @@ init_lxc_SOURCES = lxc_init.c
 lxc_monitor_SOURCES = lxc_monitor.c
 lxc_monitord_SOURCES = lxc_monitord.c
 lxc_clone_SOURCES = lxc_clone.c
+lxc_ls_SOURCES = lxc_ls.c
 lxc_copy_SOURCES = lxc_copy.c
 lxc_start_SOURCES = lxc_start.c
 lxc_stop_SOURCES = lxc_stop.c

--- a/src/lxc/arguments.h
+++ b/src/lxc/arguments.h
@@ -21,11 +21,14 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
 #ifndef __LXC_ARGUMENTS_H
 #define __LXC_ARGUMENTS_H
 
 #include <getopt.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 struct lxc_arguments;
 
@@ -116,6 +119,18 @@ struct lxc_arguments {
 	int keepdata;
 	int keepname;
 	int keepmac;
+
+	/* lxc-ls */
+	char *ls_fancy_format;
+	char *ls_groups;
+	char *ls_regex;
+	bool ls_active;
+	bool ls_fancy;
+	bool ls_frozen;
+	bool ls_line;
+	bool ls_nesting;
+	bool ls_running;
+	bool ls_stopped;
 
 	/* remaining arguments */
 	char *const *argv;


### PR DESCRIPTION
This is a reimplementation of `lxc-ls` in C. It supports all features previously supported by `lxc-ls` except `--nesting` (for now). I need to put more thought into the nesting part in since we fork when calling  `lxc_attach()`. A recursive implementation seems to be the most intuitive one. Thoughts on that appreciated.

All flags and parameters have the same name as before except when the user specifies a regex to filter container names by. In the Python implementation the regex was passed without a parameter flag. The new C-implementation has the parameter flag `-r/--regex` for this.