### PR TITLE
log: remove duplicate definitons and bump buffer size

### DIFF
--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -40,8 +40,6 @@
 #include "caps.h"
 #include "utils.h"
 
-#define LXC_LOG_PREFIX_SIZE	32
-#define LXC_LOG_BUFFER_SIZE	512
 #define LXC_LOG_DATEFOMAT_SIZE  15
 
 int lxc_log_fd = -1;

--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -44,7 +44,7 @@
 #endif
 
 #define LXC_LOG_PREFIX_SIZE	32
-#define LXC_LOG_BUFFER_SIZE	512
+#define LXC_LOG_BUFFER_SIZE	1024
 
 /* This attribute is required to silence clang warnings */
 #if defined(__GNUC__)


### PR DESCRIPTION
When writing out the CRIU exec command, we're bumping up against the buffer
size limit. Let's increase it so we can avoid:

lxc 20160509213229.921 WARN     lxc_log - log.c:log_append_logfile:111 - truncated next event from 523 to 512 bytes

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>