### PR TITLE
issue: 1164 fixed broken cron link in alpine image

### DIFF
--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -364,8 +364,13 @@ setup_services() {
 	done
 
 	# default runlevel
-	for svc_name in networking cron; do
-		ln -s /etc/init.d/$svc_name etc/runlevels/default/$svc_name
+	for svc_name in networking cron crond; do
+		# issue 1164: alpine renamed cron to crond
+		# Use the one that exists.
+		if [ -e etc/init.d/$svc_name ]
+		then
+			ln -s /etc/init.d/$svc_name etc/runlevels/default/$svc_name
+		fi
 	done
 }
 

--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -367,8 +367,7 @@ setup_services() {
 	for svc_name in networking cron crond; do
 		# issue 1164: alpine renamed cron to crond
 		# Use the one that exists.
-		if [ -e etc/init.d/$svc_name ]
-		then
+		if [ -e etc/init.d/$svc_name ]; then
 			ln -s /etc/init.d/$svc_name etc/runlevels/default/$svc_name
 		fi
 	done


### PR DESCRIPTION
tested with LXD for alpine versions 3.4, 3.2, 3.1, edge.  Did not test with plain LXC.
To test:
1) Verify that the /etc/runlevels/default/ links are not broken.
2) exec "ash" in the container, and run "crontab -e" and add the line "* * * * * /bin/date > /root/date.log"
Make sure there is an empty line at the end.
Verify that the file /root/date.log is created in the next minute.