### PR TITLE
templates: remove creation of bogus directory in Debian templates

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -239,7 +239,7 @@ configure_debian_systemd()
     fi
 
     # just in case systemd is not installed
-    mkdir -p "${rootfs}/{lib,etc}/systemd/system"
+    mkdir -p "${rootfs}/lib/systemd/system"
     mkdir -p "${rootfs}/etc/systemd/system/getty.target.wants"
 
     # Fix getty-static-service as debootstrap does not install dbus


### PR DESCRIPTION
An incorrect quoting introduced in bf39edb caused a /{lib,etc} folder to
appear in Debian templates

The very next line :
    mkdir -p "${rootfs}/etc/systemd/system/getty.target.wants

makes creating ${rootfs}/etc/systemd/system/ unnecessary in the first
place