### PR TITLE
Fix redefinition of struct in6_addr

### DIFF
--- a/src/lxc/lxc_user_nic.c
+++ b/src/lxc/lxc_user_nic.c
@@ -41,7 +41,6 @@
 #include <net/if.h>
 #include <net/if_arp.h>
 #include <netinet/in.h>
-#include <linux/if_bridge.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/sockios.h>


### PR DESCRIPTION
`struct in6_addr` is both defined in the C library header `<netinet/in.h>` and the Linux kernel header `<linux/in6.h>`.

lxc_user_nic.c includes both `<netinet/in.h>` and `<linux/if_bridge.h>`. The later one includes `<linux/in6.h>.`

This breaks build with the musl libc:
  `error: redefinition of ‘struct in6_addr’`

As lxc_user_nic.c does not use any references from `<linux/if_bridge.h>` it is safe to remove this header.