### PR TITLE
start: fix execute and improve setgroups() calls

### DIFF
--- a/src/lxc/caps.h
+++ b/src/lxc/caps.h
@@ -20,17 +20,23 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
 #include "config.h"
+#include <stdbool.h>
 
 #ifndef __LXC_CAPS_H
 #define __LXC_CAPS_H
 
 #if HAVE_SYS_CAPABILITY_H
+#include <sys/capability.h>
+
 extern int lxc_caps_down(void);
 extern int lxc_caps_up(void);
 extern int lxc_caps_init(void);
 
 extern int lxc_caps_last_cap(void);
+
+extern bool lxc_cap_is_set(cap_value_t cap, cap_flag_t flag);
 #else
 static inline int lxc_caps_down(void) {
 	return 0;
@@ -44,6 +50,12 @@ static inline int lxc_caps_init(void) {
 
 static inline int lxc_caps_last_cap(void) {
 	return 0;
+}
+
+typedef int cap_value_t;
+typedef int cap_flag_t;
+static inline bool lxc_cap_is_set(cap_value_t cap, cap_flag_t flag) {
+	return true;
 }
 #endif
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -769,32 +769,17 @@ static int do_start(void *data)
 		goto out_warn_father;
 
 	/* If we are in a new user namespace, become root there to have
-	 * privilege over our namespace. When using lxc-execute we default to
-	 * root, but this can be overriden using the lxc.init_uid and
-	 * lxc.init_gid configuration options.
+	 * privilege over our namespace.
 	 */
 	if (!lxc_list_empty(&handler->conf->id_map)) {
-		gid_t new_gid = 0;
-		if (handler->conf->is_execute && handler->conf->init_gid)
-			new_gid = handler->conf->init_gid;
+		if (lxc_switch_uid_gid(0, 0) < 0)
+			goto out_warn_father;
 
-		uid_t new_uid = 0;
-		if (handler->conf->is_execute && handler->conf->init_uid)
-			new_uid = handler->conf->init_uid;
-
-		NOTICE("Switching to uid=%d and gid=%d in new user namespace.", new_uid, new_gid);
-		if (setgid(new_gid)) {
-			SYSERROR("Failed to setgid().");
+		/* Drop groups only after we switched to a valid gid in the new
+		 * user namespace.
+		 */
+		if (lxc_setgroups(0, NULL) < 0)
 			goto out_warn_father;
-		}
-		if (setuid(new_uid)) {
-			SYSERROR("Failed to setuid().");
-			goto out_warn_father;
-		}
-		if (setgroups(0, NULL)) {
-			SYSERROR("Failed to setgroups().");
-			goto out_warn_father;
-		}
 	}
 
 	if (access(handler->lxcpath, X_OK)) {
@@ -898,6 +883,34 @@ static int do_start(void *data)
 	if (run_lxc_hooks(handler->name, "start", handler->conf, handler->lxcpath, NULL)) {
 		ERROR("Failed to run lxc.hook.start for container \"%s\".", handler->name);
 		goto out_warn_father;
+	}
+
+	/* The container has been setup. We can now switch to an unprivileged
+	 * uid/gid.
+	 */
+	if (handler->conf->is_execute) {
+		uid_t new_uid = 0;
+		gid_t new_gid = 0;
+
+		if (handler->conf->init_uid > 0)
+			new_uid = handler->conf->init_uid;
+
+		if (handler->conf->init_gid > 0)
+			new_gid = handler->conf->init_gid;
+
+		/* If we are in a new user namespace we already dropped all
+		 * groups when we switched to root in the new user namespace
+		 * further above. Only drop groups if we can, so ensure that we
+		 * have necessary privilege.
+		 */
+		bool can_setgroups = ((getuid() == 0) && (getgid() == 0));
+		if (lxc_list_empty(&handler->conf->id_map) && can_setgroups) {
+			if (lxc_setgroups(0, NULL) < 0)
+				goto out_warn_father;
+		}
+
+		if (lxc_switch_uid_gid(new_uid, new_gid) < 0)
+			goto out_warn_father;
 	}
 
 	/* The clearenv() and putenv() calls have been moved here to allow us to

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -889,22 +889,17 @@ static int do_start(void *data)
 	 * uid/gid.
 	 */
 	if (handler->conf->is_execute) {
-		uid_t new_uid = 0;
-		gid_t new_gid = 0;
-
-		if (handler->conf->init_uid > 0)
-			new_uid = handler->conf->init_uid;
-
-		if (handler->conf->init_gid > 0)
-			new_gid = handler->conf->init_gid;
+		bool have_cap_setgid;
+		uid_t new_uid = handler->conf->init_uid;
+		gid_t new_gid = handler->conf->init_gid;
 
 		/* If we are in a new user namespace we already dropped all
 		 * groups when we switched to root in the new user namespace
 		 * further above. Only drop groups if we can, so ensure that we
 		 * have necessary privilege.
 		 */
-		bool can_setgroups = ((getuid() == 0) && (getgid() == 0));
-		if (lxc_list_empty(&handler->conf->id_map) && can_setgroups) {
+		have_cap_setgid = lxc_cap_is_set(CAP_SETGID, CAP_EFFECTIVE);
+		if (lxc_list_empty(&handler->conf->id_map) && have_cap_setgid) {
 			if (lxc_setgroups(0, NULL) < 0)
 				goto out_warn_father;
 		}

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -26,6 +26,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <grp.h>
 #include <libgen.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -2051,5 +2052,34 @@ int lxc_safe_long(const char *numstr, long int *converted)
 		return -ERANGE;
 
 	*converted = sli;
+	return 0;
+}
+
+int lxc_switch_uid_gid(uid_t uid, gid_t gid)
+{
+	if (setgid(gid) < 0) {
+		SYSERROR("Failed to switch to gid %d.", gid);
+		return -errno;
+	}
+	NOTICE("Switched to gid %d.", gid);
+
+	if (setuid(uid) < 0) {
+		SYSERROR("Failed to switch to uid %d.", uid);
+		return -errno;
+	}
+	NOTICE("Switched to uid %d.", uid);
+
+	return 0;
+}
+
+/* Simple covenience function which enables uniform logging. */
+int lxc_setgroups(int size, gid_t list[])
+{
+	if (setgroups(size, list) < 0) {
+		SYSERROR("Failed to setgroups().");
+		return -errno;
+	}
+	NOTICE("Dropped additional groups.");
+
 	return 0;
 }

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -327,4 +327,8 @@ int lxc_safe_uint(const char *numstr, unsigned int *converted);
 int lxc_safe_int(const char *numstr, int *converted);
 int lxc_safe_long(const char *numstr, long int *converted);
 
+/* Switch to a new uid and gid. */
+int lxc_switch_uid_gid(uid_t uid, gid_t gid);
+int lxc_setgroups(int size, gid_t list[]);
+
 #endif /* __LXC_UTILS_H */


### PR DESCRIPTION
lxc_execute() and lxc-execute where broken when a user tried to switch to a
non-root uid/gid. This prevented necessary setup operations like mounting the
rootfs which require root in the user namespace. This commit separates
switching to root in the user namespace from switching to the requested uid/gid
by lxc_execute().
This should be safe: Once we switched to root in the user namespace via
setuid() and then switch to a non-root uid/gid in the user namespace for
lxc_execute() via setuid() we cannot regain root privileges again. So we can
only make us safer (Unless I forget about some very intricate user namespace
nonsense; which is not as unlikely as I try to make it sound.).

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>

Closes https://github.com/lxc/lxc/issues/1176.