### PR TITLE
Allow configuration file values to be quoted

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1964,6 +1964,14 @@ static int parse_line(char *buffer, void *data)
 	value += lxc_char_left_gc(value, strlen(value));
 	value[lxc_char_right_gc(value, strlen(value))] = '\0';
 
+	if (*value == '\'' || *value == '\"') {
+		size_t len = strlen(value);
+		if (len > 1 && value[len-1] == *value) {
+			value[len-1] = '\0';
+			value++;
+		}
+	}
+
 	config = lxc_getconfig(key);
 	if (!config) {
 		ERROR("unknown key %s", key);


### PR DESCRIPTION
If the value starts and ends with matching quote characters, those
characters are stripped automatically.   Quote characters are the
single quote (') or double quote (").  The quote removal is done after
the whitespace trimming.

This is needed particularly in order that lxc.environment values may
have trailing spaces.  However, the quote removal is done for all values
in the parse_line function, as it has non-const access to the value.

Signed-off-by: Stewart Brodie <stewart@metahusky.net>