### PR TITLE
Include all lxcmntent.h function declarations on Bionic

### DIFF
--- a/src/include/lxcmntent.h
+++ b/src/include/lxcmntent.h
@@ -36,15 +36,15 @@ extern struct mntent *getmntent (FILE *stream);
 extern struct mntent *getmntent_r (FILE *stream, struct mntent *mp, char *buffer, int bufsiz);
 #endif
 
-#ifndef HAVE_SETMNTENT
+#if !defined(HAVE_SETMNTENT) || IS_BIONIC
 FILE *setmntent (const char *file, const char *mode);
 #endif
 
-#ifndef HAVE_ENDMNTENT
+#if !defined(HAVE_ENDMNTENT) || IS_BIONIC
 int endmntent (FILE *stream);
 #endif
 
-#ifndef HAVE_HASMNTOPT
+#if !defined(HAVE_HASMNTOPT) || IS_BIONIC
 extern char *hasmntopt (const struct mntent *mnt, const char *opt);
 #endif
 


### PR DESCRIPTION
Newer versions of Android (5.0+, aka API Level 21+) include mntent.h,
which declares setmntent and endmntent. This hits an edge
case with the preprocessor checks in lxcmntent.h because HAVE_SETMNTENT
and HAVE_ENDMNTENT are both defined (in Bionic's mntent.h), but conf.c
always includes lxcmntent.h on Bionic! As a result, we get compiler
warnings of implicit function declarations for setmntent endmntent.

This patch always includes setmntent/endmntent/hasmntopt function
declarations on Bionic, which gets rid of these warnings.

Signed-off-by: Preetam D'Souza <preetamjdsouza@gmail.com>