### PR TITLE
Add a prefix to the lxc.pc

### DIFF
--- a/lxc.pc.in
+++ b/lxc.pc.in
@@ -1,7 +1,8 @@
+prefix=@prefix@
 bindir=@BINDIR@
-libdir=@LIBDIR@
+libdir=${prefix}/@LIBDIR@
 localstatedir=@LOCALSTATEDIR@
-includedir=@INCLUDEDIR@
+includedir=${prefix}/@INCLUDEDIR@
 rootfsmountdir=@LXCROOTFSMOUNT@
 
 Name: lxc


### PR DESCRIPTION
This allows installing to different locations and using
the lxc.pc to build using the generated includedir and
libdir.

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>