### PR TITLE
Avoid waiting for bridge interface on bootup

### DIFF
--- a/config/init/common/lxc-containers.in
+++ b/config/init/common/lxc-containers.in
@@ -51,6 +51,8 @@ fi
 # to start
 wait_for_bridge()
 {
+    [ "x$USE_LXC_BRIDGE" = "xtrue" ] || { return 0; }
+
     local BRNAME try flags br
     [ -f "$sysconfdir"/lxc/default.conf ] || { return 0; }
 


### PR DESCRIPTION
Don't wait for bridge if disabled via USE_LXC_BRIDGE

Signed-off-by: Torsten Fohrer <tfohrer@googlemail.com>