### PR TITLE
lxc-attach: allow for situations without /dev/tty

### DIFF
--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -441,7 +441,7 @@ static int lxc_console_peer_default(struct lxc_console *console)
 
 	console->peer = lxc_unpriv(open(path, O_CLOEXEC | O_RDWR | O_CREAT | O_APPEND, 0600));
 	if (console->peer < 0) {
-		ERROR("failed to open \"%s\"", path);
+		ERROR("failed to open \"%s\": %s", path, strerror(errno));
 		return -ENOTTY;
 	}
 	DEBUG("using \"%s\" as peer tty device", path);

--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -301,15 +301,12 @@ static int get_pty_on_host(struct lxc_container *c, struct wrapargs *wrap, int *
 
 	/* In the case of lxc-attach our peer pty will always be the current
 	 * controlling terminal. We clear whatever was set by the user for
-	 * lxc.console.path here and set it to "/dev/tty". Doing this will (a)
-	 * prevent segfaults when the container has been setup with
-	 * lxc.console = none and (b) provide an easy way to ensure that we
-	 * always do the correct thing. strdup() must be used since console.path
-	 * is free()ed when we call lxc_container_put(). */
+	 * lxc.console.path here and set it NULL. lxc_console_peer_default()
+	 * will then try to open /dev/tty. If the process doesn't have a
+	 * controlling terminal we should still proceed.
+	 */
 	free(conf->console.path);
-	conf->console.path = strdup("/dev/tty");
-	if (!conf->console.path)
-		return -1;
+	conf->console.path = NULL;
 
 	/* Create pty on the host. */
 	if (lxc_console_create(conf) < 0)


### PR DESCRIPTION
Closes #1552.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>