### PR TITLE
Fixed python-lxc reference to var before assignment

### DIFF
--- a/src/python-lxc/lxc/__init__.py
+++ b/src/python-lxc/lxc/__init__.py
@@ -222,11 +222,12 @@ class Container(_lxc.Container):
             for item in args.items():
                 tmp_args.append("--%s" % item[0])
                 tmp_args.append("%s" % item[1])
+            args = tmp_args
         template_args = {}
         if template:
     	    template_args['template'] = template
         template_args['flags'] = flags
-        template_args['args'] = tuple(tmp_args)
+        template_args['args'] = tuple(args)
         if bdevtype:
             template_args['bdevtype'] = bdevtype
         return _lxc.Container.create(self, **template_args)


### PR DESCRIPTION
```
>>> c = lxc.Container('ct')
>>> c.create('debian', args=('-r', 'jessie'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/lxc/__init__.py", line 229, in
create
    template_args['args'] = tuple(tmp_args)
UnboundLocalError: local variable 'tmp_args' referenced before
assignment
```

Signed-off-by: Aron Podrigal <aronp@guaranteedplus.com>