### PR TITLE
Prevent access to pci devices

### DIFF
--- a/config/apparmor/abstractions/container-base
+++ b/config/apparmor/abstractions/container-base
@@ -66,6 +66,9 @@
   mount options=(rw, bind) /run/ -> /var/run/,
   mount options=(rw, bind) /run/lock/ -> /var/lock/,
 
+  # deny access under /proc/bus to avoid e.g. messing with pci devices directly
+  deny @{PROC}/bus/** wklx,
+
   # deny writes in /proc/sys/fs but allow binfmt_misc to be mounted
   mount fstype=binfmt_misc -> /proc/sys/fs/binfmt_misc/,
   deny @{PROC}/sys/fs/** wklx,

--- a/config/apparmor/abstractions/container-base.in
+++ b/config/apparmor/abstractions/container-base.in
@@ -66,6 +66,9 @@
   mount options=(rw, bind) /run/ -> /var/run/,
   mount options=(rw, bind) /run/lock/ -> /var/lock/,
 
+  # deny access under /proc/bus to avoid e.g. messing with pci devices directly
+  deny @{PROC}/bus/** wklx,
+
   # deny writes in /proc/sys/fs but allow binfmt_misc to be mounted
   mount fstype=binfmt_misc -> /proc/sys/fs/binfmt_misc/,
   deny @{PROC}/sys/fs/** wklx,

--- a/config/templates/common.conf.in
+++ b/config/templates/common.conf.in
@@ -10,7 +10,7 @@ lxc.pts = 1024
 lxc.tty = 4
 
 # Drop some harmful capabilities
-lxc.cap.drop = mac_admin mac_override sys_time sys_module
+lxc.cap.drop = mac_admin mac_override sys_time sys_module sys_rawio
 
 # Set the pivot directory
 lxc.pivotdir = lxc_putold


### PR DESCRIPTION
Prevent privileged containers from messing with the host's pci devices
directly.  Refuse access under /proc/bus, and drop cap_sys_rawio.  Some
containers may need to re-enable cap_sys_rawio (i.e. if they run an
X server).

It may be desirable to break some of this stuff into files which can be
separately included (or not included), but this patch isn't the right
place for that.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>