### PR TITLE
Fix abstract socket address length issue

### DIFF
--- a/src/lxc/af_unix.c
+++ b/src/lxc/af_unix.c
@@ -56,7 +56,7 @@ int lxc_abstract_unix_open(const char *path, int type, int flags)
 	addr.sun_family = AF_UNIX;
 
 	len = strlen(&path[1]) + 1;
-	if (len >= sizeof(addr.sun_path) - 1) {
+	if (len >= sizeof(addr.sun_path)) {
 		close(fd);
 		errno = ENAMETOOLONG;
 		return -1;
@@ -110,7 +110,7 @@ int lxc_abstract_unix_connect(const char *path)
 	addr.sun_family = AF_UNIX;
 
 	len = strlen(&path[1]) + 1;
-	if (len >= sizeof(addr.sun_path) - 1) {
+	if (len >= sizeof(addr.sun_path)) {
 		close(fd);
 		errno = ENAMETOOLONG;
 		return -1;

--- a/src/lxc/monitor.c
+++ b/src/lxc/monitor.c
@@ -181,7 +181,7 @@ int lxc_monitor_sock_name(const char *lxcpath, struct sockaddr_un *addr) {
 	if (ret < 0)
 		return -1;
 
-	sockname[sizeof(addr->sun_path)-3] = '\0';
+	addr->sun_path[sizeof(addr->sun_path)-1] = '\0';
 	INFO("Using monitor socket name \"%s\".", sockname);
 
 	return 0;
@@ -205,7 +205,7 @@ int lxc_monitor_open(const char *lxcpath)
 	}
 
 	len = strlen(&addr.sun_path[1]) + 1;
-	if (len >= sizeof(addr.sun_path) - 1) {
+	if (len >= sizeof(addr.sun_path)) {
 		ret = -1;
 		errno = ENAMETOOLONG;
 		goto on_error;


### PR DESCRIPTION
commit: https://github.com/lxc/lxc/commit/073135baa78511c26e502362840f2c950cfddfe2
change `sockname[sizeof(addr->sun_path)-2] = '\0';` to
`sockname[sizeof(addr->sun_path)-3] = '\0';` and can not explain the reason.

because we use `memset` to initialize `addr` to zero, we need not the code to make
sure that the last byte of addr is zero.

when delete this code, it doesn't seem to work, because the wrong check for abstract
socker addr's length in function `lxc_mointor_open`. The max length of the address
can be 107 bytes.

also fix this in function `lxc_abstract_unix_connect` and `lxc_abstract_unix_open`.

Signed-off-by: 0x0916 <w@laoqinren.net>