### PR TITLE
Allow setting the key server as an environment variable

### DIFF
--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -204,7 +204,7 @@ Optional arguments:
 [ --variant <variant> ]: Variant of the image (default: "default")
 [ --server <server> ]: Image server (default: "images.linuxcontainers.org")
 [ --keyid <keyid> ]: GPG keyid (default: 0x...)
-[ --keyserver <keyserver> ]: GPG keyserver to use
+[ --keyserver <keyserver> ]: GPG keyserver to use. Environment variable: DOWNLOAD_KEYSERVER
 [ --no-validate ]: Disable GPG validation (not recommended)
 [ --flush-cache ]: Flush the local copy (if present)
 [ --force-cache ]: Force the use of the local copy even if expired
@@ -215,6 +215,11 @@ LXC internal arguments (do not pass manually!):
 [ --rootfs <rootfs> ]: The path to the container's rootfs
 [ --mapped-uid <map> ]: A uid map (user namespaces)
 [ --mapped-gid <map> ]: A gid map (user namespaces)
+
+Environment Variables:
+DOWNLOAD_KEYSERVER : The URL of the key server to use, instead of the default.
+                     Can be further overridden by using optional argument --keyserver
+
 EOF
     return 0
 }

--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -53,7 +53,7 @@ LXC_NAME=
 LXC_PATH=
 LXC_ROOTFS=
 
-if [ -z "${DOWNLOAD_KEYSERVER+x}" ]; then
+if [ -z "${DOWNLOAD_KEYSERVER:-}" ]; then
 	DOWNLOAD_KEYSERVER="hkp://pool.sks-keyservers.net"
 
 	# Deal with GPG over http proxy

--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -34,7 +34,6 @@ DOWNLOAD_FLUSH_CACHE="false"
 DOWNLOAD_FORCE_CACHE="false"
 DOWNLOAD_INTERACTIVE="false"
 DOWNLOAD_KEYID="0xE7FB0CAEC8173D669066514CBAEFF88C22F6E216"
-DOWNLOAD_KEYSERVER="hkp://pool.sks-keyservers.net"
 DOWNLOAD_LIST_IMAGES="false"
 DOWNLOAD_MODE="system"
 DOWNLOAD_READY_GPG="false"
@@ -54,9 +53,13 @@ LXC_NAME=
 LXC_PATH=
 LXC_ROOTFS=
 
-# Deal with GPG over http proxy
-if [ -n "${http_proxy:-}" ]; then
-    DOWNLOAD_KEYSERVER="hkp://p80.pool.sks-keyservers.net:80"
+if [ -z "${DOWNLOAD_KEYSERVER+x}" ]; then
+	DOWNLOAD_KEYSERVER="hkp://pool.sks-keyservers.net"
+
+	# Deal with GPG over http proxy
+	if [ -n "${http_proxy:-}" ]; then
+	    DOWNLOAD_KEYSERVER="hkp://p80.pool.sks-keyservers.net:80"
+	fi
 fi
 
 # Make sure the usual locations are in PATH


### PR DESCRIPTION
In some environments, outgoing port 11371 (HKP:// port) is blocked.

Manually specifying the key server on every `lxc-create` operation should not be necessary in these cases.

This change allows the variable holding the URL to the key server to be set in the environment, for example through `.bashrc` or `.profile`