### PR TITLE
Add features/small improvements to man pages (lxc-attach, lxc-copy)

### DIFF
--- a/doc/lxc-attach.sgml.in
+++ b/doc/lxc-attach.sgml.in
@@ -140,7 +140,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <replaceable>CGROUP|LSM</replaceable>. Allowed values are
       <replaceable>CGROUP</replaceable>, <replaceable>CAP</replaceable> and
       <replaceable>LSM</replaceable> representing cgroup, capabilities and
-      restriction privileges respectively.
+      restriction privileges respectively. (The pipe symbol needs to be escaped,
+      e.g. <replaceable>CGROUP\|LSM</replaceable> or quoted, e.g.
+      <replaceable>"CGROUP|LSM"</replaceable>.)
     </para>
 	  <para>
 	    <emphasis>Warning:</emphasis> This may leak privileges into the
@@ -168,7 +170,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 	    <replaceable>NETWORK</replaceable>. This allows one to change
 	    the context of the process to e.g. the network namespace of the
 	    container while retaining the other namespaces as those of the
-	    host.
+            host. (The pipe symbol needs to be escaped, e.g.
+            <replaceable>MOUNT\|PID</replaceable> or quoted, e.g.
+            <replaceable>"MOUNT|PID"</replaceable>.)
 	  </para>
 	  <para>
 	    <emphasis>Important:</emphasis> This option implies

--- a/doc/lxc-copy.sgml.in
+++ b/doc/lxc-copy.sgml.in
@@ -58,6 +58,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <arg choice="opt">-K, --keepdata</arg>
       <arg choice="opt">-M, --keepmac</arg>
       <arg choice="opt">-L, --fssize <replaceable>size [unit]</replaceable></arg>
+      <arg choice="opt">-- hook arguments</arg>
     </cmdsynopsis>
     <cmdsynopsis>
       <command>lxc-copy</command>
@@ -71,6 +72,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <arg choice="opt">-K, --keepdata</arg>
       <arg choice="opt">-M, --keepmac</arg>
       <arg choice="opt">-L, --fssize <replaceable>size [unit]</replaceable></arg>
+      <arg choice="opt">-- hook arguments</arg>
     </cmdsynopsis>
     <cmdsynopsis>
       <command>lxc-copy</command>
@@ -260,6 +262,25 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
     </variablelist>
 
+  </refsect1>
+
+  <refsect1>
+    <title>Copy hook</title>
+    <para>
+      If the container being copied has one or more
+      <filename>lxc.hook.clone</filename> specified, then the specified hooks
+      will be called for the new container. The first 3 arguments passed to the
+      clone hook will be the container name, a section ('lxc'), and the hook
+      type ('clone'). Extra arguments passed to <command>lxc-copy</command> will
+      be passed to the hook program starting at argument 4. The
+      <filename>LXC_ROOTFS_MOUNT</filename> environment variable gives
+      the path under which the container's root filesystem is mounted. The
+      configuration file pathname is stored in
+      <filename>LXC_CONFIG_FILE</filename>, the new container name in
+      <filename>LXC_NAME</filename>, the old container name in
+      <filename>LXC_SRC_NAME</filename>, and the path or device on which the
+      rootfs is located is in <filename>LXC_ROOTFS_PATH</filename>.
+    </para>
   </refsect1>
 
   &commonoptions;

--- a/src/lxc/lxc_copy.c
+++ b/src/lxc/lxc_copy.c
@@ -101,8 +101,8 @@ static char *const keys[] = {
 static struct lxc_arguments my_args = {
 	.progname = "lxc-copy",
 	.help = "\n\
---name=NAME [-P lxcpath] -N newname [-p newpath] [-B backingstorage] [-s] [-K] [-M] [-L size [unit]]\n\
---name=NAME [-P lxcpath] [-N newname] [-p newpath] [-B backingstorage] -e [-d] [-D] [-K] [-M] [-m {bind,aufs,overlay}=/src:/dest]\n\
+--name=NAME [-P lxcpath] -N newname [-p newpath] [-B backingstorage] [-s] [-K] [-M] [-L size [unit]] -- hook options\n\
+--name=NAME [-P lxcpath] [-N newname] [-p newpath] [-B backingstorage] -e [-d] [-D] [-K] [-M] [-m {bind,aufs,overlay}=/src:/dest] -- hook options\n\
 --name=NAME [-P lxcpath] -N newname -R\n\
 \n\
 lxc-copy clone a container\n\
@@ -122,6 +122,7 @@ Options :\n\
   -L, --fssize		    size of the new block device for block device containers\n\
   -D, --keedata	            pass together with -e start a persistent snapshot \n\
   -K, --keepname	    keep the hostname of the original container\n\
+  --  hook options	    arguments passed to the hook program\n\
   -M, --keepmac		    keep the MAC address of the original container\n",
 	.options = my_longopts,
 	.parser = my_parser,


### PR DESCRIPTION
Explain that the pipe symbol needs to be escaped for -e and -s.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>