### PR TITLE
RPM build fixes

### DIFF
--- a/lxc.spec.in
+++ b/lxc.spec.in
@@ -269,9 +269,6 @@ fi
 %{_sbindir}/*
 %{_libdir}/*.so.*
 %{_libdir}/%{name}
-%if %{with_python}
-%{_libdir}/python*
-%endif
 %{_localstatedir}/*
 %{_libexecdir}/%{name}
 %attr(4111,root,root) %{_libexecdir}/%{name}/lxc-user-nic
@@ -281,8 +278,7 @@ fi
 %endif
 
 %if %{with_python}
-%{_libdir}/python3.3/site-packages/_lxc*
-%{_libdir}/python3.3/site-packages/lxc/*
+%{python3_sitearch}/*
 %endif
 
 %if %{with_lua}

--- a/lxc.spec.in
+++ b/lxc.spec.in
@@ -252,13 +252,13 @@ fi
 %{_datadir}/doc/*
 %{_datadir}/lxc/*
 %{_sysconfdir}/bash_completion.d
-%{_sysconfdir}/sysconfig/*
 %config(noreplace) %{_sysconfdir}/lxc/*
 %config(noreplace) %{_sysconfdir}/sysconfig/*
 
 %if %{with_systemd}
 %{_unitdir}/lxc-net.service
 %{_unitdir}/lxc.service
+%{_unitdir}/lxc@.service
 %else
 %{_sysconfdir}/rc.d/init.d/lxc
 %{_sysconfdir}/rc.d/init.d/lxc-net
@@ -270,7 +270,9 @@ fi
 %{_libdir}/*.so.*
 %{_libdir}/%{name}
 %{_localstatedir}/*
-%{_libexecdir}/%{name}
+%{_libexecdir}/%{name}/hooks/unmount-namespace
+%{_libexecdir}/%{name}/lxc-apparmor-load
+%{_libexecdir}/%{name}/lxc-monitord
 %attr(4111,root,root) %{_libexecdir}/%{name}/lxc-user-nic
 %if %{with_systemd}
 %attr(555,root,root) %{_libexecdir}/%{name}/lxc-net


### PR DESCRIPTION
* use python3_sitearch for including the python code (closes #502)
* include all built files, but only once, otherwise rpmbuild fails because files are either installed twice or not at all