### PR TITLE
debian: Make systemd honor SIGPWR

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -253,12 +253,12 @@ configure_debian_systemd()
 
     # This function has been copied and adapted from lxc-fedora
     rm -f "${rootfs}/etc/systemd/system/default.target"
+    rm -f "${rootfs}/etc/systemd/system/sigpwr.target
     chroot "${rootfs}" ln -s /dev/null /etc/systemd/system/udev.service
     chroot "${rootfs}" ln -s /dev/null /etc/systemd/system/systemd-udevd.service
     chroot "${rootfs}" ln -s /lib/systemd/system/multi-user.target /etc/systemd/system/default.target
-    
+
     # Make systemd honor SIGPWR
-    chroot "${rootfs}" rm -f /etc/systemd/system/sigpwr.target
     chroot "${rootfs}" ln -s /lib/systemd/system/halt.target /etc/systemd/system/sigpwr.target
 
     # Setup getty service on the ttys we are going to allow in the

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -256,6 +256,11 @@ configure_debian_systemd()
     chroot "${rootfs}" ln -s /dev/null /etc/systemd/system/udev.service
     chroot "${rootfs}" ln -s /dev/null /etc/systemd/system/systemd-udevd.service
     chroot "${rootfs}" ln -s /lib/systemd/system/multi-user.target /etc/systemd/system/default.target
+    
+    # Make systemd honor SIGPWR
+    chroot "${rootfs}" rm -f /etc/systemd/system/sigpwr.target
+    chroot "${rootfs}" ln -s /lib/systemd/system/halt.target /etc/systemd/system/sigpwr.target
+
     # Setup getty service on the ttys we are going to allow in the
     # default config.  Number should match lxc.tty
     ( cd "${rootfs}/etc/systemd/system/getty.target.wants"


### PR DESCRIPTION
without this symbolic（sigpwr） link， systemd-shutdownd hung in stopping container, so i think it's not a good idea to remove it!

Signed-off-by: Xiahou Feng <xiahoufeng@yahoo.com>
