### PR TITLE
conf, criu: add make_anonymous_mount_file()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -625,10 +625,10 @@ AC_CHECK_DECLS([PR_SET_NO_NEW_PRIVS], [], [], [#include <sys/prctl.h>])
 AC_CHECK_DECLS([PR_GET_NO_NEW_PRIVS], [], [], [#include <sys/prctl.h>])
 
 # Check for some headers
-AC_CHECK_HEADERS([sys/signalfd.h pty.h ifaddrs.h sys/capability.h sys/personality.h utmpx.h sys/timerfd.h])
+AC_CHECK_HEADERS([sys/signalfd.h pty.h ifaddrs.h sys/capability.h sys/memfd.h sys/personality.h utmpx.h sys/timerfd.h])
 
 # Check for some syscalls functions
-AC_CHECK_FUNCS([setns pivot_root sethostname unshare rand_r confstr faccessat gettid])
+AC_CHECK_FUNCS([setns pivot_root sethostname unshare rand_r confstr faccessat gettid memfd_create])
 
 # Check for some functions
 AC_CHECK_LIB(pthread, main)

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -452,6 +452,6 @@ extern int parse_mntopts(const char *mntopts, unsigned long *mntflags,
 extern void tmp_proc_unmount(struct lxc_conf *lxc_conf);
 void remount_all_slave(void);
 extern void suggest_default_idmap(void);
-FILE *write_mount_file(struct lxc_list *mount);
+FILE *make_anonymous_mount_file(struct lxc_list *mount);
 struct lxc_list *sort_cgroup_settings(struct lxc_list* cgroup_settings);
 #endif

--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -330,7 +330,7 @@ static void exec_criu(struct criu_opts *opts)
 		DECLARE_ARG(opts->user->action_script);
 	}
 
-	mnts = write_mount_file(&opts->c->lxc_conf->mount_list);
+	mnts = make_anonymous_mount_file(&opts->c->lxc_conf->mount_list);
 	if (!mnts)
 		goto err;
 


### PR DESCRIPTION
Before we used tmpfile() to write out mount entries for the container. This
requires a writeable /tmp file system which can be a problem for Android where
this filesystem is not necessarily present. This commit switches from tmpfile()
to using the memfd_create() syscall. It allows us to create an anonymous tmpfs
file (And is somewhat similar to mmap().) which is automatically deleted as
soon as any references to it are dropped.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>

Closes #1296.