### PR TITLE
cgroups: improve cgfsng debugging

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,7 +9,7 @@ Feel free to remove anything which doesn't apply to you and add more information
    * `lxc-start --version`
    * `lxc-checkconfig`
    * `uname -a`
-   * `cat /proc/self/cgroups`
+   * `cat /proc/self/cgroup`
    * `cat /proc/1/mounts`
 
 # Issue description


### PR DESCRIPTION
In a lot of cases we need a list of the writeable cgroup controllers detected
by the cgfsng driver.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>