### PR TITLE
configure: remove -Werror=vla

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -663,7 +663,7 @@ LXC_CHECK_TLS
 if test "x$GCC" = "xyes"; then
 	CFLAGS="$CFLAGS -Wall"
 	if test "x$enable_werror" = "xyes"; then
-		CFLAGS="$CFLAGS -Werror -Werror=vla"
+		CFLAGS="$CFLAGS -Werror"
 	fi
 fi
 


### PR DESCRIPTION
Because we include a header that uses a vla (/me scoffs at header).

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>