### PR TITLE
Fix null derefence if attach is called without access to any tty

### DIFF
--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -321,7 +321,7 @@ static int get_pty_on_host(struct lxc_container *c, struct wrapargs *wrap, int *
 err3:
 	lxc_mainloop_close(&descr);
 err2:
-	if (ts->sigfd != -1)
+	if (ts && ts->sigfd != -1)
 		lxc_console_sigwinch_fini(ts);
 err1:
 	lxc_console_delete(&conf->console);


### PR DESCRIPTION
Discovered while trying to invoke lxc through salt stack. If ```lxc_console_peer_default``` fails to allocate the peer (```src/lxc/console.c +432```) then``` ts``` is unset and will segfault on close. 


Signed-off-by: Oliver Matthews <oliver@codersoffortune.net>