### PR TITLE
conf: clearly report to either use drop or keep

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3952,7 +3952,7 @@ int lxc_setup(struct lxc_handler *handler)
 
 	if (!lxc_list_empty(&lxc_conf->keepcaps)) {
 		if (!lxc_list_empty(&lxc_conf->caps)) {
-			ERROR("Simultaneously requested dropping and keeping caps");
+			ERROR("Container requests lxc.cap.drop and lxc.cap.keep: either use lxc.cap.drop or lxc.cap.keep, not both.");
 			return -1;
 		}
 		if (dropcaps_except(&lxc_conf->keepcaps)) {


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>