### PR TITLE
simplify pty allocation and implement pty logging

### DIFF
--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -27,10 +27,10 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/epoll.h>
-#include <sys/types.h>
 #include <termios.h>
 #include <unistd.h>
+#include <sys/epoll.h>
+#include <sys/types.h>
 
 #include <lxc/lxccontainer.h>
 
@@ -163,6 +163,9 @@ static int lxc_console_cb_con(int fd, uint32_t events, void *data,
 	char buf[1024];
 	int r,w;
 
+	if (events & EPOLLHUP)
+		return 1;
+
 	w = r = read(fd, buf, sizeof(buf));
 	if (r < 0) {
 		SYSERROR("failed to read");
@@ -212,10 +215,9 @@ static void lxc_console_mainloop_add_peer(struct lxc_console *console)
 	}
 }
 
-int lxc_console_mainloop_add(struct lxc_epoll_descr *descr,
-			     struct lxc_handler *handler)
+extern int lxc_console_mainloop_add(struct lxc_epoll_descr *descr,
+				    struct lxc_conf *conf)
 {
-	struct lxc_conf *conf = handler->conf;
 	struct lxc_console *console = &conf->console;
 
 	if (conf->is_execute) {

--- a/src/lxc/console.h
+++ b/src/lxc/console.h
@@ -102,7 +102,7 @@ extern void lxc_console_free(struct lxc_conf *conf, int fd);
 /*
  * Register pty event handlers in an open mainloop
  */
-extern int  lxc_console_mainloop_add(struct lxc_epoll_descr *, struct lxc_handler *);
+extern int  lxc_console_mainloop_add(struct lxc_epoll_descr *, struct lxc_conf *);
 
 /*
  * Handle SIGWINCH events on the allocated ptys.

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -365,7 +365,7 @@ int lxc_poll(const char *name, struct lxc_handler *handler)
 		goto out_mainloop_open;
 	}
 
-	if (lxc_console_mainloop_add(&descr, handler)) {
+	if (lxc_console_mainloop_add(&descr, handler->conf)) {
 		ERROR("failed to add console handler to mainloop");
 		goto out_mainloop_open;
 	}


### PR DESCRIPTION
lxc-attach allocated a pty in a manner that relied on ts->stdinfd and
ts->stdoutfd to be set. We had to resort to a trick to get it working when
output is redirected. The new implementation gets rid of the black magic and
also simplifies the code.

This commit also implements pty logging for lxc-attach. Users will now be able
to log commands and corresponding output to a file given that lxc-attach
allocates a pty.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>