### PR TITLE
debian: Don't depend on libui-dialog-perl

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -325,7 +325,6 @@ download_debian()
 $init,\
 ifupdown,\
 locales,\
-libui-dialog-perl,\
 dialog,\
 isc-dhcp-client,\
 netbase,\


### PR DESCRIPTION
This package doesn't exist in stretch anymore, and it's unclear why we
were depending on a library to begin with (as opposed to having it
brought by whatever needs it).

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>