### PR TITLE
don't set a default password for altlinux, gentoo, openmandriva and pld

### DIFF
--- a/templates/lxc-altlinux.in
+++ b/templates/lxc-altlinux.in
@@ -43,7 +43,6 @@ cache_base=@LOCALSTATEDIR@/cache/lxc/altlinux/$arch
 default_path=@LXCPATH@
 default_profile=default
 profile_dir=/etc/lxc/profiles
-root_password=rooter
 lxc_network_type=veth
 lxc_network_link=virbr0
 
@@ -156,8 +155,10 @@ EOF
     mkdir -m 755 ${dev_path}/net
     mknod -m 666 ${dev_path}/net/tun c 10 200
 
-    echo "setting root passwd to $root_password"
-    echo "root:$root_password" | chroot $rootfs_path chpasswd
+    if [ -n "${root_password}" ]; then
+        echo "setting root passwd to $root_password"
+        echo "root:$root_password" | chroot $rootfs_path chpasswd
+    fi
 
     return 0
 }

--- a/templates/lxc-gentoo.in
+++ b/templates/lxc-gentoo.in
@@ -654,8 +654,6 @@ container_auth()
         printf "  => done. if you didn't specify , default is 'toor'\n"
         if [[ -n "${forced_password}" ]]; then
             store_user_message "${user} has the password you give for him"
-        else
-            store_user_message "${user} has the default password 'toor', please change it ASAP"
         fi
     fi
 
@@ -779,7 +777,6 @@ set_default_arch
 
 mirror="http://distfiles.gentoo.org"
 user="root"
-password="toor"
 tty=1
 settings="common"
 options=$(getopt -o hp:n:a:FcPv:t:S:u:w:s:m: -l help,rootfs:,path:,name:,arch:,flush-cache,cache-only,private-portage,variant:,portage-dir:,tarball:,auth-key:,user:,autologin,password:,settings:,mirror:,tty: -- "$@")

--- a/templates/lxc-openmandriva.in
+++ b/templates/lxc-openmandriva.in
@@ -46,7 +46,6 @@ hostarch=$(uname -m)
 cache_base="${LXC_CACHE_PATH:-@LOCALSTATEDIR@/cache/lxc/openmandriva/$arch}"
 default_path=@LXCPATH@
 default_profile=default
-root_password=root
 lxc_network_type=veth
 lxc_network_link=br0
 

--- a/templates/lxc-pld.in
+++ b/templates/lxc-pld.in
@@ -38,7 +38,6 @@ done
 arch=$(uname -m)
 cache_base=@LOCALSTATEDIR@/cache/lxc/pld/$arch
 default_path=@LXCPATH@
-root_password=root
 
 if [ -e /etc/os-release ]; then
 	# This is a shell friendly configuration file.  We can just source it.
@@ -105,8 +104,10 @@ EOF
 	mknod -m 600 ${dev_path}/initctl p
 	mknod -m 666 ${dev_path}/ptmx c 5 2
 
-	echo "setting root passwd to $root_password"
-	echo "root:$root_password" | chroot $rootfs_path chpasswd
+	if [ -n "${root_password}" ]; then
+		echo "setting root passwd to $root_password"
+		echo "root:$root_password" | chroot $rootfs_path chpasswd
+	fi
 
 	return 0
 }


### PR DESCRIPTION
Refs: #1158
Signed-off-by: Evgeni Golov <evgeni@debian.org>