### PR TITLE
add lxc.egg-info to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ src/lxc/version.h
 
 src/python-lxc/build/
 src/python-lxc/lxc/__pycache__/
+src/python-lxc/lxc.egg-info/
 
 src/tests/lxc-test-device-add-remove
 src/tests/lxc-test-attach


### PR DESCRIPTION
Signed-off-by: Evgeni Golov <evgeni@debian.org>