### PR TITLE
log: fix log_append_stderr()

### DIFF
--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -125,7 +125,7 @@ static int log_append_stderr(const struct lxc_log_appender *appender,
 	if (event->priority < LXC_LOG_PRIORITY_ERROR)
 		return 0;
 
-	fprintf(stderr, "%s: %s", log_prefix, log_vmname ? log_vmname : "");
+	fprintf(stderr, "%s: %s%s", log_prefix, log_vmname ? log_vmname : "", log_vmname ? ": " : "");
 	fprintf(stderr, "%s: %s: %d ", event->locinfo->file, event->locinfo->func, event->locinfo->line);
 	vfprintf(stderr, event->fmt, *event->vap);
 	fprintf(stderr, "\n");


### PR DESCRIPTION
Log output currently looks like this:

	lxc-copy: debbdev/lxcdir.c: dir_clonepaths: 45 directories cannot be snapshotted.  Try aufs or overlayfs.

we rather want it to be:

	lxc-copy: deb: bdev/lxcdir.c: dir_clonepaths: 45 directories cannot be snapshotted.  Try aufs or overlayfs.

Signed-off-by: Christian Brauner <cbrauner@suse.de>