### PR TITLE
Fix opening wrong file in suggest_default_idmap

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4560,7 +4560,7 @@ void suggest_default_idmap(void)
 	}
 	fclose(f);
 
-	f = fopen(subuidfile, "r");
+	f = fopen(subgidfile, "r");
 	if (!f) {
 		ERROR("Your system is not configured with subgids");
 		free(gname);


### PR DESCRIPTION
Fixing the typo making `suggest_default_idmap` open `subuidfile` instead of `subgidfile` to read subgid information.

