### PR TITLE
fix btrfs_recursive_destroy

### DIFF
--- a/src/lxc/bdev/lxcbtrfs.c
+++ b/src/lxc/bdev/lxcbtrfs.c
@@ -616,8 +616,13 @@ static int btrfs_recursive_destroy(const char *path)
 		ret = ioctl(fd, BTRFS_IOC_TREE_SEARCH, &args);
 		if (ret < 0) {
 			close(fd);
-			ERROR("Error: can't perform the search under %s\n", path);
 			free_btrfs_tree(tree);
+			if (errno == EPERM || errno == EACCES) {
+				WARN("Warn: can't perform the search under %s. Will simply try removing", path);
+				goto ignore_search;
+			}
+
+			ERROR("Error: can't perform the search under %s\n", path);
 			return -1;
 		}
 		if (sk->nr_items == 0)

--- a/src/lxc/bdev/lxcbtrfs.c
+++ b/src/lxc/bdev/lxcbtrfs.c
@@ -568,7 +568,7 @@ static int btrfs_recursive_destroy(const char *path)
 	struct btrfs_ioctl_search_header sh;
 	struct btrfs_root_ref *ref;
 	struct my_btrfs_tree *tree;
-	int ret, i;
+	int ret, e, i;
 	unsigned long off = 0;
 	int name_len;
 	char *name;
@@ -582,8 +582,9 @@ static int btrfs_recursive_destroy(const char *path)
 	}
 
 	if (btrfs_list_get_path_rootid(fd, &root_id)) {
+		e = errno;
 		close(fd);
-		if (errno == EPERM || errno == EACCES) {
+		if (e == EPERM || e == EACCES) {
 			WARN("Will simply try removing");
 			goto ignore_search;
 		}
@@ -614,10 +615,11 @@ static int btrfs_recursive_destroy(const char *path)
 
 	while(1) {
 		ret = ioctl(fd, BTRFS_IOC_TREE_SEARCH, &args);
+		e = errno;
 		if (ret < 0) {
 			close(fd);
 			free_btrfs_tree(tree);
-			if (errno == EPERM || errno == EACCES) {
+			if (e == EPERM || e == EACCES) {
 				WARN("Warn: can't perform the search under %s. Will simply try removing", path);
 				goto ignore_search;
 			}


### PR DESCRIPTION
A change in kernel 4.2 caused btrfs_recursive_destroy to
fail to delete unprivileged containers.  This patch restores
the pre-kernel-4.2 behaviour.  Ref: Issue #935 .

Signed-off-by: Oleg Freedhom <overlayfs@gmail.com>