### PR TITLE
log: sanity check the returned value from snprintf()

### DIFF
--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -170,10 +170,13 @@ static int log_append_logfile(const struct lxc_log_appender *appender,
 		     event->locinfo->file, event->locinfo->func,
 		     event->locinfo->line);
 
-	n += vsnprintf(buffer + n, sizeof(buffer) - n, event->fmt,
-		       *event->vap);
+	if (n < 0)
+		return n;
 
-	if (n >= sizeof(buffer) - 1) {
+	if (n < sizeof(buffer) - 1)
+		n += vsnprintf(buffer + n, sizeof(buffer) - n, event->fmt,
+			       *event->vap);
+	else {
 		WARN("truncated next event from %d to %zd bytes", n,
 		     sizeof(buffer));
 		n = sizeof(buffer) - 1;


### PR DESCRIPTION
The returned value from snprintf() should be checked carefully.

This bug can be leveraged to execute arbitrary code through carefully
constructing the payload, e.g,

lxc-freeze -n `python -c "print 'AAAAAAAA' + 'B'*959"` -P PADPAD -o /tmp/log

This command running on Ubuntu 14.04 (x86-64) can cause a segment fault.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>