### PR TITLE
lxc-alpine: do not drop setfcap

### DIFF
--- a/config/templates/alpine.common.conf.in
+++ b/config/templates/alpine.common.conf.in
@@ -8,7 +8,6 @@ lxc.devttydir =
 lxc.cap.drop = audit_write
 lxc.cap.drop = ipc_owner
 lxc.cap.drop = mknod
-lxc.cap.drop = setfcap
 lxc.cap.drop = setpcap
 lxc.cap.drop = sys_nice
 lxc.cap.drop = sys_pacct


### PR DESCRIPTION
@brauner I’m not entirely sure about this, could you please answer me two questions?

1. Am I right that `setfcap` is not a security risk, i.e. it cannot be abused to escape from container to the host system?
2. Is it true that `setcap` cannot work in unprivileged containers (i.e. containers that uses user namespace) anyway, only in privileged ones?