### PR TITLE
exit with error if no controlling tty is available

### DIFF
--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -527,6 +527,11 @@ int lxc_console_create(struct lxc_conf *conf)
 
 	lxc_console_peer_default(console);
 
+	if (console->peer < 0) {
+		SYSERROR("failed to open console peer - no controlling tty?");
+		goto err;
+	}
+
 	if (console->log_path) {
 		console->log_fd = lxc_unpriv(open(console->log_path,
 						  O_CLOEXEC | O_RDWR |


### PR DESCRIPTION
Avoids a segfault in lxc_attach.c: get_pty_on_host when executed with su: https://bugs.launchpad.net/ubuntu/+source/lxc/+bug/1567037