### PR TITLE
templates: fix getty service startup

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -231,11 +231,11 @@ configure_debian_systemd()
     num_tty=$4
 
     # this only works if we have getty@.service to manipulate
-    if [ -f "${rootfs}/lib/systemd/system/getty\@.service" ]; then
+    if [ -f "${rootfs}/lib/systemd/system/getty@.service" ]; then
        sed -e 's/^ConditionPathExists=/# ConditionPathExists=/' \
            -e 's/After=dev-%i.device/After=/' \
-           < "${rootfs}/lib/systemd/system/getty\@.service" \
-           > "${rootfs}/etc/systemd/system/getty\@.service"
+           < "${rootfs}/lib/systemd/system/getty@.service" \
+           > "${rootfs}/etc/systemd/system/getty@.service"
     fi
 
     # just in case systemd is not installed


### PR DESCRIPTION
Commit bf39edb39ecaea25801d716aebef798885277992 broke the handling of the getty service file with an '@' character in filename. So the startup condition was not fixed.

Because the parameter was quoted with the causal commit, the escaping has to be removed.

Signed-off-by: Andreas Eberlein foodeas@aeberlein.de