### PR TITLE
do not set the root password in the debian template

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -140,9 +140,6 @@ EOF
         echo "Timezone in container is not configured. Adjust it manually."
     fi
 
-    echo "root:root" | chroot $rootfs chpasswd
-    echo "Root password is 'root', please change !"
-
     return 0
 }
 


### PR DESCRIPTION
closes #302

as discussed with @terceiro, this should go away. make it so :)

Signed-off-by: Evgeni Golov <evgeni@debian.org>