### PR TITLE
always provide a default mirror for debootstraping Ubuntu

### DIFF
--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -39,6 +39,8 @@ export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
 
 set -e
 
+MIRROR=${MIRROR:-http://archive.ubuntu.com/ubuntu}
+SECURITY_MIRROR=${SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu}
 LOCALSTATEDIR="@LOCALSTATEDIR@"
 LXC_TEMPLATE_CONFIG="@LXCTEMPLATECONFIG@"
 # Allows the lxc-cache directory to be set by environment variable


### PR DESCRIPTION
debootstrap sometimes selects the wrong mirror due to [1]

[1] https://bugs.debian.org/819300

Signed-off-by: Evgeni Golov <evgeni@debian.org>