### PR TITLE
lxc-copy: correct order of copy and original & lxc-attach: setup ts->stdoutfd

### DIFF
--- a/src/lxc/lxc_attach.c
+++ b/src/lxc/lxc_attach.c
@@ -273,6 +273,7 @@ static int get_pty_on_host(struct lxc_container *c, struct wrapargs *wrap, int *
 	if (lxc_console_create(conf) < 0)
 		return -1;
 	ts = conf->console.tty_state;
+	ts->stdoutfd = STDOUT_FILENO;
 	conf->console.descr = &descr;
 
 	/* Shift ttys to container. */

--- a/src/lxc/lxc_copy.c
+++ b/src/lxc/lxc_copy.c
@@ -358,8 +358,7 @@ static int do_clone(struct lxc_container *c, char *newname, char *newpath,
 		return -1;
 	}
 
-	INFO("Created container %s as %s of %s\n", newname,
-	     task ? "snapshot" : "copy", c->name);
+	INFO("Created %s as %s of %s\n", newname, task ? "snapshot" : "copy", c->name);
 
 	lxc_container_put(clone);
 
@@ -421,7 +420,7 @@ static int do_clone_ephemeral(struct lxc_container *c,
 		goto destroy_and_put;
 
 	if (!my_args.quiet)
-		printf("Created %s as %s of %s\n", arg->name, "clone", arg->newname);
+		printf("Created %s as clone of %s\n", arg->newname, arg->name);
 
 	if (!arg->daemonize && arg->argc) {
 		clone->want_daemonize(clone, true);


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/ubuntu/+source/lxc/+bug/1551935)

	lxc-copy -n ORIG -N COPY -e

accidently printed

	"Created ORIG as clone of COPY"

instead of

	"Created COPY as clone of ORIG".
Fix the ordering.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>