### PR TITLE
confile: clear lxc.network.<n>.ipv{4,6} when empty

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -870,6 +870,9 @@ static int config_network_ipv4(const char *key, const char *value,
 	struct lxc_list *list;
 	char *cursor, *slash, *addr = NULL, *bcast = NULL, *prefix = NULL;
 
+	if (!value || !strlen(value))
+		return lxc_clear_config_item(lxc_conf, key);
+
 	netdev = network_netdev(key, value, &lxc_conf->network);
 	if (!netdev)
 		return -1;
@@ -996,6 +999,9 @@ static int config_network_ipv6(const char *key, const char *value,
 	struct lxc_list *list;
 	char *slash,*valdup;
 	char *netmask;
+
+	if (!value || !strlen(value))
+		return lxc_clear_config_item(lxc_conf, key);
 
 	netdev = network_netdev(key, value, &lxc_conf->network);
 	if (!netdev)


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>

Closes  #1415.