### PR TITLE
tools: make overlay a valid backend for lxc-copy

### DIFF
--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -154,7 +154,9 @@ static int my_parser(struct lxc_arguments* args, int c, char* arg)
 	case 'L':
 		args->console_log = arg;
 		break;
-	case 'f': args->rcfile = arg; break;
+	case 'f':
+		args->rcfile = arg;
+		break;
 	}
 
 	return 0;

--- a/src/lxc/tools/lxc_copy.c
+++ b/src/lxc/tools/lxc_copy.c
@@ -620,6 +620,8 @@ static int my_parser(struct lxc_arguments *args, int c, char *arg)
 			return -1;
 		break;
 	case 'B':
+		if (strcmp(arg, "overlay") == 0)
+			arg = "overlayfs";
 		args->bdevtype = arg;
 		break;
 	case 't':


### PR DESCRIPTION
Closes https://bugs.launchpad.net/ubuntu/+source/lxc/+bug/1591513.
Closes #1076.