### PR TITLE
fix android build

### DIFF
--- a/src/lxc/lxc_attach.c
+++ b/src/lxc/lxc_attach.c
@@ -228,9 +228,9 @@ static pid_t fork_pty(int *masterfd)
 		close(master);
 		setsid();
 		if (ioctl(slave, TIOCSCTTY, NULL) < 0)
-			_Exit(-1); /* automatically closes fds */
+			_exit(-1); /* automatically closes fds */
 		if (lxc_console_set_stdfds(slave) < 0)
-			_Exit(-1); /* automatically closes fds */
+			_exit(-1); /* automatically closes fds */
 		return 0;
 	} else {
 		*masterfd = master;


### PR DESCRIPTION
bionic libc doesn't know _Exit(). Replace it with _exit().

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>