### PR TITLE
Option to force lxc-copy and lxc-snapshot for running domains

### DIFF
--- a/doc/lxc-copy.sgml.in
+++ b/doc/lxc-copy.sgml.in
@@ -57,6 +57,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <arg choice="opt">-s, --snapshot</arg>
       <arg choice="opt">-K, --keepname</arg>
       <arg choice="opt">-D, --keepdata</arg>
+      <arg choice="opt">-f, --force</arg>
       <arg choice="opt">-M, --keepmac</arg>
       <arg choice="opt">-L, --fssize <replaceable>size [unit]</replaceable></arg>
       <arg choice="opt">-- hook arguments</arg>
@@ -72,6 +73,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <arg choice="opt">-s, --snapshot</arg>
       <arg choice="opt">-K, --keepname</arg>
       <arg choice="opt">-D, --keepdata</arg>
+      <arg choice="opt">-f, --force</arg>
       <arg choice="opt">-M, --keepmac</arg>
       <arg choice="opt">-L, --fssize <replaceable>size [unit]</replaceable></arg>
       <arg choice="opt">-- hook arguments</arg>
@@ -117,7 +119,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       support snapshots. This currently includes aufs, btrfs, lvm (lvm devices
       do not support snapshots of snapshots.), overlay, and zfs.
     </para>
-      
+
     <para>
     The copy's backing storage will be of the same type as the original
     container. aufs or overlayfs snapshots of directory backed containers are
@@ -205,6 +207,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             <para> Create a snapshot of the original container. The backing
             storage for the copy must support snapshots. This currently includes
             aufs, btrfs, lvm, overlay, and zfs. </para>
+	   </listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+	    <term> <option>-f,--force </option> </term>
+	   <listitem>
+            <para> Force the copy even if the container is running. Please be
+            careful with this mode, as it can produce non-persistent data
+            (typically with non-locked running databases, etc…). Has no effect
+            during a rename, as it would totally break a running
+            container.</para>
 	   </listitem>
 	  </varlistentry>
 

--- a/doc/lxc-snapshot.sgml.in
+++ b/doc/lxc-snapshot.sgml.in
@@ -51,6 +51,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <command>lxc-snapshot</command>
       <arg choice="req">-n, --name <replaceable>name</replaceable></arg>
       <arg choice="opt">-c, --comment <replaceable>file</replaceable></arg>
+      <arg choice="opt">-f, --force</arg>
     </cmdsynopsis>
     <cmdsynopsis>
       <command>lxc-snapshot</command>
@@ -123,6 +124,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 	    <term> <option>-r,--restore snapshot-name</option> </term>
 	   <listitem>
 	    <para> Restore the named snapshot, meaning a full new container is created which is a copy of the snapshot.</para>
+	   </listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+	    <term> <option>-f,--force </option> </term>
+	   <listitem>
+            <para> Force the snapshot even if the container is running. Please
+            be careful with this mode, as it can produce non-persistent data
+            (typically with non-locked running databases, etc…). Has no effect
+            for a restoration, as it would totally break a running
+            container.</para>
 	   </listitem>
 	  </varlistentry>
 

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3357,9 +3357,9 @@ static bool get_snappath_dir(struct lxc_container *c, char *snappath)
 	return true;
 }
 
