### PR TITLE
[RFC]: pre-allocate and retrieve pre-allocated pts devices from container

### DIFF
--- a/src/lxc/commands.h
+++ b/src/lxc/commands.h
@@ -43,6 +43,7 @@ typedef enum {
 	LXC_CMD_GET_CONFIG_ITEM,
 	LXC_CMD_GET_NAME,
 	LXC_CMD_GET_LXCPATH,
+	LXC_CMD_GET_PTY,
 	LXC_CMD_MAX,
 } lxc_cmd_t;
 
@@ -68,9 +69,21 @@ struct lxc_cmd_console_rsp_data {
 	int ttynum;
 };
 
+#define CMD_PTY_FD_PAIR 2
+#define CMD_PTY_MASTER_FD 0
+#define CMD_PTY_SLAVE_FD 1
+
+struct lxc_cmd_pty_rsp_data {
+	int masterfd;
+	int slavefd;
+	int ttynum;
+};
+
 extern int lxc_cmd_console_winch(const char *name, const char *lxcpath);
 extern int lxc_cmd_console(const char *name, int *ttynum, int *fd,
 			   const char *lxcpath);
+extern int lxc_cmd_get_pty(const char *name, int *ttynum, int *masterfd,
+			   int *slavefd, const char *lxcpath);
 /*
  * Get the 'real' cgroup path (as seen in /proc/self/cgroup) for a container
  * for a particular subsystem

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -5034,6 +5034,8 @@ int lxc_clear_simple_config_item(struct lxc_conf *c, const char *key)
 		c->monitor_unshare = 0;
 	} else if (strcmp(key, "lxc.pts") == 0) {
 		c->pts = 0;
+	} else if (strcmp(key, "lxc.pts.allocate") == 0) {
+		c->pts_allocate = 0;
 	} else {
 		return -1;
 	}

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2713,6 +2713,9 @@ struct lxc_conf *lxc_conf_init(void)
 	new->loglevel = LXC_LOG_PRIORITY_NOTSET;
 	new->personality = -1;
 	new->autodev = 1;
+	new->console.descr = NULL;
+	new->console.tios = NULL;
+	new->console.tty_state = NULL;
 	new->console.log_path = NULL;
 	new->console.log_fd = -1;
 	new->console.path = NULL;

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -974,7 +974,7 @@ static int lxc_setup_tty(struct lxc_conf *conf)
 	if (!conf->rootfs.path)
 		return 0;
 
-	for (i = 0; i < tty_info->nbtty; i++) {
+	for (i = 0; i < conf->tty; i++) {
 		struct lxc_pty_info *pty_info = &tty_info->pty_info[i];
 
 		ret = snprintf(path, sizeof(path), "/dev/tty%d", i + 1);
@@ -1059,7 +1059,7 @@ static int lxc_setup_tty(struct lxc_conf *conf)
 		}
 	}
 
-	INFO("finished setting up %d /dev/tty<N> device(s)", tty_info->nbtty);
+	INFO("finished setting up %d /dev/tty<N> device(s)", conf->tty);
 	return 0;
 }
 
@@ -3660,22 +3660,28 @@ int lxc_find_gateway_addresses(struct lxc_handler *handler)
 	return 0;
 }
 
-int lxc_create_tty(const char *name, struct lxc_conf *conf)
+/*
+ * lxc_allocate_pty_devices() allocates the requested number of pty master and
+ * slave file descriptors in the containers mount namespace. This presupposes
+ * that a fresh devpts instance has been mounted!
+ */
+int lxc_allocate_pty_devices(const char *name, struct lxc_conf *conf)
 {
 	struct lxc_tty_info *tty_info = &conf->tty_info;
 	int i, ret;
+	int npty = conf->tty + conf->pts_allocate;
 
 	/* no tty in the configuration */
-	if (!conf->tty)
+	if (!npty)
 		return 0;
 
-	tty_info->pty_info = malloc(sizeof(*tty_info->pty_info) * conf->tty);
+	tty_info->pty_info = malloc(sizeof(*tty_info->pty_info) * npty);
 	if (!tty_info->pty_info) {
 		SYSERROR("failed to allocate struct *pty_info");
 		return -ENOMEM;
 	}
 
-	for (i = 0; i < conf->tty; i++) {
+	for (i = 0; i < npty; i++) {
 		struct lxc_pty_info *pty_info = &tty_info->pty_info[i];
 
 		process_lock();
@@ -3708,9 +3714,8 @@ int lxc_create_tty(const char *name, struct lxc_conf *conf)
 		pty_info->busy = 0;
 	}
 
-	tty_info->nbtty = conf->tty;
-
-	INFO("finished allocating %d pts devices", conf->tty);
+	tty_info->nbtty = npty;
+	INFO("finished allocating %d pts devices", npty);
 	return 0;
 }
 
@@ -3721,13 +3726,18 @@ void lxc_delete_tty(struct lxc_tty_info *tty_info)
 	for (i = 0; i < tty_info->nbtty; i++) {
 		struct lxc_pty_info *pty_info = &tty_info->pty_info[i];
 
-		close(pty_info->master);
-		close(pty_info->slave);
+		if (pty_info->master >= 0)
+			close(pty_info->master);
+
+		if (pty_info->slave >= 0)
+			close(pty_info->slave);
 	}
 
-	free(tty_info->pty_info);
-	tty_info->pty_info = NULL;
-	tty_info->nbtty = 0;
+	if (tty_info->pty_info) {
+		free(tty_info->pty_info);
+		tty_info->pty_info = NULL;
+		tty_info->nbtty = 0;
+	}
 }
 
 /*
@@ -4206,7 +4216,7 @@ int lxc_setup(struct lxc_handler *handler)
 		return -1;
 	}
 
-	if (lxc_create_tty(name, lxc_conf)) {
+	if (lxc_allocate_pty_devices(name, lxc_conf)) {
 		ERROR("failed to create the ttys");
 		return -1;
 	}

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -408,6 +408,10 @@ struct lxc_conf {
 
 	/* RLIMIT_* limits */
 	struct lxc_list limits;
