### PR TITLE
console: use correct log name

### DIFF
--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -52,7 +52,7 @@
 #include <../include/openpty.h>
 #endif
 
-lxc_log_define(lxc_console, lxc);
+lxc_log_define(console, lxc);
 
 static struct lxc_list lxc_ttys;
 


### PR DESCRIPTION
lxc_console is used with lxc_console.c

Signed-off-by: Christian Brauner <christian.brauner@mailbox.org>