### PR TITLE
adding warning for mtu ignoring

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3351,6 +3351,8 @@ int lxc_assign_network(const char *lxcpath, char *lxcname,
 		netdev = iterator->elem;
 
 		if (netdev->type == LXC_NET_VETH && !am_root) {
+			if (netdev->mtu)
+				INFO("mtu ignored due to insufficient privilege");
 			if (unpriv_assign_nic(lxcpath, lxcname, netdev, pid))
 				return -1;
 			// lxc-user-nic has moved the nic to the new ns.


### PR DESCRIPTION
Because of unprivileged container cannot set MTU by configuration,
Adding a warning can be better.
Closing https://github.com/lxc/lxc/issues/1602
Signed-off-by: Shane Chen <ss1ha3tw@gmail.com>