### PR TITLE
tools: use correct exit code for lxc-stop

### DIFF
--- a/src/lxc/tools/lxc_stop.c
+++ b/src/lxc/tools/lxc_stop.c
@@ -226,7 +226,10 @@ int main(int argc, char *argv[])
 
 	if (!c->is_running(c)) {
 		fprintf(stderr, "%s is not running\n", c->name);
-		ret = EXIT_FAILURE;
+		/* Per our manpage we need to exit with exit code:
+		 * 2: The specified container exists but was not running.
+		 */
+		ret = 2;
 		goto out;
 	}
 


### PR DESCRIPTION
When the container is already running our manpage promises to exit with 2.
Let's make it so.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>

Closes #1263.