### PR TITLE
templates: add support for new arch on Alpine Linux

### DIFF
--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -123,6 +123,8 @@ parse_arch() {
 	case "$1" in
 		x86 | i[3-6]86) echo 'x86';;
 		x86_64 | amd64) echo 'x86_64';;
+		aarch64 | arm64) echo 'aarch64';;
+		armv7) echo 'armv7';;
 		arm*) echo 'armhf';;
 		*) return 1;;
 	esac


### PR DESCRIPTION
We are adding support for both armv7 and aarch64 architectures to Alpine Linux. We do not have official repositories yet but they will come with next Alpine release.