### PR TITLE
Add openSUSE Leap release in opensuse template

### DIFF
--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -202,7 +202,11 @@ EOF
 
     CLEAN_BUILD=1 BUILD_ARCH="$arch" BUILD_ROOT="$cache/partial-$arch" BUILD_DIST="$cache/partial-$arch-packages/opensuse.conf" PATH="$PATH:/usr/lib/build" /usr/lib/build/init_buildsystem  --clean --configdir /usr/lib/build/configs --cachedir $cache/partial-$arch-cache --repository $cache/partial-$arch-packages/var/cache/zypp/packages/repo-oss/suse/$arch --repository $cache/partial-$arch-packages/var/cache/zypp/packages/repo-oss/suse/noarch --repository $cache/partial-$arch-packages/var/cache/zypp/packages/update/$arch --repository $cache/partial-$arch-packages/var/cache/zypp/packages/update/noarch || return 1
     chroot $cache/partial-$arch /usr/bin/zypper --quiet --non-interactive ar http://download.opensuse.org/distribution/$DISTRO/repo/oss repo-oss || return 1
-    chroot $cache/partial-$arch /usr/bin/zypper --quiet --non-interactive ar http://download.opensuse.org/update/$DISTRO/ update || return 1
+    if [ $DISTRO == "leap/42.1" ]; then
+        chroot $cache/partial-$arch /usr/bin/zypper --quiet --non-interactive ar http://download.opensuse.org/update/$DISTRO/oss update || return 1
+    else
+        chroot $cache/partial-$arch /usr/bin/zypper --quiet --non-interactive ar http://download.opensuse.org/update/$DISTRO/ update || return 1
+    fi
 #   really clean the image
     rm -fr $cache/partial-$arch/{.build,.guessed_dist,.srcfiles*,installed-pkg}
     rm -fr $cache/partial-$arch/dev

--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -136,8 +136,13 @@ download_opensuse()
     echo "Downloading opensuse minimal ..."
     mkdir -p "$cache/partial-$arch-packages"
     zypper --quiet --root $cache/partial-$arch-packages --non-interactive ar http://download.opensuse.org/distribution/$DISTRO/repo/oss/ repo-oss || return 1
-    zypper --quiet --root $cache/partial-$arch-packages --non-interactive ar http://download.opensuse.org/update/$DISTRO/ update || return 1
-    zypper --quiet --root $cache/partial-$arch-packages --non-interactive --gpg-auto-import-keys update || return 1
+    # Leap update repos were rearranged
+    if [ $DISTRO == "leap/42.1" ]; then
+        zypper --quiet --root $cache/partial-$arch-packages --non-interactive ar http://download.opensuse.org/update/$DISTRO/oss/ update || return 1
+    else
+        zypper --quiet --root $cache/partial-$arch-packages --non-interactive ar http://download.opensuse.org/update/$DISTRO/ update || return 1
+    fi
+	zypper --quiet --root $cache/partial-$arch-packages --non-interactive --gpg-auto-import-keys update || return 1
     zypper --root $cache/partial-$arch-packages --non-interactive in --auto-agree-with-licenses --download-only zypper lxc patterns-openSUSE-base bash iputils sed tar rsyslog || return 1
     cat > $cache/partial-$arch-packages/opensuse.conf << EOF
 Preinstall: aaa_base bash coreutils diffutils
@@ -157,7 +162,7 @@ Support: ncurses-utils
 Support: iputils
 Support: udev
 Support: netcfg
-Support: dhcpcd hwinfo insserv-compat module-init-tools openSUSE-release openssh
+Support: hwinfo insserv-compat module-init-tools openSUSE-release openssh
 Support: pwdutils rpcbind sysconfig
 
 Ignore: rpm:suse-build-key,build-key
@@ -167,6 +172,12 @@ EOF
     if [ $DISTRO = "13.2" ]
     then
 	echo "Support: python3-base" >> $cache/partial-$arch-packages/opensuse.conf
+    fi
+
+    # dhcpcd is not in the default repos with Leap 42.1
+    if [ $DISTRO != "leap/42.1"]
+    then
+    echo "Support: dhcpcd" >> $cache/partial-$arch-packages/opensuse.conf
     fi
 
     if [ "$arch" = "i686" ]; then
@@ -442,6 +453,11 @@ else
 
 	13.2)
 	    echo "Selected openSUSE 13.2"
+	    ;;
+
+	42.1|leap/42.1|leap)
+	    echo "Selected openSUSE Leap 42.1"
+	    DISTRO="leap/42.1"
 	    ;;
 
 	*)

--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -175,7 +175,7 @@ EOF
     fi
 
     # dhcpcd is not in the default repos with Leap 42.1
-    if [ $DISTRO != "leap/42.1"]
+    if [ $DISTRO != "leap/42.1" ]
     then
     echo "Support: dhcpcd" >> $cache/partial-$arch-packages/opensuse.conf
     fi

--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -180,6 +180,12 @@ EOF
     echo "Support: dhcpcd" >> $cache/partial-$arch-packages/opensuse.conf
     fi
 
+    # Leap doesn't seem to have iproute2 utils installed
+    if [ $DISTRO == "leap/42.1" ]
+    then
+    echo "Support: net-tools iproute2" >> $cache/partial-$arch-packages/opensuse.conf
+    fi
+
     if [ "$arch" = "i686" ]; then
         mkdir -p $cache/partial-$arch-packages/var/cache/zypp/packages/repo-oss/suse/i686/
         for i in "$cache/partial-$arch-packages/var/cache/zypp/packages/repo-oss/suse/i586/*" ; do


### PR DESCRIPTION
Adding release Leap 42.1. Repo locations were moved one level deeper with it, explaining why $DISTRO is made to "leap/42.1". I couldn't think of a cleaner way to do it.