### PR TITLE
You can specify additional parameters for lxc.script.up/down

### DIFF
--- a/doc/examples/ovs.sh
+++ b/doc/examples/ovs.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+#lxc.network.script.args = br10 vlan52
+# or
+#lxc.network.script.args = br10 trunk53
+
+BRIDGE="${6}"
+VLAN="${7}"
+
+case "$3" in
+up)
+	[ -n "$BRIDGE" ] || exit 1
+
+	ovs-vsctl --may-exist add-br $BRIDGE
+	ovs-vsctl --if-exists del-port $BRIDGE $5
+	vcfg=""
+	if [ -n "$VLAN" ]; then
+		if [ "${VLAN#vlan}" != "${VLAN}" ]; then
+			vcfg="tag=${VLAN#vlan}"
+		fi
+		if [ "${VLAN#trunk}" != "${VLAN}" ]; then
+			vcfg="trunks=${VLAN#trunk}"
+		fi
+	fi
+	ovs-vsctl add-port $BRIDGE $5 $vcfg
+	;;
+down)
+	[ -z "$BRIDGE" ] && BRIDGE="`ovs-vsctl port-to-br $5`"
+	[ -n "$BRIDGE" ] && ovs-vsctl --if-exists del-port $BRIDGE $5
+	;;
+esac

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2605,7 +2605,7 @@ static int instantiate_veth(struct lxc_handler *handler, struct lxc_netdev *netd
 
 	if (netdev->upscript) {
 		err = run_script(handler->name, "net", netdev->upscript, "up",
-				 "veth", veth1, (char*) NULL);
+				 "veth", veth1, netdev->upscript_args, (char*) NULL);
 		if (err)
 			goto out_delete;
 	}
@@ -2635,7 +2635,7 @@ static int shutdown_veth(struct lxc_handler *handler, struct lxc_netdev *netdev)
 
 	if (netdev->downscript) {
 		err = run_script(handler->name, "net", netdev->downscript,
-				 "down", "veth", veth1, (char*) NULL);
+				 "down", "veth", veth1, netdev->upscript_args, (char*) NULL);
 		if (err)
 			return -1;
 	}
@@ -2678,7 +2678,7 @@ static int instantiate_macvlan(struct lxc_handler *handler, struct lxc_netdev *n
 
 	if (netdev->upscript) {
 		err = run_script(handler->name, "net", netdev->upscript, "up",
-				 "macvlan", netdev->link, (char*) NULL);
+				 "macvlan", netdev->link, netdev->upscript_args, (char*) NULL);
 		if (err)
 			goto out;
 	}
@@ -2700,7 +2700,7 @@ static int shutdown_macvlan(struct lxc_handler *handler, struct lxc_netdev *netd
 	if (netdev->downscript) {
 		err = run_script(handler->name, "net", netdev->downscript,
 				 "down", "macvlan", netdev->link,
-				 (char*) NULL);
+				  netdev->upscript_args,(char*) NULL);
 		if (err)
 			return -1;
 	}
@@ -2766,7 +2766,7 @@ static int instantiate_phys(struct lxc_handler *handler, struct lxc_netdev *netd
 	if (netdev->upscript) {
 		int err;
 		err = run_script(handler->name, "net", netdev->upscript,
-				 "up", "phys", netdev->link, (char*) NULL);
+				 "up", "phys", netdev->upscript_args, netdev->link, (char*) NULL);
 		if (err)
 			return -1;
 	}
@@ -2780,7 +2780,7 @@ static int shutdown_phys(struct lxc_handler *handler, struct lxc_netdev *netdev)
 
 	if (netdev->downscript) {
 		err = run_script(handler->name, "net", netdev->downscript,
-				 "down", "phys", netdev->link, (char*) NULL);
+			 "down", "phys", netdev->link, netdev->upscript_args, (char*) NULL);
 		if (err)
 			return -1;
 	}
@@ -2799,7 +2799,7 @@ static int instantiate_empty(struct lxc_handler *handler, struct lxc_netdev *net
 	if (netdev->upscript) {
 		int err;
 		err = run_script(handler->name, "net", netdev->upscript,
-				 "up", "empty", (char*) NULL);
+				 "up", "empty", netdev->upscript_args, (char*) NULL);
 		if (err)
 			return -1;
 	}