+
+	/* Number of pts devices to allocate before the container's init starts.
+	 */
+	unsigned int pts_allocate;
 };
 
 #ifdef HAVE_TLS

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -124,10 +124,11 @@ static int config_init_gid(const char *, const char *, struct lxc_conf *);
 static int config_ephemeral(const char *, const char *, struct lxc_conf *);
 static int config_no_new_privs(const char *, const char *, struct lxc_conf *);
 static int config_limit(const char *, const char *, struct lxc_conf *);
+static int config_pts_allocate(const char *, const char *, struct lxc_conf *);
 
 static struct lxc_config_t config[] = {
-
 	{ "lxc.arch",                 config_personality          },
+	{ "lxc.pts.allocate",	      config_pts_allocate	  },
 	{ "lxc.pts",                  config_pts                  },
 	{ "lxc.tty",                  config_tty                  },
 	{ "lxc.devttydir",            config_ttydir               },
@@ -2839,6 +2840,8 @@ int lxc_get_config_item(struct lxc_conf *c, const char *key, char *retv,
 		return lxc_get_limit_entry(c, retv, inlen, "all");
 	else if (strncmp(key, "lxc.limit.", 10) == 0) // specific limit
 		return lxc_get_limit_entry(c, retv, inlen, key + 10);
+	else if (strcmp(key, "lxc.pts.allocate") == 0)
+		return lxc_get_conf_int(c, retv, inlen, c->pts_allocate);
 	else return -1;
 
 	if (!v)
@@ -3259,6 +3262,15 @@ static int config_no_new_privs(const char *key, const char *value,
 	}
 
 	lxc_conf->no_new_privs = v ? true : false;
+
+	return 0;
+}
+
+static int config_pts_allocate(const char *key, const char *value,
+			       struct lxc_conf *lxc_conf)
+{
+	if (lxc_safe_uint(value, &lxc_conf->pts_allocate) < 0)
+		return -1;
 
 	return 0;
 }

--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -378,7 +378,7 @@ int lxc_console_allocate(struct lxc_conf *conf, int sockfd, int *ttyreq)
 	}
 
 	if (*ttyreq > 0) {
-		if (*ttyreq > tty_info->nbtty)
+		if (*ttyreq > conf->tty)
 			goto out;
 
 		if (tty_info->pty_info[*ttyreq - 1].busy)
@@ -390,11 +390,12 @@ int lxc_console_allocate(struct lxc_conf *conf, int sockfd, int *ttyreq)
 	}
 
 	/* search for next available tty, fixup index tty1 => [0] */
