### PR TITLE
monitor: delete unneccessory include file

### DIFF
--- a/src/lxc/monitor.h
+++ b/src/lxc/monitor.h
@@ -28,8 +28,6 @@
 #include <sys/un.h>
 #include <poll.h>
 
-#include "conf.h"
-
 typedef enum {
 	lxc_msg_state,
 	lxc_msg_priority,


### PR DESCRIPTION
we want to export `monitor.h`, `#include "conf.h"` will cause error
and it is unneccessory so just delete it.

Signed-off-by: 0x0916 <w@laoqinren.net>