### PR TITLE
[RFC] api extension: lxc_config_item_is_supported()

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4522,3 +4522,8 @@ free_ct_name:
 	free(ct_name);
 	return ret;
 }
+
+bool lxc_config_item_is_supported(const char *key)
+{
+	return !!lxc_getconfig(key);
+}

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -1022,6 +1022,13 @@ int list_all_containers(const char *lxcpath, char ***names, struct lxc_container
  */
 void lxc_log_close(void);
 
+/*!
+ * \brief Check if the configuration item is supported by this LXC instance.
+ *
+ * \param key Configuration item to check for.
+ */
+bool lxc_config_item_is_supported(const char *key);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/src/tests/get_item.c
+++ b/src/tests/get_item.c
@@ -391,6 +391,17 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "%d: failed clearing lxc.hook\n", __LINE__);
 		goto out;
 	}
+
+	if (!lxc_config_item_is_supported("lxc.arch")) {
+		fprintf(stderr, "%d: failed to report \"lxc.arch\" as supported configuration item\n", __LINE__);
+		goto out;
+	}
+
+	if (lxc_config_item_is_supported("lxc.nonsense")) {
+		fprintf(stderr, "%d: failed to detect \"lxc.nonsense\" as unsupported configuration item\n", __LINE__);
+		goto out;
+	}
+
 	printf("All get_item tests passed\n");
 	ret = EXIT_SUCCESS;
 out:


### PR DESCRIPTION
This adds lxc_config_item_is_supported() as API extension. It allows to check
whether a given config item (e.g. lxc.autodev) is supported by this LXC
instance. The function is useful in the following scenarios:
1. Users have compiled liblxc from source and have removed a config items from
   the corresponding struct in confile.c. (For example, embedded users might
   decide to gut a bunch of options that they cannot use.)
2. Callers that want to check for a specific configuration item independent of
   the version numbers exposed in our version.h header.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>