### PR TITLE
Refactor templates section of .gitignore - no need to specify individual templates anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,25 +26,9 @@ libtool
 lxc.spec
 lxc.pc
 
-templates/lxc-alpine
-templates/lxc-altlinux
-templates/lxc-archlinux
-templates/lxc-busybox
-templates/lxc-centos
-templates/lxc-cirros
-templates/lxc-debian
-templates/lxc-download
-templates/lxc-fedora
-templates/lxc-gentoo
-templates/lxc-openmandriva
-templates/lxc-opensuse
-templates/lxc-oracle
-templates/lxc-plamo
-templates/lxc-slackware
-templates/lxc-sparclinux
-templates/lxc-sshd
-templates/lxc-ubuntu
-templates/lxc-ubuntu-cloud
+templates/*
+!templates/*.in
+templates/Makefile.in
 
 src/lxc/init.lxc
 src/lxc/init.lxc.static

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ templates/lxc-opensuse
 templates/lxc-oracle
 templates/lxc-plamo
 templates/lxc-slackware
+templates/lxc-sparclinux
 templates/lxc-sshd
 templates/lxc-ubuntu
 templates/lxc-ubuntu-cloud


### PR DESCRIPTION
Seems like a nice simplification.

Please evaluate and merge PR #770 first.

b.
