### PR TITLE
Increased buffer length in print_stats()

### DIFF
--- a/src/lxc/tools/lxc_info.c
+++ b/src/lxc/tools/lxc_info.c
@@ -204,7 +204,7 @@ static void print_net_stats(struct lxc_container *c)
 static void print_stats(struct lxc_container *c)
 {
 	int i, ret;
-	char buf[256];
+	char buf[4096];
 
 	ret = c->get_cgroup_item(c, "cpuacct.usage", buf, sizeof(buf));
 	if (ret > 0 && ret < sizeof(buf)) {


### PR DESCRIPTION
Some "/sys" entries exceeds buffer size.
This results to some statistics loss ('BlkIO' in particular):

 wc -c /sys/fs/cgroup/blkio/lxc/alt/blkio.throttle.io_service_bytes
 318 /sys/fs/cgroup/blkio/lxc/alt/blkio.throttle.io_service_bytes

Signed-off-by: Denis Pynkin <dans@altlinux.org>