### PR TITLE
fix spelling mistakes spotted by Debian's lintian

### DIFF
--- a/doc/ja/lxc-attach.sgml.in
+++ b/doc/ja/lxc-attach.sgml.in
@@ -435,7 +435,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       network/pid namespace context of the attached process. In order
       not to interfere with the host's actual filesystem, the mount
       namespace will be unshared (like <command>lxc-unshare</command>
-      does) before this is done, esentially giving the process a new
+      does) before this is done, essentially giving the process a new
       mount namespace, which is identical to the hosts's mount namespace
       except for the <replaceable>/proc</replaceable> and
       <replaceable>/sys</replaceable> filesystems.

--- a/doc/ja/lxc-copy.sgml.in
+++ b/doc/ja/lxc-copy.sgml.in
@@ -219,7 +219,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 	  <varlistentry>
 	    <term> <option>-s,--snapshot </option> </term>
 	   <listitem>
-            <para><!-- Create a snapshot of the orginal container. The backing
+            <para><!-- Create a snapshot of the original container. The backing
             storage for the copy must support snapshots. This currently includes
             aufs, btrfs, lvm, overlay, and zfs. -->
 	      元のコンテナのスナップショットを作成します。コピー先のバッキングストレージがスナップショットをサポートしている必要があります。現時点では aufs、btrfs、lvm、overlay、zfs が対象となります。

--- a/doc/ja/lxc-info.sgml.in
+++ b/doc/ja/lxc-info.sgml.in
@@ -86,7 +86,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <para>
             <!--
             Print a configuration key from the container. This option
-            may be given mulitple times to print out multiple key = value pairs.
+            may be given multiple times to print out multiple key = value pairs.
             -->
             コンテナの設定値を表示します。このオプションは複数の key = value のペアを表示したい場合には複数回指定することも可能です。
           </para>

--- a/doc/ko/lxc-attach.sgml.in
+++ b/doc/ko/lxc-attach.sgml.in
@@ -420,7 +420,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
       network/pid namespace context of the attached process. In order
       not to interfere with the host's actual filesystem, the mount
       namespace will be unshared (like <command>lxc-unshare</command>
-      does) before this is done, esentially giving the process a new
+      does) before this is done, essentially giving the process a new
       mount namespace, which is identical to the hosts's mount namespace
       except for the <replaceable>/proc</replaceable> and
       <replaceable>/sys</replaceable> filesystems.

--- a/doc/ko/lxc-copy.sgml.in
+++ b/doc/ko/lxc-copy.sgml.in
@@ -214,7 +214,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 	   <listitem>
             <para>
             <!--
-            Create a snapshot of the orginal container. The backing
+            Create a snapshot of the original container. The backing
             storage for the copy must support snapshots. This currently includes
             aufs, btrfs, lvm, overlay, and zfs.
             -->

--- a/doc/ko/lxc-info.sgml.in
+++ b/doc/ko/lxc-info.sgml.in
@@ -86,7 +86,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
           <para>
             <!--
             Print a configuration key from the container. This option
-            may be given mulitple times to print out multiple key = value pairs.
+            may be given multiple times to print out multiple key = value pairs.
             -->
             컨테이너의 설정값을 표시한다. 이 옵션은 1개 이상의 key = value 쌍을 표시할 수 있다.
           </para>

--- a/doc/lxc-attach.sgml.in
+++ b/doc/lxc-attach.sgml.in
@@ -324,7 +324,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       network/pid namespace context of the attached process. In order
       not to interfere with the host's actual filesystem, the mount
       namespace will be unshared (like <command>lxc-unshare</command>
-      does) before this is done, esentially giving the process a new
+      does) before this is done, essentially giving the process a new
       mount namespace, which is identical to the hosts's mount namespace
       except for the <replaceable>/proc</replaceable> and
       <replaceable>/sys</replaceable> filesystems.

--- a/doc/lxc-copy.sgml.in
+++ b/doc/lxc-copy.sgml.in
@@ -182,7 +182,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 	  <varlistentry>
 	    <term> <option>-s,--snapshot </option> </term>
 	   <listitem>
-            <para> Create a snapshot of the orginal container. The backing
+            <para> Create a snapshot of the original container. The backing
             storage for the copy must support snapshots. This currently includes
             aufs, btrfs, lvm, overlay, and zfs. </para>
 	   </listitem>

--- a/doc/lxc-info.sgml.in
+++ b/doc/lxc-info.sgml.in
@@ -76,7 +76,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         <listitem>
           <para>
             Print a configuration key from the container. This option
-            may be given mulitple times to print out multiple key = value pairs.
+            may be given multiple times to print out multiple key = value pairs.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
Signed-off-by: Evgeni Golov <evgeni@debian.org>