### PR TITLE
tools: exit with return code of lxc_execute()

### DIFF
--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -290,7 +290,7 @@ init_lxc_static_SOURCES += ../include/getline.c
 endif
 endif
 
-init_lxc_static_LDFLAGS = -static
+init_lxc_static_LDFLAGS = -all-static
 init_lxc_static_LDADD = @CAP_LIBS@
 init_lxc_static_CFLAGS = $(AM_CFLAGS) -DNO_LXC_CONF
 endif

--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -166,5 +166,5 @@ int main(int argc, char *argv[])
 
 	if (ret < 0)
 		exit(EXIT_FAILURE);
-	exit(EXIT_SUCCESS);
+	exit(ret);
 }


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>

Closes #1431.