### PR TITLE
fix possible buffer overflow

### DIFF
--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -364,10 +364,13 @@ static void exec_criu(struct criu_opts *opts)
 
 	buf[0] = 0;
 	pos = 0;
+
 	for (i = 0; argv[i]; i++) {
-		strncat(buf, argv[i], sizeof(buf) - pos - 1);
-		strncat(buf, " ", sizeof(buf) - pos - 1);
-		pos += strlen(argv[i]);
+		ret = snprintf(buf + pos, sizeof(buf) - pos, "%s ", argv[i]);
+		if (ret < 0 || ret >= sizeof(buf) - pos)
+			goto err;
+		else
+			pos += ret;
 	}
 
 	INFO("execing: %s", buf);

--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -126,8 +126,8 @@ static void exec_criu(struct criu_opts *opts)
 	int netnr = 0;
 	struct lxc_list *it;
 
-	char buf[4096], *pos, tty_info[32];
-
+	char buf[4096], tty_info[32];
+	size_t pos;
 	/* If we are currently in a cgroup /foo/bar, and the container is in a
 	 * cgroup /lxc/foo, lxcfs will give us an ENOENT if some task in the
 	 * container has an open fd that points to one of the cgroup files
@@ -363,10 +363,11 @@ static void exec_criu(struct criu_opts *opts)
 	argv[argc] = NULL;
 
 	buf[0] = 0;
-	pos = buf;
+	pos = 0;
 	for (i = 0; argv[i]; i++) {
-		pos = strncat(buf, argv[i], buf + sizeof(buf) - pos);
-		pos = strncat(buf, " ", buf + sizeof(buf) - pos);
+		strncat(buf, argv[i], sizeof(buf) - pos - 1);
+		strncat(buf, " ", sizeof(buf) - pos - 1);
+		pos += strlen(argv[i]);
 	}
 
 	INFO("execing: %s", buf);


### PR DESCRIPTION
strncat only returns its first argument and not the end of the written string.
Thus "buf-pos" is always 0 and consquently no range check is performed.
Also the terminating null character was not being accounted for.

Signed-off-by: Niklas Eiling <niklas.eiling@rwth-aachen.de>