### PR TITLE
drop obsolete syslog.target from lxc.service.in

### DIFF
--- a/config/init/systemd/lxc.service.in
+++ b/config/init/systemd/lxc.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=LXC Container Initialization and Autoboot Code
-After=syslog.target network.target lxc-net.service
+After=network.target lxc-net.service
 Wants=lxc-net.service
 
 [Service]


### PR DESCRIPTION
the target is obsolete since systemd v38 which everybody should have.

original patch by Daniel Baumann

Signed-off-by: Evgeni Golov <evgeni@debian.org>