### PR TITLE
use httpredir.debian.org as the default Debian mirror

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -34,7 +34,7 @@ done
 export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
 export GREP_OPTIONS=""
 
-MIRROR=${MIRROR:-http://http.debian.net/debian}
+MIRROR=${MIRROR:-http://httpredir.debian.org/debian}
 SECURITY_MIRROR=${SECURITY_MIRROR:-http://security.debian.org/}
 LOCALSTATEDIR="@LOCALSTATEDIR@"
 LXC_TEMPLATE_CONFIG="@LXCTEMPLATECONFIG@"


### PR DESCRIPTION
http.debian.net is an alias anyways and httpredir.debian.org is the official name of the service

Signed-off-by: Evgeni Golov <evgeni@debian.org>