### PR TITLE
Keep veth.pair.name on network shutdown

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3026,8 +3026,6 @@ bool lxc_delete_network(struct lxc_handler *handler)
 					WARN("Failed to remove interface \"%s\" from host: %s.", hostveth, strerror(-ret));
 				} else {
 					INFO("Removed interface \"%s\" from host.", hostveth);
-					free(netdev->priv.veth_attr.pair);
-					netdev->priv.veth_attr.pair = NULL;
 				}
 			} else if (strlen(netdev->priv.veth_attr.veth1) > 0) {
 				hostveth = netdev->priv.veth_attr.veth1;


### PR DESCRIPTION
In case of a container that is rebooting, freeing veth.pair.name here results in losing given veth.pair name
(Only if given lxc_netdev is reused).

Signed-off-by: Torsten Fohrer <tfohrer@googlemail.com>

issue #1477 