### PR TITLE
lxc-create -t debian fails on ppc64el arch

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -654,6 +654,8 @@ elif [ "$arch" = "x86_64" ]; then
     arch="amd64"
 elif [ "$arch" = "armv7l" ]; then
     arch="armhf"
+elif [ "$arch" = "ppc64le" ]; then
+    arch="ppc64el"
 elif [ "$arch" = "mips" -a "$littleendian" = "yes" ]; then
     arch="mipsel"
 elif [ "$arch" = "mips64" -a "$littleendian" = "yes" ]; then


### PR DESCRIPTION
Template catches arch from uname -m, but for ppc64el system, arch reports ppc64le
which doesn't match image repo.

Signed-off-by: Thierry Fauck <tfauck@free.fr>
Signed-off-by: Serge Hallyn <serge@hallyn.com>