### PR TITLE
Fix regressions in lxc 1.1.x for containers without rootfs

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3669,6 +3669,7 @@ int ttys_shift_ids(struct lxc_conf *c)
 	return 0;
 }
 
+/* NOTE: not to be called from inside the container namespace! */
 int tmp_proc_mount(struct lxc_conf *lxc_conf)
 {
 	int mounted;

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -948,10 +948,15 @@ static int setup_dev_symlinks(const struct lxc_rootfs *rootfs)
 	int ret,i;
 	struct stat s;
 
+	/* rootfs struct will be empty when container is created without rootfs. */
+	char *rootfs_path = NULL;
+	if (rootfs && rootfs->path)
+		rootfs_path = rootfs->mount;
+
 
 	for (i = 0; i < sizeof(dev_symlinks) / sizeof(dev_symlinks[0]); i++) {
 		const struct dev_symlinks *d = &dev_symlinks[i];
-		ret = snprintf(path, sizeof(path), "%s/dev/%s", rootfs->path ? rootfs->mount : "", d->name);
+		ret = snprintf(path, sizeof(path), "%s/dev/%s", rootfs_path ? rootfs_path : "", d->name);
 		if (ret < 0 || ret >= MAXPATHLEN)
 			return -1;
 
@@ -1154,13 +1159,18 @@ static int mount_autodev(const char *name, const struct lxc_rootfs *rootfs, cons
 	size_t clen;
 	char *path;
 
+	/* rootfs struct will be empty when container is created without rootfs. */
+	char *rootfs_path = NULL;
+	if (rootfs && rootfs->path)
+		rootfs_path = rootfs->mount;
+
 	INFO("Mounting container /dev");
 
 	/* $(rootfs->mount) + "/dev/pts" + '\0' */
-	clen = (rootfs->path ? strlen(rootfs->mount) : 0) + 9;
+	clen = (rootfs_path ? strlen(rootfs_path) : 0) + 9;
 	path = alloca(clen);
 
-	ret = snprintf(path, clen, "%s/dev", rootfs->path ? rootfs->mount : "");
+	ret = snprintf(path, clen, "%s/dev", rootfs_path ? rootfs_path : "");
 	if (ret < 0 || ret >= clen)
 		return -1;
 
@@ -1170,15 +1180,16 @@ static int mount_autodev(const char *name, const struct lxc_rootfs *rootfs, cons
 		return 0;
 	}
 
-	if (safe_mount("none", path, "tmpfs", 0, "size=100000,mode=755",
-				rootfs->path ? rootfs->mount : NULL)) {
+	ret = safe_mount("none", path, "tmpfs", 0, "size=100000,mode=755",
+			rootfs_path);
+	if (ret != 0) {
 		SYSERROR("Failed mounting tmpfs onto %s\n", path);
-		return false;
+		return -1;
 	}
 
 	INFO("Mounted tmpfs onto %s",  path);
 
-	ret = snprintf(path, clen, "%s/dev/pts", rootfs->path ? rootfs->mount : "");
+	ret = snprintf(path, clen, "%s/dev/pts", rootfs_path ? rootfs_path : "");
 	if (ret < 0 || ret >= clen)
 		return -1;
 
@@ -1222,9 +1233,14 @@ static int fill_autodev(const struct lxc_rootfs *rootfs)
 	int i;
 	mode_t cmask;
 
+	/* rootfs struct will be empty when container is created without rootfs. */
+	char *rootfs_path = NULL;
+	if (rootfs && rootfs->path)
+		rootfs_path = rootfs->mount;
+
 	INFO("Creating initial consoles under container /dev");
 
-	ret = snprintf(path, MAXPATHLEN, "%s/dev", rootfs->path ? rootfs->mount : "");
+	ret = snprintf(path, MAXPATHLEN, "%s/dev", rootfs_path ? rootfs_path : "");
 	if (ret < 0 || ret >= MAXPATHLEN) {
 		ERROR("Error calculating container /dev location");
 		return -1;
@@ -1237,7 +1253,7 @@ static int fill_autodev(const struct lxc_rootfs *rootfs)
 	cmask = umask(S_IXUSR | S_IXGRP | S_IXOTH);
 	for (i = 0; i < sizeof(lxc_devs) / sizeof(lxc_devs[0]); i++) {
 		const struct lxc_devs *d = &lxc_devs[i];
-		ret = snprintf(path, MAXPATHLEN, "%s/dev/%s", rootfs->path ? rootfs->mount : "", d->name);
+		ret = snprintf(path, MAXPATHLEN, "%s/dev/%s", rootfs_path ? rootfs_path : "", d->name);
 		if (ret < 0 || ret >= MAXPATHLEN)
 			return -1;
 		ret = mknod(path, d->mode, makedev(d->maj, d->min));
@@ -1257,7 +1273,7 @@ static int fill_autodev(const struct lxc_rootfs *rootfs)
 			}
 			fclose(pathfile);
 			if (safe_mount(hostpath, path, 0, MS_BIND, NULL,
-						rootfs->path ? rootfs->mount : NULL) != 0) {
+						rootfs_path ? rootfs_path : NULL) != 0) {
 				SYSERROR("Failed bind mounting device %s from host into container",
 					d->name);
 				return -1;
@@ -1868,7 +1884,7 @@ static int mount_entry_create_overlay_dirs(const struct mntent *mntent,
 	size_t len = 0;
 	size_t rootfslen = 0;
 
-	if (!rootfs->path || !lxc_name || !lxc_path)
+	if (!rootfs || !rootfs->path || !lxc_name || !lxc_path)
 		goto err;
 
 	opts = lxc_string_split(mntent->mnt_opts, ',');
@@ -1934,7 +1950,7 @@ static int mount_entry_create_aufs_dirs(const struct mntent *mntent,
 	size_t len = 0;
 	size_t rootfslen = 0;
 
-	if (!rootfs->path || !lxc_name || !lxc_path)
+	if (!rootfs || !rootfs->path || !lxc_name || !lxc_path)
 		goto err;
 
 	opts = lxc_string_split(mntent->mnt_opts, ',');
@@ -2040,9 +2056,13 @@ static inline int mount_entry_on_generic(struct mntent *mntent,
 		return -1;
 	}
 
+	/* rootfs struct will be empty when container is created without rootfs. */
+	char *rootfs_path = NULL;
+	if (rootfs && rootfs->path)
+		rootfs_path = rootfs->mount;
+
 	ret = mount_entry(mntent->mnt_fsname, path, mntent->mnt_type, mntflags,
-			  mntdata, optional,
-			  rootfs->path ? rootfs->mount : NULL);
+			mntdata, optional, rootfs_path);
 
 	free(mntdata);
 	return ret;

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2061,7 +2061,22 @@ static inline int mount_entry_on_generic(struct mntent *mntent,
 
 static inline int mount_entry_on_systemfs(struct mntent *mntent)
 {
-	return mount_entry_on_generic(mntent, mntent->mnt_dir, NULL, NULL, NULL);
+	char path[MAXPATHLEN];
+	int ret;
+
+	/* For containers created without a rootfs all mounts are treated as
+	 * absolute paths starting at / on the host. */
+	if (mntent->mnt_dir[0] != '/')
+		ret = snprintf(path, sizeof(path), "/%s", mntent->mnt_dir);
+	else
+		ret = snprintf(path, sizeof(path), "%s", mntent->mnt_dir);
+
+	if (ret < 0 || ret >= sizeof(path)) {
+		ERROR("path name too long");
+		return -1;
+	}
+
+	return mount_entry_on_generic(mntent, path, NULL, NULL, NULL);
 }
 
 static int mount_entry_on_absolute_rootfs(struct mntent *mntent,
@@ -2122,7 +2137,7 @@ static int mount_entry_on_relative_rootfs(struct mntent *mntent,
 
 	/* relative to root mount point */
 	ret = snprintf(path, sizeof(path), "%s/%s", rootfs->mount, mntent->mnt_dir);
-	if (ret >= sizeof(path)) {
+	if (ret < 0 || ret >= sizeof(path)) {
 		ERROR("path name too long");
 		return -1;
 	}

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1622,8 +1622,6 @@ static int open_without_symlink(const char *target, const char *prefix_skip)
 			errno = saved_errno;
 			if (errno == ELOOP)
 				SYSERROR("%s in %s was a symbolic link!", nextpath, target);
-			else
-				SYSERROR("Error examining %s in %s", nextpath, target);
 			goto out;
 		}
 	}
@@ -1668,8 +1666,11 @@ int safe_mount(const char *src, const char *dest, const char *fstype,
 
 	destfd = open_without_symlink(dest, rootfs);
 	if (destfd < 0) {
-		if (srcfd != -1)
+		if (srcfd != -1) {
+			saved_errno = errno;
 			close(srcfd);
+			errno = saved_errno;
+		}
 		return destfd;
 	}
 

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1576,7 +1576,7 @@ static int open_without_symlink(const char *target, const char *prefix_skip)
 	fulllen = strlen(target);
 
 	/* make sure prefix-skip makes sense */
-	if (prefix_skip) {
+	if (prefix_skip && strlen(prefix_skip) > 0) {
 		curlen = strlen(prefix_skip);
 		if (!is_subdir(target, prefix_skip, curlen)) {
 			ERROR("WHOA there - target '%s' didn't start with prefix '%s'",

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1705,6 +1705,8 @@ int safe_mount(const char *src, const char *dest, const char *fstype,
  *
  * Returns < 0 on failure, 0 if the correct proc was already mounted
  * and 1 if a new proc was mounted.
+ *
+ * NOTE: not to be called from inside the container namespace!
  */
 int mount_proc_if_needed(const char *rootfs)
 {
@@ -1738,8 +1740,14 @@ int mount_proc_if_needed(const char *rootfs)
 	return 0;
 
 domount:
-	if (safe_mount("proc", path, "proc", 0, NULL, rootfs) < 0)
+	if (!strcmp(rootfs,"")) /* rootfs is NULL */
+		ret = mount("proc", path, "proc", 0, NULL);
+	else
+		ret = safe_mount("proc", path, "proc", 0, NULL, rootfs);
+
+	if (ret < 0)
 		return -1;
+
 	INFO("Mounted /proc in container for security transition");
 	return 1;
 }


### PR DESCRIPTION
Commit 6de26af93d3dd87c8b21a42fdf20f30fa1c1948d ("CVE-2015-1335: Protect container mounts against symlinks") introduced regressions for containers without a rootfs. These have been fixed in the master branch and are included in lxc 2.0.0. Backport the necessary commits to the stable-1.1 branch to restore functionality.