### PR TITLE
[WIP] add functions to mmap() file to \0-terminated str

### DIFF
--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -216,6 +216,40 @@ extern int sha1sum_file(char *fnam, unsigned char *md_value);
 extern int lxc_write_to_file(const char *filename, const void* buf, size_t count, bool add_newline);
 extern int lxc_read_from_file(const char *filename, void* buf, size_t count);
 
+/*
+ * mmap() a file to a \0-terminated string.
+ * The function will write a terminating \0-byte to the underlying file. Hence,
+ * @fildes must refer to a writeable file. lxc_munmap_str() must be used to
+ * unmap the file.
+ *
+ * \param addr             : see mmap()
+ * \param len              : see mmap()
+ * \param flags            : see mmap()
+ * \param fildes           : see mmap()
+ * \param off              : see mmap()
+ * \param[out] wrote_zero  : Whether a terminating \0-byte was written to the
+ *			     underlying file. Must be passed to
+ *			     lxc_munmap_str().
+ */
+extern void *lxc_mmap_str(void *addr, size_t len, int flags, int fildes,
+			  off_t off, bool *wrote_zero);
+
+/*
+ * munmap() a file that has been mmap()ed with lxc_mmap_str().
+ * If a terminating \0-byte has been written to the file underlying the mapping
+ * it will be truncated back to its original size.
+ *
+ * \param addr        : see munmap()
+ * \param len         : see munmap()
+ * \param newlen      : size the underlying file will be resized to via
+ *			ftruncate()
+ * \param fildes      : file descriptor of the file underlying the mapping
+ * \param wrote_zero  : Whether a terminating \0-byte has been written to the
+ *		        underlying file
+ */
+extern int lxc_munmap_str(void *addr, size_t len, size_t newlen, int fildes,
+			  bool wrote_zero);
+
 /* convert variadic argument lists to arrays (for execl type argument lists) */
 extern char** lxc_va_arg_list_to_argv(va_list ap, size_t skip, int do_strdup);
 extern const char** lxc_va_arg_list_to_argv_const(va_list ap, size_t skip);

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -23,6 +23,7 @@ lxc_test_list_SOURCES = list.c
 lxc_test_attach_SOURCES = attach.c
 lxc_test_device_add_remove_SOURCES = device_add_remove.c
 lxc_test_apparmor_SOURCES = aa.c
+lxc_test_utils_lxc_mmap_str_SOURCES = lxc-test-utils-lxc_mmap_str.c
 
 AM_CFLAGS=-I$(top_srcdir)/src \
 	-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
@@ -46,7 +47,7 @@ bin_PROGRAMS = lxc-test-containertests lxc-test-locktests lxc-test-startone \
 	lxc-test-cgpath lxc-test-clonetest lxc-test-console \
 	lxc-test-snapshot lxc-test-concurrent lxc-test-may-control \
 	lxc-test-reboot lxc-test-list lxc-test-attach lxc-test-device-add-remove \
-	lxc-test-apparmor
+	lxc-test-apparmor lxc-test-utils_lxc_mmap_str
 
 bin_SCRIPTS = lxc-test-automount lxc-test-autostart lxc-test-cloneconfig \
 	lxc-test-createconfig
@@ -90,6 +91,7 @@ EXTRA_DIST = \
 	lxc-test-symlink \
 	lxc-test-ubuntu \
 	lxc-test-unpriv \
+	lxc-test-utils-lxc_mmap_str.c \
 	may_control.c \
 	saveconfig.c \
 	shutdowntest.c \

