### PR TITLE
lxc-checkconfig: warn about fuse as well

### DIFF
--- a/src/lxc/lxc-checkconfig.in
+++ b/src/lxc/lxc-checkconfig.in
@@ -122,6 +122,7 @@ echo -n "CONFIG_NF_NAT_IPV6: " && is_enabled CONFIG_NF_NAT_IPV6
 echo -n "CONFIG_IP_NF_TARGET_MASQUERADE: " && is_enabled CONFIG_IP_NF_TARGET_MASQUERADE
 echo -n "CONFIG_IP6_NF_TARGET_MASQUERADE: " && is_enabled CONFIG_IP6_NF_TARGET_MASQUERADE
 echo -n "CONFIG_NETFILTER_XT_TARGET_CHECKSUM: " && is_enabled CONFIG_NETFILTER_XT_TARGET_CHECKSUM
+echo -n "FUSE (for use with lxcfs): " && is_enabled CONFIG_FUSE_FS
 
 echo
 echo "--- Checkpoint/Restore ---"


### PR DESCRIPTION
Since we need fuse to run lxcfs, which is required by systemd, let's warn
about that as well.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>