### PR TITLE
Fix typo in lxc manpage

### DIFF
--- a/doc/ja/lxc.sgml.in
+++ b/doc/ja/lxc.sgml.in
@@ -690,7 +690,7 @@ rootfs
       <para>
         <!--
 	Here is an example on how the combination of these commands
-	allow to list all the containers and retrieve their state.
+	allows one to list all the containers and retrieve their state.
 	<programlisting>
 	  for i in $(lxc-ls -1); do
 	    lxc-info -n $i

--- a/doc/ko/lxc.sgml.in
+++ b/doc/ko/lxc.sgml.in
@@ -675,7 +675,7 @@ rootfs
       <para>
         <!--
 	Here is an example on how the combination of these commands
-	allow to list all the containers and retrieve their state.
+	allows one to list all the containers and retrieve their state.
 	<programlisting>
 	  for i in $(lxc-ls -1); do
 	    lxc-info -n $i

--- a/doc/lxc.sgml.in
+++ b/doc/lxc.sgml.in
@@ -458,7 +458,7 @@ rootfs
 
       <para>
 	Here is an example on how the combination of these commands
-	allow to list all the containers and retrieve their state.
+	allows one to list all the containers and retrieve their state.
 	<programlisting>
 	  for i in $(lxc-ls -1); do
 	    lxc-info -n $i


### PR DESCRIPTION
Reported-by: lintian
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>