--- a/src/tests/lxc-test-utils-lxc_mmap_str.c
+++ b/src/tests/lxc-test-utils-lxc_mmap_str.c
@@ -1,0 +1,268 @@
+/*
+ *
+ * Copyright © 2016 Christian Brauner <christian.brauner@mailbox.org>.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "lxc/utils.h"
+
+#define TSTERR(fmt, ...) do { \
+	fprintf(stderr, "%s:%d " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); fflush(NULL); \
+} while (0)
+
+static bool is_expected_size(int fd, long expected_size)
+{
+	struct stat f;
+	if (fstat(fd, &f) < 0) {
+		TSTERR("Failed to fstat file descriptor %d of temporary file", fd);
+		return false;
+	}
+
+	if (f.st_size != expected_size)
+		return false;
+
+	return true;
+}
+
+/*
+ * Test whether mapping a file exactly the size of a single page is handeled
+ * correctly. Expected behaviour:
+ *	- lxc_mmap_str() will extend the underlying file by exactly one
+ *	  terminating \0-byte.
+ *	- lxc_munmap_str() will truncate the underlying file back to its
+ *	  original size.
+ */
+static int test_pagesize_1(long pagesize)
+{
+	int ret = -1;
+	char buf[1];
+	char tmp[PATH_MAX] = "tmp_XXXXXX";
+
+	// create unique temporary file
+	int fd = mkstemp(tmp);
+	if (fd < 0) {
+		TSTERR("Failed to create temporary file.");
+		exit(EXIT_FAILURE);
+	}
+
+	/* First test: Resize the file to exactly the size of a single page on
+	 * the system. */
+	if (ftruncate(fd, pagesize) < 0) {
+		TSTERR("Failed to resize file.");
+		goto out;
+	}
+
+	// Write a dummy letter as the last byte of the file.
+	if (pwrite(fd, "A", 1, pagesize - 1) <= 0) {
+		TSTERR("Failed to write dummy byte to file.");
+		goto out;
+	}
+
+	if (!is_expected_size(fd, pagesize)) {
+		TSTERR("Size of the file was not equal to one page.");
+		goto out;
+	}
+
+	// Read the last byte of the file.
+	if (pread(fd, &buf, 1, pagesize - 1) <= 0) {
+		TSTERR("Failed to read next to last byte from file.");
+		goto out;
+	}
+
+	// Check if it is really the dummy letter we read.
+	if (*buf != 'A') {
+		TSTERR("Next to last byte of file was not equal to 'A'.");
+		goto out;
+	}
+
+	/* First test: We have just created a file exactly the size of a single
+	 * page. That means mmap_file_to_str() should write a terminating
+	 * \0-byte to the underlying file. */
+	bool wrote_zero;
+	char *map = lxc_mmap_str(NULL, pagesize, MAP_PRIVATE, fd, 0, &wrote_zero);
+	if (!map) {
+		TSTERR("Could not establish a mapping for the underlying file.");
+		goto out;
+	}
+
+	// File should be exactly one byte bigger after calling lxc_mmap_str().
+	if (!is_expected_size(fd, pagesize + 1)) {
+		TSTERR("Size of the file was not equal to one page + one extra terminating \\0-byte.");
+		goto out;
+	}
+
+	/* If the last byte is not \0 then mmap_file_to_str() is not behaving as
+	 * advertised. */
+	if (map[pagesize] != '\0') {
+		TSTERR("Last byte was not '\\0'.");
+		goto out;
+	}
+
+	if (map[pagesize - 1] != 'A') {
+		TSTERR("Next to last byte was not 'A'.");
+		goto out;
+	}
+
+	if (!wrote_zero) {
+		TSTERR("We falsely reported that we did write not write a terminating '\\0'-byte to the underlying file.");
+		goto out;
+	}
+
+	if (lxc_munmap_str(map, pagesize, pagesize, fd, wrote_zero) < 0) {
+		TSTERR("Could not unmap the underlying file.");
+		goto out;
+	}
+
+	/* File should be exactly the size of a single page after the call to
+	 * lxc_munmap_str(). */
+	if (!is_expected_size(fd, pagesize)) {
+		TSTERR("Size of the file was not equal to one page.");
+		goto out;
+	}
+
+	ret = 0;
+out:
+	unlink(tmp);
+	close(fd);
+	return ret;
+}
+
+/*
+ * Test whether mapping a file exactly one byte less than the size of a single
+ * page is handeled correctly. Expected behaviour:
+ *	- lxc_mmap_str() will not extend the underlying file.
+ *	- lxc_munmap_str() will not change the size of the underlying file.
+ */
+static int test_pagesize_2(long pagesize)
+{
+	int ret = -1;
+	char buf[1];
+	char tmp[PATH_MAX] = "tmp_XXXXXX";
+
+	// create unique temporary file
+	int fd = mkstemp(tmp);
+	if (fd < 0) {
+		TSTERR("Failed to create temporary file.");
+		exit(EXIT_FAILURE);
+	}
+
+	/* Second test: Resize the file to exactly one byte less than the page
+	 * size. */
+	if (ftruncate(fd, pagesize - 1) < 0) {
+		TSTERR("Failed to resize file.");
+		goto out;
+	}
+
+	// Write a dummy letter as the last byte of the file.
+	if (pwrite(fd, "A", 1, pagesize - 2) < 0) {
+		TSTERR("Failed to write dummy byte as next to last byte to file.");
+		goto out;
+	}
+
+	if (!is_expected_size(fd, pagesize - 1)) {
+		TSTERR("Size of the file was not exactly one byte less than a single page.");
+		goto out;
+	}
+
+	// Read the last byte of the file.
+	if (pread(fd, &buf, 1, pagesize - 2) <= 0) {
+		TSTERR("Failed to read next to last byte from file.");
+		goto out;
+	}
+
+	// Check if it is really the dummy letter we read.
+	if (*buf != 'A') {
+		TSTERR("Next to last byte of file was not equal to 'A'.");
+		goto out;
+	}
+
+	/* Second test: We have just created a file whose size is exactly one
+	 * byte less than the size of a single page. That means
+	 * mmap_file_to_str() should not write a terminating \0-byte to the
+	 * underlying file. */
+	bool wrote_zero;
+	char *map = lxc_mmap_str(NULL, pagesize - 1, MAP_PRIVATE, fd, 0, &wrote_zero);
+	if (!map) {
+		TSTERR("Could not establish a mapping for the underlying file.");
+		goto out;
+	}
+
+	if (!is_expected_size(fd, pagesize - 1)) {
+		TSTERR("Size of the file was not equal to one page - one byte.");
+		goto out;
+	}
+
+	/* If the last byte is not \0 then mmap_file_to_str() is not behaving as
+	 * advertised. */
+	if (map[pagesize - 1] != '\0') {
+		TSTERR("Last byte was not '\\0'.");
+		goto out;
+	}
+
+	if (map[pagesize - 2] != 'A') {
+		TSTERR("Next to last byte was not 'A'.");
+		goto out;
+	}
+
+	if (wrote_zero) {
+		TSTERR("We falsely reported that we did write a terminating '\\0'-byte to the underlying file.");
+		goto out;
+	}
+
+	if (lxc_munmap_str(map, pagesize - 1, pagesize - 1, fd, wrote_zero) < 0) {
+		TSTERR("Could not unmap the underlying file.");
+		goto out;
+	}
+
+	/* File should be exactly the size of a single page minus one byte after
+	 * the call to lxc_munmap_str(). */
+	if (!is_expected_size(fd, pagesize - 1)) {
+		TSTERR("Size of the file was not equal to one page.");
+		goto out;
+	}
+
+	ret = 0;
+out:
+	unlink(tmp);
+	close(fd);
+	return ret;
+}
+
+int main(int argc, char *argv[])
+{
+	long pagesize = sysconf(_SC_PAGESIZE);
+	if (pagesize <= 0)
+		exit(EXIT_FAILURE);
+
+	if (test_pagesize_1(pagesize) < 0)
+		exit(EXIT_FAILURE);
+
+	if (test_pagesize_2(pagesize) < 0)
+		exit(EXIT_FAILURE);
+
+	exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
The functions lxc_mmap_str() and lxc_munmap_str() mmap() a file as a
\0-terminated string.
mmap() memory is only \0-terminated when the size of the file is not a multiple
of the pagesize. lxc_mmap_str() will guarantee that the mapping is
\0-terminated by writing a \0-byte to the underlying file prior to establishing
the mapping. Hence, the file descriptor must refer to a writeable file.
lxc_munmap_str() will take care of unmapping the file and truncating it to its
original size.

Tests for lxc_mmap_str() are included.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>