### PR TITLE
c/r: support for the criu pageserver

### DIFF
--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -83,9 +83,9 @@ struct criu_opts {
 	 */
 	char *console_name;
 
-    /* Address and port where a criu pageserver ist listening */
-    char *pageserver_address;
-    char *pageserver_port;
+	/* Address and port where a criu pageserver is listening */
+	char *pageserver_address;
+	char *pageserver_port;
 };
 
 static int load_tty_major_minor(char *directory, char *output, int len)
@@ -159,6 +159,10 @@ static void exec_criu(struct criu_opts *opts)
 		/* --prev-images-dir <path-to-directory-A-relative-to-B> */
 		if (opts->predump_dir)
 			static_args += 2;
+
+		/* --page-server --address <address> --port <port> */
+		if (opts->pageserver_address && opts->pageserver_port)
+			static_args += 5;
 
 		/* --leave-running (only for final dump) */
 		if (strcmp(opts->action, "dump") == 0 && !opts->stop)
@@ -274,15 +278,15 @@ static void exec_criu(struct criu_opts *opts)
 		if (opts->predump_dir) {
 			DECLARE_ARG("--prev-images-dir");
 			DECLARE_ARG(opts->predump_dir);
-        }
+		}
 
-        if (opts->pageserver_address && opts->pageserver_port) {
-            DECLARE_ARG("--page-server");
-            DECLARE_ARG("--address");
-            DECLARE_ARG(opts->pageserver_address);
-            DECLARE_ARG("--port");
-            DECLARE_ARG(opts->pageserver_port);
-        }
+		if (opts->pageserver_address && opts->pageserver_port) {
+			DECLARE_ARG("--page-server");
+			DECLARE_ARG("--address");
+			DECLARE_ARG(opts->pageserver_address);
+			DECLARE_ARG("--port");
+			DECLARE_ARG(opts->pageserver_port);
+		}
 
 		/* only for final dump */
 		if (strcmp(opts->action, "dump") == 0 && !opts->stop)
