### PR TITLE
Move apt-transport-https to global packages_template

### DIFF
--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -342,7 +342,7 @@ download_ubuntu()
             ;;
     esac
 
-    packages_template=${packages_template:-"ssh,vim"}
+    packages_template=${packages_template:-"apt-transport-https,ssh,vim"}
     debootstrap_parameters=
 
     # Try to guess a list of langpacks to install
@@ -359,7 +359,7 @@ download_ubuntu()
         debootstrap_parameters="$debootstrap_parameters --variant=$variant"
     fi
     if [ "$variant" = 'minbase' ]; then
-        packages_template="${packages_template},sudo,ifupdown,isc-dhcp-client,apt-transport-https"
+        packages_template="${packages_template},sudo,ifupdown,isc-dhcp-client"
     fi
 
     echo "Installing packages in template: ${packages_template}"


### PR DESCRIPTION
In many environments the preference is to configure containers with
apt mirrors that are SSL-secured.

When building containers using the download template this can't be
done unless an insecure mirror is first used to install the
apt-transport-https package, then the sources reconfigured to
use the https URL.

When building containers without using the download template this
can't be done unless the container creator specifically includes
this package in the package list at build time. It seems more
intuitive to me to have the package installed by default.

Commit 396f75abb3d319adc7d871b94b08bc6bb9c49585 added the package
to the minbase variant, but this variant is not used by the download
template build process. The build process instead specifies no
variant, so this patch moves the package from the packages_template
package list in the minbase variant to the global packages_template
package list, ensuring that this package is included in all Ubuntu
build images that use the lxc-ubuntu template.

Signed-off-by: Jesse Pretorius <jesse.pretorius@rackspace.co.uk>