### PR TITLE
add missing cgroup namespace to ns_info struct

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -82,7 +82,8 @@ const struct ns_info ns_info[LXC_NS_MAX] = {
 	[LXC_NS_UTS] = {"uts", CLONE_NEWUTS},
 	[LXC_NS_IPC] = {"ipc", CLONE_NEWIPC},
 	[LXC_NS_USER] = {"user", CLONE_NEWUSER},
-	[LXC_NS_NET] = {"net", CLONE_NEWNET}
+	[LXC_NS_NET] = {"net", CLONE_NEWNET},
+	[LXC_NS_CGROUP] = {"cgroup", CLONE_NEWCGROUP}
 };
 
 extern void mod_all_rdeps(struct lxc_container *c, bool inc);

--- a/src/lxc/start.h
+++ b/src/lxc/start.h
@@ -49,6 +49,7 @@ enum {
 	LXC_NS_IPC,
 	LXC_NS_USER,
 	LXC_NS_NET,
+	LXC_NS_CGROUP,
 	LXC_NS_MAX
 };
 


### PR DESCRIPTION
Signed-off-by: Christian Brauner <cbrauner@suse.de>