-static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
+static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile, int flags)
 {
-	int i, flags, ret;
+	int i, ret;
 	struct lxc_container *c2;
 	char snappath[MAXPATHLEN], newname[20];
 
@@ -3390,7 +3390,7 @@ static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
 	 * We pass LXC_CLONE_SNAPSHOT to make sure that a rdepends file entry is
 	 * created in the original container
 	 */
-	flags = LXC_CLONE_SNAPSHOT | LXC_CLONE_KEEPMACADDR | LXC_CLONE_KEEPNAME |
+	flags |= LXC_CLONE_SNAPSHOT | LXC_CLONE_KEEPMACADDR | LXC_CLONE_KEEPNAME |
 		LXC_CLONE_KEEPBDEVTYPE | LXC_CLONE_MAYBE_SNAPSHOT;
 	if (bdev_is_dir(c->lxc_conf, c->lxc_conf->rootfs.path)) {
 		ERROR("Snapshot of directory-backed container requested.");
@@ -3447,7 +3447,7 @@ static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
 	return i;
 }
 
-WRAP_API_1(int, lxcapi_snapshot, const char *)
+WRAP_API_2(int, lxcapi_snapshot, const char *, int)
 
 static void lxcsnap_free(struct lxc_snapshot *s)
 {

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3064,7 +3064,7 @@ static struct lxc_container *do_lxcapi_clone(struct lxc_container *c, const char
 	if (container_mem_lock(c))
 		return NULL;
 
-	if (!is_stopped(c)) {
+	if (!(flags & LXC_CLONE_FORCE) && !is_stopped(c)) {
 		ERROR("error: Original container (%s) is running", c->name);
 		goto out;
 	}

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -39,7 +39,8 @@ extern "C" {
 #define LXC_CLONE_SNAPSHOT        (1 << 2) /*!< Snapshot the original filesystem(s) */
 #define LXC_CLONE_KEEPBDEVTYPE    (1 << 3) /*!< Use the same bdev type */
 #define LXC_CLONE_MAYBE_SNAPSHOT  (1 << 4) /*!< Snapshot only if bdev supports it, else copy */
-#define LXC_CLONE_MAXFLAGS        (1 << 5) /*!< Number of \c LXC_CLONE_* flags */
+#define LXC_CLONE_FORCE           (1 << 5) /*!< Ignore warning if the target domain is running, and force clone */
+#define LXC_CLONE_MAXFLAGS        (1 << 6) /*!< Number of \c LXC_CLONE_* flags */
 #define LXC_CREATE_QUIET          (1 << 0) /*!< Redirect \c stdin to \c /dev/zero and \c stdout and \c stderr to \c /dev/null */
 #define LXC_CREATE_MAXFLAGS       (1 << 1) /*!< Number of \c LXC_CREATE* flags */
 
@@ -547,6 +548,7 @@ struct lxc_container {
 	 *  - \ref LXC_CLONE_KEEPNAME
 	 *  - \ref LXC_CLONE_KEEPMACADDR
 	 *  - \ref LXC_CLONE_SNAPSHOT
+	 *  - \ref LXC_CLONE_FORCE
 	 * \param bdevtype Optionally force the cloned bdevtype to a specified plugin.
 	 *  By default the original is used (subject to snapshot requirements).
 	 * \param bdevdata Information about how to create the new storage

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -663,12 +663,14 @@ struct lxc_container {
 	 * \param c Container.
 	 * \param commentfile Full path to file containing a description
 	 *  of the snapshot.
+	 * \param flags Additional \c LXC_CLONE* flags to change the cloning behaviour:
+	 *  - \ref LXC_CLONE_FORCE
 	 *
 	 * \return -1 on error, or zero-based snapshot number.
 	 *
 	 * \note \p commentfile may be \c NULL but this is discouraged.
 	 */
-	int (*snapshot)(struct lxc_container *c, const char *commentfile);
+	int (*snapshot)(struct lxc_container *c, const char *commentfile, int flags);
 
 	/*!
 	 * \brief Obtain a list of container snapshots.

--- a/src/lxc/tools/lxc_copy.c
+++ b/src/lxc/tools/lxc_copy.c
@@ -88,6 +88,7 @@ static const struct option my_longopts[] = {
 	{ "keepname", no_argument, 0, 'K'},
 	{ "keepmac", no_argument, 0, 'M'},
 	{ "tmpfs", no_argument, 0, 't'},
+	{ "force", no_argument, 0, 'f'},
 	LXC_COMMON_OPTIONS
 };
 
@@ -102,8 +103,8 @@ static char *const keys[] = {
 static struct lxc_arguments my_args = {
 	.progname = "lxc-copy",
 	.help = "\n\
---name=NAME [-P lxcpath] -N newname [-p newpath] [-B backingstorage] [-s] [-K] [-M] [-L size [unit]] -- hook options\n\
---name=NAME [-P lxcpath] [-N newname] [-p newpath] [-B backingstorage] -e [-d] [-D] [-K] [-M] [-m {bind,aufs,overlay}=/src:/dest] -- hook options\n\
+--name=NAME [-P lxcpath] -N newname [-p newpath] [-B backingstorage] [-f] [-s] [-K] [-M] [-L size [unit]] -- hook options\n\
+--name=NAME [-P lxcpath] [-N newname] [-p newpath] [-B backingstorage] -e [-f] [-d] [-D] [-K] [-M] [-m {bind,aufs,overlay}=/src:/dest] -- hook options\n\
 --name=NAME [-P lxcpath] -N newname -R\n\
 \n\
 lxc-copy clone a container\n\
@@ -114,6 +115,7 @@ Options :\n\
   -p, --newpath=NEWPATH     NEWPATH for the container to be stored\n\
   -R, --rename              rename container\n\
   -s, --snapshot            create snapshot instead of clone\n\
+  -f, --force               force the copy even if the container is running\n\
   -F, --foreground          start with current tty attached to /dev/console\n\
   -d, --daemon              daemonize the container (default)\n\
   -e, --ephemeral           start ephemeral container\n\
@@ -203,6 +205,8 @@ int main(int argc, char *argv[])
 		flags |= LXC_CLONE_KEEPNAME;
 	if (my_args.keepmac)
 		flags |= LXC_CLONE_KEEPMACADDR;
+	if (my_args.force)
+		flags |= LXC_CLONE_FORCE;
 
 	if (!my_args.newpath)
 		my_args.newpath = (char *)my_args.lxcpath[0];
@@ -604,6 +608,9 @@ static int my_parser(struct lxc_arguments *args, int c, char *arg)
 		break;
 	case 's':
 		args->task = SNAP;
+		break;
+	case 'f':
+		args->force = 1;
 		break;
 	case 'F':
 		args->daemonize = 0;

--- a/src/python-lxc/lxc.c
+++ b/src/python-lxc/lxc.c
@@ -1376,6 +1376,7 @@ Container_snapshot(Container *self, PyObject *args, PyObject *kwds)
 {
     char *comment_path = NULL;
     static char *kwlist[] = {"comment_path", NULL};
+    int flags = 0;
     int retval = 0;
     int ret = 0;
     char newname[20];
@@ -1390,7 +1391,7 @@ Container_snapshot(Container *self, PyObject *args, PyObject *kwds)
         assert(comment_path != NULL);
     }
 
-    retval = self->container->snapshot(self->container, comment_path);
+    retval = self->container->snapshot(self->container, comment_path, flags);
 
     Py_XDECREF(py_comment_path);
 

--- a/src/tests/snapshot.c
+++ b/src/tests/snapshot.c
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
 	}
 	c->load_config(c, NULL);
 
-	if (c->snapshot(c, NULL) != 0) {
+	if (c->snapshot(c, NULL, 0) != 0) {
 		fprintf(stderr, "%s: %d: failed to create snapshot\n", __FILE__, __LINE__);
 		goto err;
 	}
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
 		goto good;
 	}
 
-	if (c2->snapshot(c2, NULL) != 0) {
+	if (c2->snapshot(c2, NULL, 0) != 0) {
 		fprintf(stderr, "%s: %d: failed to create snapshot\n", __FILE__, __LINE__);
 		goto err;
 	}


### PR DESCRIPTION
Hello,
This PR is linked with the issue #1254. It adds a flag to force the clone of a container, even if it is running.
The python API has not been touched, though.