### PR TITLE
tools: use fclose() after fdopen() + add newline

### DIFF
--- a/src/lxc/tools/lxc_copy.c
+++ b/src/lxc/tools/lxc_copy.c
@@ -454,7 +454,7 @@ static int do_clone_ephemeral(struct lxc_container *c,
 
 	if (arg->tmpfs && !my_args.quiet)
 		printf("Container is placed on tmpfs.\nRebooting will cause "
-		       "all changes made to it to be lost!");
+		       "all changes made to it to be lost!\n");
 
 	if (!arg->daemonize && arg->argc) {
 		clone->want_daemonize(clone, true);
@@ -863,7 +863,7 @@ static char *mount_tmpfs(const char *oldname, const char *newname,
 			goto err_close;
 	}
 
-	close(fd);
+	fclose(fp);
 	return premount;
 
 err_close:


### PR DESCRIPTION
So far we accidently used close() on the original file descriptor. (After
fdopen() the original fd is considered private and should not be used anymore.
The close operations should be performed on the new file handle. We did the
correct thing on error but not on success.) Using close() on the original fd
caused "Text file busy" errors and prevented the cloned tmpfs container from
starting.

Signed-off-by: Christian Brauner <cbrauner@suse.de>