### PR TITLE
tree-wide: replace readdir_r() with readdir()

### DIFF
--- a/src/lxc/bdev.c
+++ b/src/lxc/bdev.c
@@ -1897,7 +1897,7 @@ static int loop_detect(const char *path)
 
 static int find_free_loopdev_no_control(int *retfd, char *namep)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	struct loop_info64 lo;
 	DIR *dir;
 	int fd = -1;
@@ -1907,8 +1907,8 @@ static int find_free_loopdev_no_control(int *retfd, char *namep)
 		SYSERROR("Error opening /dev");
 		return -1;
 	}
-	while (!readdir_r(dir, &dirent, &direntp)) {
 
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 		if (strncmp(direntp->d_name, "loop", 4) != 0)

--- a/src/lxc/cgfs.c
+++ b/src/lxc/cgfs.c
@@ -155,7 +155,7 @@ static struct cgroup_ops cgfs_ops;
 
 static int cgroup_rmdir(char *dirname)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	int saved_errno = 0;
 	DIR *dir;
 	int ret, failed=0;
@@ -167,7 +167,7 @@ static int cgroup_rmdir(char *dirname)
 		return -1;
 	}
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		struct stat mystat;
 		int rc;
 
@@ -2068,26 +2068,14 @@ out:
 static int cgroup_recursive_task_count(const char *cgroup_path)
 {
 	DIR *d;
-	struct dirent *dent_buf;
 	struct dirent *dent;
-	ssize_t name_max;
 	int n = 0, r;
 
-	/* see man readdir_r(3) */
-	name_max = pathconf(cgroup_path, _PC_NAME_MAX);
-	if (name_max <= 0)
-		name_max = 255;
-	dent_buf = malloc(offsetof(struct dirent, d_name) + name_max + 1);
-	if (!dent_buf)
-		return -1;
-
 	d = opendir(cgroup_path);
-	if (!d) {
-		free(dent_buf);
+	if (!d)
 		return 0;
-	}
 
-	while (readdir_r(d, dent_buf, &dent) == 0 && dent) {
+	while ((dent = readdir(d))) {
 		const char *parts[3] = {
 			cgroup_path,
 			dent->d_name,
@@ -2101,13 +2089,11 @@ static int cgroup_recursive_task_count(const char *cgroup_path)
 		sub_path = lxc_string_join("/", parts, false);
 		if (!sub_path) {
 			closedir(d);
-			free(dent_buf);
 			return -1;
 		}
 		r = stat(sub_path, &st);
 		if (r < 0) {
 			closedir(d);
-			free(dent_buf);
 			free(sub_path);
 			return -1;
 		}
@@ -2123,7 +2109,6 @@ static int cgroup_recursive_task_count(const char *cgroup_path)
 		free(sub_path);
 	}
 	closedir(d);
-	free(dent_buf);
 
 	return n;
 }

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -590,7 +590,7 @@ out:
 static int mount_rootfs_file(const char *rootfs, const char *target,
 				             const char *options)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	struct loop_info64 loinfo;
 	int ret = -1, fd = -1, rc;
 	DIR *dir;
@@ -602,8 +602,7 @@ static int mount_rootfs_file(const char *rootfs, const char *target,
 		return -1;
 	}
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
-
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 
@@ -2938,7 +2937,7 @@ void lxc_restore_phys_nics_to_netns(int netnsfd, struct lxc_conf *conf)
 {
 	int i, ret, oldfd;
 	char path[MAXPATHLEN];
-	char ifname[IFNAMSIZ]; 
+	char ifname[IFNAMSIZ];
 
 	if (netnsfd < 0 || conf->num_savednics == 0)
 		return;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1007,7 +1007,7 @@ static int config_hook(const char *key, const char *value,
 				 struct lxc_conf *lxc_conf)
 {
 	char *copy;
-	
+
 	if (!value || strlen(value) == 0)
 		return lxc_clear_hooks(lxc_conf, key);
 

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -509,7 +509,7 @@ static bool wait_on_daemonized_start(struct lxc_container *c, int pid)
 
 static bool am_single_threaded(void)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	DIR *dir;
 	int count=0;
 
@@ -519,7 +519,7 @@ static bool am_single_threaded(void)
 		return false;
 	}
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 
@@ -2988,7 +2988,7 @@ static int lxcapi_snapshot_list(struct lxc_container *c, struct lxc_snapshot **r
 {
 	char snappath[MAXPATHLEN], path2[MAXPATHLEN];
 	int dirlen, count = 0, ret;
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	struct lxc_snapshot *snaps =NULL, *nsnaps;
 	DIR *dir;
 
@@ -3007,7 +3007,7 @@ static int lxcapi_snapshot_list(struct lxc_container *c, struct lxc_snapshot **r
 		return 0;
 	}
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 
@@ -3439,7 +3439,7 @@ int list_defined_containers(const char *lxcpath, char ***names, struct lxc_conta
 {
 	DIR *dir;
 	int i, cfound = 0, nfound = 0;
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	struct lxc_container *c;
 
 	if (!lxcpath)
@@ -3456,7 +3456,7 @@ int list_defined_containers(const char *lxcpath, char ***names, struct lxc_conta
 	if (names)
 		*names = NULL;
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -188,7 +188,7 @@ static int match_fd(int fd)
 
 int lxc_check_inherited(struct lxc_conf *conf, int fd_to_ignore)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	int fd, fddir;
 	DIR *dir;
 
@@ -201,7 +201,7 @@ restart:
 
 	fddir = dirfd(dir);
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		if (!direntp)
 			break;
 

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -62,7 +62,7 @@ extern bool btrfs_try_remove_subvol(const char *path);
 
 static int _recursive_rmdir(char *dirname, dev_t pdev, bool onedev)
 {
-	struct dirent dirent, *direntp;
+	struct dirent *direntp;
 	DIR *dir;
 	int ret, failed=0;
 	char pathname[MAXPATHLEN];
@@ -73,7 +73,7 @@ static int _recursive_rmdir(char *dirname, dev_t pdev, bool onedev)
 		return -1;
 	}
 
-	while (!readdir_r(dir, &dirent, &direntp)) {
+	while ((direntp = readdir(dir))) {
 		struct stat mystat;
 		int rc;
 


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@canonical.com>