### PR TITLE
cgroups: do not fail if setting devices cgroup fails due to EPERM

### DIFF
--- a/src/lxc/cgmanager.c
+++ b/src/lxc/cgmanager.c
@@ -1523,6 +1523,14 @@ static bool cgm_setup_limits(void *hdata, struct lxc_list *cgroup_settings, bool
 					 d->cgroup_path, cg->subsystem, cg->value) != 0) {
 			NihError *nerr;
 			nerr = nih_error_get();
+			if (do_devices) {
+				WARN("call to cgmanager_set_value_sync failed: %s", nerr->message);
+				nih_free(nerr);
+				WARN("Error setting cgroup %s:%s limit type %s", controller,
+					d->cgroup_path, cg->subsystem);
+				continue;
+			}
+
 			ERROR("call to cgmanager_set_value_sync failed: %s", nerr->message);
 			nih_free(nerr);
 			ERROR("Error setting cgroup %s:%s limit type %s", controller,


### PR DESCRIPTION
If we're trying to allow a device which was denied to our parent
container, just continue.

Cgmanager does not help us to distinguish between eperm and other
errors, so just always continue.

We may want to consider actually computing the range of devices
to which the container monitor has access, but OTOH that introduces
a whole new set of complexity to compute access sets.

Closes #827

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>