### PR TITLE
mark the python examples as having utf-8 encoding

### DIFF
--- a/src/python-lxc/examples/api_test.py
+++ b/src/python-lxc/examples/api_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # api_test.py: Test/demo of the python3-lxc API
 #

--- a/src/python-lxc/examples/pyconsole-vte.py
+++ b/src/python-lxc/examples/pyconsole-vte.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # pyconsole-vte: Example program showing use of console functions
 #                in the lxc python binding

--- a/src/python-lxc/examples/pyconsole.py
+++ b/src/python-lxc/examples/pyconsole.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # pyconsole: Example program showing use of console functions
 #            in the lxc python binding


### PR DESCRIPTION
this allows running them also under Python2, which otherwise
would choke on Stéphane's name and error out with
 SyntaxError: Non-ASCII character '\xc3' in file …

Signed-off-by: Evgeni Golov <evgeni@debian.org>