### PR TITLE
python-lxc: fix breakage caused by the switch to setuptools

### DIFF
--- a/src/python-lxc/Makefile.am
+++ b/src/python-lxc/Makefile.am
@@ -6,7 +6,7 @@ else
     DISTSETUPOPTS=
 endif
 
-CALL_SETUP_PY := cd @srcdir@ && $(PYTHON) setup.py build -b @abs_builddir@/build
+CALL_SETUP_PY := cd @srcdir@ && $(PYTHON) setup.py build -b @abs_builddir@/build egg_info -e @abs_builddir@
 
 all:
 	$(CALL_SETUP_PY) build_ext -I @abs_top_srcdir@/src -L @abs_top_builddir@/src/lxc --no-pkg-config

--- a/src/python-lxc/Makefile.am
+++ b/src/python-lxc/Makefile.am
@@ -6,18 +6,15 @@ else
     DISTSETUPOPTS=
 endif
 
-INSTALL_OPTS := install --prefix=$(prefix) --no-compile $(DISTSETUPOPTS)
 CALL_SETUP_PY := cd @srcdir@ && $(PYTHON) setup.py build -b @abs_builddir@/build
 
 all:
 	$(CALL_SETUP_PY) build_ext -I @abs_top_srcdir@/src -L @abs_top_builddir@/src/lxc --no-pkg-config
 
+DESTDIR = / # default
+
 install:
-	if [ -z "$(DESTDIR)" ]; then \
-		$(CALL_SETUP_PY) $(INSTALL_OPTS); \
-	else \
-		$(CALL_SETUP_PY) $(INSTALL_OPTS) --root=$(DESTDIR); \
-	fi
+	$(CALL_SETUP_PY) install --prefix=$(prefix) --no-compile $(DISTSETUPOPTS) --root=$(DESTDIR)
 
 clean-local:
 	rm -rf @builddir@/build


### PR DESCRIPTION
Looks like it's a bug in Debian or Ubuntu Python/setuptools patches.
When `--install-layout=deb` is passed to `setup.py`, setuptools don't generate stub helpers for loading extensions from .egg files. The same command without `--install-layout` works as expected.

However, it could simply be an unsupported configuration, because distro packages should be built with `--single-version-externally-managed`, which prevents .egg builds.

So, I assume setuptools builds will be used for distro packages. Then the fix is very simple: always pass `--root=` to `setup.py`, even when `DESTDIR` isn't set. As `--root` implies `--single-version-externally-managed`.