### PR TITLE
use more accurate bdev_type name for rootfs.bdev

### DIFF
--- a/src/lxc/bdev/bdev.c
+++ b/src/lxc/bdev/bdev.c
@@ -858,8 +858,8 @@ static const struct bdev_type *bdev_query(struct lxc_conf *conf, const char *src
 {
 	int i;
 
-	if (conf->rootfs.bdev)
-		return get_bdev_by_name(conf->rootfs.bdev);
+	if (conf->rootfs.bdev_type)
+		return get_bdev_by_name(conf->rootfs.bdev_type);
 
 	for (i = 0; i < numbdevs; i++) {
 		int r;

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4142,7 +4142,7 @@ void lxc_conf_free(struct lxc_conf *conf)
 	free(conf->console.log_path);
 	free(conf->console.path);
 	free(conf->rootfs.mount);
-	free(conf->rootfs.bdev);
+	free(conf->rootfs.bdev_type);
 	free(conf->rootfs.options);
 	free(conf->rootfs.path);
 	free(conf->logfile);

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -220,13 +220,13 @@ struct lxc_console {
  * @path       : the rootfs source (directory or device)
  * @mount      : where it is mounted
  * @options    : mount options
- * @bev        : optional backing store type
+ * @bev_type   : optional backing store type
  */
 struct lxc_rootfs {
 	char *path;
 	char *mount;
 	char *options;
-	char *bdev;
+	char *bdev_type;
 };
 
 /*

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -73,7 +73,7 @@ static int config_fstab(const char *, const char *, struct lxc_conf *);
 static int config_rootfs(const char *, const char *, struct lxc_conf *);
 static int config_rootfs_mount(const char *, const char *, struct lxc_conf *);
 static int config_rootfs_options(const char *, const char *, struct lxc_conf *);
-static int config_rootfs_bdev(const char *, const char *, struct lxc_conf *);
+static int config_rootfs_bdev_type(const char *, const char *, struct lxc_conf *);
 static int config_pivotdir(const char *, const char *, struct lxc_conf *);
 static int config_utsname(const char *, const char *, struct lxc_conf *);
 static int config_hook(const char *, const char *, struct lxc_conf *lxc_conf);
@@ -132,7 +132,7 @@ static struct lxc_config_t config[] = {
 	{ "lxc.mount",                config_fstab                },
 	{ "lxc.rootfs.mount",         config_rootfs_mount         },
 	{ "lxc.rootfs.options",       config_rootfs_options       },
-	{ "lxc.rootfs.bdev",          config_rootfs_bdev          },
+	{ "lxc.rootfs.bdev",          config_rootfs_bdev_type     },
 	{ "lxc.rootfs",               config_rootfs               },
 	{ "lxc.pivotdir",             config_pivotdir             },
 	{ "lxc.utsname",              config_utsname              },
@@ -1856,7 +1856,7 @@ static int config_rootfs_options(const char *key, const char *value,
 	return config_string_item(&lxc_conf->rootfs.options, value);
 }
 
-static int config_rootfs_bdev(const char *key, const char *value,
+static int config_rootfs_bdev_type(const char *key, const char *value,
 			       struct lxc_conf *lxc_conf)
 {
 	if (!is_valid_bdev_type(value)) {
@@ -1864,7 +1864,7 @@ static int config_rootfs_bdev(const char *key, const char *value,
 		return -1;
 	}
 
-	return config_string_item(&lxc_conf->rootfs.bdev, value);
+	return config_string_item(&lxc_conf->rootfs.bdev_type, value);
 }
 
 static int config_pivotdir(const char *key, const char *value,


### PR DESCRIPTION
It'll make future code reading easier.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>