### PR TITLE
Revert "Merge pull request #1103 from brauner/2016-07-27/fix_android_…

### DIFF
--- a/src/lxc/bdev/bdev.h
+++ b/src/lxc/bdev/bdev.h
@@ -33,13 +33,6 @@
 
 #include "config.h"
 
-/* Define getline() if missing from the C library */
-#ifndef HAVE_GETLINE
-#ifdef HAVE_FGETLN
-#include <../../include/getline.h>
-#endif
-#endif
-
 /* define constants if the kernel/glibc headers don't define them */
 #ifndef MS_DIRSYNC
 #define MS_DIRSYNC 128


### PR DESCRIPTION
…getline"

This reverts commit 25796416084f3cecf036bd922d6ead094500191e, reversing
changes made to 813d7f1453e6e28adc0fdfac62d9c4597a87e430.

Contrary to what we suspected the android build errors were not caused by
missing wrong relative include paths. Rather, they were caused by autoconf.

Signed-off-by: Christian Brauner <cbrauner@suse.de>