### PR TITLE
python3-lxc: fix api_test.py on s390x

### DIFF
--- a/src/python-lxc/examples/api_test.py
+++ b/src/python-lxc/examples/api_test.py
@@ -66,7 +66,7 @@ except:
 print("Creating rootfs using 'download', arch=%s" % arch)
 container.create("download", 0,
                  {"dist": "ubuntu",
-                  "release": "trusty",
+                  "release": "xenial",
                   "arch": arch})
 
 assert(container.defined)


### PR DESCRIPTION
The api_test.py script uses Trusty release by default, which does not
have s390x image. Switch to Xenial to solve this.

This fixes #1377

Signed-off-by: Po-Hsu Lin <po-hsu.lin@canonical.com>