### PR TITLE
Fix build of conf.c when capabilities is disabled

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3469,8 +3469,10 @@ int lxc_map_ids(struct lxc_list *idmap, pid_t pid)
 	 * will protected it by preventing another user from being handed the
 	 * range by shadow.
 	 */
+	#if HAVE_LIBCAP
 	uidmap = idmaptool_on_path_and_privileged("newuidmap", CAP_SETUID);
 	gidmap = idmaptool_on_path_and_privileged("newgidmap", CAP_SETGID);
+	#endif
 	if (uidmap > 0 && gidmap > 0) {
 		DEBUG("Functional newuidmap and newgidmap binary found.");
 		use_shadow = true;


### PR DESCRIPTION
Do not call idmaptool_on_path_and_privileged with CAP_SETUID and
CAP_SETGID if HAVE_LIBCAP is not defined otherwise compilation fails

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>