### PR TITLE
Rename physical devices earlier during shutdown [WIP

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2885,9 +2885,6 @@ void lxc_delete_network(struct lxc_handler *handler)
 		netdev = iterator->elem;
 
 		if (netdev->ifindex != 0 && netdev->type == LXC_NET_PHYS) {
-			if (lxc_netdev_rename_by_index(netdev->ifindex, netdev->link))
-				WARN("failed to rename to the initial name the " \
-				     "netdev '%s'", netdev->link);
 			continue;
 		}
 

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2397,14 +2397,16 @@ static int setup_network(struct lxc_list *network)
 }
 
 /* try to move physical nics to the init netns */
-void restore_phys_nics_to_netns(int netnsfd, struct lxc_conf *conf)
+void lxc_restore_phys_nics_on_shutdown(int netnsfd, struct lxc_conf *conf)
 {
 	int i, ret, oldfd;
 	char path[MAXPATHLEN];
 	char ifname[IFNAMSIZ];
 
-	if (netnsfd < 0)
+	if (netnsfd < 0 || conf->num_savednics == 0)
 		return;
+
+	INFO("running to reset %d nic names", conf->num_savednics);
 
 	ret = snprintf(path, MAXPATHLEN, "/proc/self/ns/net");
 	if (ret < 0 || ret >= MAXPATHLEN) {
@@ -2427,30 +2429,15 @@ void restore_phys_nics_to_netns(int netnsfd, struct lxc_conf *conf)
 			WARN("no interface corresponding to index '%d'", s->ifindex);
 			continue;
 		}
-		if (lxc_netdev_move_by_name(ifname, 1, NULL))
+		if (lxc_netdev_move_by_name(ifname, 1, s->orig_name))
 			WARN("Error moving nic name:%s back to host netns", ifname);
-	}
-	if (setns(oldfd, 0) != 0)
-		SYSERROR("Failed to re-enter monitor's netns");
-	close(oldfd);
-}
-
-void lxc_rename_phys_nics_on_shutdown(int netnsfd, struct lxc_conf *conf)
-{
-	int i;
-
-	if (conf->num_savednics == 0)
-		return;
-
-	INFO("running to reset %d nic names", conf->num_savednics);
-	restore_phys_nics_to_netns(netnsfd, conf);
-	for (i=0; i<conf->num_savednics; i++) {
-		struct saved_nic *s = &conf->saved_nics[i];
-		INFO("resetting nic %d to %s", s->ifindex, s->orig_name);
-		lxc_netdev_rename_by_index(s->ifindex, s->orig_name);
 		free(s->orig_name);
 	}
 	conf->num_savednics = 0;
+
+	if (setns(oldfd, 0) != 0)
+		SYSERROR("Failed to re-enter monitor's netns");
+	close(oldfd);
 }
 
 static char *default_rootfs_mount = LXCROOTFSMOUNT;

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -433,7 +433,7 @@ extern int do_rootfs_setup(struct lxc_conf *conf, const char *name,
 struct cgroup_process_info;
 extern int lxc_setup(struct lxc_handler *handler);
 
-extern void lxc_rename_phys_nics_on_shutdown(int netnsfd, struct lxc_conf *conf);
+extern void lxc_restore_phys_nics_on_shutdown(int netnsfd, struct lxc_conf *conf);
 
 extern int find_unmapped_nsuid(struct lxc_conf *conf, enum idtype idtype);
 extern int mapped_hostid(unsigned id, struct lxc_conf *conf, enum idtype idtype);

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1402,7 +1402,7 @@ int __lxc_start(const char *name, struct lxc_conf *conf,
 	}
 
 	DEBUG("Pushing physical nics back to host namespace");
-	lxc_rename_phys_nics_on_shutdown(netnsfd, handler->conf);
+	lxc_restore_phys_nics_on_shutdown(netnsfd, handler->conf);
 
 	DEBUG("Tearing down virtual network devices used by container");
 	lxc_delete_network(handler);


### PR DESCRIPTION
The second commit probably requires some additional auditing. I've gone through the involved git commit history and am not entirely convinced the current code is necessary.
I've com across #649 while going through the history and saw that the call added there already happens during a regular shutdown anyway a few lines below (and already did back then).
We've had some reports of interface deletions not always working apparently due to the fact that netlink is "not a reliable protocol", and said patch looks to me like a simple retry attempt reducing the probability of failures but not completely ruling them out.
So I'm wondering if maybe we should add a retry loop to the delete netlink events?

And finally: Should we also rename interfaces to temporary names before moving them to the container? Eg. if you want to assign eth0 to a container as eth1, and start with a veth named eth0 inside the container, then moving eth0 will fail as the veth is already named eth0 in the container's namespace.
