### PR TITLE
ls: simplify the judgment condition when list active containers

### DIFF
--- a/src/lxc/tools/lxc_ls.c
+++ b/src/lxc/tools/lxc_ls.c
@@ -356,7 +356,7 @@ static int ls_get(struct ls **m, size_t *size, const struct lxc_arguments *args,
 	}
 
 	/* Do not do more work than is necessary right from the start. */
-	if (args->ls_active || (args->ls_active && args->ls_frozen))
+	if (args->ls_active || args->ls_frozen)
 		num = list_active_containers(path, &containers, NULL);
 	else
 		num = list_all_containers(path, &containers, NULL);


### PR DESCRIPTION
In the following code 
```
if ( args->ls_active || (args->ls_active && args->ls_frozen))
```
`(args->ls_active && args->ls_frozen)` always false if `args->ls_active` is false.
so we can delete the second  judgment condition and only keep the first one.

Signed-off-by: 0x0916 <w@laoqinren.net>