### PR TITLE
Added `type` to keys in lxc_list_nicconfigs

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -521,6 +521,7 @@ extern int lxc_list_nicconfigs(struct lxc_conf *c, const char *key,
 	else
 		memset(retv, 0, inlen);
 
+	strprint(retv, inlen, "type\n");
 	strprint(retv, inlen, "script.up\n");
 	strprint(retv, inlen, "script.down\n");
 	if (netdev->type != LXC_NET_EMPTY) {


### PR DESCRIPTION
I wanted to have network.type exposed in lxc-python. I'm not sure if we want this key to be part of the network config, if not here I would modify lxc-python to allow such access `Container('ct').network[0].type`.

Signed-off-by: Aron Podrigal <aronp@guaranteedplus.com>