### PR TITLE
lxc-debian: fix regression when creating wheezy containers

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -296,8 +296,16 @@ cleanup()
 
 download_debian()
 {
+    case "$release" in
+      wheezy)
+        init=sysvinit
+        ;;
+      *)
+        init=init
+        ;;
+    esac
     packages=\
-init,\
+$init,\
 ifupdown,\
 locales,\
 libui-dialog-perl,\


### PR DESCRIPTION
The regression was introduced by commit
3c39b0b7a2b445e08d2e2aecb05566075f4f3423 which makes it possible to
create working stretch containeres by forcinig `init` to be in the
included package list.

However, `init` didn't exit before jessie, so now for wheezy we
explicitly include `sysvinit`; sysvinit on wheezy has `Essential yes`,
so it would already be included anyway.