### PR TITLE
tools: lxc-start: set configfile after load_config

### DIFF
--- a/src/lxc/tools/lxc_start.c
+++ b/src/lxc/tools/lxc_start.c
@@ -259,6 +259,11 @@ int main(int argc, char *argv[])
 			lxc_container_put(c);
 			exit(err);
 		}
+		c->configfile = strdup(my_args.rcfile);
+		if (!c->configfile) {
+			ERROR("Out of memory setting new config filename");
+			goto out;
+		}
 	} else {
 		int rc;
 


### PR DESCRIPTION
Same change as in 6118210e0a which was missing in lxc-start
and back then is_defined() wasn't being called.

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>