### PR TITLE
cgroups: use %zu format specifier to print size_t

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -358,20 +358,21 @@ static uint32_t *lxc_cpumask(char *buf, size_t nbits)
 }
 
 /* The largest integer that can fit into long int is 2^64. This is a
- * 20-digit number. */
-#define LEN 21
+ * 20-digit number.
+ */
+#define __IN_TO_STR_LEN 21
 /* Turn cpumask into simple, comma-separated cpulist. */
 static char *lxc_cpumask_to_cpulist(uint32_t *bitarr, size_t nbits)
 {
 	size_t i;
 	int ret;
-	char numstr[LEN] = {0};
+	char numstr[__IN_TO_STR_LEN] = {0};
 	char **cpulist = NULL;
 
 	for (i = 0; i <= nbits; i++) {
 		if (is_set(i, bitarr)) {
-			ret = snprintf(numstr, LEN, "%lu", i);
-			if (ret < 0 || (size_t)ret >= LEN) {
+			ret = snprintf(numstr, __IN_TO_STR_LEN, "%zu", i);
+			if (ret < 0 || (size_t)ret >= __IN_TO_STR_LEN) {
 				lxc_free_array((void **)cpulist, free);
 				return NULL;
 			}


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@canonical.com>

Fixes https://launchpadlibrarian.net/293453637/buildlog_ubuntu-xenial-armhf.lxc_2.0.5+master~20161114-2016-0ubuntu1~xenial_BUILDING.txt.gz and related build failures.