### PR TITLE
start: remove umount2() 

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1287,23 +1287,23 @@ int prepare_ramfs_root(char *root)
 	char *p2;
 
 	if (realpath(root, nroot) == NULL)
-		return -1;
+		return -errno;
 
 	if (chdir("/") == -1)
-		return -1;
+		return -errno;
 
 	/*
 	 * We could use here MS_MOVE, but in userns this mount is
 	 * locked and can't be moved.
 	 */
-	if (mount(root, "/", NULL, MS_REC | MS_BIND, NULL)) {
+	if (mount(root, "/", NULL, MS_REC | MS_BIND, NULL) < 0) {
 		SYSERROR("Failed to move %s into /", root);
-		return -1;
+		return -errno;
 	}
 
-	if (mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL)) {
+	if (mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL) < 0) {
 		SYSERROR("Failed to make . rprivate");
-		return -1;
+		return -errno;
 	}
 
 	/*
@@ -1369,17 +1369,28 @@ int prepare_ramfs_root(char *root)
 
 static int setup_pivot_root(const struct lxc_rootfs *rootfs)
 {
-	if (!rootfs->path)
+	if (!rootfs->path) {
+		DEBUG("container does not have a rootfs, so not doing pivot root");
 		return 0;
+	}
 
 	if (detect_ramfs_rootfs()) {
-		if (prepare_ramfs_root(rootfs->mount))
+		DEBUG("detected that container is on ramfs");
+		if (prepare_ramfs_root(rootfs->mount)) {
+			ERROR("failed to prepare minimal ramfs root");
 			return -1;
-	} else if (setup_rootfs_pivot_root(rootfs->mount)) {
-		ERROR("failed to setup pivot root");
+		}
+
+		DEBUG("prepared ramfs root for container");
+		return 0;
+	}
+
+	if (setup_rootfs_pivot_root(rootfs->mount) < 0) {
+		ERROR("failed to pivot root");
 		return -1;
 	}
 
+	DEBUG("finished pivot root");
 	return 0;
 }
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1289,9 +1289,6 @@ static int lxc_spawn(struct lxc_handler *handler)
 	if (lxc_sync_barrier_child(handler, LXC_SYNC_POST_CGROUP))
 		return -1;
 
-	if (detect_shared_rootfs())
-		umount2(handler->conf->rootfs.mount, MNT_DETACH);
-
 	if (handler->ops->post_start(handler, handler->data))
 		goto out_abort;
 


### PR DESCRIPTION
I really fail to see the point of this and git {blame, log -S} don't really
enlighten me on the reason for this as well. But I might be dense. The way I
see it the only thing this line achieves is causing trouble when the container
is started as root because the umount2() call will umount e.g.
/usr/lib/x86_64-linux-gnu/lxc in case it is a mountpoint on the host. Note,
this is because lxc_spawn() is still called in the hosts namespaces.

Closes https://github.com/lxc/lxd/#3255.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>