### PR TITLE
use smarter error handling for lxc_strmmap()

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -23,24 +23,24 @@
 
 #include "config.h"
 
-#include <errno.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <stddef.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/vfs.h>
-#include <sys/stat.h>
-#include <sys/mman.h>
-#include <sys/param.h>
-#include <sys/mount.h>
+#include <assert.h>
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <libgen.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <assert.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/mount.h>
+#include <sys/param.h>
 #include <sys/prctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/vfs.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "utils.h"
 #include "log.h"
@@ -1821,17 +1821,16 @@ void *lxc_strmmap(void *addr, size_t length, int prot, int flags, int fd,
 	 * underlying file. The pages handed to us are zero filled. */
 	tmp = mmap(addr, length + 1, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 	if (tmp == MAP_FAILED)
-		goto out;
+		return tmp;
 
 	/* Now we establish a fixed-address mapping starting at the address we
 	 * received from our anonymous mapping and replace all bytes excluding
 	 * the additional \0-byte with the file. This allows us to use normal
-	 * string-handling function. */
+	 * string-handling functions. */
 	overlap = mmap(tmp, length, prot, MAP_FIXED | flags, fd, offset);
 	if (overlap == MAP_FAILED)
-		goto out;
+		munmap(tmp, length + 1);
 
-out:
 	return overlap;
 }
 

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/mman.h>
 #include <sys/mount.h>
 #include <sys/param.h>
@@ -40,12 +41,11 @@
 #include <sys/types.h>
 #include <sys/vfs.h>
 #include <sys/wait.h>
-#include <unistd.h>
 
-#include "utils.h"
 #include "log.h"
 #include "lxclock.h"
 #include "namespace.h"
+#include "utils.h"
 
 #ifndef PR_SET_MM
 #define PR_SET_MM 35

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -23,6 +23,8 @@
 #ifndef __LXC_UTILS_H
 #define __LXC_UTILS_H
 
+#include "config.h"
+
 #include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -31,7 +33,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "config.h"
 #include "initutils.h"
 
 /* returns 1 on success, 0 if there were any failures */
@@ -253,11 +254,11 @@ extern size_t lxc_array_len(void **array);
 
 extern void **lxc_append_null_to_array(void **array, size_t count);
 
-/* mmap() wrapper. lxc_mmap() will take care to \0-terminate files so that
+/* mmap() wrapper. lxc_strmmap() will take care to \0-terminate files so that
  * normal string-handling functions can be used on the buffer. */
 extern void *lxc_strmmap(void *addr, size_t length, int prot, int flags, int fd,
 			 off_t offset);
-/* munmap() wrapper. Use it to free memory mmap()ed with lxc_mmap(). */
+/* munmap() wrapper. Use it to free memory mmap()ed with lxc_strmmap(). */
 extern int lxc_strmunmap(void *addr, size_t length);
 
 //initialize rand with urandom


### PR DESCRIPTION
Additionally, fix the comment for lxc_strmmap() and cleanup #includes in
utils.{c,h}.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>