### PR TITLE
Use lxc-stop to stop systemd service

### DIFF
--- a/config/init/systemd/lxc@.service.in
+++ b/config/init/systemd/lxc@.service.in
@@ -8,9 +8,9 @@ Documentation=man:lxc-start man:lxc
 [Service]
 Type=simple
 KillMode=mixed
-KillSignal=SIGPWR
 TimeoutStopSec=120s
 ExecStart=@BINDIR@/lxc-start -F -n %i
+ExecStop=@BINDIR@/lxc-stop -n %i
 # Environment=BOOTUP=serial
 # Environment=CONSOLETYPE=serial
 Delegate=yes


### PR DESCRIPTION
Ever since 8eb62c2, systemd has not been able to cleanly stop lxc
containers (via lxc@) because it's still using SIGPWR for systemd-based
containers.

We should now use the nice logic in 330ae3d to stop the containers
instead.