### PR TITLE
c/r: free valid_opts if necessary

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4007,6 +4007,9 @@ static int do_lxcapi_migrate(struct lxc_container *c, unsigned int cmd,
 		ret = -EINVAL;
 	}
 
+	if (size < sizeof(*opts))
+		free(valid_opts);
+
 	return ret;
 }
 


### PR DESCRIPTION
2cb80427bc468f7647309c3eca66cfc9afa85b61 introduced a malloc without a
matching free.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>