### PR TITLE
lxc-ls: return all containers by default, new filter - list only defi…

### DIFF
--- a/doc/lxc-ls.sgml.in
+++ b/doc/lxc-ls.sgml.in
@@ -55,6 +55,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <arg choice="opt">--frozen</arg>
       <arg choice="opt">--running</arg>
       <arg choice="opt">--stopped</arg>
+      <arg choice="opt">--defined</arg>
       <arg choice="opt">-f</arg>
       <arg choice="opt">-F <replaceable>format</replaceable></arg>
       <arg choice="opt">-g <replaceable>groups</replaceable></arg>
@@ -125,6 +126,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         <listitem>
           <para>
             List only stopped containers.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
+          <option>--defined</option>
+        </term>
+        <listitem>
+          <para>
+            List only defined containers.
           </para>
         </listitem>
       </varlistentry>

--- a/src/lxc/arguments.h
+++ b/src/lxc/arguments.h
@@ -130,6 +130,7 @@ struct lxc_arguments {
 	bool ls_line;
 	bool ls_running;
 	bool ls_stopped;
+	bool ls_defined;
 
 	/* lxc-copy */
 	bool tmpfs;

--- a/src/lxc/tools/lxc_ls.c
+++ b/src/lxc/tools/lxc_ls.c
@@ -53,6 +53,7 @@ lxc_log_define(lxc_ls, lxc);
 #define LS_RUNNING 4
 #define LS_NESTING 5
 #define LS_FILTER 6
+#define LS_DEFINED 7
 
 #ifndef SOCK_CLOEXEC
 #  define SOCK_CLOEXEC                02000000
@@ -167,6 +168,7 @@ static const struct option my_longopts[] = {
 	{"running", no_argument, 0, LS_RUNNING},
 	{"frozen", no_argument, 0, LS_FROZEN},
 	{"stopped", no_argument, 0, LS_STOPPED},
+	{"defined", no_argument, 0, LS_DEFINED},
 	{"nesting", optional_argument, 0, LS_NESTING},
 	{"groups", required_argument, 0, 'g'},
 	{"filter", required_argument, 0, LS_FILTER},
@@ -192,6 +194,7 @@ Options :\n\
   --running          list only running containers\n\
   --frozen           list only frozen containers\n\
   --stopped          list only stopped containers\n\
+  --defined          list only defined containers\n\
   --nesting=NUM      list nested containers up to NUM (default is 5) levels of nesting\n\
   --filter=REGEX     filter container names by regular expression\n\
   -g --groups        comma separated list of groups a container must have to be displayed\n",
@@ -395,8 +398,9 @@ static int ls_get(struct ls **m, size_t *size, const struct lxc_arguments *args,
  		else if (!c)
  			continue;
 
-		if (!c->is_defined(c))
+		if (args->ls_defined && !c->is_defined(c)){
 			goto put_and_next;
+		}
 
 		/* This does not allocate memory so no worries about freeing it
 		 * when we goto next or out. */
@@ -927,6 +931,9 @@ static int my_parser(struct lxc_arguments *args, int c, char *arg)
 		break;
 	case LS_STOPPED:
 		args->ls_stopped = true;
+		break;
+	case LS_DEFINED:
+		args->ls_defined = true;
 		break;
 	case LS_NESTING:
 		/* In case strtoul() receives a string that represents a


### PR DESCRIPTION
…ned containers.

1.x.x lxc-ls list all containers, new lxc-ls (2.x.x) implementation is
ignoring not defined containers.

related with issue: #984

Signed-off-by: Grzegorz Grzywacz <grzgrzgrz3@gmail.com>