### PR TITLE
lxc-attach: error on -L/--pty-log + redirection

### DIFF
--- a/src/tests/lxc-test-lxc-attach
+++ b/src/tests/lxc-test-lxc-attach
@@ -190,14 +190,16 @@ fi
 
 rm -f $out $err
 
-# Test whether logging pty output to a file works.
-trap "rm -f /tmp/ptylog" EXIT INT QUIT PIPE
-lxc-attach -n busy -L /tmp/ptylog -- hostname || FAIL "to allocate or setup pty"
-if [ $allocate_pty == "pty" ] && [ ! -s /tmp/ptylog ]; then
-        FAIL "lxc-attach -n busy -L /tmp/ptylog -- hostname"
-fi
+if [ $allocate_pty = "pty" ]; then
+	# Test whether logging pty output to a file works.
+	trap "rm -f /tmp/ptylog" EXIT INT QUIT PIPE
+	lxc-attach -n busy -L /tmp/ptylog -- hostname || FAIL "to allocate or setup pty"
+	if [ ! -s /tmp/ptylog ]; then
+		FAIL "lxc-attach -n busy -L /tmp/ptylog -- hostname"
+	fi
 
-rm -f /tmp/ptylog
+	rm -f /tmp/ptylog
+fi
 
 lxc-destroy -n busy -f
 


### PR DESCRIPTION
pty logging only works correctly when stdout and stderr refer to a pty. If they
do not, we do not dup2() them and lxc_console_cb_con() will never write to the
corresponding log file descriptor.

When redirection on stdout and stderr is used we can safely assume that the user
is already logging to a file or /dev/null and creating an additional pty log
doesn't seem to make sense.

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>