### PR TITLE
c/r: use criu's "full" mode for cgroups

### DIFF
--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -135,7 +135,7 @@ static void exec_criu(struct criu_opts *opts)
 
 	/* The command line always looks like:
 	 * criu $(action) --tcp-established --file-locks --link-remap \
-	 * --manage-cgroups action-script foo.sh -D $(directory) \
+	 * --manage-cgroups=full action-script foo.sh -D $(directory) \
 	 * -o $(directory)/$(action).log --ext-mount-map auto
 	 * --enable-external-sharing --enable-external-masters
 	 * --enable-fs hugetlbfs --enable-fs tracefs --ext-mount-map console:/dev/pts/n
@@ -218,7 +218,7 @@ static void exec_criu(struct criu_opts *opts)
 	DECLARE_ARG("--tcp-established");
 	DECLARE_ARG("--file-locks");
 	DECLARE_ARG("--link-remap");
-	DECLARE_ARG("--manage-cgroups");
+	DECLARE_ARG("--manage-cgroups=full");
 	DECLARE_ARG("--ext-mount-map");
 	DECLARE_ARG("auto");
 	DECLARE_ARG("--enable-external-sharing");


### PR DESCRIPTION
A while ago cgroup modes were introduced to CRIU, which slightly changed
the behavior w.r.t. cgroups under the hood. What we're really after is
criu's --full mode, i.e. even if a particular cgroup directory exists
(in particular /lxc/$container[-$number] will, since we create it), we
should restore perms on that cgroup.

Things worked just fine for actual properties (except "special" properties
as criu refers to them, which I've just sent a patch for) because liblxc
creates no subdirectories, just the TLD.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>