### PR TITLE
Check if the stdout is a terminal in lxc-checkconfig

### DIFF
--- a/src/lxc/lxc-checkconfig.in
+++ b/src/lxc/lxc-checkconfig.in
@@ -6,10 +6,17 @@
 
 CAT="cat"
 
-SETCOLOR_SUCCESS="printf \\033[1;32m"
-SETCOLOR_FAILURE="printf \\033[1;31m"
-SETCOLOR_WARNING="printf \\033[1;33m"
-SETCOLOR_NORMAL="printf \\033[0;39m"
+if [ -t 1 ]; then
+    SETCOLOR_SUCCESS="printf \\033[1;32m"
+    SETCOLOR_FAILURE="printf \\033[1;31m"
+    SETCOLOR_WARNING="printf \\033[1;33m"
+    SETCOLOR_NORMAL="printf \\033[0;39m"
+else
+    SETCOLOR_SUCCESS=":"
+    SETCOLOR_FAILURE=":"
+    SETCOLOR_WARNING=":"
+    SETCOLOR_NORMAL=":"
+fi
 
 is_set() {
     $CAT $CONFIG | grep "$1=[y|m]" > /dev/null


### PR DESCRIPTION
This makes me feel more convenient when reading a long  `lxc-checkconfig` output using `less` or redirecting the `lxc-checkconfig` output to file for sending to others.

I don't know if you guys think this is necessary... 
