### PR TITLE
start: setsid in init task as well

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -851,6 +851,8 @@ static int do_start(void *data)
 		goto out_warn_father;
 	}
 
+	setsid();
+
 	/* after this call, we are in error because this
 	 * ops should not return as it execs */
 	handler->ops->start(handler, handler->data);


### PR DESCRIPTION
If we don't do this, we'll leak the parent's session id to the container,
which maybe doesn't matter, but it still seems better to set it anyway.

Also, it breaks CRIU for containers that don't call setsid themselves.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>