### PR TITLE
Use size_t as an iteration point over int

### DIFF
--- a/src/lxc/arguments.c
+++ b/src/lxc/arguments.c
@@ -40,7 +40,7 @@ static int build_shortopts(const struct option *a_options,
 			   char *a_shortopts, size_t a_size)
 {
 	const struct option *opt;
-	int i = 0;
+	size_t i = 0;
 
 	if (!a_options || !a_shortopts || !a_size)
 		return -1;

--- a/src/lxc/bdev/bdev.c
+++ b/src/lxc/bdev/bdev.c
@@ -823,7 +823,7 @@ static struct bdev *do_bdev_create(const char *dest, const char *type,
 
 static struct bdev *bdev_get(const char *type)
 {
-	int i;
+	size_t i;
 	struct bdev *bdev;
 
 	for (i = 0; i < numbdevs; i++) {
@@ -843,7 +843,7 @@ static struct bdev *bdev_get(const char *type)
 
 static const struct bdev_type *get_bdev_by_name(const char *name)
 {
-	int i;
+	size_t i;
 
 	for (i = 0; i < numbdevs; i++) {
 		if (strcmp(bdevs[i].name, name) == 0)
@@ -856,7 +856,7 @@ static const struct bdev_type *get_bdev_by_name(const char *name)
 
 static const struct bdev_type *bdev_query(struct lxc_conf *conf, const char *src)
 {
-	int i;
+	size_t i;
 
 	if (conf->rootfs.bdev_type)
 		return get_bdev_by_name(conf->rootfs.bdev_type);

--- a/src/lxc/bdev/lxcoverlay.c
+++ b/src/lxc/bdev/lxcoverlay.c
@@ -569,7 +569,7 @@ int ovl_update_abs_paths(struct lxc_conf *lxc_conf, const char *lxc_path,
 	char old_upper[MAXPATHLEN];
 	char old_work[MAXPATHLEN];
 	char *cleanpath = NULL;
-	int i;
+	size_t i;
 	int fret = -1;
 	int ret = 0;
 	struct lxc_list *iterator;

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1989,7 +1989,8 @@ static int setup_mount_entries(const struct lxc_rootfs *rootfs, struct lxc_list 
 static int parse_cap(const char *cap)
 {
 	char *ptr = NULL;
-	int i, capid = -1;
+	size_t i;
+	int capid = -1;
 
 	if (!strcmp(cap, "none"))
 		return -2;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -274,7 +274,7 @@ static const size_t config_size = sizeof(config)/sizeof(struct lxc_config_t);
 
 extern struct lxc_config_t *lxc_getconfig(const char *key)
 {
-	int i;
+	size_t i;
 
 	for (i = 0; i < config_size; i++)
 		if (!strncmp(config[i].name, key,
@@ -297,7 +297,8 @@ extern struct lxc_config_t *lxc_getconfig(const char *key)
 
 int lxc_listconfigs(char *retv, int inlen)
 {
-	int i, fulllen = 0, len;
+	size_t i;
+	int fulllen = 0, len;
 
 	if (!retv)
 		inlen = 0;
@@ -607,7 +608,7 @@ static int macvlan_mode(int *valuep, const char *value)
 		{ "passthru", MACVLAN_MODE_PASSTHRU },
 	};
 
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(m)/sizeof(m[0]); i++) {
 		if (strcmp(m[i].name, value))
@@ -1350,7 +1351,7 @@ static int rt_sig_num(const char *signame)
 }
 
 static int sig_parse(const char *signame) {
-	int n;
+	size_t n;
 
 	if (isdigit(*signame)) {
 		return sig_num(signame);
@@ -2055,7 +2056,7 @@ signed long lxc_config_parse_arch(const char *arch)
 	};
 	size_t len = sizeof(pername) / sizeof(pername[0]);
 
-	int i;
+	size_t i;
 
 	for (i = 0; i < len; i++) {
 		if (!strcmp(pername[i].name, arch))

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -1507,7 +1507,7 @@ static const char padchar[] =
 char *lxc_mkifname(char *template)
 {
 	char *name = NULL;
-	int i = 0;
+	size_t i = 0;
 	FILE *urandom;
 	unsigned int seed;
 	struct ifaddrs *ifaddr, *ifa;

--- a/src/lxc/nl.c
+++ b/src/lxc/nl.c
@@ -54,7 +54,7 @@ static int nla_put(struct nlmsg *nlmsg, int attr,
 	struct rtattr *rta;
 	size_t rtalen = RTA_LENGTH(len);
 	size_t tlen = NLMSG_ALIGN(nlmsg->nlmsghdr->nlmsg_len) + RTA_ALIGN(rtalen);
-	
+
 	if (tlen > nlmsg->cap)
 		return -ENOMEM;
 

--- a/src/lxc/parse.c
+++ b/src/lxc/parse.c
@@ -66,7 +66,7 @@ int lxc_file_for_each_line(const char *file, lxc_file_cb callback, void *data)
 
 int lxc_char_left_gc(const char *buffer, size_t len)
 {
-	int i;
+	size_t i;
 	for (i = 0; i < len; i++) {
 		if (buffer[i] == ' ' ||
 		    buffer[i] == '\t')

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -941,7 +941,7 @@ void **lxc_append_null_to_array(void **array, size_t count)
 	if (count) {
 		temp = realloc(array, (count + 1) * sizeof(*array));
 		if (!temp) {
-			int i;
+			size_t i;
 			for (i = 0; i < count; i++)
 				free(array[i]);
 			free(array);


### PR DESCRIPTION
This cleans up some sign-compare warnings as well as avoids any
possibilities of unintended signed offsets for indices during
iteration.

Signed-off-by: Matt Ullman <staticfox@staticfox.net>