### PR TITLE
python-lxc: follow global rpath setting for autotools builds

### DIFF
--- a/src/python-lxc/Makefile.am
+++ b/src/python-lxc/Makefile.am
@@ -6,10 +6,16 @@ else
     DISTSETUPOPTS=
 endif
 
+if ENABLE_RPATH
+    RPATHOPTS=-R $(libdir)
+else
+    RPATHOPTS=
+endif
+
 CALL_SETUP_PY := cd @srcdir@ && $(PYTHON) setup.py build -b @abs_builddir@/build egg_info -e @abs_builddir@
 
 all:
-	$(CALL_SETUP_PY) build_ext -I @abs_top_srcdir@/src -L @abs_top_builddir@/src/lxc --no-pkg-config
+	$(CALL_SETUP_PY) build_ext -I @abs_top_srcdir@/src -L @abs_top_builddir@/src/lxc $(RPATHOPTS) --no-pkg-config
 
 DESTDIR = / # default
 


### PR DESCRIPTION
When LXC is configured with --enable-rpath, I expect Python bindings
to be able to find the library in a non-standard location, just like
LXC command-line tools.

Signed-off-by: Aleksandr Mezin <mezin.alexander@gmail.com>