### PR TITLE
separate the limiting from the namespaced cgroup root

### DIFF
--- a/src/lxc/cgroups/cgfs.c
+++ b/src/lxc/cgroups/cgfs.c
@@ -2383,11 +2383,14 @@ static void cgfs_destroy(void *hdata, struct lxc_conf *conf)
 	free(d);
 }
 
-static inline bool cgfs_create(void *hdata)
+static inline bool cgfs_create(void *hdata, bool inner)
 {
 	struct cgfs_data *d = hdata;
 	struct cgroup_process_info *i;
 	struct cgroup_meta_data *md;
+
+	if (inner)
+		return true;
 
 	if (!d)
 		return false;
@@ -2399,11 +2402,14 @@ static inline bool cgfs_create(void *hdata)
 	return true;
 }
 
-static inline bool cgfs_enter(void *hdata, pid_t pid)
+static inline bool cgfs_enter(void *hdata, pid_t pid, bool inner)
 {
 	struct cgfs_data *d = hdata;
 	struct cgroup_process_info *i;
 	int ret;
+
+	if (inner)
+		return true;
 
 	if (!d)
 		return false;
@@ -2428,9 +2434,11 @@ static inline bool cgfs_create_legacy(void *hdata, pid_t pid)
 	return true;
 }
 
-static const char *cgfs_get_cgroup(void *hdata, const char *subsystem)
+static const char *cgfs_get_cgroup(void *hdata, const char *subsystem, bool inner)
 {
 	struct cgfs_data *d = hdata;
+
+	(void)inner;
 
 	if (!d)
 		return NULL;
@@ -2646,12 +2654,15 @@ static bool do_cgfs_chown(char *cgroup_path, struct lxc_conf *conf)
 	return true;
 }
 
