### PR TITLE
utils: lxc_deslashify() prevent fallthrough

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -738,8 +738,9 @@ bool lxc_deslashify(char **path)
 				return false;
 			free(*path);
 			*path = p;
-			return true;
 		}
+		/* Assume that the path we were passed was already clean. */
+		return true;
 	}
 
 	p = lxc_string_join("/", (const char **)parts, **path == '/');


### PR DESCRIPTION
lxc_string_join() should not be reached when !*path, otherwise we'll risk a
segfault.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>