-	for (ttynum = 1; ttynum <= tty_info->nbtty && tty_info->pty_info[ttynum - 1].busy; ttynum++)
-		;
+	ttynum = 1;
+	while (ttynum <= conf->tty && tty_info->pty_info[ttynum - 1].busy)
+		ttynum++;
 
 	/* we didn't find any available slot for tty */
-	if (ttynum > tty_info->nbtty)
+	if (ttynum > conf->tty)
 		goto out;
 
 	*ttyreq = ttynum;

--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -593,7 +593,7 @@ int lxc_console_set_stdfds(int fd)
 }
 
 int lxc_console_cb_tty_stdin(int fd, uint32_t events, void *cbdata,
-		struct lxc_epoll_descr *descr)
+			     struct lxc_epoll_descr *descr)
 {
 	struct lxc_tty_state *ts = cbdata;
 	char c;
@@ -624,11 +624,11 @@ int lxc_console_cb_tty_stdin(int fd, uint32_t events, void *cbdata,
 }
 
 int lxc_console_cb_tty_master(int fd, uint32_t events, void *cbdata,
-		struct lxc_epoll_descr *descr)
+			      struct lxc_epoll_descr *descr)
 {
 	struct lxc_tty_state *ts = cbdata;
 	char buf[1024];
-	int r, w;
+	ssize_t r, w;
 
 	if (fd != ts->masterfd)
 		return 1;
@@ -752,4 +752,3 @@ err1:
 
 	return ret;
 }
-

--- a/src/lxc/console.h
+++ b/src/lxc/console.h
@@ -27,6 +27,9 @@
 #include "conf.h"
 #include "list.h"
 
+#define LXC_GET_TTY_FD -1
+#define LXC_GET_PTY_FDS -2
+
 struct lxc_epoll_descr; /* defined in mainloop.h */
 struct lxc_container; /* defined in lxccontainer.h */
 struct lxc_tty_state
@@ -214,5 +217,13 @@ extern int lxc_console_cb_sigwinch_fd(int fd, uint32_t events, void *cbdata,
  * from a non-threaded context.
  */
 extern void lxc_console_sigwinch_fini(struct lxc_tty_state *ts);
+
+/*
+ * lxc_pty_allocate: allocate pty master slave file descriptor pair
+ * @data : can be used to extend the function to send additional data about the
+ *	   pty device, e.g. it's /dev/pts/<n> name.
+ */
+extern int lxc_pty_allocate(struct lxc_conf *conf, int sockfd, int *ttyreq,
+			    int *masterfd, int *slavefd, void *data);
 
 #endif

--- a/src/lxc/console.h
+++ b/src/lxc/console.h
@@ -62,7 +62,7 @@ struct lxc_tty_state
  *            indication that the console or tty is no longer in use
  * @ttyreq  : the tty requested to be opened, -1 for any, 0 for the console
  */
-extern int  lxc_console_allocate(struct lxc_conf *conf, int sockfd, int *ttynum);
+extern int lxc_console_allocate(struct lxc_conf *conf, int sockfd, int *ttynum);
 
 /*
  * Create a new pty:
@@ -76,7 +76,7 @@ extern int  lxc_console_allocate(struct lxc_conf *conf, int sockfd, int *ttynum)
  * automatically chowned to the uid/gid of the unprivileged user. For this
  * ttys_shift_ids() can be called.)
  */
-extern int  lxc_console_create(struct lxc_conf *);
+extern int lxc_console_create(struct lxc_conf *);
 
 /*
  * Delete a pty created via lxc_console_create():
@@ -102,7 +102,8 @@ extern void lxc_console_free(struct lxc_conf *conf, int fd);
 /*
  * Register pty event handlers in an open mainloop
  */
-extern int  lxc_console_mainloop_add(struct lxc_epoll_descr *, struct lxc_conf *);
+extern int lxc_console_mainloop_add(struct lxc_epoll_descr *,
+				    struct lxc_conf *);
 
 /*
  * Handle SIGWINCH events on the allocated ptys.
@@ -118,9 +119,8 @@ extern void lxc_console_sigwinch(int sig);
  * - registers SIGWINCH, I/O handlers in the mainloop
  * - performs all necessary cleanup operations
  */
-extern int  lxc_console(struct lxc_container *c, int ttynum,
-		        int stdinfd, int stdoutfd, int stderrfd,
-		        int escape);
+extern int lxc_console(struct lxc_container *c, int ttynum, int stdinfd,
+		       int stdoutfd, int stderrfd, int escape);
 
 /*
  * Allocate one of the ptys given to the container via lxc.tty. Returns an open
@@ -128,8 +128,8 @@ extern int  lxc_console(struct lxc_container *c, int ttynum,
  * Set ttynum to -1 to allocate the first available pty, or to a value within
  * the range specified by lxc.tty to allocate a specific pty.
  */
-extern int  lxc_console_getfd(struct lxc_container *c, int *ttynum,
-			      int *masterfd);
+extern int lxc_console_getfd(struct lxc_container *c, int *ttynum,
+			     int *masterfd);
 
 /*
  * Make fd a duplicate of the standard file descriptors:
@@ -145,7 +145,8 @@ extern int lxc_console_set_stdfds(int fd);
  * This function exits the loop cleanly when an EPOLLHUP event is received.
  */
 extern int lxc_console_cb_tty_stdin(int fd, uint32_t events, void *cbdata,
-		struct lxc_epoll_descr *descr);
+				    struct lxc_epoll_descr *descr);
+
 
 /*
  * Handler for events on the master fd of the pty. To be registered via the
@@ -154,14 +155,13 @@ extern int lxc_console_cb_tty_stdin(int fd, uint32_t events, void *cbdata,
  * This function exits the loop cleanly when an EPOLLHUP event is received.
  */
 extern int lxc_console_cb_tty_master(int fd, uint32_t events, void *cbdata,
-		struct lxc_epoll_descr *descr);
+				     struct lxc_epoll_descr *descr);
 
 /*
  * Setup new terminal properties. The old terminal settings are stored in
  * oldtios.
  */
 extern int lxc_setup_tios(int fd, struct termios *oldtios);
