### PR TITLE
cgfs: stab in the dark

### DIFF
--- a/src/lxc/cgfs.c
+++ b/src/lxc/cgfs.c
@@ -1245,7 +1245,7 @@ void lxc_cgroup_process_info_free_and_remove(struct cgroup_process_info *info, s
 	if (!info)
 		return;
 	next = info->next;
-	{
+	if (info->cgroup_path && strcmp(info->cgroup_path, "/") != 0) {
 		struct cgroup_mount_point *mp = info->designated_mount_point;
 		if (!mp)
 			mp = lxc_cgroup_find_mount_point(info->hierarchy, info->cgroup_path, true);


### PR DESCRIPTION
Tycho is reporting errors looking like:

            lxc 20160303090016.268 ERROR    lxc_cgfs - cgfs.c:lxc_cgroupfs_create:890 - Could not find writable mount point for cgroup hierarchy 13 while trying to create cgroup.
            lxc 20160303090016.268 ERROR    lxc_cgfs - cgfs.c:cgroup_rmdir:210 - Read-only file system - cgroup_rmdir: failed to delete /sys/fs/cgroup/hugetlb/
            lxc 20160303090016.268 ERROR    lxc_cgfs - cgfs.c:cgroup_rmdir:210 - Device or resource busy - cgroup_rmdir: failed to delete /sys/fs/cgroup/pids//init.scope
[...]
            lxc 20160303090016.270 ERROR    lxc_cgfs - cgfs.c:cgroup_rmdir:210 - Read-only file system - cgroup_rmdir: failed to delete /sys/fs/cgroup/pids/

on occasional migration runs.  I've not reproduced this, but it looks
like cgroup_rmdir is trying to delete '/'.

This isn't terrible, as any populated cgroups cannot be removed, and
we don't enforce removal by killing tasks :)  But we could race with
someone doing

mkdir cgroup
move task > cgroup

So catch any case where it looks like we have not properly set a cgroup
path, and don't remove null or / cgroup.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>