### PR TITLE
Add apt-transport-https to minbase variant packages_template

### DIFF
--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -359,7 +359,7 @@ download_ubuntu()
         debootstrap_parameters="$debootstrap_parameters --variant=$variant"
     fi
     if [ "$variant" = 'minbase' ]; then
-        packages_template="${packages_template},sudo,ifupdown,isc-dhcp-client"
+        packages_template="${packages_template},sudo,ifupdown,isc-dhcp-client,apt-transport-https"
     fi
 
     echo "Installing packages in template: ${packages_template}"


### PR DESCRIPTION
In many environments the preference is to configure containers with
apt mirrors that are SSL-secured.

When building containers using the download template this can't be
done unless an insecure mirror is first used to install the
apt-transport-https package, then the sources reconfigured to
use the https URL.

When building containers without using the download template this
can't be done unless the container creator specifically includes
this package in the package list at build time.

It seems more intuitive to me to have the package installed by
default. This patch includes the required package for the minbase
variant only as this is the default.