### PR TITLE
templates: rm halt.target -> sigpwr.target symlink

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -256,8 +256,6 @@ configure_debian_systemd()
     chroot "${rootfs}" ln -s /dev/null /etc/systemd/system/udev.service
     chroot "${rootfs}" ln -s /dev/null /etc/systemd/system/systemd-udevd.service
     chroot "${rootfs}" ln -s /lib/systemd/system/multi-user.target /etc/systemd/system/default.target
-    # Make systemd honor SIGPWR
-    chroot "${rootfs}" ln -s /lib/systemd/system/halt.target /etc/systemd/system/sigpwr.target
     # Setup getty service on the ttys we are going to allow in the
     # default config.  Number should match lxc.tty
     ( cd "${rootfs}/etc/systemd/system/getty.target.wants"

--- a/templates/lxc-oracle.in
+++ b/templates/lxc-oracle.in
@@ -169,9 +169,6 @@ EOF
         rm -f $container_rootfs/usr/lib/systemd/system/sysinit.target.wants/kmod-static-nodes.service
         chroot $container_rootfs systemctl -q disable graphical.target
         chroot $container_rootfs systemctl -q enable multi-user.target
-        if [ ! -e $container_rootfs/etc/systemd/system/sigpwr.target ]; then
-            chroot $container_rootfs ln -s /usr/lib/systemd/system/halt.target /etc/systemd/system/sigpwr.target
-        fi
 
         # systemd in userns won't be able to set /proc/self/oom_score_adj which
         # prevents the dbus service from starting


### PR DESCRIPTION
Given commit 330ae3d350e060e5702a0e5ef5d0faeeeea8df6e:

    lxccontainer: detect if we should send SIGRTMIN+3

    This is required by systemd to cleanly shutdown. Other init systems should not
    have SIGRTMIN+3 in the blocked signals set.

we should stop symlinking halt.target to sigpwr.target for systemd.

Signed-off-by: Christian Brauner <cbrauner@suse.de>