### PR TITLE
Unshare netns after setting the userns mappings

### DIFF
--- a/src/lxc/sync.c
+++ b/src/lxc/sync.c
@@ -99,6 +99,11 @@ int lxc_sync_wake_parent(struct lxc_handler *handler, int sequence)
 	return __sync_wake(handler->sv[0], sequence);
 }
 
+int lxc_sync_wait_parent(struct lxc_handler *handler, int sequence)
+{
+	return __sync_wait(handler->sv[0], sequence);
+}
+
 int lxc_sync_wait_child(struct lxc_handler *handler, int sequence)
 {
 	return __sync_wait(handler->sv[1], sequence);

--- a/src/lxc/sync.h
+++ b/src/lxc/sync.h
@@ -26,6 +26,7 @@
 struct lxc_handler;
 
 enum {
+	LXC_SYNC_STARTUP,
 	LXC_SYNC_CONFIGURE,
 	LXC_SYNC_POST_CONFIGURE,
 	LXC_SYNC_CGROUP,
@@ -42,6 +43,7 @@ void lxc_sync_fini_child(struct lxc_handler *);
 int lxc_sync_wake_child(struct lxc_handler *, int);
 int lxc_sync_wait_child(struct lxc_handler *, int);
 int lxc_sync_wake_parent(struct lxc_handler *, int);
+int lxc_sync_wait_parent(struct lxc_handler *, int);
 int lxc_sync_barrier_parent(struct lxc_handler *, int);
 int lxc_sync_barrier_child(struct lxc_handler *, int);
 


### PR DESCRIPTION
so that there is a root uid mapping for the /proc/net files.

This is a fix for lxd issue #1978.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>