### PR TITLE
lxc-opensuse: fix default value for release code

### DIFF
--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -458,7 +458,7 @@ fi
 if [ -z "$DISTRO" ]; then
     echo ""
     echo "No release selected, using openSUSE Leap 42.2"
-    DISTRO=42.2
+    DISTRO="leap/42.2"
 else
     echo ""
     case "$DISTRO" in


### PR DESCRIPTION
The template scripts assumes that DISTRO should contain leap/4* when dealing with Opensuse Leap releases, but the default value did not contain the leap/ prefix