### PR TITLE
tests: set clone_children if need be

### DIFF
--- a/src/tests/lxc-test-apparmor-mount
+++ b/src/tests/lxc-test-apparmor-mount
@@ -131,6 +131,7 @@ elif [ -e /sys/fs/cgroup/cgmanager/sock ]; then
 	done
 else
 	for d in /sys/fs/cgroup/*; do
+		[ -f $d/cgroup.clone_children ] && echo 1 > $d/cgroup.clone_children
 		[ ! -d $d/lxctest ] && mkdir $d/lxctest
 		chown -R $TUSER: $d/lxctest
 		echo $$ > $d/lxctest/tasks

--- a/src/tests/lxc-test-unpriv
+++ b/src/tests/lxc-test-unpriv
@@ -112,6 +112,7 @@ elif [ -e /sys/fs/cgroup/cgmanager/sock ]; then
 	done
 else
 	for d in /sys/fs/cgroup/*; do
+		[ -f $d/cgroup.clone_children ] && echo 1 > $d/cgroup.clone_children
 		[ ! -d $d/lxctest ] && mkdir $d/lxctest
 		chown -R $TUSER: $d/lxctest
 		echo $$ > $d/lxctest/tasks

--- a/src/tests/lxc-test-usernic.in
+++ b/src/tests/lxc-test-usernic.in
@@ -104,6 +104,7 @@ elif [ -e /sys/fs/cgroup/cgmanager/sock ]; then
 	done
 else
 	for d in /sys/fs/cgroup/*; do
+		[ -f $d/cgroup.clone_children ] && echo 1 > $d/cgroup.clone_children
 		[ ! -d $d/lxctest ] && mkdir $d/lxctest
 		chown -R usernic-user: $d/lxctest
 		echo $$ > $d/lxctest/tasks


### PR DESCRIPTION
Lxc only sets it on /lxc, not on /.

It's conceivable that we should really re-set this to the original
value, to prevent making later tests not fail when they should.  I
didn't do that.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>