### PR TITLE
conf: do not use %m format specifier

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1958,7 +1958,7 @@ FILE *write_mount_file(struct lxc_list *mount)
 
 	file = tmpfile();
 	if (!file) {
-		ERROR("tmpfile error: %m");
+		ERROR("Could not create temporary file: %s.", strerror(errno));
 		return NULL;
 	}
 


### PR DESCRIPTION
This is a GNU extension and some libcs might be missing it.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>

As observed in #1296.