### PR TITLE
bash completion: the 'have' command was deprecated in favor of '_have'

### DIFF
--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -1,4 +1,4 @@
-have lxc-start && {
+_have lxc-start && {
     _lxc_names() {
         COMPREPLY=( $( compgen -W "$( lxc-ls )" "$cur" ) )
     }


### PR DESCRIPTION
`bash-completion` version 2.1 and later no longer include the `have` command, and consequently the `lxc` competion file fails on such systems. The command is now called `_have`.