### PR TITLE
Comment the lxc_rootfs structure

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -997,7 +997,7 @@ static int setup_tty(struct lxc_conf *conf)
 }
 
 
-static int setup_rootfs_pivot_root(const char *rootfs, const char *pivotdir)
+static int setup_rootfs_pivot_root(const char *rootfs)
 {
 	int oldroot = -1, newroot = -1;
 
@@ -1319,7 +1319,7 @@ static int setup_pivot_root(const struct lxc_rootfs *rootfs)
 	if (detect_ramfs_rootfs()) {
 		if (prepare_ramfs_root(rootfs->mount))
 			return -1;
-	} else if (setup_rootfs_pivot_root(rootfs->mount, rootfs->pivot)) {
+	} else if (setup_rootfs_pivot_root(rootfs->mount)) {
 		ERROR("failed to setup pivot root");
 		return -1;
 	}
@@ -4139,7 +4139,6 @@ void lxc_conf_free(struct lxc_conf *conf)
 	free(conf->rootfs.mount);
 	free(conf->rootfs.options);
 	free(conf->rootfs.path);
-	free(conf->rootfs.pivot);
 	free(conf->logfile);
 	if (conf->logfd != -1)
 		close(conf->logfd);

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -217,13 +217,13 @@ struct lxc_console {
 /*
  * Defines a structure to store the rootfs location, the
  * optionals pivot_root, rootfs mount paths
- * @rootfs     : a path to the rootfs
- * @pivot_root : a path to a pivot_root location to be used
+ * @path       : the rootfs source (directory or device)
+ * @mount      : where it is mounted
+ * @options    : mount options
  */
 struct lxc_rootfs {
 	char *path;
 	char *mount;
-	char *pivot;
 	char *options;
 };
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1857,7 +1857,7 @@ static int config_pivotdir(const char *key, const char *value,
 			   struct lxc_conf *lxc_conf)
 {
 	WARN("lxc.pivotdir is ignored.  It will soon become an error.");
-	return config_path_item(&lxc_conf->rootfs.pivot, value);
+	return 0;
 }
 
 static int config_utsname(const char *key, const char *value,
@@ -2478,8 +2478,6 @@ int lxc_get_config_item(struct lxc_conf *c, const char *key, char *retv,
 		v = c->rootfs.options;
 	else if (strcmp(key, "lxc.rootfs") == 0)
 		v = c->rootfs.path;
-	else if (strcmp(key, "lxc.pivotdir") == 0)
-		v = c->rootfs.pivot;
 	else if (strcmp(key, "lxc.cap.drop") == 0)
 		return lxc_get_item_cap_drop(c, retv, inlen);
 	else if (strcmp(key, "lxc.cap.keep") == 0)


### PR DESCRIPTION
Comment rootfs.path and rootfs.mount so people can better figure
out which to use.

Remove the unused pivotdir argument from setup_rootfs_pivot_root().
Remove the unused pivot member of the lxc_rootfs struct.  And just
return 0 (success) when someone passes a lxc.pivotdir entry.  One
day we'll turn that into an error, but not yet...

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>