### PR TITLE
Fixed - set PyErr when Container.__init__ fails

### DIFF
--- a/src/python-lxc/lxc.c
+++ b/src/python-lxc/lxc.c
@@ -449,7 +449,9 @@ Container_init(Container *self, PyObject *args, PyObject *kwds)
     self->container = lxc_container_new(name, config_path);
     if (!self->container) {
         Py_XDECREF(fs_config_path);
-        fprintf(stderr, "%d: error creating container %s\n", __LINE__, name);
+
+        PyErr_Format(PyExc_RuntimeError, "%s:%s:%d: error during init for container '%s'.",
+			__FUNCTION__, __FILE__, __LINE__, name);
         return -1;
     }
 


### PR DESCRIPTION
When container init failed for whatever reason, previously it resulted
in a `SystemError: NULL result without error in PyObject_Call`
This will now result in a RuntimeError
```
>>> import lxc
>>> 
>>> c = lxc.Container('aron')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3/dist-packages/lxc/__init__.py", line 157, in __init__
    _lxc.Container.__init__(self, name)
RuntimeError: Container_init:lxc.c:454: error during init for container 'aron'.
>>> 
```

Signed-off-by: Aron Podrigal <aronp@guaranteedplus.com>