### PR TITLE
c/r: use PRIu64 format specifier

### DIFF
--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -22,6 +22,7 @@
  */
 #define _GNU_SOURCE
 #include <assert.h>
+#include <inttypes.h>
 #include <linux/limits.h>
 #include <sched.h>
 #include <stdio.h>
@@ -307,9 +308,9 @@ static void exec_criu(struct criu_opts *opts)
 		if (opts->user->ghost_limit) {
 			char ghost_limit[32];
 
-			ret = sprintf(ghost_limit, "%lu", opts->user->ghost_limit);
+			ret = sprintf(ghost_limit, "%"PRIu64, opts->user->ghost_limit);
 			if (ret < 0 || ret >= sizeof(ghost_limit)) {
-				ERROR("failed to print ghost limit %lu", opts->user->ghost_limit);
+				ERROR("failed to print ghost limit %"PRIu64, opts->user->ghost_limit);
 				goto err;
 			}
 


### PR DESCRIPTION
Fixes build failures on arm:

criu.c: In function ‘exec_criu’:
criu.c:310:4: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘uint64_t’ [-Werror=format=]
    ret = sprintf(ghost_limit, "%lu", opts->user->ghost_limit);
    ^
In file included from criu.c:42:0:
log.h:285:9: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘uint64_t’ [-Werror=format=]
  struct lxc_log_locinfo locinfo = LXC_LOG_LOCINFO_INIT;  \
         ^
criu.c:312:5: note: in expansion of macro ‘ERROR’
     ERROR("failed to print ghost limit %lu", opts->user->ghost_limit);
     ^

Signed-off-by: Christian Brauner <cbrauner@suse.de>