### PR TITLE
tree-wide: remove any variable length arrays

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -663,7 +663,7 @@ LXC_CHECK_TLS
 if test "x$GCC" = "xyes"; then
 	CFLAGS="$CFLAGS -Wall"
 	if test "x$enable_werror" = "xyes"; then
-		CFLAGS="$CFLAGS -Werror"
+		CFLAGS="$CFLAGS -Werror -Werror=vla"
 	fi
 fi
 

--- a/src/lxc/tools/lxc_cgroup.c
+++ b/src/lxc/tools/lxc_cgroup.c
@@ -121,9 +121,8 @@ int main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 		}
 	} else {
-		int len = 4096;
-		char buffer[len];
-		int ret = c->get_cgroup_item(c, state_object, buffer, len);
+		char buffer[MAXPATHLEN];
+		int ret = c->get_cgroup_item(c, state_object, buffer, MAXPATHLEN);
 		if (ret < 0) {
 			ERROR("failed to retrieve value of '%s' for '%s:%s'",
 			      state_object, my_args.lxcpath[0], my_args.name);

--- a/src/lxc/tools/lxc_unshare.c
+++ b/src/lxc/tools/lxc_unshare.c
@@ -82,7 +82,7 @@ static void usage(char *cmd)
 
 static bool lookup_user(const char *optarg, uid_t *uid)
 {
-	char name[sysconf(_SC_LOGIN_NAME_MAX)];
+	char name[MAXPATHLEN];
 	struct passwd *pwent = NULL;
 
 	if (!optarg || (optarg[0] == '\0'))

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1896,6 +1896,8 @@ int lxc_strmunmap(void *addr, size_t length)
 }
 
 /* Check whether a signal is blocked by a process. */
+/* /proc/pid-to-str/status\0 = (5 + 21 + 7 + 1) */
+#define __PROC_STATUS_LEN (5 + 21 + 7 + 1)
 bool task_blocking_signal(pid_t pid, int signal)
 {
 	bool bret = false;
@@ -1905,13 +1907,10 @@ bool task_blocking_signal(pid_t pid, int signal)
 	int ret;
 	FILE *f;
 
-	/* The largest integer that can fit into long int is 2^64. This is a
-	 * 20-digit number. */
-	size_t len = /* /proc */ 5 + /* /pid-to-str */ 21 + /* /status */ 7 + /* \0 */ 1;
-	char status[len];
+	char status[__PROC_STATUS_LEN];
 
-	ret = snprintf(status, len, "/proc/%d/status", pid);
-	if (ret < 0 || ret >= len)
+	ret = snprintf(status, __PROC_STATUS_LEN, "/proc/%d/status", pid);
+	if (ret < 0 || ret >= __PROC_STATUS_LEN)
 		return bret;
 
 	f = fopen(status, "r");

--- a/src/tests/lxc-test-utils.c
+++ b/src/tests/lxc-test-utils.c
@@ -70,13 +70,14 @@ void test_lxc_deslashify(void)
 	free(s);
 }
 
+/* /proc/int_as_str/ns/mnt\0 = (5 + 21 + 7 + 1) */
+#define __MNTNS_LEN (5 + 21 + 7 + 1)
 void test_detect_ramfs_rootfs(void)
 {
 	size_t i;
 	int ret;
 	int fret = EXIT_FAILURE;
-	size_t len = 5 /* /proc */ + 21 /* /int_as_str */ + 7 /* /ns/mnt */ + 1 /* \0 */;
-	char path[len];
+	char path[__MNTNS_LEN];
 	int init_ns = -1;
 	char tmpf1[] = "lxc-test-utils-XXXXXX";
 	char tmpf2[] = "lxc-test-utils-XXXXXX";
@@ -118,8 +119,8 @@ void test_detect_ramfs_rootfs(void)
 		"78 24 8:1 / /boot/efi rw,relatime shared:30 - vfat /dev/sda1 rw,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro",
 	};
 
-	ret = snprintf(path, len, "/proc/self/ns/mnt");
-	if (ret < 0 || (size_t)ret >= len) {
+	ret = snprintf(path, __MNTNS_LEN, "/proc/self/ns/mnt");
+	if (ret < 0 || (size_t)ret >= __MNTNS_LEN) {
 		lxc_error("%s\n", "Failed to create path with snprintf().");
 		goto non_test_error;
 	}


### PR DESCRIPTION
They are pointless and marked optional since C11.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
