### PR TITLE
Fix the bug of 'ts->stdoutfd' did not fill with parameters 'stdoutfd'

### DIFF
--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -683,6 +683,7 @@ int lxc_console(struct lxc_container *c, int ttynum,
 	ts->escape = escape;
 	ts->winch_proxy = c->name;
 	ts->winch_proxy_lxcpath = c->config_path;
+	ts->stdoutfd = stdoutfd;
 
 	lxc_console_winsz(stdinfd, masterfd);
 	lxc_cmd_console_winch(ts->winch_proxy, ts->winch_proxy_lxcpath);


### PR DESCRIPTION
The 'ts->stdoutfd' did not fill with parameters 'stdoutfd', it used the default value "0".
I think we should fix that mistake.

Signed-off-by: Li Feng <lifeng68@huawei.com>