### PR TITLE
python-lxc: change distribution name _lxc -> lxc

### DIFF
--- a/src/python-lxc/setup.py
+++ b/src/python-lxc/setup.py
@@ -63,7 +63,7 @@ class LxcBuildExtCommand(BuildExtCommand):
         super(LxcBuildExtCommand, self).build_extensions()
 
 
-setup(name='_lxc',
+setup(name='lxc',
       version='0.1',
       description='LXC',
       packages=['lxc'],


### PR DESCRIPTION
Distribution name starting with an underscore is considered invalid by
many tools. For example, you can't list such name in
install_requires in your setup.py.

error: Invalid distribution name or version syntax: -lxc-0.1

Signed-off-by: Aleksandr Mezin <mezin.alexander@gmail.com>