### PR TITLE
.gitignore: add missing templates/sparclinux to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ templates/lxc-opensuse
 templates/lxc-oracle
 templates/lxc-plamo
 templates/lxc-slackware
+templates/lxc-sparclinux
 templates/lxc-sshd
 templates/lxc-ubuntu
 templates/lxc-ubuntu-cloud


### PR DESCRIPTION
Just noticed it after build was done.