### PR TITLE
tests: enforce all methods for config items being implemented

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -195,6 +195,7 @@ static int get_config_seccomp(const char *, char *, int, struct lxc_conf *);
 static int clr_config_seccomp(const char *, struct lxc_conf *);
 
 static int set_config_includefiles(const char *, const char *, struct lxc_conf *);
+static int get_config_includefiles(const char *, char *, int, struct lxc_conf *);
 static int clr_config_includefiles(const char *, struct lxc_conf *);
 
 static int set_config_autodev(const char *, const char *, struct lxc_conf *);
@@ -311,7 +312,7 @@ static struct lxc_config_t config[] = {
 	{ "lxc.console.logfile",      set_config_console_logfile,      get_config_console_logfile,   clr_config_console_logfile,   },
 	{ "lxc.console",              set_config_console,              get_config_console,           clr_config_console,           },
 	{ "lxc.seccomp",              set_config_seccomp,              get_config_seccomp,           clr_config_seccomp,           },
-	{ "lxc.include",              set_config_includefiles,         NULL,                         clr_config_includefiles,       },
+	{ "lxc.include",              set_config_includefiles,         get_config_includefiles,      clr_config_includefiles,      },
 	{ "lxc.autodev",              set_config_autodev,              get_config_autodev,           clr_config_autodev,           },
 	{ "lxc.haltsignal",           set_config_haltsignal,           get_config_haltsignal,        clr_config_haltsignal,        },
 	{ "lxc.rebootsignal",         set_config_rebootsignal,         get_config_rebootsignal,      clr_config_rebootsignal,      },
@@ -4245,4 +4246,10 @@ static inline int clr_config_includefiles(const char *key, struct lxc_conf *c)
 {
 	lxc_clear_includes(c);
 	return 0;
+}
+
+static int get_config_includefiles(const char *key, char *retv, int inlen,
+				   struct lxc_conf *c)
+{
+	return -ENOSYS;
 }

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -25,6 +25,7 @@ lxc_test_device_add_remove_SOURCES = device_add_remove.c
 lxc_test_apparmor_SOURCES = aa.c
 lxc_test_utils_SOURCES = lxc-test-utils.c lxctest.h
 lxc_test_parse_config_file_SOURCES = parse_config_file.c lxctest.h
+lxc_test_config_jump_table_SOURCES = config_jump_table.c lxctest.h
 
 AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	-DLXCPATH=\"$(LXCPATH)\" \
@@ -52,7 +53,8 @@ bin_PROGRAMS = lxc-test-containertests lxc-test-locktests lxc-test-startone \
 	lxc-test-cgpath lxc-test-clonetest lxc-test-console \
 	lxc-test-snapshot lxc-test-concurrent lxc-test-may-control \
 	lxc-test-reboot lxc-test-list lxc-test-attach lxc-test-device-add-remove \
-	lxc-test-apparmor lxc-test-utils lxc-test-parse-config-file
+	lxc-test-apparmor lxc-test-utils lxc-test-parse-config-file \
+	lxc-test-config-jump-table
 
 bin_SCRIPTS = lxc-test-automount \
 	      lxc-test-autostart \
@@ -78,6 +80,7 @@ EXTRA_DIST = \
 	cgpath.c \
 	clonetest.c \
 	concurrent.c \
+	config_jump_table.c \
 	console.c \
 	containertests.c \
 	createtest.c \

--- a/src/tests/config_jump_table.c
+++ b/src/tests/config_jump_table.c
@@ -1,0 +1,94 @@
+/* liblxcapi
+ *
+ * Copyright © 2017 Christian Brauner <christian.brauner@ubuntu.com>.
+ * Copyright © 2017 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include <lxc/lxccontainer.h>
+
+#include <unistd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+
+#include "confile.h"
+#include "lxc/state.h"
+#include "lxctest.h"
+
+int main(int argc, char *argv[])
+{
+	int fulllen = 0, inlen = 0, ret = EXIT_FAILURE;
+	char *key, *keys, *saveptr = NULL;
+
+	fulllen = lxc_listconfigs(NULL, inlen);
+
+	keys = malloc(sizeof(char) * fulllen + 1);
+	if (!keys) {
+		lxc_error("%s\n", "failed to allocate memory");
+		exit(ret);
+	}
+
+	if (lxc_listconfigs(keys, fulllen) != fulllen) {
+		lxc_error("%s\n", "failed to retrieve configuration keys");
+		goto on_error;
+	}
+
+	for (key = strtok_r(keys, "\n", &saveptr); key != NULL;
+	     key = strtok_r(NULL, "\n", &saveptr)) {
+		struct lxc_config_t *config;
+		config = lxc_getconfig(key);
+		if (!config) {
+			lxc_error("configuration key \"%s\" not implemented in "
+				  "jump table",
+				  key);
+			goto on_error;
+		}
+
+		if (!config->set) {
+			lxc_error("configuration key \"%s\" has no set method "
+				  "in jump table",
+				  key);
+			goto on_error;
+		}
+
+		if (!config->get) {
+			lxc_error("configuration key \"%s\" has no get method "
+				  "in jump table",
+				  key);
+			goto on_error;
+		}
+
+		if (!config->clr) {
+			lxc_error("configuration key \"%s\" has no clr (clear) "
+				  "method in jump table",
+				  key);
+			goto on_error;
+		}
+	}
+
+	ret = EXIT_SUCCESS;
+
+on_error:
+	free(keys);
+
+	exit(ret);
+
+}


### PR DESCRIPTION
This adds a test that checks LXC's configuration jump table whether all methods
for a given configuration item are implemented. If it is not, we'll error out.
This should provide additional safety since a) the API can now be sure that
dereferencing the pointer for a given method in the config struct is safe and
b) when users implement new configuration keys and forget to implement a
required method we'll see it right away.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>