### PR TITLE
Fix issue with the clonehostname hook not working for overlayfs snapshot clones

### DIFF
--- a/hooks/clonehostname
+++ b/hooks/clonehostname
@@ -19,9 +19,9 @@
 
 # Note that /etc/hostname is updated by lxc itself
 for file in \
-    $LXC_ROOTFS_PATH/etc/sysconfig/network \
-    $LXC_ROOTFS_PATH/etc/sysconfig/network-scripts/ifcfg-* \
-    $LXC_ROOTFS_PATH/etc/hosts ;
+    $LXC_ROOTFS_MOUNT/etc/sysconfig/network \
+    $LXC_ROOTFS_MOUNT/etc/sysconfig/network-scripts/ifcfg-* \
+    $LXC_ROOTFS_MOUNT/etc/hosts ;
 do
     if [ -f $file ]; then
         sed -i "s|$LXC_SRC_NAME|$LXC_NAME|" $file


### PR DESCRIPTION
Previously this hook did not work when cloning containers using an overlayfs snapshot as the LXC_ROOTFS_PATH didn't point to the actual filesystem that the container would see. LXC_ROOTFS_MOUNT should be used instead and in fact lxc.container.conf man page says that you usually would want to use the _MOUNT variant.