### PR TITLE
set lxc.rootfs.backend on container creation

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2845,6 +2845,8 @@ static int copy_storage(struct lxc_container *c0, struct lxc_container *c,
 	}
 	free(c->lxc_conf->rootfs.path);
 	c->lxc_conf->rootfs.path = strdup(bdev->src);
+	free(c->lxc_conf->rootfs.bdev_type);
+	c->lxc_conf->rootfs.bdev_type = strdup(bdev->type);
 	bdev_put(bdev);
 	if (!c->lxc_conf->rootfs.path) {
 		ERROR("Out of memory while setting storage path");
@@ -2853,6 +2855,11 @@ static int copy_storage(struct lxc_container *c0, struct lxc_container *c,
 	// We will simply append a new lxc.rootfs entry to the unexpanded config
 	clear_unexp_config_line(c->lxc_conf, "lxc.rootfs", false);
 	if (!do_append_unexp_config_line(c->lxc_conf, "lxc.rootfs", c->lxc_conf->rootfs.path)) {
+		ERROR("Error saving new rootfs to cloned config");
+		return -1;
+	}
+	clear_unexp_config_line(c->lxc_conf, "lxc.rootfs.backend", false);
+	if (!do_append_unexp_config_line(c->lxc_conf, "lxc.rootfs.backend", c->lxc_conf->rootfs.bdev_type)) {
 		ERROR("Error saving new rootfs to cloned config");
 		return -1;
 	}

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -1037,6 +1037,7 @@ static struct bdev *do_bdev_create(struct lxc_container *c, const char *type,
 	}
 
 	do_lxcapi_set_config_item(c, "lxc.rootfs", bdev->src);
+	do_lxcapi_set_config_item(c, "lxc.rootfs.backend", bdev->type);
 
 	/* if we are not root, chown the rootfs dir to root in the
 	 * target uidmap */
@@ -1076,7 +1077,7 @@ static bool create_run_template(struct lxc_container *c, char *tpath, bool need_
 	}
 
 	if (pid == 0) { // child
-		char *patharg, *namearg, *rootfsarg, *src;
+		char *patharg, *namearg, *rootfsarg;
 		struct bdev *bdev = NULL;
 		int i;
 		int ret, len, nargs = 0;
@@ -1087,18 +1088,7 @@ static bool create_run_template(struct lxc_container *c, char *tpath, bool need_
 			exit(1);
 		}
 
-		src = c->lxc_conf->rootfs.path;
-		/*
-		 * for an overlay create, what the user wants is the template to fill
-		 * in what will become the readonly lower layer.  So don't mount for
-		 * the template
-		 */
-		if (strncmp(src, "overlayfs:", 10) == 0)
-			src = ovl_getlower(src+10);
-		if (strncmp(src, "aufs:", 5) == 0)
-			src = ovl_getlower(src+5);
-
-		bdev = bdev_init(c->lxc_conf, src, c->lxc_conf->rootfs.mount, NULL);
+		bdev = bdev_init(c->lxc_conf, c->lxc_conf->rootfs.path, c->lxc_conf->rootfs.mount, NULL);
 		if (!bdev) {
 			ERROR("Error opening rootfs");
 			exit(1);


### PR DESCRIPTION
Since specifying lxc.rootfs.backend can lead to performance improvements we
always set it during container creation.

This also fixes a bug. do_bdev_create() tried to be smart and retrieve the lower
directory when bdev->type == overlayfs or aufs thereby cutting the path.
However, this operation is done in ovl_mount() and aufs_mount() and both
functions need the full src path for this. The bug didn't show before because
when creating a overlayfs container with e.g.:

	lxc-create -n c -t busybox -B overlayfs

still left bdev->type set to dir and so the code for retrieving the lower dir in
do_bdev_create() was skipped. But by setting lxc.rootfs.backend on container
creation we force bdev->type to be set to e.g. overlayfs and the code gets
executed thereby exposing the bug.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>