-
 
 /*
  * lxc_console_winsz: propagte winsz from one terminal to another
@@ -200,7 +200,7 @@ extern struct lxc_tty_state *lxc_console_sigwinch_init(int srcfd, int dstfd);
  * declared and defined in mainloop.{c,h} or lxc_console_mainloop_add().
  */
 extern int lxc_console_cb_sigwinch_fd(int fd, uint32_t events, void *cbdata,
-		struct lxc_epoll_descr *descr);
+				      struct lxc_epoll_descr *descr);
 
 /*
  * lxc_console_sigwinch_fini: uninstall SIGWINCH handler

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1024,15 +1024,16 @@ static int recv_ttys_from_child(struct lxc_handler *handler)
 	struct lxc_conf *conf = handler->conf;
 	int i, sock = handler->ttysock[1];
 	struct lxc_tty_info *tty_info = &conf->tty_info;
+	int npty = conf->tty + conf->pts_allocate;
 
-	if (!conf->tty)
+	if (!npty)
 		return 0;
 
-	tty_info->pty_info = malloc(sizeof(*tty_info->pty_info) * conf->tty);
+	tty_info->pty_info = malloc(sizeof(*tty_info->pty_info) * npty);
 	if (!tty_info->pty_info)
 		return -1;
 
-	for (i = 0; i < conf->tty; i++) {
+	for (i = 0; i < npty; i++) {
 		struct lxc_pty_info *pty_info = &tty_info->pty_info[i];
 		pty_info->busy = 0;
 		if (recv_fd(sock, &pty_info->slave) < 0 ||
@@ -1041,7 +1042,7 @@ static int recv_ttys_from_child(struct lxc_handler *handler)
 			return -1;
 		}
 	}
-	tty_info->nbtty = conf->tty;
+	tty_info->nbtty = npty;
 
 	return 0;
 }


### PR DESCRIPTION
This implements `lxc.pts.allocate` which when set to a non-zero value will pre-allocate a number of pty devices from the container's private devpts mount inside of the container's namespaces **before** the init binary is spawned. `LXC` caches the master and slave side file descriptors for later retrieval. This guarantees that the `fd`s have not been tampered with by the program running inside of the container.

In order to retrieve a set of cached pty {master,slave} fd pair from the container this PR adds

    int lxc_cmd_get_pty(const char *name, int *ttynum, int *masterfd, int *slavefd, const char *lxcpath);

a to the lxc commands api. The function will retrieve a pty {master,slave} pair and hand it back to the caller. The fds can then be used to e.g. run an interactive command on a pts device that actually exists inside the container's namespaces at `/dev/pts/<n>`. This is different from the current `lxc.tty` fds which refer to prepared `/dev/tty<n>` devices which likely are running a login session from the init binary.