### PR TITLE
allow overlay lxc.mount.entry with no rootfs

### DIFF
--- a/src/lxc/bdev/lxcaufs.h
+++ b/src/lxc/bdev/lxcaufs.h
@@ -42,6 +42,9 @@ struct bdev_specs;
 /* defined conf.h */
 struct lxc_conf;
 
+/* defined in conf.h */
+struct lxc_rootfs;
+
 /*
  * Functions associated with an aufs bdev struct.
  */

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1145,7 +1145,7 @@ static int fill_autodev(const struct lxc_rootfs *rootfs)
 		return -1;
 	}
 
-	if (!dir_exists(path))  // ignore, just don't try to fill in
+	if (!dir_exists(path)) // ignore, just don't try to fill in
 		return 0;
 
 	INFO("Populating container /dev");


### PR DESCRIPTION
Allow lxc.mount.entry entries for containers without a rootfs.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>