### PR TITLE
add funs to mmap() files to \0-terminated strings

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2164,7 +2164,7 @@ static bool mod_rdep(struct lxc_container *c0, struct lxc_container *c, bool inc
 
 			if (fbuf.st_size != 0) {
 
-				buf = lxc_mmap(NULL, fbuf.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+				buf = lxc_strmmap(NULL, fbuf.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 				if (buf == MAP_FAILED) {
 					SYSERROR("Failed to create mapping %s", path);
 					close(fd);
@@ -2177,7 +2177,7 @@ static bool mod_rdep(struct lxc_container *c0, struct lxc_container *c, bool inc
 					bytes += len;
 				}
 
-				lxc_munmap(buf, fbuf.st_size);
+				lxc_strmunmap(buf, fbuf.st_size);
 				if (ftruncate(fd, fbuf.st_size - bytes) < 0) {
 					SYSERROR("Failed to truncate file %s", path);
 					close(fd);

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2163,13 +2163,8 @@ static bool mod_rdep(struct lxc_container *c0, struct lxc_container *c, bool inc
 			}
 
 			if (fbuf.st_size != 0) {
-				/* write terminating \0-byte to file */
-				if (pwrite(fd, "", 1, fbuf.st_size) <= 0) {
-					close(fd);
-					goto out;
-				}
 
-				buf = mmap(NULL, fbuf.st_size + 1, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+				buf = lxc_mmap(NULL, fbuf.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 				if (buf == MAP_FAILED) {
 					SYSERROR("Failed to create mapping %s", path);
 					close(fd);
@@ -2182,7 +2177,7 @@ static bool mod_rdep(struct lxc_container *c0, struct lxc_container *c, bool inc
 					bytes += len;
 				}
 
-				munmap(buf, fbuf.st_size + 1);
+				lxc_munmap(buf, fbuf.st_size);
 				if (ftruncate(fd, fbuf.st_size - bytes) < 0) {
 					SYSERROR("Failed to truncate file %s", path);
 					close(fd);

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1812,8 +1812,8 @@ int lxc_count_file_lines(const char *fn)
 	return n;
 }
 
-void *lxc_mmap(void *addr, size_t length, int prot, int flags, int fd,
-	       off_t offset)
+void *lxc_strmmap(void *addr, size_t length, int prot, int flags, int fd,
+		  off_t offset)
 {
 	void *tmp = NULL, *overlap = NULL;
 
@@ -1835,7 +1835,7 @@ out:
 	return overlap;
 }
 
-int lxc_munmap(void *addr, size_t length)
+int lxc_strmunmap(void *addr, size_t length)
 {
 	return munmap(addr, length + 1);
 }

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -69,7 +69,7 @@ struct prctl_mm_map {
         uint64_t   *auxv;
         uint32_t   auxv_size;
         uint32_t   exe_fd;
-};              
+};
 #endif
 
 #ifndef O_PATH
@@ -1810,4 +1810,32 @@ int lxc_count_file_lines(const char *fn)
 	free(line);
 	fclose(f);
 	return n;
+}
+
+void *lxc_mmap(void *addr, size_t length, int prot, int flags, int fd,
+	       off_t offset)
+{
+	void *tmp = NULL, *overlap = NULL;
+
+	/* We establish an anonymous mapping that is one byte larger than the
+	 * underlying file. The pages handed to us are zero filled. */
+	tmp = mmap(addr, length + 1, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (tmp == MAP_FAILED)
+		goto out;
+
+	/* Now we establish a fixed-address mapping starting at the address we
+	 * received from our anonymous mapping and replace all bytes excluding
+	 * the additional \0-byte with the file. This allows us to use normal
+	 * string-handling function. */
+	overlap = mmap(tmp, length, prot, MAP_FIXED | flags, fd, offset);
+	if (overlap == MAP_FAILED)
+		goto out;
+
+out:
+	return overlap;
+}
+
+int lxc_munmap(void *addr, size_t length)
+{
+	return munmap(addr, length + 1);
 }

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -252,6 +252,14 @@ extern void lxc_free_array(void **array, lxc_free_fn element_free_fn);
 extern size_t lxc_array_len(void **array);
 
 extern void **lxc_append_null_to_array(void **array, size_t count);
+
+/* mmap() wrapper. lxc_mmap() will take care to \0-terminate files so that
+ * normal string-handling functions can be used on the buffer. */
+extern void *lxc_mmap(void *addr, size_t length, int prot, int flags, int fd,
+		      off_t offset);
+/* munmap() wrapper. Use it to free memory mmap()ed with lxc_mmap(). */
+extern int lxc_munmap(void *addr, size_t length);
+
 //initialize rand with urandom
 extern int randseed(bool);
 

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -255,10 +255,10 @@ extern void **lxc_append_null_to_array(void **array, size_t count);
 
 /* mmap() wrapper. lxc_mmap() will take care to \0-terminate files so that
  * normal string-handling functions can be used on the buffer. */
-extern void *lxc_mmap(void *addr, size_t length, int prot, int flags, int fd,
-		      off_t offset);
+extern void *lxc_strmmap(void *addr, size_t length, int prot, int flags, int fd,
+			 off_t offset);
 /* munmap() wrapper. Use it to free memory mmap()ed with lxc_mmap(). */
-extern int lxc_munmap(void *addr, size_t length);
+extern int lxc_strmunmap(void *addr, size_t length);
 
 //initialize rand with urandom
 extern int randseed(bool);


### PR DESCRIPTION
In order to do this we make use of the MAP_FIXED flag of mmap(). MAP_FIXED
should be safe to use when it replaces an already existing mapping. To this
end, we establish an anonymous mapping that is one byte larger than the
underlying file. The pages handed to us are zero filled.  Now we establish a
fixed-address mapping starting at the address we received from our anonymous
mapping and replace all bytes excluding the additional \0-byte with the file.
This allows us to use normal string-handling function.  The idea implemented
here is similar to how shared libraries are mapped.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>