### PR TITLE
s390x: Fix seccomp handling of personalities

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -378,15 +378,6 @@ static int parse_config_v2(FILE *f, char *line, struct lxc_conf *conf)
 		if (!compat_ctx[0] || !compat_ctx[1])
 			goto bad;
 #endif
-#ifdef SCMP_ARCH_S390X
-	} else if (native_arch == lxc_seccomp_arch_s390x) {
-		cur_rule_arch = lxc_seccomp_arch_all;
-		compat_arch[0] = SCMP_ARCH_S390X;
-		compat_ctx[0] = get_new_ctx(lxc_seccomp_arch_s390x,
-				default_policy_action);
-		if (!compat_ctx[0])
-			goto bad;
-#endif
 	}
 
 	if (default_policy_action != SCMP_ACT_KILL) {


### PR DESCRIPTION
There are no personalities for s390x, so don't list itself as one.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>