### PR TITLE
[RFC]: lxccontainer: detect if we should send SIGRTMIN+3

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -1604,8 +1604,16 @@ static bool do_lxcapi_shutdown(struct lxc_container *c, int timeout)
 	pid = do_lxcapi_init_pid(c);
 	if (pid <= 0)
 		return true;
+
+	/* Detect whether we should send SIGRTMIN + 3 (e.g. systemd). */
+	if (task_blocking_signal(pid, (SIGRTMIN + 3)))
+		haltsignal = (SIGRTMIN + 3);
+
 	if (c->lxc_conf && c->lxc_conf->haltsignal)
 		haltsignal = c->lxc_conf->haltsignal;
+
+	INFO("Using signal number '%d' as halt signal.", haltsignal);
+
 	kill(pid, haltsignal);
 	retv = do_lxcapi_wait(c, "STOPPED", timeout);
 	return retv;

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -296,4 +296,7 @@ int open_devnull(void);
 int set_stdfds(int fd);
 int null_stdfds(void);
 int lxc_count_file_lines(const char *fn);
+
+/* Check whether a signal is blocked by a process. */
+bool task_blocking_signal(pid_t pid, int signal);
 #endif /* __LXC_UTILS_H */


### PR DESCRIPTION
This is required by systemd to cleanly shutdown. Other init systems should not
have SIGRTMIN+3 in the blocked signals set.

Signed-off-by: Christian Brauner <cbrauner@suse.de>