### PR TITLE
cgroups: remove isolated cpus from cpuset.cpus  …

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1953,8 +1953,12 @@ static int lxc_append_null_to_list(void ***list)
 
 int lxc_append_string(char ***list, char *entry)
 {
-	int newentry = lxc_append_null_to_list((void ***)list);
 	char *copy;
+	int newentry;
+
+	newentry = lxc_append_null_to_list((void ***)list);
+	if (newentry < 0)
+		return -1;
 
 	copy = strdup(entry);
 	if (!copy)

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1930,3 +1930,37 @@ out:
 	fclose(f);
 	return bret;
 }
+
+static int lxc_append_null_to_list(void ***list)
+{
+	int newentry = 0;
+	void **tmp;
+
+	if (*list)
+		for (; (*list)[newentry]; newentry++) {
+			;
+		}
+
+	tmp = realloc(*list, (newentry + 2) * sizeof(void **));
+	if (!tmp)
+		return -1;
+
+	*list = tmp;
+	(*list)[newentry + 1] = NULL;
+
+	return newentry;
+}
+
+int lxc_append_string(char ***list, char *entry)
+{
+	int newentry = lxc_append_null_to_list((void ***)list);
+	char *copy;
+
+	copy = strdup(entry);
+	if (!copy)
+		return -1;
+
+	(*list)[newentry] = copy;
+
+	return 0;
+}

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -258,6 +258,8 @@ extern char *lxc_append_paths(const char *first, const char *second);
 extern bool lxc_string_in_list(const char *needle, const char *haystack, char sep);
 extern char **lxc_string_split(const char *string, char sep);
 extern char **lxc_string_split_and_trim(const char *string, char sep);
+/* Append string to NULL-terminated string array. */
+extern int lxc_append_string(char ***list, char *entry);
 
 /* some simple array manipulation utilities */
 typedef void (*lxc_free_fn)(void *);


### PR DESCRIPTION
In case the system was booted with

    isolcpus=n_i-n_j,n_k,n_m

we cannot simply copy the cpuset.cpus file from our parent cgroup. For example,
in the root cgroup cpuset.cpus will contain all of the cpus including the
isolated cpus. Copying the values of the root cgroup into a child cgroup will
lead to a wrong view in /proc/self/status: For the root cgroup
/sys/fs/cgroup/cpuset /proc/self/status will correctly show

    Cpus_allowed_list:      0-1,3

even though cpuset.cpus will show

    0-3

However, initializing a subcgroup in the cpuset controller by copying the
cpuset.cpus setting from the root cgroup will cause /proc/self/status to
incorrectly show

    Cpus_allowed_list:      0-3

Hence, we need to make sure to remove the isolated cpus from cpuset.cpus. Seth
has argued that this is not a kernel bug but by design. So let us be the smart
guys and fix this in liblxc.

The solution is straightforward: To avoid having to work with raw cpulist
strings we create cpumasks based on uint32_t bit arrays.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>

See discussion in https://bugs.launchpad.net/ubuntu/+source/lxc/+bug/1623143, especially [Seth's comment](https://bugs.launchpad.net/ubuntu/+source/lxc/+bug/1623143/comments/8).