### PR TITLE
c/r: drop in-flight connections during CRIU dump

### DIFF
--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -896,6 +896,12 @@ struct migrate_opts {
 	 * "action script"
 	 */
 	char *action_script;
+
+	/* If CRIU >= 2.4 is detected the option to skip in-flight connections
+	 * will be enabled by default. The flag 'disable_skip_in_flight' will
+	 * unconditionally disable this feature. In-flight connections are
+	 * not fully established TCP connections: SYN, SYN-ACK */
+	bool disable_skip_in_flight;
 };
 
 /*!


### PR DESCRIPTION
Shortly after CRIU 2.3 has been released a patch has been added to skip
in-flight TCP connections. In-flight connections are not completely
established connections (SYN, SYN-ACK). Skipping in-flight TCP
connections means that the client has to re-initiate the connection
establishment.

This patch stores the CRIU version detected during version check, so
that during dump/checkpoint options can be dynamically enabled depending
on the available CRIU version.

Signed-off-by: Adrian Reber <areber@redhat.com>