### PR TITLE
Use external API of bash completion

### DIFF
--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -1,4 +1,4 @@
-_have lxc-start && {
+have lxc-start && {
     _lxc_names() {
         COMPREPLY=( $( compgen -W "$( lxc-ls )" "$cur" ) )
     }


### PR DESCRIPTION
The _have method of bash completion is internal
and have should not  be used.

In particular when using old versions of bash
completion the _have method does not even
exist.