### PR TITLE
travis: test VPATH builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,12 @@ before_install:
  - sudo add-apt-repository ppa:ubuntu-lxc/daily -y
  - sudo apt-get update -qq
  - sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev python3-dev docbook2x libgnutls-dev liblua5.2-dev libselinux1-dev libcgmanager-dev
-script: ./autogen.sh && ./configure --enable-tests && make -j4
+script:
+ - ./autogen.sh
+ - mkdir build
+ - cd build
+ - ../configure --enable-tests
+ - make -j4
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
  - cd build
  - ../configure --enable-tests
  - make -j4
+ - make DESTDIR=$TRAVIS_BUILD_DIR/install install
 notifications:
   email:
     recipients:


### PR DESCRIPTION
It looks like VPATH (split source and build directories) builds
are frequently broken. So let's test them on travis-ci.

Personally I use VPATH build in my deployment scripts.

Signed-off-by: Aleksandr Mezin <mezin.alexander@gmail.com>