### PR TITLE
Change sys_resources to sys_resource.

### DIFF
--- a/config/templates/gentoo.moresecure.conf.in
+++ b/config/templates/gentoo.moresecure.conf.in
@@ -29,8 +29,8 @@ lxc.mount.entry=run run tmpfs rw,nosuid,nodev,relatime,mode=755 0 0
 # lxc.cap.drop = audit_control    # breaks sshd (set_loginuid failed)
 # lxc.cap.drop = audit_write
 # lxc.cap.drop = setpcap          # breaks journald
-# lxc.cap.drop = sys_resources    # breaks systemd
-lxc.cap.drop = audit_control audit_write dac_read_search fsetid ipc_owner linux_immutable mknod setfcap setpcap sys_admin sys_boot sys_nice sys_pacct sys_ptrace sys_rawio sys_resources sys_tty_config syslog
+# lxc.cap.drop = sys_resource     # breaks systemd
+lxc.cap.drop = audit_control audit_write dac_read_search fsetid ipc_owner linux_immutable mknod setfcap setpcap sys_admin sys_boot sys_nice sys_pacct sys_ptrace sys_rawio sys_resource sys_tty_config syslog
 
 # WARNING: the security vulnerability reported for 'cap_net_admin' at
 # http://mainisusuallyafunction.blogspot.com/2012/11/attacking-hardened-linux-systems-with.html

--- a/config/templates/slackware.common.conf.in
+++ b/config/templates/slackware.common.conf.in
@@ -41,6 +41,6 @@ lxc.mount.entry = none dev/shm tmpfs rw,nosuid,nodev,create=dir
 # lxc.cap.drop = audit_control    # breaks sshd (set_loginuid failed)
 # lxc.cap.drop = audit_write
 # lxc.cap.drop = setpcap          # breaks journald
-# lxc.cap.drop = sys_resources    # breaks systemd
+# lxc.cap.drop = sys_resource     # breaks systemd
 #
 lxc.cap.drop = mknod setfcap setpcap


### PR DESCRIPTION
gentoo.moresecure.conf tries to drop the capability CAP_SYS_RESOURCES.
However, that capability doesn't exist, so the container doesn't start.
Change it to CAP_SYS_RESOURCE, according to capabilities(7).

Also correct the same typo in a comment in slackware.common.conf.

Signed-off-by: Karl-Johan Karlsson <creideiki@ferretporn.se>