### PR TITLE
Make lxc-net return non-zero on failure

### DIFF
--- a/config/init/common/lxc-net.in
+++ b/config/init/common/lxc-net.in
@@ -66,6 +66,7 @@ start() {
         if [ "$FAILED" = "1" ]; then
             echo "Failed to setup lxc-net." >&2
             stop force
+            exit 1
         fi
     }
 


### PR DESCRIPTION
I found that even though the service lxc-net failed to start because I made some wrong configuration
settings the command exists zero.
So systemd reports the status of the service as good even though it failed:

    # service lxc-net status
    ● lxc-net.service - LXC network bridge setup
       Loaded: loaded (/lib/systemd/system/lxc-net.service; enabled)
       Active: active (exited) since Wed 2017-02-08 08:17:32 EST; 21min ago
      Process: 529 ExecStart=/usr/lib/x86_64-linux-gnu/lxc/lxc-net start (code=exited, status=0/SUCCESS)
     Main PID: 529 (code=exited, status=0/SUCCESS)
       CGroup: /system.slice/lxc-net.service
    
    Feb 08 08:17:30 dvm2 systemd[1]: Starting LXC network bridge setup...
    Feb 08 08:17:32 dvm2 lxc-net[529]: dnsmasq: failed to create listening socket for 10.2.2.1: Address already in use
    Feb 08 08:17:32 dvm2 lxc-net[529]: Failed to setup lxc-net.
    Feb 08 08:17:32 dvm2 systemd[1]: Started LXC network bridge setup.

Adding `exit 1` here makes it exit non-zero to make systemd recognize the failure.

Also reported on the debian bugtracker: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=854591