### PR TITLE
DO NOT add the handles of adjust winsize when the 'stdin' is not a tty

### DIFF
--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -121,6 +121,11 @@ struct lxc_tty_state *lxc_console_sigwinch_init(int srcfd, int dstfd)
 	ts->masterfd = dstfd;
 	ts->sigfd = -1;
 
+	if (!isatty(srcfd)) {
+		INFO("fd %d does not refer to a tty device", srcfd);
+		return ts;
+	}
+
 	/* add tty to list to be scanned at SIGWINCH time */
 	lxc_list_add_elem(&ts->node, ts);
 	lxc_list_add_tail(&lxc_ttys, &ts->node);
@@ -128,20 +133,20 @@ struct lxc_tty_state *lxc_console_sigwinch_init(int srcfd, int dstfd)
 	sigemptyset(&mask);
 	sigaddset(&mask, SIGWINCH);
 	if (sigprocmask(SIG_BLOCK, &mask, &ts->oldmask)) {
-		SYSERROR("failed to block SIGWINCH.");
+		SYSERROR("failed to block SIGWINCH");
 		ts->sigfd = -1;
 		return ts;
 	}
 
 	ts->sigfd = signalfd(-1, &mask, 0);
 	if (ts->sigfd < 0) {
-		SYSERROR("failed to get signalfd.");
+		SYSERROR("failed to create signal fd");
 		sigprocmask(SIG_SETMASK, &ts->oldmask, NULL);
 		ts->sigfd = -1;
 		return ts;
 	}
 
-	DEBUG("%d got SIGWINCH fd %d", getpid(), ts->sigfd);
+	DEBUG("process %d created signal fd %d to handle SIGWINCH events", getpid(), ts->sigfd);
 	return ts;
 }
 
@@ -647,16 +652,17 @@ int lxc_console(struct lxc_container *c, int ttynum,
 	struct lxc_epoll_descr descr;
 	struct termios oldtios;
 	struct lxc_tty_state *ts;
+	int istty = 0;
 
-	if (!isatty(stdinfd)) {
-		ERROR("stdin is not a tty");
-		return -1;
-	}
-
-	ret = lxc_setup_tios(stdinfd, &oldtios);
-	if (ret) {
-		ERROR("failed to setup tios");
-		return -1;
+	istty = isatty(stdinfd);
+	if (istty) {
+		ret = lxc_setup_tios(stdinfd, &oldtios);
+		if (ret) {
+			ERROR("failed to setup terminal properties");
+			return -1;
+		}
+	} else {
+		INFO("fd %d does not refer to a tty device", stdinfd);
 	}
 
 	ttyfd = lxc_cmd_console(c->name, &ttynum, &masterfd, c->config_path);
@@ -684,8 +690,10 @@ int lxc_console(struct lxc_container *c, int ttynum,
 	ts->winch_proxy = c->name;
 	ts->winch_proxy_lxcpath = c->config_path;
 
-	lxc_console_winsz(stdinfd, masterfd);
-	lxc_cmd_console_winch(ts->winch_proxy, ts->winch_proxy_lxcpath);
+	if (istty) {
+		lxc_console_winsz(stdinfd, masterfd);
+		lxc_cmd_console_winch(ts->winch_proxy, ts->winch_proxy_lxcpath);
+	}
 
 	ret = lxc_mainloop_open(&descr);
 	if (ret) {
@@ -733,8 +741,10 @@ err2:
 	close(masterfd);
 	close(ttyfd);
 err1:
-	tcsetattr(stdinfd, TCSAFLUSH, &oldtios);
+	if (istty) {
+		if (tcsetattr(stdinfd, TCSAFLUSH, &oldtios) < 0)
+			WARN("failed to reset terminal properties: %s.", strerror(errno));
+	}
 
 	return ret;
 }
-


### PR DESCRIPTION

I think it is not necessary that  the 'stdin'  must be a tty device.  For example, we can pass a FIFO fd as the ‘stdin’ parameter, then we can do more flexible work on the container console.

Signed-off-by: Li Feng <lifeng68@huawei.com>