### PR TITLE
tools: only check for O_RDONLY

### DIFF
--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -395,7 +395,7 @@ int main(int argc, char *argv[])
 	lxc_log_options_no_override();
 
 	if (geteuid()) {
-		if (access(my_args.lxcpath[0], O_RDWR) < 0) {
+		if (access(my_args.lxcpath[0], O_RDONLY) < 0) {
 			if (!my_args.quiet)
 				fprintf(stderr, "You lack access to %s\n", my_args.lxcpath[0]);
 			exit(EXIT_FAILURE);

--- a/src/lxc/tools/lxc_copy.c
+++ b/src/lxc/tools/lxc_copy.c
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
 	lxc_log_options_no_override();
 
 	if (geteuid()) {
-		if (access(my_args.lxcpath[0], O_RDWR) < 0) {
+		if (access(my_args.lxcpath[0], O_RDONLY) < 0) {
 			if (!my_args.quiet)
 				fprintf(stderr, "You lack access to %s\n", my_args.lxcpath[0]);
 			exit(ret);

--- a/src/lxc/tools/lxc_create.c
+++ b/src/lxc/tools/lxc_create.c
@@ -252,7 +252,7 @@ int main(int argc, char *argv[])
 		if (mkdir_p(my_args.lxcpath[0], 0755)) {
 			exit(EXIT_FAILURE);
 		}
-		if (access(my_args.lxcpath[0], O_RDWR) < 0) {
+		if (access(my_args.lxcpath[0], O_RDONLY) < 0) {
 			fprintf(stderr, "You lack access to %s\n", my_args.lxcpath[0]);
 			exit(EXIT_FAILURE);
 		}

--- a/src/lxc/tools/lxc_snapshot.c
+++ b/src/lxc/tools/lxc_snapshot.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 	lxc_log_options_no_override();
 
 	if (geteuid()) {
-		if (access(my_args.lxcpath[0], O_RDWR) < 0) {
+		if (access(my_args.lxcpath[0], O_RDONLY) < 0) {
 			fprintf(stderr, "You lack access to %s\n",
 				my_args.lxcpath[0]);
 			exit(EXIT_FAILURE);

--- a/src/lxc/tools/lxc_start.c
+++ b/src/lxc/tools/lxc_start.c
@@ -231,7 +231,7 @@ int main(int argc, char *argv[])
 		exit(err);
 	lxc_log_options_no_override();
 
-	if (access(my_args.lxcpath[0], O_RDWR) < 0) {
+	if (access(my_args.lxcpath[0], O_RDONLY) < 0) {
 		if (!my_args.quiet)
 			fprintf(stderr, "You lack access to %s\n", my_args.lxcpath[0]);
 		exit(err);


### PR DESCRIPTION
On some Android systems the lxc folders where containers are stored might be
read-only and so checking for O_RDWR, will effectively make the tools useless
on these systems, so let's dumb the check down to O_RDONLY.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>