### PR TITLE
start: fix error handling when limits fail to apply

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1263,7 +1263,7 @@ static int lxc_spawn(struct lxc_handler *handler)
 
 	if (!lxc_list_empty(&handler->conf->limits) && setup_resource_limits(&handler->conf->limits, handler->pid)) {
 		ERROR("failed to setup resource limits for '%s'", name);
-		return -1;
+		goto out_delete_net;
 	}
 
 	if (!cgroup_setup_limits(handler, true)) {


### PR DESCRIPTION
(The code was moved here from the child side of the startup
without adapting the error case.)

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>