### PR TITLE
Configure a static MAC address on the LXC bridge

### DIFF
--- a/config/init/common/lxc-net.in
+++ b/config/init/common/lxc-net.in
@@ -9,6 +9,7 @@ varlib="@LOCALSTATEDIR@/lib"
 
 USE_LXC_BRIDGE="true"
 LXC_BRIDGE="lxcbr0"
+LXC_BRIDGE_MAC="00:16:3e:00:00:00"
 LXC_ADDR="10.0.3.1"
 LXC_NETMASK="255.255.255.0"
 LXC_NETWORK="10.0.3.0/24"
@@ -45,6 +46,7 @@ ifup() {
     MASK=`_netmask2cidr ${LXC_NETMASK}`
     CIDR_ADDR="${LXC_ADDR}/${MASK}"
     ip addr add ${CIDR_ADDR} dev $1
+    ip link set dev $1 address $LXC_BRIDGE_MAC
     ip link set dev $1 up
 }
 

--- a/lxc.spec.in
+++ b/lxc.spec.in
@@ -196,6 +196,7 @@ USE_LXC_BRIDGE="true"
 # If you have the dnsmasq daemon installed, you'll also have to update
 # /etc/dnsmasq.d/lxc and restart the system wide dnsmasq daemon.
 LXC_BRIDGE="lxcbr0"
+LXC_BRIDGE_MAC="00:16:3e:00:00:00"
 LXC_ADDR="$SUBNET.1"
 LXC_NETMASK="255.255.255.0"
 LXC_NETWORK="$SUBNET.0/24"


### PR DESCRIPTION
Requires Linux >= 2.6.26. Prior to that, you could not set a fixed mac address on a bridge.

This is just a random MAC address, the maintainers of LXC should request a MAC Address Block Small assignment from the IEEE here: https://regauth.standards.ieee.org/standards-ra-web/app

Resolves #604 