### PR TITLE
lxczfs: small fixes

### DIFF
--- a/src/lxc/bdev/lxczfs.c
+++ b/src/lxc/bdev/lxczfs.c
@@ -26,6 +26,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/mount.h>
 
 #include "bdev.h"
@@ -170,6 +171,9 @@ int zfs_clone(const char *opath, const char *npath, const char *oname,
 		if ((pid = fork()) < 0)
 			return -1;
 		if (!pid) {
+			int dev0 = open("/dev/null", O_WRONLY);
+			if (dev0 >= 0)
+				dup2(dev0, STDERR_FILENO);
 			execlp("zfs", "zfs", "destroy", path1, (char *)NULL);
 			exit(EXIT_FAILURE);
 		}
@@ -252,7 +256,7 @@ int zfs_destroy(struct bdev *orig)
 		return -1;
 	*p = '\0';
 
-	execlp("zfs", "zfs", "destroy", output, (char *)NULL);
+	execlp("zfs", "zfs", "destroy", "-r", output, (char *)NULL);
 	exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
- We expect destroy to fail in zfs_clone() so try to silence it so users are
  not irritated when they create zfs snapshots.
- Add -r recursive to zfs_destroy(). This code is only hit when a) the
  container has no snapshots or b) the user calls destroy with snapshots. So
  this should be safe. Without -r snapshots will remain.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>