### PR TITLE
cast NULL pointers passed to execl*()

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1252,12 +1252,12 @@ int lxc_attach_run_shell(void* payload)
 		user_shell = passwd->pw_shell;
 
 	if (user_shell)
-		execlp(user_shell, user_shell, NULL);
+		execlp(user_shell, user_shell, (char *)NULL);
 
 	/* executed if either no passwd entry or execvp fails,
 	 * we will fall back on /bin/sh as a default shell
 	 */
-	execlp("/bin/sh", "/bin/sh", NULL);
+	execlp("/bin/sh", "/bin/sh", (char *)NULL);
 	SYSERROR("failed to exec shell");
 	return -1;
 }

--- a/src/lxc/bdev/bdev.c
+++ b/src/lxc/bdev/bdev.c
@@ -721,7 +721,7 @@ int do_mkfs(const char *path, const char *fstype)
 	// us about whether to proceed.
 	if (null_stdfds() < 0)
 		exit(1);
-	execlp("mkfs", "mkfs", "-t", fstype, path, NULL);
+	execlp("mkfs", "mkfs", "-t", fstype, path, (char *)NULL);
 	exit(1);
 }
 

--- a/src/lxc/bdev/lxclvm.c
+++ b/src/lxc/bdev/lxclvm.c
@@ -356,7 +356,7 @@ int lvm_destroy(struct bdev *orig)
 	if ((pid = fork()) < 0)
 		return -1;
 	if (!pid) {
-		execlp("lvremove", "lvremove", "-f", orig->src, NULL);
+		execlp("lvremove", "lvremove", "-f", orig->src, (char *)NULL);
 		exit(EXIT_FAILURE);
 	}
 	return wait_for_pid(pid);

--- a/src/lxc/bdev/lxcnbd.c
+++ b/src/lxc/bdev/lxcnbd.c
@@ -228,7 +228,7 @@ static int do_attach_nbd(void *d)
 	if (sigprocmask(SIG_UNBLOCK, &mask, NULL) == -1)
 		WARN("Warning: unblocking signals for nbd watcher");
 
-	execlp("qemu-nbd", "qemu-nbd", "-c", nbd, path, NULL);
+	execlp("qemu-nbd", "qemu-nbd", "-c", nbd, path, (char *)NULL);
 	SYSERROR("Error executing qemu-nbd");
 	exit(1);
 }
@@ -273,7 +273,7 @@ static void nbd_detach(const char *path)
 			ERROR("nbd disconnect returned an error");
 		return;
 	}
-	execlp("qemu-nbd", "qemu-nbd", "-d", path, NULL);
+	execlp("qemu-nbd", "qemu-nbd", "-d", path, (char *)NULL);
 	SYSERROR("Error executing qemu-nbd");
 	exit(1);
 }

