### PR TITLE
Use ${utsname} instead of ${UTSNAME} because latter variable is not defined

### DIFF
--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -249,7 +249,7 @@ configure_centos()
 DEVICE=eth0
 BOOTPROTO=dhcp
 ONBOOT=yes
-HOSTNAME=${UTSNAME}
+HOSTNAME=${utsname}
 NM_CONTROLLED=no
 TYPE=Ethernet
 MTU=${MTU}
@@ -259,7 +259,7 @@ EOF
     # set the hostname
     cat <<EOF > ${rootfs_path}/etc/sysconfig/network
 NETWORKING=yes
-HOSTNAME=${UTSNAME}
+HOSTNAME=${utsname}
 EOF
 
     # set minimal hosts


### PR DESCRIPTION
I found this when I created a CentOS5.5 container in Ubuntu. The container requested dhcp address with incorrect hostname because `HOSTNAME` was empty in `/etc/sysconfig/network` .
