### PR TITLE
python-lxc: use setuptools instead of distutils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
 before_install:
  - sudo add-apt-repository ppa:ubuntu-lxc/daily -y
  - sudo apt-get update -qq
- - sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev python3-dev docbook2x libgnutls-dev liblua5.2-dev libselinux1-dev libcgmanager-dev
+ - sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev python3-dev python3-setuptools docbook2x libgnutls-dev liblua5.2-dev libselinux1-dev libcgmanager-dev
 script:
  - ./autogen.sh
  - mkdir build

--- a/lxc.spec.in
+++ b/lxc.spec.in
@@ -97,6 +97,7 @@ BuildRequires:  libseccomp-devel
 %if %{with_python}
 Requires: python3
 BuildRequires: python3-devel
+BuildRequires: python3-setuptools
 %endif
 
 %description

--- a/src/python-lxc/setup.py
+++ b/src/python-lxc/setup.py
@@ -25,8 +25,8 @@
 import os
 import subprocess
 
-from distutils.core import setup, Extension
-from distutils.command.build_ext import build_ext as BuildExtCommand
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext as BuildExtCommand
 
 
 class LxcBuildExtCommand(BuildExtCommand):


### PR DESCRIPTION
setuptools is recommended by Python Packaging Guide
https://python-packaging-user-guide.readthedocs.io/en/latest/current/

It contains some useful extensions like 'develop' command. Also it
is required for building wheels AFAIK.

The only downside is an extra build-time dependency. setuptools are
packaged in both Debian and Ubuntu (python3-setuptools), as well as
other major distros, so it shouldn't be an issue, I think.

Signed-off-by: Aleksandr Mezin <mezin.alexander@gmail.com>