--- a/src/lxc/bdev/lxcrbd.c
+++ b/src/lxc/bdev/lxcrbd.c
@@ -85,7 +85,7 @@ int rbd_create(struct bdev *bdev, const char *dest, const char *n,
 	if ((pid = fork()) < 0)
 		return -1;
 	if (!pid) {
-		execlp("rbd", "rbd", "create" , "--pool", rbdpool, rbdname, "--size", sz, NULL);
+		execlp("rbd", "rbd", "create" , "--pool", rbdpool, rbdname, "--size", sz, (char *)NULL);
 		exit(1);
 	}
 	if (wait_for_pid(pid) < 0)
@@ -94,7 +94,7 @@ int rbd_create(struct bdev *bdev, const char *dest, const char *n,
 	if ((pid = fork()) < 0)
 		return -1;
 	if (!pid) {
-		execlp("rbd", "rbd", "map", "--pool", rbdpool, rbdname, NULL);
+		execlp("rbd", "rbd", "map", "--pool", rbdpool, rbdname, (char *)NULL);
 		exit(1);
 	}
 	if (wait_for_pid(pid) < 0)
@@ -129,7 +129,7 @@ int rbd_destroy(struct bdev *orig)
 		if ((pid = fork()) < 0)
 			return -1;
 		if (!pid) {
-			execlp("rbd", "rbd", "unmap" , orig->src, NULL);
+			execlp("rbd", "rbd", "unmap" , orig->src, (char *)NULL);
 			exit(1);
 		}
 		if (wait_for_pid(pid) < 0)
@@ -141,7 +141,7 @@ int rbd_destroy(struct bdev *orig)
 	if (!pid) {
 		rbdfullname = alloca(strlen(orig->src) - 8);
 		strcpy( rbdfullname, &orig->src[9] );
-		execlp("rbd", "rbd", "rm" , rbdfullname, NULL);
+		execlp("rbd", "rbd", "rm" , rbdfullname, (char *)NULL);
 		exit(1);
 	}
 	return wait_for_pid(pid);

--- a/src/lxc/bdev/lxczfs.c
+++ b/src/lxc/bdev/lxczfs.c
@@ -150,7 +150,7 @@ int zfs_clone(const char *opath, const char *npath, const char *oname,
 			ret = snprintf(dev, MAXPATHLEN, "%s/%s", zfsroot, nname);
 			if (ret < 0  || ret >= MAXPATHLEN)
 				exit(EXIT_FAILURE);
-			execlp("zfs", "zfs", "create", option, dev, NULL);
+			execlp("zfs", "zfs", "create", option, dev, (char *)NULL);
 			exit(EXIT_FAILURE);
 		}
 		return wait_for_pid(pid);
@@ -170,7 +170,7 @@ int zfs_clone(const char *opath, const char *npath, const char *oname,
 		if ((pid = fork()) < 0)
 			return -1;
 		if (!pid) {
-			execlp("zfs", "zfs", "destroy", path1, NULL);
+			execlp("zfs", "zfs", "destroy", path1, (char *)NULL);
 			exit(EXIT_FAILURE);
 		}
 		// it probably doesn't exist so destroy probably will fail.
@@ -180,7 +180,7 @@ int zfs_clone(const char *opath, const char *npath, const char *oname,
 		if ((pid = fork()) < 0)
 			return -1;
 		if (!pid) {
-			execlp("zfs", "zfs", "snapshot", path1, NULL);
+			execlp("zfs", "zfs", "snapshot", path1, (char *)NULL);
 			exit(EXIT_FAILURE);
 		}
 		if (wait_for_pid(pid) < 0)
@@ -190,7 +190,7 @@ int zfs_clone(const char *opath, const char *npath, const char *oname,
 		if ((pid = fork()) < 0)
 			return -1;
 		if (!pid) {
-			execlp("zfs", "zfs", "clone", option, path1, path2, NULL);
+			execlp("zfs", "zfs", "clone", option, path1, path2, (char *)NULL);
 			exit(EXIT_FAILURE);
 		}
 		return wait_for_pid(pid);
@@ -252,7 +252,7 @@ int zfs_destroy(struct bdev *orig)
 		return -1;
 	*p = '\0';
 
-	execlp("zfs", "zfs", "destroy", output, NULL);
+	execlp("zfs", "zfs", "destroy", output, (char *)NULL);
 	exit(EXIT_FAILURE);
 }
 
@@ -291,6 +291,6 @@ int zfs_create(struct bdev *bdev, const char *dest, const char *n,
 	if (ret < 0  || ret >= MAXPATHLEN)
 		exit(EXIT_FAILURE);
 
-	execlp("zfs", "zfs", "create", option, dev, NULL);
+	execlp("zfs", "zfs", "create", option, dev, (char *)NULL);
 	exit(EXIT_FAILURE);
 }

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -162,7 +162,7 @@ static char * is_wlan(const char *ifname)
 	fseek(f, 0, SEEK_SET);
 	physname = malloc(physlen+1);
 	if (!physname) {
-		fclose(f);	
+		fclose(f);
 		goto bad;
 	}
 	memset(physname, 0, physlen+1);
@@ -221,7 +221,7 @@ lxc_netdev_move_wlan(char *physname, const char *ifname, pid_t pid, const char* 
 	if (fpid == 0) {
 		char pidstr[30];
 		sprintf(pidstr, "%d", pid);
-		if (execlp("iw", "iw", "phy", physname, "set", "netns", pidstr, NULL))
+		if (execlp("iw", "iw", "phy", physname, "set", "netns", pidstr, (char *)NULL))
 			exit(1);
 		exit(0); // notreached
 	}
@@ -1056,13 +1056,13 @@ static int ip_addr_add(int family, int ifindex,
 	nlmsg->nlmsghdr->nlmsg_type = RTM_NEWADDR;
 
 	ifa = nlmsg_reserve(nlmsg, sizeof(struct ifaddrmsg));
-	if (!ifa) 
+	if (!ifa)
 		goto out;
 	ifa->ifa_prefixlen = prefix;
 	ifa->ifa_index = ifindex;
 	ifa->ifa_family = family;
 	ifa->ifa_scope = 0;
-	
+
 	err = -EINVAL;
 	if (nla_put_buffer(nlmsg, IFA_LOCAL, addr, addrlen))
 		goto out;
@@ -1339,23 +1339,23 @@ static int ip_route_dest_add(int family, int ifindex, void *dest)
 	struct rtmsg *rt;
 	int addrlen;
 	int err;
-	
+
 	addrlen = family == AF_INET ? sizeof(struct in_addr) :
 		sizeof(struct in6_addr);
-	
+
 	err = netlink_open(&nlh, NETLINK_ROUTE);
 	if (err)
 		return err;
-	
+
 	err = -ENOMEM;
 	nlmsg = nlmsg_alloc(NLMSG_GOOD_SIZE);
 	if (!nlmsg)
 		goto out;
-	
+
 	answer = nlmsg_alloc_reserve(NLMSG_GOOD_SIZE);
 	if (!answer)
 		goto out;
-	
+
 	nlmsg->nlmsghdr->nlmsg_flags =
 		NLM_F_ACK|NLM_F_REQUEST|NLM_F_CREATE|NLM_F_EXCL;
 	nlmsg->nlmsghdr->nlmsg_type = RTM_NEWROUTE;
@@ -1369,7 +1369,7 @@ static int ip_route_dest_add(int family, int ifindex, void *dest)
 	rt->rtm_protocol = RTPROT_BOOT;
 	rt->rtm_type = RTN_UNICAST;
 	rt->rtm_dst_len = addrlen*8;
-	
+
 	err = -EINVAL;
 	if (nla_put_buffer(nlmsg, RTA_DST, dest, addrlen))
 		goto out;
@@ -1414,7 +1414,7 @@ static void ovs_cleanup_nic(const char *lxcpath, const char *name, const char *b
 		return;
 	if (lxc_wait(name, "STOPPED", -1, lxcpath) < 0)
 		return;
-	execlp("ovs-vsctl", "ovs-vsctl", "del-port", bridge, nic, NULL);
+	execlp("ovs-vsctl", "ovs-vsctl", "del-port", bridge, nic, (char *)NULL);
 	exit(1); /* not reached */
 }
 
@@ -1445,7 +1445,7 @@ static int attach_to_ovs_bridge(const char *lxcpath, const char *name, const cha
 		exit(0);
 	}
 
-	if (execlp("ovs-vsctl", "ovs-vsctl", "add-port", bridge, nic, NULL))
+	if (execlp("ovs-vsctl", "ovs-vsctl", "add-port", bridge, nic, (char *)NULL))
 		exit(1);
 	// not reached
 	exit(1);


### PR DESCRIPTION
NULL pointers passed to execl*() functions must be cast to (char *)NULL since
they are variadic functions.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>