### PR TITLE
tree-wide: replace readdir_r() with readdir()

### DIFF
--- a/src/lxc/bdev/lxcloop.c
+++ b/src/lxc/bdev/lxcloop.c
@@ -269,7 +269,7 @@ static int do_loop_create(const char *path, uint64_t size, const char *fstype)
 
 static int find_free_loopdev_no_control(int *retfd, char *namep)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	struct loop_info64 lo;
 	DIR *dir;
 	int fd = -1;
@@ -279,7 +279,7 @@ static int find_free_loopdev_no_control(int *retfd, char *namep)
 		SYSERROR("Error opening /dev");
 		return -1;
 	}
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 
 		if (!direntp)
 			break;

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -907,7 +907,7 @@ static char *must_make_path(const char *first, ...)
 
 static int cgroup_rmdir(char *dirname)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	DIR *dir;
 	int r = 0;
 
@@ -915,7 +915,7 @@ static int cgroup_rmdir(char *dirname)
 	if (!dir)
 		return -1;
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		struct stat mystat;
 		char *pathname;
 
@@ -1367,7 +1367,7 @@ bad:
 
 static int recursive_count_nrtasks(char *dirname)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	DIR *dir;
 	int count = 0, ret;
 	char *path;
@@ -1376,7 +1376,7 @@ static int recursive_count_nrtasks(char *dirname)
 	if (!dir)
 		return 0;
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		struct stat mystat;
 
 		if (!direntp)

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -510,7 +510,7 @@ out:
 static int mount_rootfs_file(const char *rootfs, const char *target,
 				             const char *options)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	struct loop_info64 loinfo;
 	int ret = -1, fd = -1, rc;
 	DIR *dir;
@@ -522,7 +522,7 @@ static int mount_rootfs_file(const char *rootfs, const char *target,
 		return -1;
 	}
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 
 		if (!direntp)
 			break;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1805,7 +1805,7 @@ int append_unexp_config_line(const char *line, struct lxc_conf *conf)
 
 static int do_includedir(const char *dirp, struct lxc_conf *lxc_conf)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	DIR *dir;
 	char path[MAXPATHLEN];
 	int ret = -1, len;
@@ -1816,7 +1816,7 @@ static int do_includedir(const char *dirp, struct lxc_conf *lxc_conf)
 		return -1;
 	}
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		const char *fnam;
 		if (!direntp)
 			break;

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -623,7 +623,7 @@ WRAP_API_1(bool, wait_on_daemonized_start, int)
 
 static bool am_single_threaded(void)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	DIR *dir;
 	int count=0;
 
@@ -633,7 +633,7 @@ static bool am_single_threaded(void)
 		return false;
 	}
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 
@@ -2284,7 +2284,7 @@ out:
 static bool has_snapshots(struct lxc_container *c)
 {
 	char path[MAXPATHLEN];
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	int count=0;
 	DIR *dir;
 
@@ -2293,7 +2293,7 @@ static bool has_snapshots(struct lxc_container *c)
 	dir = opendir(path);
 	if (!dir)
 		return false;
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 
@@ -3503,7 +3503,7 @@ static int do_lxcapi_snapshot_list(struct lxc_container *c, struct lxc_snapshot 
 {
 	char snappath[MAXPATHLEN], path2[MAXPATHLEN];
 	int count = 0, ret;
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	struct lxc_snapshot *snaps =NULL, *nsnaps;
 	DIR *dir;
 
@@ -3520,7 +3520,7 @@ static int do_lxcapi_snapshot_list(struct lxc_container *c, struct lxc_snapshot 
 		return 0;
 	}
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 
@@ -3666,7 +3666,7 @@ err:
 static bool remove_all_snapshots(const char *path)
 {
 	DIR *dir;
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	bool bret = true;
 
 	dir = opendir(path);
@@ -3674,7 +3674,7 @@ static bool remove_all_snapshots(const char *path)
 		SYSERROR("opendir on snapshot path %s", path);
 		return false;
 	}
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 		if (!strcmp(direntp->d_name, "."))
@@ -4191,7 +4191,7 @@ int list_defined_containers(const char *lxcpath, char ***names, struct lxc_conta
 {
 	DIR *dir;
 	int i, cfound = 0, nfound = 0;
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	struct lxc_container *c;
 
 	if (!lxcpath)
@@ -4208,7 +4208,7 @@ int list_defined_containers(const char *lxcpath, char ***names, struct lxc_conta
 	if (names)
 		*names = NULL;
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -209,7 +209,7 @@ static int match_fd(int fd)
  */
 int lxc_check_inherited(struct lxc_conf *conf, bool closeall, int fd_to_ignore)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	int fd, fddir;
 	DIR *dir;
 
@@ -225,7 +225,7 @@ restart:
 
 	fddir = dirfd(dir);
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -90,7 +90,7 @@ extern bool btrfs_try_remove_subvol(const char *path);
 static int _recursive_rmdir(char *dirname, dev_t pdev,
 			    const char *exclude, int level, bool onedev)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	DIR *dir;
 	int ret, failed=0;
 	char pathname[MAXPATHLEN];
@@ -102,7 +102,7 @@ static int _recursive_rmdir(char *dirname, dev_t pdev,
 		return -1;
 	}
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		struct stat mystat;
 		int rc;
 


### PR DESCRIPTION
To clarify the motivation behind this PR: `glibc 2.24` has deprecated `readdir_r()` (https://lwn.net/Articles/696469/) and some users already report that they can't compile the `LXC` sources because of that. So we should replace `readdir_r()` with `readdir()`. The problem however is that POSIX currently doesn't require that `readdir()` be thread-safe but it seems all of the relevant `libc`s actually provide a version of `readdir()` that is thread-safe. At least when multiple threads read from different `DIR` streams.

closes #1117.

Signed-off-by: Christian Brauner <cbrauner@suse.de>