### PR TITLE
Add --enable-gnutls option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -256,12 +256,25 @@ if test "$enable_apparmor" = "auto" ; then
 fi
 AM_CONDITIONAL([ENABLE_APPARMOR], [test "x$enable_apparmor" = "xyes"])
 
-AC_CHECK_LIB([gnutls], [gnutls_hash_fast], [enable_gnutls=yes], [enable_gnutls=no])
-
 AM_COND_IF([ENABLE_APPARMOR],
 	[AC_CHECK_HEADER([sys/apparmor.h],[],[AC_MSG_ERROR([You must install the AppArmor development package in order to compile lxc])])
 	AC_CHECK_LIB([apparmor], [aa_change_profile],[],[AC_MSG_ERROR([You must install the AppArmor development package in order to compile lxc])])
 	AC_SUBST([APPARMOR_LIBS], [-lapparmor])])
+
+# GnuTLS
+AC_ARG_ENABLE([gnutls],
+	[AC_HELP_STRING([--enable-gnutls], [enable GnuTLS support [default=auto]])],
+	[], [enable_gnutls=auto])
+
+if test "$enable_gnutls" = "auto" ; then
+	AC_CHECK_LIB([gnutls], [gnutls_hash_fast], [enable_gnutls=yes], [enable_gnutls=no])
+fi
+AM_CONDITIONAL([ENABLE_GNUTLS], [test "x$enable_gnutls" = "xyes"])
+
+AM_COND_IF([ENABLE_GNUTLS],
+	[AC_CHECK_HEADER([gnutls/gnutls.h],[],[AC_MSG_ERROR([You must install the GnuTLS development package in order to compile lxc])])
+	AC_CHECK_LIB([gnutls], [gnutls_hash_fast],[],[AC_MSG_ERROR([You must install the GnuTLS development package in order to compile lxc])])
+	AC_SUBST([GNUTLS_LIBS], [-lgnutls])])
 
 # SELinux
 AC_ARG_ENABLE([selinux],


### PR DESCRIPTION
Previously HAVE_LIBGNUTLS was never set in config.h even if gnutls was
detected as AC_CHECK_LIB default action-if-found was overriden by
enable_gnutls=yes
This patch adds an --enable-gnutls option and will call AC_CHECK_LIB
with the default action to write HAVE_LIBGNUTLS in config.h

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>