### PR TITLE
bdev: be smarter about btrfs subvolume detection

### DIFF
--- a/src/lxc/bdev/lxcbtrfs.h
+++ b/src/lxc/bdev/lxcbtrfs.h
@@ -30,6 +30,10 @@
 #include <stdint.h>
 #include <byteswap.h>
 
+#ifndef BTRFS_SUPER_MAGIC
+#  define BTRFS_SUPER_MAGIC       0x9123683E
+#endif
+
 typedef uint8_t u8;
 typedef uint16_t u16;
 typedef uint32_t u32;
@@ -404,6 +408,7 @@ char *get_btrfs_subvol_path(int fd, u64 dir_id, u64 objid, char *name,
 			    int name_len);
 int btrfs_list_get_path_rootid(int fd, u64 *treeid);
 bool is_btrfs_fs(const char *path);
+int is_btrfs_subvol(const char *path);
 bool btrfs_try_remove_subvol(const char *path);
 int btrfs_same_fs(const char *orig, const char *new);
 int btrfs_snapshot(const char *orig, const char *new);

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2826,11 +2826,15 @@ bool should_default_to_snapshot(struct lxc_container *c0,
 	size_t l1 = strlen(c1->config_path) + strlen(c1->name) + 2;
 	char *p0 = alloca(l0 + 1);
 	char *p1 = alloca(l1 + 1);
+	char *rootfs = c0->lxc_conf->rootfs.path;
 
 	snprintf(p0, l0, "%s/%s", c0->config_path, c0->name);
 	snprintf(p1, l1, "%s/%s", c1->config_path, c1->name);
 
 	if (!is_btrfs_fs(p0) || !is_btrfs_fs(p1))
+		return false;
+
+	if (is_btrfs_subvol(rootfs) <= 0)
 		return false;
 
 	return btrfs_same_fs(p0, p1) == 0;


### PR DESCRIPTION
When a container c is on a btrfs filesystem but is directory backed, copying the container will default to snapshot. This is because of should_default_to_snapshot() returning true in this case because c is on a
btrfs filesystem. We should make sure that should_default_to_snapshot() only returns true, when c itself is a btrfs subvolume.

closes  #1124.

Signed-off-by: Christian Brauner <cbrauner@suse.de>