### PR TITLE
tests: fix image download for s390x

### DIFF
--- a/src/tests/lxc-test-apparmor-mount
+++ b/src/tests/lxc-test-apparmor-mount
@@ -42,6 +42,7 @@ run_cmd() {
 }
 
 DONE=0
+KNOWN_RELEASES="precise trusty wily xenial yakkety"
 MOUNTSR=/sys/kernel/security/apparmor/features/mount
 dnam=`mktemp -d`
 cname=`basename $dnam`
@@ -144,7 +145,18 @@ run_cmd mkdir -p $HDIR/.cache/lxc
     cp -R /var/cache/lxc/download $HDIR/.cache/lxc && \
     chown -R $TUSER: $HDIR/.cache/lxc
 
-run_cmd lxc-create -t download -n $cname -- -d ubuntu -r trusty -a $ARCH
+# default release is trusty, or the systems release if recognized
+release=trusty
+if [ -f /etc/lsb-release ]; then
+    . /etc/lsb-release
+    rels=$(ubuntu-distro-info --supported 2>/dev/null) ||
+        rels="$KNOWN_RELEASES"
+    for r in $rels; do
+        [ "$DISTRIB_CODENAME" = "$r" ] && release="$r"
+    done
+fi
+
+run_cmd lxc-create -t download -n $cname -- -d ubuntu -r $release -a $ARCH
 
 echo "test default confined container"
 run_cmd lxc-start -n $cname -d

--- a/src/tests/lxc-test-autostart
+++ b/src/tests/lxc-test-autostart
@@ -22,6 +22,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 DONE=0
+KNOWN_RELEASES="precise trusty wily xenial yakkety"
 cleanup() {
 	lxc-destroy -n $CONTAINER_NAME >/dev/null 2>&1 || true
 
@@ -42,7 +43,19 @@ set -eu
 
 # Create a container
 CONTAINER_NAME=lxc-test-auto
-lxc-create -t download -n $CONTAINER_NAME -- -d ubuntu -r trusty -a $ARCH
+
+# default release is trusty, or the systems release if recognized
+release=trusty
+if [ -f /etc/lsb-release ]; then
+    . /etc/lsb-release
+    rels=$(ubuntu-distro-info --supported 2>/dev/null) ||
+        rels="$KNOWN_RELEASES"
+    for r in $rels; do
+        [ "$DISTRIB_CODENAME" = "$r" ] && release="$r"
+    done
+fi
+
+lxc-create -t download -n $CONTAINER_NAME -- -d ubuntu -r $release -a $ARCH
 CONTAINER_PATH=$(dirname $(lxc-info -n $CONTAINER_NAME -c lxc.rootfs -H))
 cp $CONTAINER_PATH/config $CONTAINER_PATH/config.bak
 

--- a/src/tests/lxc-test-unpriv
+++ b/src/tests/lxc-test-unpriv
@@ -30,6 +30,7 @@ fi
 which newuidmap >/dev/null 2>&1 || { echo "'newuidmap' command is missing" >&2; exit 1; }
 
 DONE=0
+KNOWN_RELEASES="precise trusty wily xenial yakkety"
 cleanup() {
 	cd /
 
@@ -119,13 +120,24 @@ else
 	done
 fi
 
+# default release is trusty, or the systems release if recognized
+release=trusty
+if [ -f /etc/lsb-release ]; then
+    . /etc/lsb-release
+    rels=$(ubuntu-distro-info --supported 2>/dev/null) ||
+        rels="$KNOWN_RELEASES"
+    for r in $rels; do
+        [ "$DISTRIB_CODENAME" = "$r" ] && release="$r"
+    done
+fi
+
 # Copy the download template cache if available
 run_cmd mkdir -p $HDIR/.cache/lxc
 [ -d /var/cache/lxc/download ] && \
     cp -R /var/cache/lxc/download $HDIR/.cache/lxc && \
     chown -R $TUSER: $HDIR/.cache/lxc
 
-run_cmd lxc-create -t download -n c1 -- -d ubuntu -r trusty -a $ARCH
+run_cmd lxc-create -t download -n c1 -- -d ubuntu -r $release -a $ARCH
 
 # Make sure we can start it - twice
 

--- a/src/tests/lxc-test-usernic.in
+++ b/src/tests/lxc-test-usernic.in
@@ -24,6 +24,7 @@
 # This test assumes an Ubuntu host
 
 DONE=0
+KNOWN_RELEASES="precise trusty wily xenial yakkety"
 LXC_USER_NIC="@LIBEXECDIR@/lxc/lxc-user-nic"
 
 cleanup() {
@@ -132,8 +133,19 @@ if type dpkg >/dev/null 2>&1; then
 	ARCH=$(dpkg --print-architecture)
 fi
 
+# default release is trusty, or the systems release if recognized
+release=trusty
+if [ -f /etc/lsb-release ]; then
+    . /etc/lsb-release
+    rels=$(ubuntu-distro-info --supported 2>/dev/null) ||
+        rels="$KNOWN_RELEASES"
+    for r in $rels; do
+        [ "$DISTRIB_CODENAME" = "$r" ] && release="$r"
+    done
+fi
+
 # Create three containers
-run_cmd "lxc-create -t download -n b1 -- -d ubuntu -r trusty -a $ARCH"
+run_cmd "lxc-create -t download -n b1 -- -d ubuntu -r $release -a $ARCH"
 run_cmd "lxc-start -n b1 -d"
 p1=$(run_cmd "lxc-info -n b1 -p -H")
 

--- a/templates/lxc-ubuntu-cloud.in
+++ b/templates/lxc-ubuntu-cloud.in
@@ -25,7 +25,7 @@ STATE_DIR="@LOCALSTATEDIR@"
 HOOK_DIR="@LXCHOOKDIR@"
 CLONE_HOOK_FN="$HOOK_DIR/ubuntu-cloud-prep"
 LXC_TEMPLATE_CONFIG="@LXCTEMPLATECONFIG@"
-KNOWN_RELEASES="precise trusty vivid wily xenial"
+KNOWN_RELEASES="precise trusty wily xenial yakkety"
 skip_arch_check=${UCTEMPLATE_SKIP_ARCH_CHECK:-0}
 
 # Make sure the usual locations are in PATH


### PR DESCRIPTION
Make release selection more flexible with the algorithm in templates/lxc-ubuntu-cloud.in
Update the KNOWN_RELEAES list, add yakkety and remove vivid.

This closes issue #1231 

Signed-off-by: Po-Hsu Lin <po-hsu.lin@canonical.com>