### PR TITLE
lxc-debian: make sure init is installed

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -262,6 +262,7 @@ cleanup()
 download_debian()
 {
     packages=\
+init,\
 ifupdown,\
 locales,\
 libui-dialog-perl,\


### PR DESCRIPTION
init 1.34 is not "Essential" anymore, in order to make it not required
on minimal chroots, docker containers, etc. Because of that we now need
to manually include it on systems that are expected to boot.