### PR TITLE
preserve inherited fds for stop hook

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1068,7 +1068,7 @@ static int lxc_spawn(struct lxc_handler *handler)
 		goto out_delete_net;
 	}
 
-	if (!preserve_ns(handler->nsfd, handler->clone_flags, handler->pid, &errmsg)) {
+	if (!preserve_ns(handler->nsfd, handler->clone_flags | preserve_mask, handler->pid, &errmsg)) {
 		INFO("Failed to store namespace references for stop hook: %s",
 			errmsg ? errmsg : "(Out of memory)");
 		free(errmsg);


### PR DESCRIPTION
When preserving fds for the stop hook, make sure to also save
any fds we've inherited.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>