### PR TITLE
cleanup: /usr/bin/bash vs /bin/bash consistency

### DIFF
--- a/templates/lxc-voidlinux.in
+++ b/templates/lxc-voidlinux.in
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 #
 # template script for generating Void Linux container for LXC


### PR DESCRIPTION
All the other templates use `#!/bin/bash`