### PR TITLE
seccomp: export the seccomp filter after load it into kernel successful

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -791,6 +791,18 @@ int lxc_seccomp_load(struct lxc_conf *conf)
 		ERROR("Error loading the seccomp policy: %s.", strerror(-ret));
 		return -1;
 	}
+
+/* After load seccomp filter into the kernel successfully, export the current seccomp
+ * filter to log file */
+#if HAVE_SCMP_FILTER_CTX
+	if ((lxc_log_get_level() <= LXC_LOG_PRIORITY_TRACE || conf->loglevel <= LXC_LOG_PRIORITY_TRACE) &&
+	    lxc_log_fd >= 0) {
+		ret = seccomp_export_pfc(conf->seccomp_ctx, lxc_log_fd);
+		/* Just give an warning when export error */
+		if (ret < 0)
+			WARN("Failed to export seccomp filter to log file: %s.", strerror(-ret));
+	}
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
when the log level is `TRACE`, this patch export the seccomp
filter to log file.

the ouput of `seccomp_export_pfc()` is human readable and this feature
is useful for user to make sure their `seccomp configuration file` is
right.

Output for he default ubuntu container's seccomp filter is the
following:

```
      lxc-start ubuntu 20170520024159.412 INFO     lxc_apparmor - lsm/apparmor.c:apparmor_process_label_set:238 - changed apparmor profile to lxc-container-default-cgns
if ($arch == 3221225534)
  # filter for syscall "finit_module" (313) [priority: 65535]
  if ($syscall == 313)
    action ERRNO(1);
  # filter for syscall "open_by_handle_at" (304) [priority: 65535]
  if ($syscall == 304)
    action ERRNO(1);
  # filter for syscall "kexec_load" (246) [priority: 65535]
  if ($syscall == 246)
    action ERRNO(1);
  # filter for syscall "delete_module" (176) [priority: 65535]
  if ($syscall == 176)
    action ERRNO(1);
  # filter for syscall "init_module" (175) [priority: 65535]
  if ($syscall == 175)
    action ERRNO(1);
  # filter for syscall "umount2" (166) [priority: 65533]
  if ($syscall == 166)
    if ($a1.hi32 & 0x00000000 == 0)
      if ($a1.lo32 & 0x00000001 == 1)
        action ERRNO(13);
  # default action
  action ALLOW;
if ($arch == 1073741827)
  # filter for syscall "finit_module" (350) [priority: 65535]
  if ($syscall == 350)
    action ERRNO(1);
  # filter for syscall "open_by_handle_at" (342) [priority: 65535]
  if ($syscall == 342)
    action ERRNO(1);
  # filter for syscall "kexec_load" (283) [priority: 65535]
  if ($syscall == 283)
    action ERRNO(1);
  # filter for syscall "delete_module" (129) [priority: 65535]
  if ($syscall == 129)
    action ERRNO(1);
  # filter for syscall "init_module" (128) [priority: 65535]
  if ($syscall == 128)
    action ERRNO(1);
  # filter for syscall "umount2" (52) [priority: 65534]
  if ($syscall == 52)
    if ($a1 & 0x00000001 == 1)
      action ERRNO(13);
  # default action
  action ALLOW;
if ($arch == 3221225534)
  # filter for syscall "kexec_load" (1073742352) [priority: 65535]
  if ($syscall == 1073742352)
    action ERRNO(1);
  # filter for syscall "finit_module" (1073742137) [priority: 65535]
  if ($syscall == 1073742137)
    action ERRNO(1);
  # filter for syscall "open_by_handle_at" (1073742128) [priority: 65535]
  if ($syscall == 1073742128)
    action ERRNO(1);
  # filter for syscall "delete_module" (1073742000) [priority: 65535]
  if ($syscall == 1073742000)
    action ERRNO(1);
  # filter for syscall "init_module" (1073741999) [priority: 65535]
  if ($syscall == 1073741999)
    action ERRNO(1);
  # filter for syscall "umount2" (1073741990) [priority: 65534]
  if ($syscall == 1073741990)
    if ($a1 & 0x00000001 == 1)
      action ERRNO(13);
  # default action
  action ALLOW;
action KILL;
      lxc-start ubuntu 20170520024159.412 NOTICE   lxc_start - start.c:start:1470 - Exec'ing "/sbin/init".
```

Signed-off-by: 0x0916 <w@laoqinren.net>