### PR TITLE
Ignore any container named '.git'

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4188,9 +4188,9 @@ int list_defined_containers(const char *lxcpath, char ***names, struct lxc_conta
 	while (!readdir_r(dir, &dirent, &direntp)) {
 		if (!direntp)
 			break;
-		if (!strcmp(direntp->d_name, "."))
-			continue;
-		if (!strcmp(direntp->d_name, ".."))
+
+		// Ignore '.', '..' and any hidden directory
+		if (!strncmp(direntp->d_name, ".", 1))
 			continue;
 
 		if (!config_file_exists(lxcpath, direntp->d_name))


### PR DESCRIPTION
  * Suppose that you create a git repository under lxc.lxcpath (it
    can be useful to keep track of the configurations of your containers)

    Then, when you run lxc-ls you will get the following output:

        # lxc-ls
        .git      container1      container2    ....

    This is because there is a 'config' file inside the '.git' directory.
    It is where git stores the configuration of the repository.

    And the test lxc-ls does to check if a directory contains a container
    is just to check if the 'directory/config' file exists.

  * Given that the odds of someone naming a container '.git' is almost zero,
    ignore any directory/container with such name.