### PR TITLE
fix cgfs failure for unpriv users

### DIFF
--- a/src/lxc/cgmanager.c
+++ b/src/lxc/cgmanager.c
@@ -1242,21 +1242,6 @@ static bool subsys_is_writeable(const char *controller, const char *probe)
 	return ret;
 }
 
-/*
- * Return true if this is a subsystem which we cannot do
- * without
- */
-static bool is_crucial_subsys(const char *s)
-{
-	if (strcmp(s, "systemd") == 0)
-		return true;
-	if (strcmp(s, "name=systemd") == 0)
-		return true;
-	if (strcmp(s, "freezer") == 0)
-		return true;
-	return false;
-}
-
 static char *get_last_controller_in_list(char *list)
 {
 	char *p;
@@ -1302,7 +1287,7 @@ static bool verify_final_subsystems(const char *cgroup_use)
 		char *p = get_last_controller_in_list(subsystems[i]);
 
 		if (!subsys_is_writeable(p, probe)) {
-			if (is_crucial_subsys(p)) {
+			if (is_crucial_cgroup_subsystem(p)) {
 				ERROR("Cannot write to crucial subsystem %s\n",
 					subsystems[i]);
 				goto out;

--- a/src/lxc/cgroup.c
+++ b/src/lxc/cgroup.c
@@ -220,3 +220,18 @@ void prune_init_scope(char *cg)
 			*point = '\0';
 	}
 }
+
+/*
+ * Return true if this is a subsystem which we cannot do
+ * without
+ */
+bool is_crucial_cgroup_subsystem(const char *s)
+{
+	if (strcmp(s, "systemd") == 0)
+		return true;
+	if (strcmp(s, "name=systemd") == 0)
+		return true;
+	if (strcmp(s, "freezer") == 0)
+		return true;
+	return false;
+}

--- a/src/lxc/cgroup.h
+++ b/src/lxc/cgroup.h
@@ -83,5 +83,6 @@ extern void cgroup_disconnect(void);
 extern cgroup_driver_t cgroup_driver(void);
 
 extern void prune_init_scope(char *cg);
+extern bool is_crucial_cgroup_subsystem(const char *s);
 
 #endif


### PR DESCRIPTION
Cgmanager was taught awhile ago that only some cgroup controllers are
crucial.  Teach cgfs the same thing.

This patch needs improvement, but will fix failure of lxc without cgmanager
for unprivileged users for now.  In particular, needed improvements include:

1. the check for crucial subsystems needs to include lxc.use
2. we should keep a list of the actually used subsystems so we don't keep
trying to chmod and enter after create has found we couldn't use a particular
subsystem

This fixes unprivileged lxc use.  It does not appear to suffice to fix
nested unprivilegd lxd usage.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>