### PR TITLE
Added OR for ID = rhel in RHEL 7+

### DIFF
--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -137,8 +137,9 @@ if [ "${CPE_NAME}" != "" -a "${ID}" = "centos" -a "${VERSION_ID}" != "" ]
 then
     centos_host_ver=${VERSION_ID}
     is_centos=true
-elif [ "${CPE_NAME}" != "" -a "${ID}" = "redhat" -a "${VERSION_ID}" != "" ]
+elif [ "${CPE_NAME}" != "" -a "${ID}" = "redhat" -o "${ID}" = "rhel" -a "${VERSION_ID}" != "" ]
 then
+    # RHEL 7+ /etc/os-release ID = 'rhel', which doesn't enter this elif without the added OR
     redhat_host_ver=${VERSION_ID}
     is_redhat=true
 elif [ -e /etc/centos-release ]
@@ -394,7 +395,7 @@ configure_centos_init()
 #  power-status-changed - shutdown on SIGPWR
 #
 start on power-status-changed
-    
+
 exec /sbin/shutdown -h now "SIGPWR received"
 EOF
     fi

--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -139,7 +139,7 @@ then
     is_centos=true
 elif [ "${CPE_NAME}" != "" -a "${ID}" = "redhat" -o "${ID}" = "rhel" -a "${VERSION_ID}" != "" ]
 then
-    # RHEL 7+ /etc/os-release ID = 'rhel', which doesn't enter this elif without the added OR
+    # RHEL 7+ /etc/os-release ID = 'rhel', which doesn't enter this elif without the added OR statement
     redhat_host_ver=${VERSION_ID}
     is_redhat=true
 elif [ -e /etc/centos-release ]


### PR DESCRIPTION
Discovered a bug when attempting to create CentOS containers on RHEL 7.2, where lxc-create would fail due to ID in /etc/os-release being 'rhel' rather than 'redhat'.