### PR TITLE
don't make sysv init scripts dependant on distribution specifics

### DIFF
--- a/config/init/sysvinit/lxc-containers.in
+++ b/config/init/sysvinit/lxc-containers.in
@@ -17,30 +17,26 @@
 # Description: Bring up/down LXC autostart containers
 ### END INIT INFO
 
-sysconfdir="@SYSCONFDIR@"
+# To be replaced by LSB functions, if they can be found
+# Defined here for distributions that don't have log_daemon_msg
+log_daemon_msg () {
+    echo $@
+}
 
-# Source function library.
-test ! -r "$sysconfdir"/rc.d/init.d/functions ||
-        . "$sysconfdir"/rc.d/init.d/functions
-
-# provide action() fallback
-if ! type action >/dev/null 2>&1; then
-    # Real basic fallback for sysvinit "action" verbage.
-    action() {
-        echo -n "$1	"
-        shift
-        "$@" && echo "OK" || echo "Failed"
-    }
-fi
+# Try to source LSB init functions to define LSB log_* functions.
+test ! -r /lib/lsb/init-functions ||
+        . /lib/lsb/init-functions
 
 start() {
     # Setup host /dev for autodev containers.
     @LIBEXECDIR@/lxc/lxc-devsetup
-    action $"Starting LXC autoboot containers: " @LIBEXECDIR@/lxc/lxc-containers start
+    log_daemon_msg "Starting LXC autoboot containers: "
+    @LIBEXECDIR@/lxc/lxc-containers start
 }
 
 stop() {
-    action $"Stopping LXC containers: " @LIBEXECDIR@/lxc/lxc-containers stop
+    log_daemon_msg "Stopping LXC containers: "
+    @LIBEXECDIR@/lxc/lxc-containers stop
 }
 
 # See how we were called.

--- a/config/init/sysvinit/lxc-net.in
+++ b/config/init/sysvinit/lxc-net.in
@@ -17,28 +17,24 @@
 # Description: Bring up/down LXC Network Bridge
 ### END INIT INFO
 
-sysconfdir="@SYSCONFDIR@"
+# To be replaced by LSB functions, if they can be found
+# Defined here for distributions that don't have log_daemon_msg
+log_daemon_msg () {
+    echo $@
+}
 
-# Source function library.
-test ! -r "$sysconfdir"/rc.d/init.d/functions ||
-        . "$sysconfdir"/rc.d/init.d/functions
-
-# provide action() fallback
-if ! type action >/dev/null 2>&1; then
-    # Real basic fallback for sysvinit "action" verbage.
-    action() {
-        echo -n "$1	"
-        shift
-        "$@" && echo "OK" || echo "Failed"
-    }
-fi
+# Try to source LSB init functions to define LSB log_* functions.
+test ! -r /lib/lsb/init-functions ||
+        . /lib/lsb/init-functions
 
 start() {
-    action $"Starting LXC network bridge: " @LIBEXECDIR@/lxc/lxc-net start
+    log_daemon_msg "Starting LXC network bridge: "
+    @LIBEXECDIR@/lxc/lxc-net start
 }
 
 stop() {
-    action $"Stopping LXC network bridge: " @LIBEXECDIR@/lxc/lxc-net stop
+    log_daemon_msg "Stopping LXC network bridge: "
+    @LIBEXECDIR@/lxc/lxc-net stop
 }
 
 # See how we were called.


### PR DESCRIPTION
- /etc(/rc.d)?/init.d/functions does not exist on all distributions
- LSB does not define a message function without an explicit status
- Debian-derived systems add a log_daemon_msg for that

lets define an own log_daemon_msg as echo and try to load LSB init
functions afterwards, which might overload it with a nicer version

that way the init scripts should work on any system, without hard
dependencies on neither LSB nor /etc/init.d/functions

Signed-off-by: Evgeni Golov <evgeni@debian.org>