### PR TITLE
2016 03 02/cgfs.rmperms

### DIFF
--- a/src/lxc/cgfs.c
+++ b/src/lxc/cgfs.c
@@ -935,6 +935,8 @@ static struct cgroup_process_info *lxc_cgroupfs_create(const char *name, const c
 		 * In that case, remove the cgroup from all previous hierarchies
 		 */
 		for (j = 0, info_ptr = base_info; j < i && info_ptr; info_ptr = info_ptr->next, j++) {
+			if (info_ptr->created_paths_count < 1)
+				continue;
 			r = remove_cgroup(info_ptr->designated_mount_point, info_ptr->created_paths[info_ptr->created_paths_count - 1], false, NULL);
 			if (r < 0)
 				WARN("could not clean up cgroup we created when trying to create container");

--- a/src/lxc/cgfs.c
+++ b/src/lxc/cgfs.c
@@ -1150,7 +1150,6 @@ static struct cgroup_process_info *lxc_cgroup_get_container_info(const char *nam
 		path = lxc_cmd_get_cgroup_path(name, lxcpath, h->subsystems[0]);
 		if (!path) {
 			h->used = false;
-			WARN("Not attaching to cgroup %s unknown to %s %s", h->subsystems[0], lxcpath, name);
 			continue;
 		}
 

--- a/src/lxc/cgmanager.c
+++ b/src/lxc/cgmanager.c
@@ -558,7 +558,7 @@ err1:
 }
 
 /* Called after a failed container startup */
-static void cgm_destroy(void *hdata)
+static void cgm_destroy(void *hdata, struct lxc_conf *conf)
 {
 	struct cgm_data *d = hdata;
 	char **slist = subsystems;

--- a/src/lxc/cgroup.c
+++ b/src/lxc/cgroup.c
@@ -71,7 +71,7 @@ bool cgroup_init(struct lxc_handler *handler)
 void cgroup_destroy(struct lxc_handler *handler)
 {
 	if (ops) {
-		ops->destroy(handler->cgroup_data);
+		ops->destroy(handler->cgroup_data, handler->conf);
 		handler->cgroup_data = NULL;
 	}
 }

--- a/src/lxc/cgroup.h
+++ b/src/lxc/cgroup.h
@@ -41,7 +41,7 @@ struct cgroup_ops {
 	const char *name;
 
 	void *(*init)(const char *name);
-	void (*destroy)(void *hdata);
+	void (*destroy)(void *hdata, struct lxc_conf *conf);
 	bool (*create)(void *hdata);
 	bool (*enter)(void *hdata, pid_t pid);
 	bool (*create_legacy)(void *hdata, pid_t pid);

--- a/src/tests/lxc-test-unpriv
+++ b/src/tests/lxc-test-unpriv
@@ -125,15 +125,21 @@ run_cmd mkdir -p $HDIR/.cache/lxc
     chown -R $TUSER: $HDIR/.cache/lxc
 
 run_cmd lxc-create -t download -n c1 -- -d ubuntu -r trusty -a $ARCH
-run_cmd lxc-start -n c1 -d
 
-p1=$(run_cmd lxc-info -n c1 -p -H)
-[ "$p1" != "-1" ] || { echo "Failed to start container c1"; false; }
+# Make sure we can start it - twice
 
-run_cmd lxc-info -n c1
-run_cmd lxc-attach -n c1 -- /bin/true
+for count in `seq 1 2`; do
+    run_cmd lxc-start -n c1 -d
 
-run_cmd lxc-stop -n c1
+    p1=$(run_cmd lxc-info -n c1 -p -H)
+    [ "$p1" != "-1" ] || { echo "Failed to start container c1 (run $count)"; false; }
+
+    run_cmd lxc-info -n c1
+    run_cmd lxc-attach -n c1 -- /bin/true
+
+    run_cmd lxc-stop -n c1
+done
+
 run_cmd lxc-copy -s -n c1 -N c2
 run_cmd lxc-start -n c2 -d
 p1=$(run_cmd lxc-info -n c2 -p -H)


### PR DESCRIPTION
cgfs was failing to clean up its cgroups when unprivileged, and then segfaulting on an error path on subsequent lxc-start.  Fix the lxc-start segfault so it properly falls back to %n-1 if %n exists, and switch to a container namespace to clean up cgroups on exit so that lxc has the permission to remove it.

Also add a test to catch regression in unprivileged restart in the future.