### PR TITLE
make lxc-attach use a pty

### DIFF
--- a/src/lxc/cgmanager.c
+++ b/src/lxc/cgmanager.c
@@ -1332,7 +1332,7 @@ out:
 	return bret;
 }
 
-static bool collect_subsytems(void)
+static bool collect_subsystems(void)
 {
 	char *line = NULL;
 	nih_local char **cgm_subsys_list = NULL;
@@ -1444,7 +1444,7 @@ out_free:
 struct cgroup_ops *cgm_ops_init(void)
 {
 	check_supports_multiple_controllers(-1);
-	if (!collect_subsytems())
+	if (!collect_subsystems())
 		return NULL;
 
 	if (api_version < CGM_SUPPORTS_MULT_CONTROLLERS)

--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -641,16 +641,19 @@ static int lxc_console_cb_tty_stdin(int fd, uint32_t events, void *cbdata,
 		return 1;
 	}
 
-	/* we want to exit the console with Ctrl+a q */
-	if (c == ts->escape && !ts->saw_escape) {
-		ts->saw_escape = 1;
-		return 0;
+	if (ts->escape != -1) {
+		/* we want to exit the console with Ctrl+a q */
+		if (c == ts->escape && !ts->saw_escape) {
+			ts->saw_escape = 1;
+			return 0;
+		}
+
+		if (c == 'q' && ts->saw_escape)
+			return 1;
+
+		ts->saw_escape = 0;
 	}
 
-	if (c == 'q' && ts->saw_escape)
-		return 1;
-
-	ts->saw_escape = 0;
 	if (write(ts->masterfd, &c, 1) < 0) {
 		SYSERROR("failed to write");
 		return 1;

--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -598,21 +598,29 @@ err:
 	return -1;
 }
 
-int lxc_console_set_stdfds(struct lxc_handler *handler)
+int lxc_console_set_stdfds(int fd)
 {
-	struct lxc_conf *conf = handler->conf;
-	struct lxc_console *console = &conf->console;
-
-	if (console->slave < 0)
+	if (fd < 0)
 		return 0;
 
-	if (dup2(console->slave, 0) < 0 ||
-	    dup2(console->slave, 1) < 0 ||
-	    dup2(console->slave, 2) < 0)
-	{
-		SYSERROR("failed to dup console");
-		return -1;
-	}
+	if (isatty(STDIN_FILENO))
+		if (dup2(fd, STDIN_FILENO) < 0) {
+			SYSERROR("failed to duplicate stdin.");
+			return -1;
+		}
+
+	if (isatty(STDOUT_FILENO))
+		if (dup2(fd, STDOUT_FILENO) < 0) {
+			SYSERROR("failed to duplicate stdout.");
+			return -1;
+		}
+
+	if (isatty(STDERR_FILENO))
+		if (dup2(fd, STDERR_FILENO) < 0) {
+			SYSERROR("failed to duplicate stderr.");
+			return -1;
+		}
+
 	return 0;
 }
 

--- a/src/lxc/console.h
+++ b/src/lxc/console.h
@@ -24,8 +24,24 @@
 #ifndef __LXC_CONSOLE_H
 #define __LXC_CONSOLE_H
 
+#include "conf.h"
+#include "list.h"
+
 struct lxc_epoll_descr;
 struct lxc_container;
+struct lxc_tty_state
+{
+	struct lxc_list node;
+	int stdinfd;
+	int stdoutfd;
+	int masterfd;
+	int escape;
+	int saw_escape;
+	const char *winch_proxy;
+	const char *winch_proxy_lxcpath;
+	int sigfd;
+	sigset_t oldmask;
+};
 
 extern int  lxc_console_allocate(struct lxc_conf *conf, int sockfd, int *ttynum);
 extern int  lxc_console_create(struct lxc_conf *);
@@ -40,5 +56,15 @@ extern int  lxc_console(struct lxc_container *c, int ttynum,
 extern int  lxc_console_getfd(struct lxc_container *c, int *ttynum,
 			      int *masterfd);
 extern int  lxc_console_set_stdfds(struct lxc_handler *);
+extern int lxc_console_cb_tty_stdin(int fd, uint32_t events, void *cbdata,
+		struct lxc_epoll_descr *descr);
+extern int lxc_console_cb_tty_master(int fd, uint32_t events, void *cbdata,
+		struct lxc_epoll_descr *descr);
+extern int lxc_setup_tios(int fd, struct termios *oldtios);
+extern void lxc_console_winsz(int srcfd, int dstfd);
+extern int lxc_console_cb_sigwinch_fd(int fd, uint32_t events, void *cbdata,
+		struct lxc_epoll_descr *descr);
+extern struct lxc_tty_state *lxc_console_sigwinch_init(int srcfd, int dstfd);
+extern void lxc_console_sigwinch_fini(struct lxc_tty_state *ts);
 
 #endif

--- a/src/lxc/console.h
+++ b/src/lxc/console.h
@@ -55,7 +55,7 @@ extern int  lxc_console(struct lxc_container *c, int ttynum,
 		        int escape);
 extern int  lxc_console_getfd(struct lxc_container *c, int *ttynum,
 			      int *masterfd);
-extern int  lxc_console_set_stdfds(struct lxc_handler *);
+extern int lxc_console_set_stdfds(int fd);
 extern int lxc_console_cb_tty_stdin(int fd, uint32_t events, void *cbdata,
 		struct lxc_epoll_descr *descr);
 extern int lxc_console_cb_tty_master(int fd, uint32_t events, void *cbdata,

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -798,7 +798,7 @@ static int do_start(void *data)
 	 * setup on its console ie. the pty allocated in lxc_console_create()
 	 * so make sure that that pty is stdin,stdout,stderr.
 	 */
-	if (lxc_console_set_stdfds(handler) < 0)
+	if (lxc_console_set_stdfds(handler->conf->console.slave) < 0)
 		goto out_warn_father;
 
 	/* If we mounted a temporary proc, then unmount it now */


### PR DESCRIPTION
~~Work in progress.~~ Have lxc-attach use a pty. As has been discussed the default approach is to create a pty in the container. If that fails we try to create a pty on the host. ~~What needs to be decided among other things is how to handle the case where we have no tty as fd 0.~~