### PR TITLE
2016 09 21/retrieve mtu from bridge

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2521,7 +2521,7 @@ static int instantiate_veth(struct lxc_handler *handler, struct lxc_netdev *netd
 {
 	char veth1buf[IFNAMSIZ], *veth1;
 	char veth2buf[IFNAMSIZ], *veth2;
-	int err, mtu = 0;
+	int bridge_index, err, mtu = 0;
 
 	if (netdev->priv.veth_attr.pair) {
 		veth1 = netdev->priv.veth_attr.pair;
@@ -2574,8 +2574,13 @@ static int instantiate_veth(struct lxc_handler *handler, struct lxc_netdev *netd
 
 	if (netdev->mtu) {
 		mtu = atoi(netdev->mtu);
+		INFO("Retrieved mtu %d", mtu);
 	} else if (netdev->link) {
-		mtu = netdev_get_mtu(netdev->ifindex);
+		bridge_index = if_nametoindex(netdev->link);
+		if (!bridge_index)
+			INFO("Could not retrieve mtu from %s", netdev->link);
+		mtu = netdev_get_mtu(bridge_index);
+		INFO("Retrieved mtu %d from %s", mtu, netdev->link);
 	}
 
 	if (mtu) {

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2577,10 +2577,13 @@ static int instantiate_veth(struct lxc_handler *handler, struct lxc_netdev *netd
 		INFO("Retrieved mtu %d", mtu);
 	} else if (netdev->link) {
 		bridge_index = if_nametoindex(netdev->link);
-		if (!bridge_index)
-			INFO("Could not retrieve mtu from %s", netdev->link);
-		mtu = netdev_get_mtu(bridge_index);
-		INFO("Retrieved mtu %d from %s", mtu, netdev->link);
+		if (bridge_index) {
+			mtu = netdev_get_mtu(bridge_index);
+			INFO("Retrieved mtu %d from %s", mtu, netdev->link);
+		} else {
+			mtu = netdev_get_mtu(netdev->ifindex);
+			INFO("Retrieved mtu %d from %s", mtu, veth2);
+		}
 	}
 
 	if (mtu) {


### PR DESCRIPTION
This solves a problem for root started containers. Previously they reset any value set on `netdev->link`.