### PR TITLE
bdev: include own getline function in bdev.h

### DIFF
--- a/src/lxc/bdev/bdev.h
+++ b/src/lxc/bdev/bdev.h
@@ -33,6 +33,13 @@
 
 #include "config.h"
 
+/* Define getline() if missing from the C library */
+#ifndef HAVE_GETLINE
+#ifdef HAVE_FGETLN
+#include <../../include/getline.h>
+#endif
+#endif
+
 /* define constants if the kernel/glibc headers don't define them */
 #ifndef MS_DIRSYNC
 #define MS_DIRSYNC 128


### PR DESCRIPTION
Fixes android build error:

bdev/bdev.c: In function 'detect_fs':
bdev/bdev.c:686:2: error: implicit declaration of function 'getline' [-Werror=implicit-function-declaration]
  while (getline(&line, &linelen, f) != -1) {
  ^

Signed-off-by: Christian Brauner <cbrauner@suse.de>