### PR TITLE
sabayon: Use /bin/bash

### DIFF
--- a/templates/lxc-sabayon.in
+++ b/templates/lxc-sabayon.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # vim: set ts=4 sw=4 expandtab
 
 # Exit on error and treat unset variables as an error.


### PR DESCRIPTION
The script is full of bashisms making it break when run with a simple
POSIX shell.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>