### PR TITLE
start containers in foreground when using the lxc@.service

### DIFF
--- a/config/init/systemd/lxc@.service.in
+++ b/config/init/systemd/lxc@.service.in
@@ -9,7 +9,7 @@ Type=simple
 KillMode=mixed
 KillSignal=SIGPWR
 TimeoutStopSec=120s
-ExecStart=@BINDIR@/lxc-start -n %i
+ExecStart=@BINDIR@/lxc-start -F -n %i
 # Environment=BOOTUP=serial
 # Environment=CONSOLETYPE=serial
 Delegate=yes


### PR DESCRIPTION
lxc-start started to default to daemonize the container when starting
this conflicts with type=simple of the systemd unit

call lxc-start with -F and thus force execution in foreground
that way we can feed the log to journald properly and keep type=simple

Debian-Bug: https://bugs.debian.org/826100
Signed-off-by: Evgeni Golov <evgeni@golov.de>