### PR TITLE
conf: merge network namespace move & rename on shutdown

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2397,14 +2397,16 @@ static int setup_network(struct lxc_list *network)
 }
 
 /* try to move physical nics to the init netns */
-void restore_phys_nics_to_netns(int netnsfd, struct lxc_conf *conf)
+void lxc_restore_phys_nics_to_netns(int netnsfd, struct lxc_conf *conf)
 {
 	int i, ret, oldfd;
 	char path[MAXPATHLEN];
 	char ifname[IFNAMSIZ];
 
-	if (netnsfd < 0)
+	if (netnsfd < 0 || conf->num_savednics == 0)
 		return;
+
+	INFO("running to reset %d nic names", conf->num_savednics);
 
 	ret = snprintf(path, MAXPATHLEN, "/proc/self/ns/net");
 	if (ret < 0 || ret >= MAXPATHLEN) {
@@ -2427,30 +2429,15 @@ void restore_phys_nics_to_netns(int netnsfd, struct lxc_conf *conf)
 			WARN("no interface corresponding to index '%d'", s->ifindex);
 			continue;
 		}
-		if (lxc_netdev_move_by_name(ifname, 1, NULL))
+		if (lxc_netdev_move_by_name(ifname, 1, s->orig_name))
 			WARN("Error moving nic name:%s back to host netns", ifname);
-	}
-	if (setns(oldfd, 0) != 0)
-		SYSERROR("Failed to re-enter monitor's netns");
-	close(oldfd);
-}
-
-void lxc_rename_phys_nics_on_shutdown(int netnsfd, struct lxc_conf *conf)
-{
-	int i;
-
-	if (conf->num_savednics == 0)
-		return;
-
-	INFO("running to reset %d nic names", conf->num_savednics);
-	restore_phys_nics_to_netns(netnsfd, conf);
-	for (i=0; i<conf->num_savednics; i++) {
-		struct saved_nic *s = &conf->saved_nics[i];
-		INFO("resetting nic %d to %s", s->ifindex, s->orig_name);
-		lxc_netdev_rename_by_index(s->ifindex, s->orig_name);
 		free(s->orig_name);
 	}
 	conf->num_savednics = 0;
+
+	if (setns(oldfd, 0) != 0)
+		SYSERROR("Failed to re-enter monitor's netns");
+	close(oldfd);
 }
 
 static char *default_rootfs_mount = LXCROOTFSMOUNT;

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -440,7 +440,7 @@ extern int do_rootfs_setup(struct lxc_conf *conf, const char *name,
 struct cgroup_process_info;
 extern int lxc_setup(struct lxc_handler *handler);
 
-extern void lxc_rename_phys_nics_on_shutdown(int netnsfd, struct lxc_conf *conf);
+extern void lxc_restore_phys_nics_to_netns(int netnsfd, struct lxc_conf *conf);
 
 extern int find_unmapped_nsuid(struct lxc_conf *conf, enum idtype idtype);
 extern int mapped_hostid(unsigned id, struct lxc_conf *conf, enum idtype idtype);

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1420,7 +1420,7 @@ int __lxc_start(const char *name, struct lxc_conf *conf,
 	}
 
 	DEBUG("Pushing physical nics back to host namespace");
-	lxc_rename_phys_nics_on_shutdown(netnsfd, handler->conf);
+	lxc_restore_phys_nics_to_netns(netnsfd, handler->conf);
 
 	DEBUG("Tearing down virtual network devices used by container");
 	lxc_delete_network(handler);


### PR DESCRIPTION
On shutdown we move physical network interfaces back to the
host namespace and rename them afterwards as well as in the
later lxc_network_delete() step. However, if the device had
a name which already exists in the host namespace then the
moving fails and so do the subsequent rename attempts. When
the namespace ceases to exist the devices finally end up
in the host namespace named 'dev<ID>' by the kernel.

In order to avoid this, we do the moving and renaming in a
single step (lxc_netdev_move_by_*()'s move & rename happen
in a single netlink transaction).

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>