### PR TITLE
lxc-attach: attach even without sigwinch handler

### DIFF
--- a/src/lxc/console.h
+++ b/src/lxc/console.h
@@ -47,7 +47,9 @@ struct lxc_tty_state
 	const char *winch_proxy;
 	/* Path of the container to forward the SIGWINCH event to. */
 	const char *winch_proxy_lxcpath;
-	/* File descriptor that accepts SIGWINCH signals. */
+	/* File descriptor that accepts SIGWINCH signals. If set to -1 no
+	 * SIGWINCH handler could be installed. This also means that
+	 * the sigset_t oldmask member is meaningless. */
 	int sigfd;
 	sigset_t oldmask;
 };


### PR DESCRIPTION
lxc_console_create() calls lxc_console_peer_default() which in turn calls
lxc_console_sigwinch_init() which sets up the lxc_tty_state struct for the
current pty. Prior to this commit lxc_console_sigwinch_init() would consider
failures to install a SIGWINCH handler fatal and and return NULL. This commit
makes failures to install a SIGWINCH handler non-fatal. In such cases the
lxc_tty_state struct will still be set up but the sigfd member, which contains
the fd which receives SIGWINCH events, will be set to -1. (This also entails
that the sigset_t oldmaks field is meaningless.) Callers of
lxc_console_sigwinch_init() and lxc_console_sigwinch_fini() should thus make
sure that sigfd >= 0 or sigfd != -1 before trying to register a SIGWINCH handler
in e.g. an lxc_mainloop or resetting the sigmask (cf. lxc_attach.c).

These changes also imply that lxc_console_sigwinch_init() only fails with
ENOMEM. Thus, all cases where lxc_console_sigwinch_init() returns NULL are to be
considered fatal. This wasn't the case before this commit.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>