### PR TITLE
add cgroupfs-mount to Should-Start/Stop sysvinit LSB headers

### DIFF
--- a/config/init/sysvinit/lxc-containers.in
+++ b/config/init/sysvinit/lxc-containers.in
@@ -9,8 +9,8 @@
 # Provides: lxc
 # Required-Start: $syslog $remote_fs
 # Required-Stop: $syslog $remote_fs
-# Should-Start:
-# Should-Stop:
+# Should-Start: cgroupfs-mount
+# Should-Stop: cgroupfs-mount
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 # Short-Description: Bring up/down LXC autostart containers


### PR DESCRIPTION
otherwise init might try to start the containers before cgroupfs was mounted.

Debian-Bug: https://bugs.debian.org/850212

Signed-off-by: Evgeni Golov <evgeni@debian.org>