### PR TITLE
2016 01 04/cgroup.use

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -1593,6 +1593,22 @@ mknod errno 0
           </listitem>
         </varlistentry>
       </variablelist>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <option>LXC_CGNS_AWARE</option>
+          </term>
+          <listitem>
+            <para>
+	      If unset, then this version of lxc is not aware of cgroup
+	      namespaces.  If set, it will be set to 1, and lxc is aware
+	      of cgroup namespaces.  Note this does not guarantee that
+	      cgroup namespaces are enabled in the kernel.  This is used
+	      by the lxcfs mount hook.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
     </refsect2>
     <refsect2>
     <title>Logging</title>

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -957,6 +957,13 @@ int lxc_attach(const char* name, const char* lxcpath, lxc_attach_exec_t exec_fun
 		WARN("could not change directory to '%s'", new_cwd);
 	free(cwd);
 
+	if (options->attach_flags & LXC_ATTACH_MOVE_TO_CGROUP && cgns_supported()) {
+		if (unshare(CLONE_NEWCGROUP) != 0) {
+			SYSERROR("cgroupns unshare: permission denied");
+			rexit(-1);
+		}
+	}
+
 	/* now create the real child process */
 	{
 		struct attach_clone_payload payload = {

--- a/src/lxc/namespace.h
+++ b/src/lxc/namespace.h
@@ -34,6 +34,9 @@
 #ifndef CLONE_NEWNS
 #  define CLONE_NEWNS             0x00020000
 #endif
+#ifndef CLONE_NEWCGROUP
+#  define CLONE_NEWCGROUP         0x02000000
+#endif
 #ifndef CLONE_NEWUTS
 #  define CLONE_NEWUTS            0x04000000
 #endif

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -842,6 +842,11 @@ static int do_start(void *data)
 	if (handler->backgrounded && null_stdfds() < 0)
 		goto out_warn_father;
 
+	if (cgns_supported() && unshare(CLONE_NEWCGROUP) != 0) {
+		SYSERROR("Failed to unshare cgroup namespace");
+		goto out_warn_father;
+	}
+
 	/* after this call, we are in error because this
 	 * ops should not return as it execs */
 	handler->ops->start(handler, handler->data);

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -451,6 +451,9 @@ struct lxc_handler *lxc_init(const char *name, struct lxc_conf *conf, const char
 	if (conf->console.log_path && setenv("LXC_CONSOLE_LOGPATH", conf->console.log_path, 1)) {
 		SYSERROR("failed to set environment variable for console log");
 	}
+	if (setenv("LXC_CGNS_AWARE", "1", 1)) {
+		SYSERROR("failed to set LXC_CGNS_AWARE environment variable");
+	}
 	/* End of environment variable setup for hooks */
 
 	if (run_lxc_hooks(name, "pre-start", conf, handler->lxcpath, NULL)) {

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1185,6 +1185,11 @@ bool file_exists(const char *f)
 	return stat(f, &statbuf) == 0;
 }
 
+bool cgns_supported(void)
+{
+	return file_exists("/proc/self/ns/cgroup");
+}
+
 /* historically lxc-init has been under /usr/lib/lxc and under
  * /usr/lib/$ARCH/lxc.  It now lives as $prefix/sbin/init.lxc.
  */

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -273,6 +273,7 @@ int detect_shared_rootfs(void);
 int detect_ramfs_rootfs(void);
 char *on_path(char *cmd, const char *rootfs);
 bool file_exists(const char *f);
+bool cgns_supported(void);
 char *choose_init(const char *rootfs);
 int print_to_file(const char *file, const char *content);
 bool switch_to_ns(pid_t pid, const char *ns);


### PR DESCRIPTION
This set incorporates a few cgroup related changes.

1. Be more lenient in starting a container when not all cgroup
   controllers are writeable.  If a controller is not writeable,
   don't fail unless it is (a) a 'crucial' cgroup (freezer, or
   name=systemd) or (b) is listed in lxc.cgroup.use.

2. Support cgroup namespaces 
