### PR TITLE
Force DHCP client to send hostname

### DIFF
--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -346,6 +346,7 @@ setup_network() {
 	cat <<-EOF > etc/network/interfaces
 		auto eth0
 		iface eth0 inet dhcp
+		hostname $(hostname)
 	EOF
 }
 


### PR DESCRIPTION
Required for proper applying dnsmasq config entries.

Signed-off-by: Andrey Kostin <andrey@kostin.email>