### PR TITLE
set FULL_PATH_NAMES=NO in doc/api/Doxyfile

### DIFF
--- a/doc/api/Doxyfile
+++ b/doc/api/Doxyfile
@@ -130,7 +130,7 @@ INLINE_INHERITED_MEMB  = NO
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand


### PR DESCRIPTION
otherwise the generated docs have the full build path in them
and nonbody cares that the files were built in
 /build/lxc-_BVY2u/lxc-2.0.4/src/lxc/

Signed-off-by: Evgeni Golov <evgeni@debian.org>