### PR TITLE
utils: tweak lxc_mount_proc_if_needed()

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3760,20 +3760,21 @@ int ttys_shift_ids(struct lxc_conf *c)
 	return 0;
 }
 
-/* NOTE: not to be called from inside the container namespace! */
-int tmp_proc_mount(struct lxc_conf *lxc_conf)
+/* NOTE: Must not be called from inside the container namespace! */
+int lxc_create_tmp_proc_mount(struct lxc_conf *conf)
 {
 	int mounted;
 
-	mounted = mount_proc_if_needed(lxc_conf->rootfs.path ? lxc_conf->rootfs.mount : "");
+	mounted = lxc_mount_proc_if_needed(conf->rootfs.path ? conf->rootfs.mount : "");
 	if (mounted == -1) {
-		SYSERROR("failed to mount /proc in the container.");
+		SYSERROR("failed to mount /proc in the container");
 		/* continue only if there is no rootfs */
-		if (lxc_conf->rootfs.path)
+		if (conf->rootfs.path)
 			return -1;
 	} else if (mounted == 1) {
-		lxc_conf->tmp_umount_proc = 1;
+		conf->tmp_umount_proc = 1;
 	}
+
 	return 0;
 }
 
@@ -4063,7 +4064,7 @@ int lxc_setup(struct lxc_handler *handler)
 	}
 
 	/* mount /proc if it's not already there */
-	if (tmp_proc_mount(lxc_conf) < 0) {
+	if (lxc_create_tmp_proc_mount(lxc_conf) < 0) {
 		ERROR("failed to LSM mount proc for '%s'", name);
 		return -1;
 	}

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1754,7 +1754,7 @@ int safe_mount(const char *src, const char *dest, const char *fstype,
  *
  * NOTE: not to be called from inside the container namespace!
  */
-int mount_proc_if_needed(const char *rootfs)
+int lxc_mount_proc_if_needed(const char *rootfs)
 {
 	char path[MAXPATHLEN];
 	char link[20];

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -326,7 +326,7 @@ char *get_template_path(const char *t);
 int setproctitle(char *title);
 int safe_mount(const char *src, const char *dest, const char *fstype,
 		unsigned long flags, const void *data, const char *rootfs);
-int mount_proc_if_needed(const char *rootfs);
+int lxc_mount_proc_if_needed(const char *rootfs);
 int open_devnull(void);
 int set_stdfds(int fd);
 int null_stdfds(void);


### PR DESCRIPTION
Create /proc directory if it doesn't exist.

Closes #1475.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>