### PR TITLE
Fix installation of out-of-tree (VPATH) builds

### DIFF
--- a/config/apparmor/Makefile.am
+++ b/config/apparmor/Makefile.am
@@ -18,14 +18,14 @@ install-apparmor:
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/apparmor.d/
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/apparmor.d/abstractions/lxc/
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
-	$(INSTALL_DATA) abstractions/container-base $(DESTDIR)$(sysconfdir)/apparmor.d/abstractions/lxc/
-	$(INSTALL_DATA) abstractions/start-container $(DESTDIR)$(sysconfdir)/apparmor.d/abstractions/lxc/
-	$(INSTALL_DATA) profiles/lxc-default $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
-	$(INSTALL_DATA) profiles/lxc-default-cgns $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
-	$(INSTALL_DATA) profiles/lxc-default-with-mounting $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
-	$(INSTALL_DATA) profiles/lxc-default-with-nesting $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
-	$(INSTALL_DATA) lxc-containers $(DESTDIR)$(sysconfdir)/apparmor.d/
-	$(INSTALL_DATA) usr.bin.lxc-start $(DESTDIR)$(sysconfdir)/apparmor.d/
+	$(INSTALL_DATA) $(srcdir)/abstractions/container-base $(DESTDIR)$(sysconfdir)/apparmor.d/abstractions/lxc/
+	$(INSTALL_DATA) $(srcdir)/abstractions/start-container $(DESTDIR)$(sysconfdir)/apparmor.d/abstractions/lxc/
+	$(INSTALL_DATA) $(srcdir)/profiles/lxc-default $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
+	$(INSTALL_DATA) $(srcdir)/profiles/lxc-default-cgns $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
+	$(INSTALL_DATA) $(srcdir)/profiles/lxc-default-with-mounting $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
+	$(INSTALL_DATA) $(srcdir)/profiles/lxc-default-with-nesting $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/
+	$(INSTALL_DATA) $(srcdir)/lxc-containers $(DESTDIR)$(sysconfdir)/apparmor.d/
+	$(INSTALL_DATA) $(srcdir)/usr.bin.lxc-start $(DESTDIR)$(sysconfdir)/apparmor.d/
 
 uninstall-apparmor:
 	rm -f $(DESTDIR)$(sysconfdir)/apparmor.d/usr.bin.lxc-start

--- a/config/init/upstart/Makefile.am
+++ b/config/init/upstart/Makefile.am
@@ -4,7 +4,7 @@ if INIT_SCRIPT_UPSTART
 install-upstart: lxc.conf lxc-instance.conf lxc-net.conf
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/init/
 	$(INSTALL_DATA) lxc.conf $(DESTDIR)$(sysconfdir)/init/
-	$(INSTALL_DATA) lxc-instance.conf $(DESTDIR)$(sysconfdir)/init/
+	$(INSTALL_DATA) $(srcdir)/lxc-instance.conf $(DESTDIR)$(sysconfdir)/init/
 	$(INSTALL_DATA) lxc-net.conf $(DESTDIR)$(sysconfdir)/init/
 
 uninstall-upstart:


### PR DESCRIPTION
Currently, LXC successfully builds out-of-tree (at least it looks so), but `make install` fails, because it tries to install some non-generated files without full path. Prepending "$(srcdir)/" fixes it, and also doesn't break in-source build.

Signed-off-by: Aleksandr Mezin <mezin.alexander@gmail.com>