### PR TITLE
cgroup ns: move the check for whether cgns is supported

### DIFF
--- a/config/apparmor/abstractions/container-base.in
+++ b/config/apparmor/abstractions/container-base.in
@@ -86,4 +86,5 @@
   deny /sys/firmware/efi/efivars/** rwklx,
   deny /sys/kernel/security/** rwklx,
   mount options=(move) /sys/fs/cgroup/cgmanager/ -> /sys/fs/cgroup/cgmanager.lower/,
+  mount fstype=cgroup -> /sys/fs/cgroup/**,
 

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -720,6 +720,7 @@ int lxc_attach(const char* name, const char* lxcpath, lxc_attach_exec_t exec_fun
 	int ipc_sockets[2];
 	int procfd;
 	signed long personality;
+	bool unshare_cgns = false;
 
 	if (!options)
 		options = &attach_static_default_options;
@@ -930,6 +931,9 @@ int lxc_attach(const char* name, const char* lxcpath, lxc_attach_exec_t exec_fun
 		rexit(-1);
 	}
 
+	if (options->attach_flags & LXC_ATTACH_MOVE_TO_CGROUP && cgns_supported())
+		unshare_cgns = true;
+
 	procfd = open("/proc", O_DIRECTORY | O_RDONLY);
 	if (procfd < 0) {
 		SYSERROR("Unable to open /proc");
@@ -957,11 +961,12 @@ int lxc_attach(const char* name, const char* lxcpath, lxc_attach_exec_t exec_fun
 		WARN("could not change directory to '%s'", new_cwd);
 	free(cwd);
 
-	if (options->attach_flags & LXC_ATTACH_MOVE_TO_CGROUP && cgns_supported()) {
+	if (unshare_cgns) {
 		if (unshare(CLONE_NEWCGROUP) != 0) {
 			SYSERROR("cgroupns unshare: permission denied");
 			rexit(-1);
 		}
+		INFO("Unshared cgroup namespace");
 	}
 
 	/* now create the real child process */


### PR DESCRIPTION
We have to do it before we join the container's mntns so we have
the host's procdir.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>