@@ -826,8 +830,8 @@ static int save_tty_major_minor(char *directory, struct lxc_container *c, char *
 
 /* do one of either predump or a regular dump */
 static bool do_dump(struct lxc_container *c, char *mode, char *directory,
-		    bool stop, bool verbose, char *predump_dir, char *pageserver_address,
-            char *pageserver_port)
+		    bool stop, bool verbose, char *predump_dir,
+		    char *pageserver_address, char *pageserver_port)
 {
 	pid_t pid;
 
@@ -853,8 +857,9 @@ static bool do_dump(struct lxc_container *c, char *mode, char *directory,
 		os.verbose = verbose;
 		os.predump_dir = predump_dir;
 		os.console_name = c->lxc_conf->console.path;
-        os.pageserver_address = pageserver_address;
-        os.pageserver_port = pageserver_port;
+		os.pageserver_address = pageserver_address;
+		os.pageserver_port = pageserver_port;
+
 		if (save_tty_major_minor(directory, c, os.tty_id, sizeof(os.tty_id)) < 0)
 			exit(1);
 
@@ -886,14 +891,12 @@ static bool do_dump(struct lxc_container *c, char *mode, char *directory,
 	}
 }
 
-bool __criu_pre_dump(struct lxc_container *c, char *directory, bool verbose, char *predump_dir,
-                     char *pageserver_address, char *pageserver_port)
+bool __criu_pre_dump(struct lxc_container *c, char *directory, bool verbose, char *predump_dir, char *pageserver_address, char *pageserver_port)
 {
 	return do_dump(c, "pre-dump", directory, false, verbose, predump_dir, pageserver_address, pageserver_port);
 }
 
-bool __criu_dump(struct lxc_container *c, char *directory, bool stop, bool verbose, char *predump_dir,
-                 char *pageserver_address, char *pageserver_port)
+bool __criu_dump(struct lxc_container *c, char *directory, bool stop, bool verbose, char *predump_dir, char *pageserver_address, char *pageserver_port)
 {
 	char path[PATH_MAX];
 	int ret;

--- a/src/lxc/criu.h
+++ b/src/lxc/criu.h
@@ -27,8 +27,8 @@
 
 #include <lxc/lxccontainer.h>
 
-bool __criu_pre_dump(struct lxc_container *c, char *directory, bool verbose, char *predump_dir);
-bool __criu_dump(struct lxc_container *c, char *directory, bool stop, bool verbose, char *predump_dir);
+bool __criu_pre_dump(struct lxc_container *c, char *directory, bool verbose, char *predump_dir, char *pageserver_address, char *pageserver_port);
+bool __criu_dump(struct lxc_container *c, char *directory, bool stop, bool verbose, char *predump_dir, char *pageserver_address, char *pageserver_port);
 bool __criu_restore(struct lxc_container *c, char *directory, bool verbose);
 
 #endif

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3955,10 +3955,12 @@ static int do_lxcapi_migrate(struct lxc_container *c, unsigned int cmd,
 
 	switch (cmd) {
 	case MIGRATE_PRE_DUMP:
-		ret = !__criu_pre_dump(c, opts->directory, opts->verbose, opts->predump_dir);
+		ret = !__criu_pre_dump(c, opts->directory, opts->verbose, opts->predump_dir,
+                               opts->pageserver_address, opts->pageserver_port);
 		break;
 	case MIGRATE_DUMP:
-		ret = !__criu_dump(c, opts->directory, opts->stop, opts->verbose, opts->predump_dir);
+		ret = !__criu_dump(c, opts->directory, opts->stop, opts->verbose, opts->predump_dir,
+                           opts->pageserver_address, opts->pageserver_port);
 		break;
 	case MIGRATE_RESTORE:
 		ret = !__criu_restore(c, opts->directory, opts->verbose);

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3955,12 +3955,10 @@ static int do_lxcapi_migrate(struct lxc_container *c, unsigned int cmd,
 
 	switch (cmd) {
 	case MIGRATE_PRE_DUMP:
-		ret = !__criu_pre_dump(c, opts->directory, opts->verbose, opts->predump_dir,
-                               opts->pageserver_address, opts->pageserver_port);
+		ret = !__criu_pre_dump(c, opts->directory, opts->verbose, opts->predump_dir, opts->pageserver_address, opts->pageserver_port);
 		break;
 	case MIGRATE_DUMP:
-		ret = !__criu_dump(c, opts->directory, opts->stop, opts->verbose, opts->predump_dir,
-                           opts->pageserver_address, opts->pageserver_port);
+		ret = !__criu_dump(c, opts->directory, opts->stop, opts->verbose, opts->predump_dir, opts->pageserver_address, opts->pageserver_port);
 		break;
 	case MIGRATE_RESTORE:
 		ret = !__criu_restore(c, opts->directory, opts->verbose);

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -882,8 +882,8 @@ struct migrate_opts {
 
 	bool stop; /* stop the container after dump? */
 	char *predump_dir; /* relative to directory above */
-    char *pageserver_address; /* where should memory pages be send? */
-    char *pageserver_port;
+	char *pageserver_address; /* where should memory pages be send? */
+	char *pageserver_port;
 };
 
 /*!

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -882,6 +882,8 @@ struct migrate_opts {
 
 	bool stop; /* stop the container after dump? */
 	char *predump_dir; /* relative to directory above */
+    char *pageserver_address; /* where should memory pages be send? */
+    char *pageserver_port;
 };
 
 /*!


### PR DESCRIPTION
this enables lxc to perform "disk-less migrations" where memory pages are sent directly to the destination machine instead of being written to the sources filesystem first.
For this, the migrate_opts struct has been added the strings "pageserver_address" and "pageserver_port" so that criu can be told where to look for a pageserver.

Signed-off-by: Niklas Eiling <niklas.eiling@rwth-aachen.de>