### PR TITLE
c/r: check state before doing a checkpoint/restore

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3994,12 +3994,24 @@ static int do_lxcapi_migrate(struct lxc_container *c, unsigned int cmd,
 
 	switch (cmd) {
 	case MIGRATE_PRE_DUMP:
+		if (!do_lxcapi_is_running(c)) {
+			ERROR("container is not running");
+			return false;
+		}
 		ret = !__criu_pre_dump(c, valid_opts);
 		break;
 	case MIGRATE_DUMP:
+		if (!do_lxcapi_is_running(c)) {
+			ERROR("container is not running");
+			return false;
+		}
 		ret = !__criu_dump(c, valid_opts);
 		break;
 	case MIGRATE_RESTORE:
+		if (do_lxcapi_is_running(c)) {
+			ERROR("container is already running");
+			return false;
+		}
 		ret = !__criu_restore(c, valid_opts);
 		break;
 	default:


### PR DESCRIPTION
This would already fail, but with a not-as-good error message. Let's make
the error better.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>