### PR TITLE
conf: set pty_info to NULL after free

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3327,6 +3327,7 @@ void lxc_delete_tty(struct lxc_tty_info *tty_info)
 	}
 
 	free(tty_info->pty_info);
+	tty_info->pty_info = NULL;
 	tty_info->nbtty = 0;
 }
 


### PR DESCRIPTION
This fixes a double free corruption on container-requested
reboots when lxc_spawn() fails before receiving the ttys, as
lxc_fini() (part of __lxc_start()'s cleanup) calls
lxc_delete_tty().

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>