### PR TITLE
make rsync deal with sparse files efficiently

### DIFF
--- a/src/lxc/bdev/lxcrsync.c
+++ b/src/lxc/bdev/lxcrsync.c
@@ -61,7 +61,7 @@ int do_rsync(const char *src, const char *dest)
 	s[l-2] = '/';
 	s[l-1] = '\0';
 
-	execlp("rsync", "rsync", "-aHX", "--delete", s, dest, (char *)NULL);
+	execlp("rsync", "rsync", "-aHXS", "--delete", s, dest, (char *)NULL);
 	exit(1);
 }
 


### PR DESCRIPTION
Without this switch, `lxc-snapshot` will inappropriately inflate sparse files that are stored in containers.
I guess this is pretty straight forward, tell me if you need a detailed example.