### PR TITLE
make Alpine template more POSIX shell friendly #1498

### DIFF
--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -263,8 +263,8 @@ install() {
 }
 
 install_packages() {
-	local arch="$1"; shift
-	local packages="$@"
+	local arch="$1"
+	local packages="$2"
 
 	$APK --arch="$arch" --root=. --keys-dir="$APK_KEYS_DIR" \
 		--update-cache --initdb add $packages


### PR DESCRIPTION
By making Alpine template more POSIX shell friendly, bug #1498 is solved

Signed-off-by: Vincent Catros <vincent.catros@laposte.net>