### PR TITLE
Drop leftover references to lxc_strerror().

### DIFF
--- a/src/lxc/arguments.h
+++ b/src/lxc/arguments.h
@@ -164,8 +164,6 @@ extern int lxc_arguments_parse(struct lxc_arguments *args,
 
 extern int lxc_arguments_str_to_int(struct lxc_arguments *args, const char *str);
 
-extern const char *lxc_strerror(int errnum);
-
 #define lxc_error(arg, fmt, args...) if (!(arg)->quiet)			\
 	fprintf(stderr, "%s: " fmt "\n", (arg)->progname,  ## args)
 

--- a/src/lxc/lxc.h
+++ b/src/lxc/lxc.h
@@ -119,14 +119,6 @@ extern int lxc_cgroup_set(const char *filename, const char *value, const char *n
 extern int lxc_cgroup_get(const char *filename, char *value, size_t len, const char *name, const char *lxcpath);
 
 /*
- * Retrieve the error string associated with the error returned by
- * the function.
- * @error : the value of the error
- * Returns a string on success or NULL otherwise.
- */
-extern const char *lxc_strerror(int error);
-
-/*
  * Create and return a new lxccontainer struct.
  */
 extern struct lxc_container *lxc_container_new(const char *name, const char *configpath);


### PR DESCRIPTION
lxc_strerror() was dropped long time ago, in 2009 to be exact.

Related commit:
https://github.com/lxc/lxc/commit/7cee8789514fb42d6a48d50b904e24284f5526e3

Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>