### PR TITLE
add vagrant for lxc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ TAGS
 
 doc/api/doxygen_sqlite3.db
 doc/api/*.tmp
+
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,15 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.synced_folder ".", "/home/vagrant/lxc"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo add-apt-repository ppa:ubuntu-lxc/daily -y
+    sudo apt-get update -qq
+    sudo apt-get install -qq gcc automake
+    sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev python3-dev docbook2x libgnutls-dev liblua5.2-dev libselinux1-dev libcgmanager-dev
+  SHELL
+end


### PR DESCRIPTION
* uses 14.04 official image
* sets up the dependencies required to compile lxc
* shares the local development directory from host to /home/vagrant/lxc

Signed-off-by: Akshay Karle <akshay.a.karle@gmail.com>