### PR TITLE
[stable-2.0] debian template: don't set a root password

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -158,9 +158,6 @@ EOF
         echo "Timezone in container is not configured. Adjust it manually."
     fi
 
-    echo "root:root" | chroot "$rootfs" chpasswd
-    echo "Root password is 'root', please change !"
-
     return 0
 }
 


### PR DESCRIPTION
This is a backport of 515fb8d20c ("do not set the root password in the
debian template") from master.

See #302 and #1158 for details.