### PR TITLE
[RFC] add minimal unit testing for liblxc functions

### DIFF
--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -32,7 +32,8 @@ noinst_HEADERS = \
 	start.h \
 	state.h \
 	utils.h \
-	criu.h
+	criu.h \
+	../tests/lxctest.h
 
 if IS_BIONIC
 noinst_HEADERS += \

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -2,8 +2,6 @@ if ENABLE_TESTS
 
 LDADD = ../lxc/liblxc.so
 
-noinst_HEADERS += lxctest.h
-
 lxc_test_containertests_SOURCES = containertests.c
 lxc_test_locktests_SOURCES = locktests.c
 lxc_test_startone_SOURCES = startone.c

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -2,6 +2,8 @@ if ENABLE_TESTS
 
 LDADD = ../lxc/liblxc.so
 
+noinst_HEADERS += lxctest.h
+
 lxc_test_containertests_SOURCES = containertests.c
 lxc_test_locktests_SOURCES = locktests.c
 lxc_test_startone_SOURCES = startone.c
@@ -23,6 +25,7 @@ lxc_test_list_SOURCES = list.c
 lxc_test_attach_SOURCES = attach.c
 lxc_test_device_add_remove_SOURCES = device_add_remove.c
 lxc_test_apparmor_SOURCES = aa.c
+lxc_test_utils_SOURCES = lxc-test-utils.c lxctest.h
 
 AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	-DLXCPATH=\"$(LXCPATH)\" \
@@ -50,7 +53,7 @@ bin_PROGRAMS = lxc-test-containertests lxc-test-locktests lxc-test-startone \
 	lxc-test-cgpath lxc-test-clonetest lxc-test-console \
 	lxc-test-snapshot lxc-test-concurrent lxc-test-may-control \
 	lxc-test-reboot lxc-test-list lxc-test-attach lxc-test-device-add-remove \
-	lxc-test-apparmor
+	lxc-test-apparmor lxc-test-utils
 
 bin_SCRIPTS = lxc-test-automount lxc-test-autostart lxc-test-cloneconfig \
 	lxc-test-createconfig
@@ -94,6 +97,7 @@ EXTRA_DIST = \
 	lxc-test-symlink \
 	lxc-test-ubuntu \
 	lxc-test-unpriv \
+	lxc-test-utils \
 	may_control.c \
 	saveconfig.c \
 	shutdowntest.c \

--- a/src/tests/lxc-test-utils.c
+++ b/src/tests/lxc-test-utils.c
@@ -28,7 +28,7 @@
 #include "lxctest.h"
 #include "utils.h"
 
-void test_string_replace(void)
+void test_lxc_string_replace(void)
 {
 	char *s;
 
@@ -65,9 +65,25 @@ void test_string_replace(void)
 	free(s);
 }
 
+void test_lxc_string_in_array(void)
+{
+	lxc_test_assert_abort(lxc_string_in_array("", (const char *[]){"", NULL}));
+	lxc_test_assert_abort(!lxc_string_in_array("A", (const char *[]){"", NULL}));
+	lxc_test_assert_abort(!lxc_string_in_array("AAA", (const char *[]){"", "3472", "jshH", NULL}));
+
+	lxc_test_assert_abort(lxc_string_in_array("A", (const char *[]){"A", NULL}));
+	lxc_test_assert_abort(lxc_string_in_array("A", (const char *[]){"A", "B", "C", NULL}));
+	lxc_test_assert_abort(lxc_string_in_array("A", (const char *[]){"B", "A", "C", NULL}));
+
+	lxc_test_assert_abort(lxc_string_in_array("ABC", (const char *[]){"ASD", "ATR", "ABC", NULL}));
+	lxc_test_assert_abort(lxc_string_in_array("GHJ", (const char *[]){"AZIU", "WRT567B", "879C", "GHJ", "IUZ89", NULL}));
+	lxc_test_assert_abort(lxc_string_in_array("XYZ", (const char *[]){"BERTA", "ARQWE(9", "C8Zhkd", "7U", "XYZ", "UOIZ9", "=)()", NULL}));
+}
+
 int main(int argc, char *argv[])
 {
-	test_string_replace();
+	test_lxc_string_replace();
+	test_lxc_string_in_array();
 
 	exit(EXIT_SUCCESS);
 }

--- a/src/tests/lxc-test-utils.c
+++ b/src/tests/lxc-test-utils.c
@@ -1,0 +1,73 @@
+/*
+ * lxc: linux Container library
+ *
+ * Copyright © 2016 Canonical Ltd.
+ *
+ * Authors:
+ * Christian Brauner <christian.brauner@mailbox.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "lxctest.h"
+#include "utils.h"
+
+void test_string_replace(void)
+{
+	char *s;
+
+	s = lxc_string_replace("A", "A", "A");
+	lxc_test_assert_abort(strcmp(s, "A") == 0);
+	free(s);
+
+	s = lxc_string_replace("A", "AA", "A");
+	lxc_test_assert_abort(strcmp(s, "AA") == 0);
+	free(s);
+
+	s = lxc_string_replace("A", "AA", "BA");
+	lxc_test_assert_abort(strcmp(s, "BAA") == 0);
+	free(s);
+
+	s = lxc_string_replace("A", "AA", "BAB");
+	lxc_test_assert_abort(strcmp(s, "BAAB") == 0);
+	free(s);
+
+	s = lxc_string_replace("AA", "A", "AA");
+	lxc_test_assert_abort(strcmp(s, "A") == 0);
+	free(s);
+
+	s = lxc_string_replace("AA", "A", "BAA");
+	lxc_test_assert_abort(strcmp(s, "BA") == 0);
+	free(s);
+
+	s = lxc_string_replace("AA", "A", "BAAB");
+	lxc_test_assert_abort(strcmp(s, "BAB") == 0);
+	free(s);
+
+	s = lxc_string_replace("\"A\"A", "\"A\"", "B\"A\"AB");
+	lxc_test_assert_abort(strcmp(s, "B\"A\"B") == 0);
+	free(s);
+}
+
+int main(int argc, char *argv[])
+{
+	test_string_replace();
+
+	exit(EXIT_SUCCESS);
+}

--- a/src/tests/lxctest.h
+++ b/src/tests/lxctest.h
@@ -1,0 +1,42 @@
+/*
+ * lxc: linux Container library
+ *
+ * Copyright © 2016 Canonical Ltd.
+ *
+ * Authors:
+ * Christian Brauner <christian.brauner@mailbox.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __LXC_TEST_H_
+#define __LXC_TEST_H_
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define lxc_test_assert_stringify(expression, stringify_expression)            \
+	do {                                                                   \
+		if (!(expression)) {                                           \
+			fprintf(stderr, "%s: %s: %d: %s\n", __FILE__,          \
+				__func__, __LINE__, stringify_expression);     \
+			abort();                                               \
+		}                                                              \
+	} while (false)
+
+#define lxc_test_assert_abort(expression) lxc_test_assert_stringify(expression, #expression)
+
+#endif /* __LXC_TEST_H */


### PR DESCRIPTION
This adds two simple test macros (We can add more later.). The main macro calls `abort()` to generate a core-dump. I'm happy to discuss other approaches.