### PR TITLE
Fix NULL-ptr derefs for container without rootfs

### DIFF
--- a/src/lxc/bdev/lxcoverlay.c
+++ b/src/lxc/bdev/lxcoverlay.c
@@ -489,7 +489,7 @@ int ovl_mkdir(const struct mntent *mntent, const struct lxc_rootfs *rootfs,
 	size_t len = 0;
 	size_t rootfslen = 0;
 
-	if (!rootfs->path || !lxc_name || !lxc_path)
+	if (!rootfs || !rootfs->path || !lxc_name || !lxc_path)
 		goto err;
 
 	opts = lxc_string_split(mntent->mnt_opts, ',');


### PR DESCRIPTION
Since we allow containers to be created without a rootfs most checks in conf.c
are not sane anymore. Instead of just checking if rootfs->path != NULL we need
to check whether rootfs != NULL.

Minor fixes:
- Have mount_autodev() always return -1 on failure: mount_autodev() returns 0
  on success and -1 on failure. But when the return value of safe_mount() was
  checked in mount_autodev() we returned false (instead of -1) which caused
  mount_autodev() to return 0 (success) instead of the correct -1 (failure).

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>

closes #782