### PR TITLE
Force lxc-instance to behave like a good Upstart client

### DIFF
--- a/config/init/upstart/lxc-instance.conf
+++ b/config/init/upstart/lxc-instance.conf
@@ -17,6 +17,4 @@ pre-start script
 	lxc-wait -s RUNNING -n $NAME -t 0 && { stop; exit 0; } || true
 end script
 
-script
-	exec lxc-start -n $NAME
-end script
+exec lxc-start -F -n $NAME


### PR DESCRIPTION
Remove unnecessary shell wrap around job start.
Force foreground execution to allow job monitoring and control.

Signed-off-by Andrey Repin <anrdaemon@yandex.ru>