### PR TITLE
Split lxc_setup to unshare cgroup before capabilities drop

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4092,6 +4092,24 @@ bad:
 	return -1;
 }
 
+int lxc_early_setup(struct lxc_handler *handler)
+{
+	const char *name = handler->name;
+	struct lxc_conf *lxc_conf = handler->conf;
+
+	if (lxc_create_tty(name, lxc_conf)) {
+		ERROR("failed to create the ttys");
+		return -1;
+	}
+
+	if (send_ttys_to_parent(handler) < 0) {
+		ERROR("failure sending console info to parent");
+		return -1;
+	}
+
+	return 0;
+}
+
 int lxc_setup(struct lxc_handler *handler)
 {
 	const char *name = handler->name;
@@ -4200,16 +4218,6 @@ int lxc_setup(struct lxc_handler *handler)
 
 	if (lxc_setup_devpts(lxc_conf->pts)) {
 		ERROR("failed to setup the new pts instance");
-		return -1;
-	}
-
-	if (lxc_create_tty(name, lxc_conf)) {
-		ERROR("failed to create the ttys");
-		return -1;
-	}
-
-	if (send_ttys_to_parent(handler) < 0) {
-		ERROR("failure sending console info to parent");
 		return -1;
 	}
 

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -463,6 +463,7 @@ extern int do_rootfs_setup(struct lxc_conf *conf, const char *name,
  */
 
 struct cgroup_process_info;
+extern int lxc_early_setup(struct lxc_handler *handler);
 extern int lxc_setup(struct lxc_handler *handler);
 
 extern int setup_resource_limits(struct lxc_list *limits, pid_t pid);

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -820,9 +820,8 @@ static int do_start(void *data)
 		     "standard file descriptors. Migration will not work.");
 	}
 
-	/* Setup the container, ip, names, utsname, ... */
-	if (lxc_setup(handler)) {
-		ERROR("Failed to setup container \"%s\".", handler->name);
+	if (lxc_early_setup(handler)) {
+		ERROR("Failed to execute early setup for container \"%s\".", handler->name);
 		goto out_warn_father;
 	}
 
@@ -848,6 +847,12 @@ static int do_start(void *data)
 			goto out_warn_father;
 		}
 		INFO("Unshared CLONE_NEWCGROUP.");
+	}
+
+	/* Setup the container, ip, names, utsname, ... */
+	if (lxc_setup(handler)) {
+		ERROR("Failed to setup container \"%s\".", handler->name);
+		goto out_warn_father;
 	}
 
 	/* Set the label to change to when we exec(2) the container's init. */


### PR DESCRIPTION
Hi everyone,

### Abstract

I'm proposing to move the capabilities drop part of `lxc_setup` in a new function named `lxc_late_setup` which is run after the cgroup unshare. I've also added a hook named `privileged-start` in `lxc_late_setup` which is run with all the capabilities and in all the namespaces (including the cgroup one). It allows me to start a systemd container without `CAP_SYS_ADMIN` on a kernel supporting the cgroup namespaces.

### systemd without `CAP_SYS_ADMIN`

If you want to run systemd without `CAP_SYS_ADMIN`, you have to mount everything "by hand" before its start. It works for most of the filesystems but cause problems with the cgroup mount. 

If your kernel supports the cgroup namespace, you can't use:

  * `lxc.mount.auto = cgroup` as the function in the lxc code directly returns without doing anything.
  * `lxc.mount.entry` or `lxc.hook.mount` because both commands are not executed in the cgroup namespace (due to reasons you can find in the LXC code) - so you'll mount your host hierarchy. 
  * `lxc.hook.start` as it is executed after the capabilities drop - so you'll have a Permission Error if you try to mount your cgroup hierarchy.

### How to use it

Add something like this in your container's configuration: 

```ini
# path of the file on the host: /var/lib/lxc/test/config
# ... (the default configuration)
lxc.mount.auto = proc:rw sys:rw
lxc.mount.entry = tmpfs dev/shm tmpfs rw,nosuid,nodev,create=dir 0 0
lxc.mount.entry = tmpfs run tmpfs rw,nosuid,nodev,mode=755,create=dir 0 0
lxc.mount.entry = tmpfs run/lock tmpfs rw,nosuid,nodev,noexec,relatime,size=5120k,create=dir 0 0
lxc.mount.entry = tmpfs run/user tmpfs rw,nosuid,nodev,mode=755,size=50m,create=dir 0 0
lxc.hook.priv-start = /bin/mount-systemd-cgroups
lxc.cap.drop = sys_admin
```

And create this script:

```bash
#!/bin/bash
# path of the file on the host: /var/lib/lxc/test/rootfs/bin/mount-systemd-cgroups
mount -t tmpfs tmpfs /sys/fs/cgroup
mkdir -p /sys/fs/cgroup/systemd
mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,xattr,name=systemd cgroup /sys/fs/cgroup/systemd
```

I'm staying open to suggestions, my first goal is to start systemd without `CAP_SYS_ADMIN` 😄 

*Notes: This pull request is a rework of GH-1593.*