### PR TITLE
templates: update openSUSE release to 42.2

### DIFF
--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -155,7 +155,7 @@ download_opensuse()
     cat > $cache/partial-$arch-packages/opensuse.conf << EOF
 Preinstall: aaa_base bash coreutils diffutils
 Preinstall: filesystem fillup glibc grep insserv-compat perl-base
-Preinstall: libbz2-1 libgcc_s1 libncurses5 pam
+Preinstall: libbz2-1 libncurses5 pam
 Preinstall: permissions libreadline6 rpm sed tar libz1 libselinux1
 Preinstall: liblzma5 libcap2 libacl1 libattr1
 Preinstall: libpopt0 libelf1 liblua5_1

--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -356,7 +356,7 @@ lxc.utsname = $name
 lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed
 
 # When using LXC with apparmor, uncomment the next line to run unconfined:
-#lxc.aa_profile = unconfined
+lxc.aa_profile = unconfined
 
 # example simple networking setup, uncomment to enable
 #lxc.network.type = $lxc_network_type

--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -407,7 +407,7 @@ usage()
     cat <<EOF
 $1 -h|--help -p|--path=<path> -r|--release nn.n --clean
 Please give the release as 13.1, 13.2 etc.
-If no release is given, openSUSE 13.1 is installed.
+If no release is given, openSUSE Leap 42.2 is installed.
 EOF
     return 0
 }
@@ -462,8 +462,8 @@ fi
 
 if [ -z "$DISTRO" ]; then
     echo ""
-    echo "No release selected, using openSUSE 13.1"
-    DISTRO=13.1
+    echo "No release selected, using openSUSE Leap 42.2"
+    DISTRO=42.2
 else
     echo ""
     case "$DISTRO" in

--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -145,7 +145,7 @@ download_opensuse()
     mkdir -p "$cache/partial-$arch-packages"
     zypper --quiet --root $cache/partial-$arch-packages --non-interactive ar http://download.opensuse.org/distribution/$DISTRO/repo/oss/ repo-oss || return 1
     # Leap update repos were rearranged
-    if [ $DISTRO == "leap/42.1" ]; then
+    if [[ $DISTRO == "leap/4"* ]]; then
         zypper --quiet --root $cache/partial-$arch-packages --non-interactive ar http://download.opensuse.org/update/$DISTRO/oss/ update || return 1
     else
         zypper --quiet --root $cache/partial-$arch-packages --non-interactive ar http://download.opensuse.org/update/$DISTRO/ update || return 1
@@ -182,14 +182,14 @@ EOF
 	echo "Support: python3-base" >> $cache/partial-$arch-packages/opensuse.conf
     fi
 
-    # dhcpcd is not in the default repos with Leap 42.1
-    if [ $DISTRO != "leap/42.1" ]
+    # dhcpcd is not in the default repos since Leap 42.1
+    if [[ $DISTRO != "leap/4"* ]]
     then
     echo "Support: dhcpcd" >> $cache/partial-$arch-packages/opensuse.conf
     fi
 
     # Leap doesn't seem to have iproute2 utils installed
-    if [ $DISTRO == "leap/42.1" ]
+    if [[ $DISTRO == "leap/4"* ]]
     then
     echo "Support: net-tools iproute2" >> $cache/partial-$arch-packages/opensuse.conf
     fi
@@ -210,11 +210,13 @@ EOF
 
     CLEAN_BUILD=1 BUILD_ARCH="$arch" BUILD_ROOT="$cache/partial-$arch" BUILD_DIST="$cache/partial-$arch-packages/opensuse.conf" PATH="$PATH:$BUILD_DIR" $BUILD_DIR/init_buildsystem  --clean --configdir $BUILD_DIR/configs --cachedir $cache/partial-$arch-cache --repository $cache/partial-$arch-packages/var/cache/zypp/packages/repo-oss/suse/$arch --repository $cache/partial-$arch-packages/var/cache/zypp/packages/repo-oss/suse/noarch --repository $cache/partial-$arch-packages/var/cache/zypp/packages/update/$arch --repository $cache/partial-$arch-packages/var/cache/zypp/packages/update/noarch || return 1
     chroot $cache/partial-$arch /usr/bin/zypper --quiet --non-interactive ar http://download.opensuse.org/distribution/$DISTRO/repo/oss repo-oss || return 1
-    if [ $DISTRO == "leap/42.1" ]; then
+
+    if [[ $DISTRO == "leap/4"* ]]; then
         chroot $cache/partial-$arch /usr/bin/zypper --quiet --non-interactive ar http://download.opensuse.org/update/$DISTRO/oss update || return 1
     else
         chroot $cache/partial-$arch /usr/bin/zypper --quiet --non-interactive ar http://download.opensuse.org/update/$DISTRO/ update || return 1
     fi
+
 #   really clean the image
     rm -fr $cache/partial-$arch/{.build,.guessed_dist,.srcfiles*,installed-pkg}
     rm -fr $cache/partial-$arch/dev
@@ -477,6 +479,11 @@ else
 	    echo "Selected openSUSE Leap 42.1"
 	    DISTRO="leap/42.1"
 	    ;;
+
+        42.2|leap/42.2|422)
+            echo "Selected openSUSE Leap 42.2"
+            DISTRO="leap/42.2"
+            ;; 
 
 	*)
 	    echo "You have chosen an invalid release, quitting..."


### PR DESCRIPTION
This updates lxc-opensuse template to include Leap 42.2 and changes the default release to 42.2. Some checks related to `[ $DISTRO == "leap/42.1 ]"` to `[[ $DISTRO == "leap/4"* ]]`  were changed so it can accomodate future releases a little bit better.

I'm not exactly sure if the following should be in separate pull requests:
* 3ddfde2 uncomments `lxc.aa_profile = unconfined` by default to resolve startup failures on openSUSE based containers
  - Sorry, I don't know any other way to fix this without compromising security.
* e080c49 removes libgcc_s1 from preinstalled packages as this was causing container creation to fail
  - Related: opensuse/obs-build#188.