### PR TITLE
Use AC_HEADER_MAJOR to detect major()/minor()/makedev()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -640,6 +640,9 @@ AC_CHECK_DECLS([PR_GET_NO_NEW_PRIVS], [], [], [#include <sys/prctl.h>])
 # Check for some headers
 AC_CHECK_HEADERS([sys/signalfd.h pty.h ifaddrs.h sys/capability.h sys/memfd.h sys/personality.h utmpx.h sys/timerfd.h])
 
+# lookup major()/minor()/makedev()
+AC_HEADER_MAJOR
+
 # Check for some syscalls functions
 AC_CHECK_FUNCS([setns pivot_root sethostname unshare rand_r confstr faccessat gettid memfd_create])
 

--- a/src/lxc/bdev/lxclvm.c
+++ b/src/lxc/bdev/lxclvm.c
@@ -32,9 +32,18 @@
 #include <sys/wait.h>
 
 #include "bdev.h"
+#include "config.h"
 #include "log.h"
 #include "lxclvm.h"
 #include "utils.h"
+
+/* major()/minor() */
+#ifdef MAJOR_IN_MKDEV
+#    include <sys/mkdev.h>
+#endif
+#ifdef MAJOR_IN_SYSMACROS
+#    include <sys/sysmacros.h>
+#endif
 
 lxc_log_define(lxclvm, lxc);
 

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -52,6 +52,14 @@
 #include <sys/utsname.h>
 #include <sys/wait.h>
 
+/* makedev() */
+#ifdef MAJOR_IN_MKDEV
+#    include <sys/mkdev.h>
+#endif
+#ifdef MAJOR_IN_SYSMACROS
+#    include <sys/sysmacros.h>
+#endif
+
 #ifdef HAVE_STATVFS
 #include <sys/statvfs.h>
 #endif

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -60,6 +60,14 @@
 #include "utils.h"
 #include "version.h"
 
+/* major()/minor() */
+#ifdef MAJOR_IN_MKDEV
+#    include <sys/mkdev.h>
+#endif
+#ifdef MAJOR_IN_SYSMACROS
+#    include <sys/sysmacros.h>
+#endif
+
 #if HAVE_IFADDRS_H
 #include <ifaddrs.h>
 #else


### PR DESCRIPTION
Before the change build failed on Gentoo as:

  bdev/lxclvm.c: In function 'lvm_detect':
  bdev/lxclvm.c:140:4: error: implicit declaration of function 'major' [-Werror=implicit-function-declaration]
    major(statbuf.st_rdev), minor(statbuf.st_rdev));
    ^~~~~
  bdev/lxclvm.c:140:28: error: implicit declaration of function 'minor' [-Werror=implicit-function-declaration]
    major(statbuf.st_rdev), minor(statbuf.st_rdev));
                            ^~~~~

glibc plans to remove <sys/sysmacros.h> from glibc's <sys/types.h>:
    https://sourceware.org/ml/libc-alpha/2015-11/msg00253.html

Gentoo already applied glibc patch to experimental glibc-2.24
to start preparingfor the change.

Autoconf has AC_HEADER_MAJOR to find out which header defines
reqiured macros:
    https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Particular-Headers.html

This change should also increase portability across other libcs.

Bug: https://bugs.gentoo.org/604360
Signed-off-by: Sergei Trofimovich <siarheit@google.com>