### PR TITLE
conf, attach: save errno across call to close

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -972,7 +972,7 @@ int lxc_attach(const char* name, const char* lxcpath, lxc_attach_exec_t exec_fun
 
 		/* Open LSM fd and send it to child. */
 		if ((options->namespaces & CLONE_NEWNS) && (options->attach_flags & LXC_ATTACH_LSM) && init_ctx->lsm_label) {
-			int on_exec;
+			int on_exec, saved_errno;
 			int labelfd = -1;
 			on_exec = options->attach_flags & LXC_ATTACH_LSM_EXEC ? 1 : 0;
 			/* Open fd for the LSM security module. */
@@ -982,9 +982,10 @@ int lxc_attach(const char* name, const char* lxcpath, lxc_attach_exec_t exec_fun
 
 			/* Send child fd of the LSM security module to write to. */
 			ret = lxc_abstract_unix_send_fd(ipc_sockets[0], labelfd, NULL, 0);
+			saved_errno = errno;
 			close(labelfd);
 			if (ret <= 0) {
-				ERROR("Intended to send file descriptor %d: %s.", labelfd, strerror(errno));
+				ERROR("Intended to send file descriptor %d: %s.", labelfd, strerror(saved_errno));
 				goto on_error;
 			}
 		}

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2018,9 +2018,10 @@ FILE *make_anonymous_mount_file(struct lxc_list *mount)
 	}
 
 	if (!file) {
+		int saved_errno = errno;
 		if (fd != -1)
 			close(fd);
-		ERROR("Could not create mount entry file: %s.", strerror(errno));
+		ERROR("Could not create mount entry file: %s.", strerror(saved_errno));
 		return NULL;
 	}
 
@@ -2188,7 +2189,7 @@ static int setup_hw_addr(char *hwaddr, const char *ifname)
 {
 	struct sockaddr sockaddr;
 	struct ifreq ifr;
-	int ret, fd;
+	int ret, fd, saved_errno;
 
 	ret = lxc_convert_mac(hwaddr, &sockaddr);
 	if (ret) {
@@ -2208,9 +2209,10 @@ static int setup_hw_addr(char *hwaddr, const char *ifname)
 	}
 
 	ret = ioctl(fd, SIOCSIFHWADDR, &ifr);
+	saved_errno = errno;
 	close(fd);
 	if (ret)
-		ERROR("ioctl failure : %s", strerror(errno));
+		ERROR("ioctl failure : %s", strerror(saved_errno));
 
 	DEBUG("mac address '%s' on '%s' has been setup", hwaddr, ifr.ifr_name);
 


### PR DESCRIPTION
Save errno across some calls to close() since it can be
interrupted.

Signed-off-by: Wolfgang Bumiller <wry.git@bumiller.com>