### PR TITLE
also stop lxc-net in runlevels 0 and 6

### DIFF
--- a/config/init/sysvinit/lxc-net.in
+++ b/config/init/sysvinit/lxc-net.in
@@ -12,7 +12,7 @@
 # Should-Start:
 # Should-Stop:
 # Default-Start: 2 3 4 5
-# Default-Stop: 1
+# Default-Stop: 0 1 6
 # Short-Description: Bring up/down LXC Network Bridge
 # Description: Bring up/down LXC Network Bridge
 ### END INIT INFO


### PR DESCRIPTION
there is no reason to not do this :)

Signed-off-by: Evgeni Golov <evgeni@debian.org>