### PR TITLE
apparmor: allow binding /run/{,lock/} -> /var/run/{,lock/}

### DIFF
--- a/config/apparmor/abstractions/container-base.in
+++ b/config/apparmor/abstractions/container-base.in
@@ -62,6 +62,10 @@
   # allow bind mount of /lib/init/fstab for lxcguest
   mount options=(rw, bind) /lib/init/fstab.lxc/ -> /lib/init/fstab/,
 
+  # allow bind mounts of /run/{,lock} to /var/run/{,lock}
+  mount options=(rw, bind) /run/ -> /var/run/,
+  mount options=(rw, bind) /run/lock/ -> /var/lock/,
+
   # deny writes in /proc/sys/fs but allow binfmt_misc to be mounted
   mount fstype=binfmt_misc -> /proc/sys/fs/binfmt_misc/,
   deny @{PROC}/sys/fs/** wklx,


### PR DESCRIPTION
Some systems need to be able to bind-mount /run to /var/run
and /run/lock to /var/run/lock. (Tested with opensuse 13.1
containers migrated from openvz.)

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>