### PR TITLE
cgfs: do not automount if cgroup namespaces are supported

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -912,7 +912,7 @@ proc proc proc nodev,noexec,nosuid 0 0
                   the container's own cgroup into that directory.
                   The container will be able to write to its own
                   cgroup directory, but not the parents, since they
-                  will be remounted read-only
+                  will be remounted read-only.
                 </para>
               </listitem>
               <listitem>
@@ -986,6 +986,12 @@ proc proc proc nodev,noexec,nosuid 0 0
                 </para>
               </listitem>
             </itemizedlist>
+            <para>
+	      If cgroup namespaces are enabled, then any <option>cgroup</option>
+	      auto-mounting request will be ignored, since the container can
+	      mount the filesystems itself, and automounting can confuse the
+	      container init.
+            </para>
             <para>
               Note that if automatic mounting of the cgroup filesystem
               is enabled, the tmpfs under

--- a/src/lxc/cgfs.c
+++ b/src/lxc/cgfs.c
@@ -1356,6 +1356,9 @@ static bool cgroupfs_mount_cgroup(void *hdata, const char *root, int type)
 	struct cgroup_process_info *info, *base_info;
 	int r, saved_errno = 0;
 
+	if (cgns_supported())
+		return true;
+
 	cgfs_d = hdata;
 	if (!cgfs_d)
 		return false;


### PR DESCRIPTION
In that case containers will be able to mount cgroup filesystems
for themselves as they do on a host.

This fixes inability to start systemd based containers on cgns-enabled
kernels with cgmanager not running.

I've tested debianjessie, busybox, ubuntu trusty and xenial, all of
which booted ok.  However if there are some setups which require
premounted cgroupfs (i.e. they don't mount if they detect being in
a container), this may cause trouble.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>