### PR TITLE
lxc-ls help fixes

### DIFF
--- a/doc/ja/lxc-ls.sgml.in
+++ b/doc/ja/lxc-ls.sgml.in
@@ -173,7 +173,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         <listitem>
           <para>
             <!--
-            Comma separate list of column to show in the fancy output.
+            Comma separated list of columns to show in the fancy output.
             The list of accepted and default fields is listed in \-\-help.
             -->
             装飾付き出力で表示するカラムのコンマ区切りのリスト。デフォルトで表示される項目と指定可能な項目名は --help オプションで確認してください。

--- a/doc/ko/lxc-ls.sgml.in
+++ b/doc/ko/lxc-ls.sgml.in
@@ -173,7 +173,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
         <listitem>
           <para>
             <!--
-            Comma separate list of column to show in the fancy output.
+            Comma separated list of columns to show in the fancy output.
             The list of accepted and default fields is listed in \-\-help.
             -->
             &#045;&#045;fancy로 출력할때 어떤 컬럼을 보여줄지 쉼표(,)로 구분된 리스트.

--- a/doc/lxc-ls.sgml.in
+++ b/doc/lxc-ls.sgml.in
@@ -146,7 +146,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         </term>
         <listitem>
           <para>
-            Comma separated list of column to show in the fancy output.
+            Comma separated list of columns to show in the fancy output.
             The list of accepted and default fields is listed in --help.
           </para>
         </listitem>

--- a/src/lxc/tools/lxc_ls.c
+++ b/src/lxc/tools/lxc_ls.c
@@ -185,8 +185,10 @@ lxc-ls list containers\n\
 \n\
 Options :\n\
   -1, --line         show one entry per line\n\
-  -f, --fancy        column-based output\n\
-  -F, --fancy-format column-based output\n\
+  -f, --fancy        use a fancy, column-based output\n\
+  -F, --fancy-format comma separated list of columns to show in the fancy output\n\
+                     valid columns are: NAME, STATE, PID, RAM, SWAP, AUTOSTART,\n\
+                     GROUPS, INTERFACE, IPV4 and IPV6\n\
   --active           list only active containers\n\
   --running          list only running containers\n\
   --frozen           list only frozen containers\n\


### PR DESCRIPTION
* improve help text for --fancy and --fancy-format
* improve wording for --fancy-format on the help page for lxc-ls