@@ -2812,7 +2812,7 @@ static int shutdown_empty(struct lxc_handler *handler, struct lxc_netdev *netdev
 
 	if (netdev->downscript) {
 		err = run_script(handler->name, "net", netdev->downscript,
-				 "down", "empty", (char*) NULL);
+				 "down", "empty", netdev->upscript_args, (char*) NULL);
 		if (err)
 			return -1;
 	}
@@ -3889,6 +3889,7 @@ static void lxc_remove_nic(struct lxc_list *it)
 	if (netdev->type == LXC_NET_VETH)
 		free(netdev->priv.veth_attr.pair);
 	free(netdev->upscript);
+	free(netdev->upscript_args);
 	free(netdev->hwaddr);
 	free(netdev->mtu);
 	free(netdev->ipv4_gateway);

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -136,6 +136,7 @@ struct lxc_netdev {
 	bool ipv6_gateway_auto;
 	char *upscript;
 	char *downscript;
+	char *upscript_args;
 };
 
 /*

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -89,6 +89,7 @@ static int config_network_vlan_id(const char *, const char *, struct lxc_conf *)
 static int config_network_mtu(const char *, const char *, struct lxc_conf *);
 static int config_network_ipv4(const char *, const char *, struct lxc_conf *);
 static int config_network_ipv4_gateway(const char *, const char *, struct lxc_conf *);
+static int config_network_script_args(const char *, const char *, struct lxc_conf *);
 static int config_network_script_up(const char *, const char *, struct lxc_conf *);
 static int config_network_script_down(const char *, const char *, struct lxc_conf *);
 static int config_network_ipv6(const char *, const char *, struct lxc_conf *);
@@ -152,6 +153,7 @@ static struct lxc_config_t config[] = {
 	{ "lxc.network.name",         config_network_name         },
 	{ "lxc.network.macvlan.mode", config_network_macvlan_mode },
 	{ "lxc.network.veth.pair",    config_network_veth_pair    },
+	{ "lxc.network.script.args",  config_network_script_args  },
 	{ "lxc.network.script.up",    config_network_script_up    },
 	{ "lxc.network.script.down",  config_network_script_down  },
 	{ "lxc.network.hwaddr",       config_network_hwaddr       },
@@ -1001,6 +1003,19 @@ static int config_network_ipv6_gateway(const char *key, const char *value,
 
 	return 0;
 }
+
+static int config_network_script_args(const char *key, const char *value,
+				    struct lxc_conf *lxc_conf)
+{
+	struct lxc_netdev *netdev;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+ 		return -1;
+
+	return config_string_item(&netdev->upscript_args, value);
+}
+
 
 static int config_network_script_up(const char *key, const char *value,
 				    struct lxc_conf *lxc_conf)
@@ -2372,6 +2387,9 @@ static int lxc_get_item_nic(struct lxc_conf *c, char *retv, int inlen,
 	} else if (strcmp(p1, "flags") == 0) {
 		if (netdev->flags & IFF_UP)
 			strprint(retv, inlen, "up");
+	} else if (strcmp(p1, "script.args") == 0) {
+		if(netdev->upscript_args)
+			strprint(retv, inlen, "%s", netdev->upscript_args);
 	} else if (strcmp(p1, "script.up") == 0) {
 		if (netdev->upscript)
 			strprint(retv, inlen, "%s", netdev->upscript);


### PR DESCRIPTION
This can be useful when working with openvswitch.

Config example:

```
lxc.network.type = veth
lxc.network.veth.pair = wfctl.v22
lxc.network.script.args = br-ovs0 vlan22
lxc.network.script.up = /etc/lxc/ovs
lxc.network.script.down = /etc/lxc/ovs
lxc.network.name = vlan0022

lxc.network.type = veth
lxc.network.veth.pair = wfctl.v23
lxc.network.script.args = br-ovs0 vlan23
lxc.network.script.up = /etc/lxc/ovs
lxc.network.script.down = /etc/lxc/ovs
lxc.network.name = vlan0023
```

Example script for setting openvswitch see in doc/example/ovs.sh
