### PR TITLE
lxc-centos.in: Change default target to multi-user and make systemd honor SIGPWR when CentOS 7

### DIFF
--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -398,6 +398,12 @@ start on power-status-changed
 
 exec /sbin/shutdown -h now "SIGPWR received"
 EOF
+    else
+        # Change default target from graphical to multi-user
+        rm -f ${rootfs_path}/etc/systemd/system/default.target
+        chroot ${rootfs_path} ln -s /lib/systemd/system/multi-user.target /etc/systemd/system/default.target
+        # Make systemd honor SIGPWR
+        chroot ${rootfs_path} ln -s /usr/lib/systemd/system/halt.target /etc/systemd/system/sigpwr.target
     fi
 }
 


### PR DESCRIPTION
These changes are copied from https://github.com/lxc/lxc/blob/master/templates/lxc-fedora.in#L368

This will resolve https://github.com/lxc/lxd/issues/1183