-static bool cgfs_chown(void *hdata, struct lxc_conf *conf)
+static bool cgfs_chown(void *hdata, struct lxc_conf *conf, bool inner)
 {
 	struct cgfs_data *d = hdata;
 	struct cgroup_process_info *info_ptr;
 	char *cgpath;
 	bool r = true;
+
+	if (inner)
+		return true;
 
 	if (!d)
 		return false;

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -72,6 +72,7 @@ struct hierarchy {
 	char *mountpoint;
 	char *base_cgroup;
 	char *fullcgpath;
+	char *innercgpath;
 };
 
 /*
@@ -814,6 +815,7 @@ static void add_controller(char **clist, char *mountpoint, char *base_cgroup)
 	new->mountpoint = mountpoint;
 	new->base_cgroup = base_cgroup;
 	new->fullcgpath = NULL;
+	new->innercgpath = false;
 
 	newentry = append_null_to_list((void ***)&hierarchies);
 	hierarchies[newentry] = new;
@@ -1286,6 +1288,8 @@ static void cgfsng_destroy(void *hdata, struct lxc_conf *conf)
 				free(h->fullcgpath);
 				h->fullcgpath = NULL;
 			}
+			free(h->innercgpath);
+			h->innercgpath = NULL;
 		}
 	}
 
@@ -1299,18 +1303,25 @@ struct cgroup_ops *cgfsng_ops_init(void)
 	return &cgfsng_ops;
 }
 
-static bool create_path_for_hierarchy(struct hierarchy *h, char *cgname)
+static bool create_path_for_hierarchy(struct hierarchy *h, char *cgname, bool inner)
 {
-	h->fullcgpath = must_make_path(h->mountpoint, h->base_cgroup, cgname, NULL);
-	if (dir_exists(h->fullcgpath)) { // it must not already exist
-		ERROR("Path \"%s\" already existed.", h->fullcgpath);
+	char *path;
+	if (inner) {
+		path = must_make_path(h->fullcgpath, CGROUP_NAMESPACE_SUBDIR, NULL);
+		h->innercgpath = path;
+	} else {
+		path = must_make_path(h->mountpoint, h->base_cgroup, cgname, NULL);
+		h->fullcgpath = path;
+	}
+	if (dir_exists(path)) { // it must not already exist
+		ERROR("Path \"%s\" already existed.", path);
 		return false;
 	}
-	if (!handle_cpuset_hierarchy(h, cgname)) {
+	if (!inner && !handle_cpuset_hierarchy(h, cgname)) {
 		ERROR("Failed to handle cgroupfs v1 cpuset controller.");
 		return false;
 	}
-	return mkdir_p(h->fullcgpath, 0755) == 0;
+	return mkdir_p(path, 0755) == 0;
 }
 
 static void remove_path_for_hierarchy(struct hierarchy *h, char *cgname)
@@ -1325,7 +1336,8 @@ static void remove_path_for_hierarchy(struct hierarchy *h, char *cgname)
  * Try to create the same cgroup in all hierarchies.
  * Start with cgroup_pattern; next cgroup_pattern-1, -2, ..., -999
  */
-static inline bool cgfsng_create(void *hdata)
+static inline bool cgfsng_create_inner(struct cgfsng_handler_data*);
+static inline bool cgfsng_create(void *hdata, bool inner)
 {
 	struct cgfsng_handler_data *d = hdata;
 	char *tmp, *cgname, *offset;
@@ -1335,7 +1347,13 @@ static inline bool cgfsng_create(void *hdata)
 	if (!d)
 		return false;
 	if (d->container_cgroup) {
+		if (inner)
+			return cgfsng_create_inner(d);
 		WARN("cgfsng_create called a second time");
+		return false;
+	}
+	if (inner) {
+		ERROR("cgfsng_create called twice for innner cgroup");
 		return false;
 	}
 
@@ -1358,7 +1376,7 @@ again:
 	if (idx)
 		snprintf(offset, 5, "-%d", idx);
 	for (i = 0; hierarchies[i]; i++) {
-		if (!create_path_for_hierarchy(hierarchies[i], cgname)) {
+		if (!create_path_for_hierarchy(hierarchies[i], cgname, false)) {
 			int j;
 			SYSERROR("Failed to create %s: %s", hierarchies[i]->fullcgpath, strerror(errno));
 			free(hierarchies[i]->fullcgpath);
@@ -1378,7 +1396,24 @@ out_free:
 	return false;
 }
 
-static bool cgfsng_enter(void *hdata, pid_t pid)
+static inline bool cgfsng_create_inner(struct cgfsng_handler_data *d)
+{
+	size_t i;
+	bool ret = true;
+	char *cgname = must_make_path(d->container_cgroup, CGROUP_NAMESPACE_SUBDIR, NULL);
+	for (i = 0; hierarchies[i]; i++) {
+		if (!create_path_for_hierarchy(hierarchies[i], cgname, true)) {
+			SYSERROR("Failed to create %s namespace subdirectory: %s", hierarchies[i]->fullcgpath, strerror(errno));
+			ret = false;
+			break;
+		}
+	}
+	free(cgname);
+	return ret;
+}
+
+
+static bool cgfsng_enter(void *hdata, pid_t pid, bool inner)
 {
 	char pidstr[25];
 	int i, len;
@@ -1388,7 +1423,13 @@ static bool cgfsng_enter(void *hdata, pid_t pid)
 		return false;
 
 	for (i = 0; hierarchies[i]; i++) {
-		char *fullpath = must_make_path(hierarchies[i]->fullcgpath,
+		char *fullpath;
+		if (inner)
+			fullpath = must_make_path(hierarchies[i]->fullcgpath,
+						CGROUP_NAMESPACE_SUBDIR,
+						"cgroup.procs", NULL);
+		else
+			fullpath = must_make_path(hierarchies[i]->fullcgpath,
 						"cgroup.procs", NULL);
 		if (lxc_write_to_file(fullpath, pidstr, len, false) != 0) {
 			SYSERROR("Failed to enter %s", fullpath);
@@ -1404,6 +1445,7 @@ static bool cgfsng_enter(void *hdata, pid_t pid)
 struct chown_data {
 	struct cgfsng_handler_data *d;
 	uid_t origuid; // target uid in parent namespace
+	bool inner;
 };
 
 /*
@@ -1432,13 +1474,20 @@ static int chown_cgroup_wrapper(void *data)
 	for (i = 0; hierarchies[i]; i++) {
 		char *fullpath, *path = hierarchies[i]->fullcgpath;
 
+		if (arg->inner)
+			path = must_make_path(path, CGROUP_NAMESPACE_SUBDIR, NULL);
+
 		if (chown(path, destuid, 0) < 0) {
 			SYSERROR("Error chowning %s to %d", path, (int) destuid);
+			if (arg->inner)
+				free(path);
 			return -1;
 		}
 
 		if (chmod(path, 0775) < 0) {
 			SYSERROR("Error chmoding %s", path);
+			if (arg->inner)
+				free(path);
 			return -1;
 		}
 
@@ -1462,12 +1511,14 @@ static int chown_cgroup_wrapper(void *data)
 		if (chmod(fullpath, 0664) < 0)
 			WARN("Error chmoding %s: %m", path);
 		free(fullpath);
+
+		free(path);
 	}
 
 	return 0;
 }
 
-static bool cgfsns_chown(void *hdata, struct lxc_conf *conf)
+static bool cgfsns_chown(void *hdata, struct lxc_conf *conf, bool inner)
 {
 	struct cgfsng_handler_data *d = hdata;
 	struct chown_data wrap;
@@ -1480,6 +1531,7 @@ static bool cgfsns_chown(void *hdata, struct lxc_conf *conf)
 
 	wrap.d = d;
 	wrap.origuid = geteuid();
+	wrap.inner = inner;
 
 	if (userns_exec_1(conf, chown_cgroup_wrapper, &wrap) < 0) {
 		ERROR("Error requesting cgroup chown in new namespace");
@@ -1774,11 +1826,14 @@ static bool cgfsng_unfreeze(void *hdata)
 	return true;
 }
 
-static const char *cgfsng_get_cgroup(void *hdata, const char *subsystem)
+static const char *cgfsng_get_cgroup(void *hdata, const char *subsystem, bool inner)
 {
 	struct hierarchy *h = get_hierarchy(subsystem);
 	if (!h)
 		return NULL;
+
+	if (inner && h->innercgpath)
+		return h->innercgpath + strlen(h->mountpoint);
 
 	return h->fullcgpath ? h->fullcgpath + strlen(h->mountpoint) : NULL;
 }
@@ -1814,7 +1869,7 @@ static bool cgfsng_attach(const char *name, const char *lxcpath, pid_t pid)
 		char *path, *fullpath;
 		struct hierarchy *h = hierarchies[i];
 
-		path = lxc_cmd_get_cgroup_path(name, lxcpath, h->controllers[0]);
+		path = lxc_cmd_get_attach_cgroup_path(name, lxcpath, h->controllers[0]);
 		if (!path) // not running
 			continue;
 

--- a/src/lxc/cgroups/cgmanager.c
+++ b/src/lxc/cgroups/cgmanager.c
@@ -609,13 +609,16 @@ static inline void cleanup_cgroups(char *path)
 		cgm_remove_cgroup(slist[i], path);
 }
 
-static inline bool cgm_create(void *hdata)
+static inline bool cgm_create(void *hdata, bool inner)
 {
 	struct cgm_data *d = hdata;
 	char **slist = subsystems;
 	int i, index=0, baselen, ret;
 	int32_t existed;
 	char result[MAXPATHLEN], *tmp, *cgroup_path;
+
+	if (inner)
+		return true;
 
 	if (!d)
 		return false;
@@ -709,12 +712,15 @@ static bool lxc_cgmanager_enter(pid_t pid, const char *controller,
 	return true;
 }
 
-static inline bool cgm_enter(void *hdata, pid_t pid)
+static inline bool cgm_enter(void *hdata, pid_t pid, bool inner)
 {
 	struct cgm_data *d = hdata;
 	char **slist = subsystems;
 	bool ret = false;
 	int i;
+
+	if (inner)
+		return true;
 
 	if (!d || !d->cgroup_path)
 		return false;
@@ -737,9 +743,11 @@ out:
 	return ret;
 }
 
-static const char *cgm_get_cgroup(void *hdata, const char *subsystem)
+static const char *cgm_get_cgroup(void *hdata, const char *subsystem, bool inner)
 {
 	struct cgm_data *d = hdata;
+
+	(void)inner;
 
 	if (!d || !d->cgroup_path)
 		return NULL;
@@ -1541,9 +1549,12 @@ out:
 	return ret;
 }
 
-static bool cgm_chown(void *hdata, struct lxc_conf *conf)
+static bool cgm_chown(void *hdata, struct lxc_conf *conf, bool inner)
 {
 	struct cgm_data *d = hdata;
+
+	if (inner)
+		return true;
 
 	if (!d || !d->cgroup_path)
 		return false;

--- a/src/lxc/cgroups/cgroup.c
+++ b/src/lxc/cgroups/cgroup.c
@@ -80,10 +80,10 @@ void cgroup_destroy(struct lxc_handler *handler)
 }
 
 /* Create the container cgroups for all requested controllers */
-bool cgroup_create(struct lxc_handler *handler)
+bool cgroup_create(struct lxc_handler *handler, bool inner)
 {
 	if (ops)
-		return ops->create(handler->cgroup_data);
+		return ops->create(handler->cgroup_data, inner);
 	return false;
 }
 
@@ -91,10 +91,10 @@ bool cgroup_create(struct lxc_handler *handler)
  * Enter the container init into its new cgroups for all
  * requested controllers
  */
-bool cgroup_enter(struct lxc_handler *handler)
+bool cgroup_enter(struct lxc_handler *handler, bool inner)
 {
 	if (ops)
-		return ops->enter(handler->cgroup_data, handler->pid);
+		return ops->enter(handler->cgroup_data, handler->pid, inner);
 	return false;
 }
 
@@ -105,10 +105,10 @@ bool cgroup_create_legacy(struct lxc_handler *handler)
 	return true;
 }
 
-const char *cgroup_get_cgroup(struct lxc_handler *handler, const char *subsystem)
+const char *cgroup_get_cgroup(struct lxc_handler *handler, const char *subsystem, bool inner)
 {
 	if (ops)
-		return ops->get_cgroup(handler->cgroup_data, subsystem);
+		return ops->get_cgroup(handler->cgroup_data, subsystem, inner);
 	return NULL;
 }
 
@@ -150,10 +150,10 @@ bool cgroup_setup_limits(struct lxc_handler *handler, bool with_devices)
 	return false;
 }
 
-bool cgroup_chown(struct lxc_handler *handler)
+bool cgroup_chown(struct lxc_handler *handler, bool inner)
 {
 	if (ops && ops->chown)
-		return ops->chown(handler->cgroup_data, handler->conf);
+		return ops->chown(handler->cgroup_data, handler->conf, inner);
 	return true;
 }
 

--- a/src/lxc/cgroups/cgroup.h
+++ b/src/lxc/cgroups/cgroup.h
@@ -28,6 +28,12 @@
 #include <stddef.h>
 #include <sys/types.h>
 
+/* When lxc.cgroup.protect_limits is in effect the container's cgroup namespace
+ * will be moved into an additional subdirectory "cgns/" inside the cgroup in
+ * order to prevent it from accessing the outer limiting cgroup.
+ */
+#define CGROUP_NAMESPACE_SUBDIR "cgns"
+
 struct lxc_handler;
 struct lxc_conf;
 struct lxc_list;
@@ -43,10 +49,10 @@ struct cgroup_ops {
 
 	void *(*init)(const char *name);
 	void (*destroy)(void *hdata, struct lxc_conf *conf);
-	bool (*create)(void *hdata);
-	bool (*enter)(void *hdata, pid_t pid);
+	bool (*create)(void *hdata, bool inner);
+	bool (*enter)(void *hdata, pid_t pid, bool inner);
 	bool (*create_legacy)(void *hdata, pid_t pid);
-	const char *(*get_cgroup)(void *hdata, const char *subsystem);
+	const char *(*get_cgroup)(void *hdata, const char *subsystem, bool inner);
 	bool (*escape)();
 	int (*num_hierarchies)();
 	bool (*get_hierarchies)(int n, char ***out);
@@ -54,7 +60,7 @@ struct cgroup_ops {
 	int (*get)(const char *filename, char *value, size_t len, const char *name, const char *lxcpath);
 	bool (*unfreeze)(void *hdata);
 	bool (*setup_limits)(void *hdata, struct lxc_list *cgroup_conf, bool with_devices);
-	bool (*chown)(void *hdata, struct lxc_conf *conf);
+	bool (*chown)(void *hdata, struct lxc_conf *conf, bool inner);
 	bool (*attach)(const char *name, const char *lxcpath, pid_t pid);
 	bool (*mount_cgroup)(void *hdata, const char *root, int type);
 	int (*nrtasks)(void *hdata);
@@ -66,14 +72,14 @@ extern bool cgroup_attach(const char *name, const char *lxcpath, pid_t pid);
 extern bool cgroup_mount(const char *root, struct lxc_handler *handler, int type);
 extern void cgroup_destroy(struct lxc_handler *handler);
 extern bool cgroup_init(struct lxc_handler *handler);
-extern bool cgroup_create(struct lxc_handler *handler);
+extern bool cgroup_create(struct lxc_handler *handler, bool inner);
 extern bool cgroup_setup_limits(struct lxc_handler *handler, bool with_devices);
-extern bool cgroup_chown(struct lxc_handler *handler);
-extern bool cgroup_enter(struct lxc_handler *handler);
+extern bool cgroup_chown(struct lxc_handler *handler, bool inner);
+extern bool cgroup_enter(struct lxc_handler *handler, bool inner);
 extern void cgroup_cleanup(struct lxc_handler *handler);
 extern bool cgroup_create_legacy(struct lxc_handler *handler);
 extern int cgroup_nrtasks(struct lxc_handler *handler);
-extern const char *cgroup_get_cgroup(struct lxc_handler *handler, const char *subsystem);
+extern const char *cgroup_get_cgroup(struct lxc_handler *handler, const char *subsystem, bool inner);
 extern bool cgroup_escape();
 extern int cgroup_num_hierarchies();
 extern bool cgroup_get_hierarchies(int i, char ***out);

--- a/src/lxc/commands.h
+++ b/src/lxc/commands.h
@@ -77,6 +77,8 @@ extern int lxc_cmd_console(const char *name, int *ttynum, int *fd,
  */
 extern char *lxc_cmd_get_cgroup_path(const char *name, const char *lxcpath,
 			const char *subsystem);
+extern char *lxc_cmd_get_attach_cgroup_path(const char *name,
+			const char *lxcpath, const char *subsystem);
 extern int lxc_cmd_get_clone_flags(const char *name, const char *lxcpath);
 extern char *lxc_cmd_get_config_item(const char *name, const char *item, const char *lxcpath);
 extern char *lxc_cmd_get_name(const char *hashed_sock);

--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -284,7 +284,7 @@ static void exec_criu(struct criu_opts *opts)
 		} else {
 			const char *p;
 
-			p = cgroup_get_cgroup(opts->handler, controllers[0]);
+			p = cgroup_get_cgroup(opts->handler, controllers[0], false);
 			if (!p) {
 				ERROR("failed to get cgroup path for %s", controllers[0]);
 				goto err;
@@ -797,7 +797,7 @@ static void do_restore(struct lxc_container *c, int status_pipe, struct migrate_
 		goto out_fini_handler;
 	}
 
-	if (!cgroup_create(handler)) {
+	if (!cgroup_create(handler, false)) {
 		ERROR("failed creating groups");
 		goto out_fini_handler;
 	}

--- a/src/lxc/initutils.c
+++ b/src/lxc/initutils.c
@@ -88,14 +88,15 @@ static char *copy_global_config_value(char *p)
 const char *lxc_global_config_value(const char *option_name)
 {
 	static const char * const options[][2] = {
-		{ "lxc.bdev.lvm.vg",        DEFAULT_VG      },
-		{ "lxc.bdev.lvm.thin_pool", DEFAULT_THIN_POOL },
-		{ "lxc.bdev.zfs.root",      DEFAULT_ZFSROOT },
-		{ "lxc.bdev.rbd.rbdpool",   DEFAULT_RBDPOOL },
-		{ "lxc.lxcpath",            NULL            },
-		{ "lxc.default_config",     NULL            },
-		{ "lxc.cgroup.pattern",     NULL            },
-		{ "lxc.cgroup.use",         NULL            },
+		{ "lxc.bdev.lvm.vg",           DEFAULT_VG      },
+		{ "lxc.bdev.lvm.thin_pool",    DEFAULT_THIN_POOL },
+		{ "lxc.bdev.zfs.root",         DEFAULT_ZFSROOT },
+		{ "lxc.bdev.rbd.rbdpool",      DEFAULT_RBDPOOL },
+		{ "lxc.lxcpath",               NULL            },
+		{ "lxc.default_config",        NULL            },
+		{ "lxc.cgroup.pattern",        NULL            },
+		{ "lxc.cgroup.use",            NULL            },
+		{ "lxc.cgroup.protect_limits", DEFAULT_CGPROTECT },
 		{ NULL, NULL },
 	};
 

--- a/src/lxc/initutils.c
+++ b/src/lxc/initutils.c
@@ -106,6 +106,23 @@ const char *lxc_global_config_value(const char *option_name)
 	static const char *values[sizeof(options) / sizeof(options[0])] = { 0 };
 #endif
 
+	const char * const (*ptr)[2];
+	size_t opt;
+	char buf[1024], *p, *p2;
+	FILE *fin = NULL;
+
+	for (opt = 0, ptr = options; (*ptr)[0]; ptr++, opt++) {
+		if (!strcmp(option_name, (*ptr)[0]))
+			break;
+	}
+	if (!(*ptr)[0]) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	if (values[opt])
+		return values[opt];
+
 	/* user_config_path is freed as soon as it is used */
 	char *user_config_path = NULL;
 
@@ -136,32 +153,6 @@ const char *lxc_global_config_value(const char *option_name)
 		user_default_config_path = strdup(LXC_DEFAULT_CONFIG);
 		user_lxc_path = strdup(LXCPATH);
 		user_cgroup_pattern = strdup(DEFAULT_CGROUP_PATTERN);
-	}
-
-	const char * const (*ptr)[2];
-	size_t opt;
-	char buf[1024], *p, *p2;
-	FILE *fin = NULL;
-
-	for (opt = 0, ptr = options; (*ptr)[0]; ptr++, opt++) {
-		if (!strcmp(option_name, (*ptr)[0]))
-			break;
-	}
-	if (!(*ptr)[0]) {
-		free(user_config_path);
-		free(user_default_config_path);
-		free(user_lxc_path);
-		free(user_cgroup_pattern);
-		errno = EINVAL;
-		return NULL;
-	}
-
-	if (values[opt]) {
-		free(user_config_path);
-		free(user_default_config_path);
-		free(user_lxc_path);
-		free(user_cgroup_pattern);
-		return values[opt];
 	}
 
 	fin = fopen_cloexec(user_config_path, "r");

--- a/src/lxc/initutils.c
+++ b/src/lxc/initutils.c
@@ -139,11 +139,11 @@ const char *lxc_global_config_value(const char *option_name)
 	}
 
 	const char * const (*ptr)[2];
-	size_t i;
+	size_t opt;
 	char buf[1024], *p, *p2;
 	FILE *fin = NULL;
 
-	for (i = 0, ptr = options; (*ptr)[0]; ptr++, i++) {
+	for (opt = 0, ptr = options; (*ptr)[0]; ptr++, opt++) {
 		if (!strcmp(option_name, (*ptr)[0]))
 			break;
 	}
@@ -156,12 +156,12 @@ const char *lxc_global_config_value(const char *option_name)
 		return NULL;
 	}
 
-	if (values[i]) {
+	if (values[opt]) {
 		free(user_config_path);
 		free(user_default_config_path);
 		free(user_lxc_path);
 		free(user_cgroup_pattern);
-		return values[i];
+		return values[opt];
 	}
 
 	fin = fopen_cloexec(user_config_path, "r");
@@ -203,36 +203,36 @@ const char *lxc_global_config_value(const char *option_name)
 				free(user_lxc_path);
 				user_lxc_path = copy_global_config_value(p);
 				remove_trailing_slashes(user_lxc_path);
-				values[i] = user_lxc_path;
+				values[opt] = user_lxc_path;
 				user_lxc_path = NULL;
 				goto out;
 			}
 
-			values[i] = copy_global_config_value(p);
+			values[opt] = copy_global_config_value(p);
 			goto out;
 		}
 	}
 	/* could not find value, use default */
 	if (strcmp(option_name, "lxc.lxcpath") == 0) {
 		remove_trailing_slashes(user_lxc_path);
-		values[i] = user_lxc_path;
+		values[opt] = user_lxc_path;
 		user_lxc_path = NULL;
 	}
 	else if (strcmp(option_name, "lxc.default_config") == 0) {
-		values[i] = user_default_config_path;
+		values[opt] = user_default_config_path;
 		user_default_config_path = NULL;
 	}
 	else if (strcmp(option_name, "lxc.cgroup.pattern") == 0) {
-		values[i] = user_cgroup_pattern;
+		values[opt] = user_cgroup_pattern;
 		user_cgroup_pattern = NULL;
 	}
 	else
-		values[i] = (*ptr)[1];
+		values[opt] = (*ptr)[1];
 
 	/* special case: if default value is NULL,
 	 * and there is no config, don't view that
 	 * as an error... */
-	if (!values[i])
+	if (!values[opt])
 		errno = 0;
 
 out:
@@ -243,7 +243,7 @@ out:
 	free(user_default_config_path);
 	free(user_lxc_path);
 
-	return values[i];
+	return values[opt];
 }
 
 extern void remove_trailing_slashes(char *p)

--- a/src/lxc/initutils.h
+++ b/src/lxc/initutils.h
@@ -43,6 +43,7 @@
 #define DEFAULT_THIN_POOL "lxc"
 #define DEFAULT_ZFSROOT "lxc"
 #define DEFAULT_RBDPOOL "lxc"
+#define DEFAULT_CGPROTECT "privileged"
 
 extern void lxc_setup_fs(void);
 extern const char *lxc_global_config_value(const char *option_name);


### PR DESCRIPTION
When cgroup namespaces are enabled a privileged container
with mixed cgroups has full write access to its own root
cgroup effectively allowing it to overwrite values written
from the outside or configured via lxc.cgroup.*.

This patch causes an additional 'inner/' directory to be
created in all cgroups if cgroup namespaces and cgfsng are
being used in order to combat this.

This is a request for comments, it currently has the subdirectory name
hardcoded and is non-optional. All of this could of course be made
configurable if a "feature" like this is acceptable. It seems to only be
necessary for privileged containers which are, well, "privileged" after
all, but cgroup limits do seem pointless if they can't be enforced even
when it's privileged containers we're dealing with.

On the other hand for unprivileged containers maybe this could allow us to
make the entire directory the container sees as root cgroup writable by
the container? (Not sure about this, currently we only chown
`cgroup.procs` and `tasks`, and otherwise the container can only create
subdirectories.)

PS: I'm not sure whether criu.c needs special code there, but from the
host's point of view it's a subdirectory within the container's cgroup,
only the point at which `CLONE_NEWCGROUP` is used is moved, so only the
container's inner view changes.
