### PR TITLE
abstract lxc_abstract_unix_{send,recv}_fd, bugfixes, and improvements

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -49,43 +49,71 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
     <title>Description</title>
 
     <para>
-      The linux containers (<command>lxc</command>) are always created
-      before being used. This creation defines a set of system
-      resources to be virtualized / isolated when a process is using
-      the container. By default, the pids, sysv ipc and mount points
-      are virtualized and isolated. The other system resources are
-      shared across containers, until they are explicitly defined in
-      the configuration file. For example, if there is no network
-      configuration, the network will be shared between the creator of
-      the container and the container itself, but if the network is
-      specified, a new network stack is created for the container and
-      the container can no longer use the network of its ancestor.
+      LXC is the well-known and heavily tested low-level Linux container
+      runtime. It is in active development since 2008 and has proven itself in
+      critical production environments world-wide. Some of its core contributors
+      are the same people that helped to implement various well-known
+      containerization features inside the Linux kernel.
     </para>
 
     <para>
-      The configuration file defines the different system resources to
-      be assigned for the container. At present, the utsname, the
-      network, the mount points, the root file system, the user namespace,
-      and the control groups are supported.
+      LXC's main focus is system containers. That is, containers which offer an
+      environment as close as possible as the one you'd get from a VM but
+      without the overhead that comes with running a separate kernel and
+      simulating all the hardware.
     </para>
 
     <para>
-      Each option in the configuration file has the form <command>key
-      = value</command> fitting in one line. The '#' character means
-      the line is a comment. List options, like capabilities and cgroups
-      options, can be used with no value to clear any previously
-      defined values of that option.
+      This is achieved through a combination of kernel security features such as
+      namespaces, mandatory access control and control groups.
+    </para>
+
+    <para>
+      LXC has supports unprivileged containers.  Unprivileged containers are
+      containers that are run without any privilege.  This requires support for
+      user namespaces in the kernel that the container is run on.  LXC was the
+      first runtime to support unprivileged containers after user namespaces
+      were merged into the mainline kernel.
+    </para>
+
+    <para>
+      In essence, user namespaces isolate given sets of UIDs and GIDs. This is
+      achieved by establishing a mapping between a range of UIDs and GIDs on the
+      host to a different (unprivileged) range of UIDs and GIDs in the
+      container. The kernel will translate this mapping in such a way that
+      inside the container all UIDs and GIDs appear as you would expect from the
+      host whereas on the host these UIDs and GIDs are in fact unprivileged. For
+      example, a process running as UID and GID 0 inside the container might
+      appear as UID and GID 100000 on the host.  The implementation and working
+      details can be gathered from the corresponding user namespace man page.
+      UID and GID mappings can be defined with the <option>lxc.id_map</option>
+      key.
+    </para>
+
+    <para>
+      Linux containers are defined with a simple configuration file.  Each
+      option in the configuration file has the form <command>key =
+      value</command> fitting in one line. The "#" character means the line is a
+      comment. List options, like capabilities and cgroups options, can be used
+      with no value to clear any previously defined values of that option.
+      </para>
+
+    <para>
+      LXC namespaces configuration keys by using single dots. This means complex
+      configuration keys such as <option>lxc.network</option> expose various
+      subkeys such as <option>lxc.network.type</option>,
+      <option>lxc.network.link</option>, <option>lxc.network.ipv6</option>, and
+      others for even more fine-grained configuration.
     </para>
 
     <refsect2>
       <title>Configuration</title>
       <para>
-        In order to ease administration of multiple related containers, it
-        is possible to have a container configuration file cause another
-        file to be loaded.  For instance, network configuration
-        can be defined in one common file which is included by multiple
-        containers.  Then, if the containers are moved to another host,
-        only one file may need to be updated.
+        In order to ease administration of multiple related containers, it is
+        possible to have a container configuration file cause another file to be
+        loaded. For instance, network configuration can be defined in one common
+        file which is included by multiple containers. Then, if the containers
+        are moved to another host, only one file may need to be updated.
       </para>
 
       <variablelist>
@@ -106,11 +134,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
     <refsect2>
       <title>Architecture</title>
       <para>
-        Allows one to set the architecture for the container. For example,
-        set a 32bits architecture for a container running 32bits
-        binaries on a 64bits host. This fixes the container scripts
-        which rely on the architecture to do some work like
-        downloading the packages.
+        Allows one to set the architecture for the container. For example, set a
+        32bits architecture for a container running 32bits binaries on a 64bits
+        host. This fixes the container scripts which rely on the architecture to
+        do some work like downloading the packages.
       </para>
 
       <variablelist>
@@ -123,7 +150,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               Specify the architecture for the container.
             </para>
             <para>
-              Valid options are
+              Some valid options are
               <option>x86</option>,
               <option>i686</option>,
               <option>x86_64</option>,
@@ -138,10 +165,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
     <refsect2>
       <title>Hostname</title>
       <para>
-        The utsname section defines the hostname to be set for the
-        container. That means the container can set its own hostname
-        without changing the one from the system. That makes the
-        hostname private for the container.
+        The utsname section defines the hostname to be set for the container.
+        That means the container can set its own hostname without changing the
+        one from the system. That makes the hostname private for the container.
       </para>
       <variablelist>
         <varlistentry>
@@ -160,12 +186,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
     <refsect2>
       <title>Halt signal</title>
       <para>
-        Allows one to specify signal name or number, sent by lxc-stop to the
-        container's init process to cleanly shutdown the container. Different
-        init systems could use different signals to perform clean shutdown
-        sequence. This option allows the signal to be specified in kill(1)
-        fashion, e.g. SIGPWR, SIGRTMIN+14, SIGRTMAX-10 or plain number. The
-        default signal is SIGPWR.
+        Allows one to specify signal name or number sent to the container's
+        init process to cleanly shutdown the container. Different init systems
+        could use different signals to perform clean shutdown sequence. This
+        option allows the signal to be specified in kill(1) fashion, e.g.
+        SIGPWR, SIGRTMIN+14, SIGRTMAX-10 or plain number. The default signal is
+        SIGPWR.
       </para>
       <variablelist>
         <varlistentry>
@@ -184,10 +210,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
     <refsect2>
       <title>Reboot signal</title>
       <para>
-        Allows one to specify signal name or number, sent by lxc-stop to
-        reboot the container. This option allows signal to be specified in
-        kill(1) fashion, e.g. SIGTERM, SIGRTMIN+14, SIGRTMAX-10 or plain number.
-        The default signal is SIGINT.
+        Allows one to specify signal name or number to reboot the container.
+        This option allows signal to be specified in kill(1) fashion, e.g.
+        SIGTERM, SIGRTMIN+14, SIGRTMAX-10 or plain number. The default signal
+        is SIGINT.
           </para>
           <variablelist>
         <varlistentry>
@@ -206,10 +232,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
     <refsect2>
       <title>Stop signal</title>
       <para>
-        Allows one to specify signal name or number, sent by lxc-stop to forcibly
-        shutdown the container. This option allows signal to be specified in
-        kill(1) fashion, e.g. SIGKILL, SIGRTMIN+14, SIGRTMAX-10 or plain number.
-        The default signal is SIGKILL.
+        Allows one to specify signal name or number to forcibly shutdown the
+        container. This option allows signal to be specified in kill(1) fashion,
+        e.g. SIGKILL, SIGRTMIN+14, SIGRTMAX-10 or plain number.  The default
+        signal is SIGKILL.
           </para>
           <variablelist>
         <varlistentry>
@@ -251,9 +277,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
     <refsect2>
       <title>Init ID</title>
       <para>
-        Sets the UID/GID to use for the init system, and subsequent command, executed by lxc-execute.
-
-        These options are only used when lxc-execute is started in a private user namespace.
+        Sets the UID/GID to use for the init system, and subsequent commands.
+        Note that using a non-root uid when booting a system container will
+        likely not work due to missing privileges. Setting the UID/GID is mostly
+        useful when running application container.
 
         Defaults to: UID(0), GID(0)
       </para>
@@ -264,7 +291,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
           </term>
           <listitem>
             <para>
-              UID to use within a private user namesapce for init.
+              UID to use for init.
             </para>
           </listitem>
         </varlistentry>
@@ -274,7 +301,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
           </term>
           <listitem>
             <para>
-              GID to use within a private user namesapce for init.
+              GID to use for init.
             </para>
           </listitem>
         </varlistentry>
@@ -325,18 +352,22 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         </varlistentry>
         <varlistentry>
           <term>
-            <option>lxc.network.type</option>
+            <option>lxc.network.[i].type</option>
           </term>
           <listitem>
             <para>
               specify what kind of network virtualization to be used
-              for the container. Each time
-              a <option>lxc.network.type</option> field is found a new
-              round of network configuration begins. In this way,
-              several network virtualization types can be specified
-              for the same container, as well as assigning several
-              network interfaces for one container. The different
-              virtualization types can be:
+              for the container.
+              Multiple networks can be specified by using an additional index
+              <option>i</option>
+              after all <option>lxc.network.*</option> keys. For example,
+              <option>lxc.network.0.type = veth</option> and
+              <option>lxc.network.1.type = veth</option> specify two different
+              networks of the same type. All keys sharing the same index
+              <option>i</option> will be treated as belonging to the same
+              network. For example, <option>lxc.network.0.link = br0</option>
+              will belong to <option>lxc.network.0.type</option>.
+              Currently, the different virtualization types can be:
             </para>
 
             <para>
@@ -427,12 +458,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.flags</option>
+            <option>lxc.network.[i].flags</option>
           </term>
           <listitem>
             <para>
-              specify an action to do for the
-              network.
+              Specify an action to do for the network.
             </para>
 
             <para><option>up:</option> activates the interface.
@@ -442,83 +472,76 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.link</option>
+            <option>lxc.network.[i].link</option>
           </term>
           <listitem>
             <para>
-              specify the interface to be used for real network
-              traffic.
+              Specify the interface to be used for real network traffic.
+              </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>
+            <option>lxc.network.[i].mtu</option>
+          </term>
+          <listitem>
+            <para>
+              Specify the maximum transfer unit for this interface.
             </para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
           <term>
-            <option>lxc.network.mtu</option>
+            <option>lxc.network.[i].name</option>
           </term>
           <listitem>
             <para>
-              specify the maximum transfer unit for this interface.
+              The interface name is dynamically allocated, but if another name
+              is needed because the configuration files being used by the
+              container use a generic name, eg. eth0, this option will rename
+              the interface in the container.
             </para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
           <term>
-            <option>lxc.network.name</option>
+            <option>lxc.network.[i].hwaddr</option>
           </term>
           <listitem>
             <para>
-              the interface name is dynamically allocated, but if
-              another name is needed because the configuration files
-              being used by the container use a generic name,
-              eg. eth0, this option will rename the interface in the
-              container.
+              The interface mac address is dynamically allocated by default to
+              the virtual interface, but in some cases, this is needed to
+              resolve a mac address conflict or to always have the same
+              link-local ipv6 address.  Any "x" in address will be replaced by
+              random value, this allows setting hwaddr templates.
             </para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
           <term>
-            <option>lxc.network.hwaddr</option>
+            <option>lxc.network.[i].ipv4</option>
           </term>
           <listitem>
             <para>
-              the interface mac address is dynamically allocated by
-              default to the virtual interface, but in some cases,
-              this is needed to resolve a mac address conflict or to
-              always have the same link-local ipv6 address.
-              Any "x" in address will be replaced by random value,
-              this allows setting hwaddr templates.
+              Specify the ipv4 address to assign to the virtualized interface.
+              Several lines specify several ipv4 addresses. The address is in
+              format x.y.z.t/m, eg. 192.168.1.123/24.
             </para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
           <term>
-            <option>lxc.network.ipv4</option>
+            <option>lxc.network.[i].ipv4.gateway</option>
           </term>
           <listitem>
             <para>
-              specify the ipv4 address to assign to the virtualized
-              interface. Several lines specify several ipv4 addresses.
-              The address is in format x.y.z.t/m,
-              eg. 192.168.1.123/24. The broadcast address should be
-              specified on the same line, right after the ipv4
-              address.
-            </para>
-          </listitem>
-        </varlistentry>
-
-        <varlistentry>
-          <term>
-            <option>lxc.network.ipv4.gateway</option>
-          </term>
-          <listitem>
-            <para>
-              specify the ipv4 address to use as the gateway inside the
-              container. The address is in format x.y.z.t, eg.
-              192.168.1.123.
+              Specify the ipv4 address to use as the gateway inside the
+              container. The address is in format x.y.z.t, eg.  192.168.1.123.
 
               Can also have the special value <option>auto</option>,
               which means to take the primary address from the bridge
@@ -534,27 +557,26 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.ipv6</option>
+            <option>lxc.network.[i].ipv6</option>
           </term>
           <listitem>
             <para>
-              specify the ipv6 address to assign to the virtualized
-              interface. Several lines specify several ipv6 addresses.
-              The address is in format x::y/m,
-              eg. 2003:db8:1:0:214:1234:fe0b:3596/64
+              Specify the ipv6 address to assign to the virtualized
+              interface. Several lines specify several ipv6 addresses. The
+              address is in format x::y/m, eg.
+              2003:db8:1:0:214:1234:fe0b:3596/64
             </para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
           <term>
-            <option>lxc.network.ipv6.gateway</option>
+            <option>lxc.network.[i].ipv6.gateway</option>
           </term>
           <listitem>
             <para>
-              specify the ipv6 address to use as the gateway inside the
-              container. The address is in format x::y,
-              eg. 2003:db8:1:0::1
+              Specify the ipv6 address to use as the gateway inside the
+              container. The address is in format x::y, eg. 2003:db8:1:0::1
 
               Can also have the special value <option>auto</option>,
               which means to take the primary address from the bridge
@@ -569,11 +591,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.script.up</option>
+            <option>lxc.network.[i].script.up</option>
           </term>
           <listitem>
             <para>
-              add a configuration option to specify a script to be
+              Add a configuration option to specify a script to be
               executed after creating and configuring the network used
               from the host side. The following arguments are passed
               to the script: container name and config section name
@@ -594,11 +616,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.script.down</option>
+            <option>lxc.network.[i].script.down</option>
           </term>
           <listitem>
             <para>
-              add a configuration option to specify a script to be
+              Add a configuration option to specify a script to be
               executed before destroying the network used from the
               host side. The following arguments are passed to the
               script: container name and config section name (net)
@@ -822,9 +844,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               most cases should be a relative path, which will become
               relative to the mounted container root.  For instance,
              </para>
-<screen>
-proc proc proc nodev,noexec,nosuid 0 0
-</screen>
+             <programlisting>
+             proc proc proc nodev,noexec,nosuid 0 0
+             </programlisting>
              <para>
               Will mount a proc filesystem under the container's /proc,
               regardless of where the root filesystem comes from.  This
@@ -1329,11 +1351,13 @@ proc proc proc nodev,noexec,nosuid 0 0
        allowed except for mknod, which will simply do nothing and
        return 0 (success), looks like:
       </para>
-<screen>
-2
-blacklist
-mknod errno 0
-</screen>
+
+      <programlisting>
+      2
+      blacklist
+      mknod errno 0
+      </programlisting>
+
       <variablelist>
         <varlistentry>
           <term>
@@ -1971,26 +1995,26 @@ mknod errno 0
       mounting some locations and a changing root file system.</para>
       <programlisting>
         lxc.utsname = complex
-        lxc.network.type = veth
-        lxc.network.flags = up
-        lxc.network.link = br0
-        lxc.network.hwaddr = 4a:49:43:49:79:bf
-        lxc.network.ipv4 = 10.2.3.5/24 10.2.3.255
-        lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
-        lxc.network.ipv6 = 2003:db8:1:0:214:5432:feab:3588
-        lxc.network.type = macvlan
-        lxc.network.flags = up
-        lxc.network.link = eth0
-        lxc.network.hwaddr = 4a:49:43:49:79:bd
-        lxc.network.ipv4 = 10.2.3.4/24
-        lxc.network.ipv4 = 192.168.10.125/24
-        lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
-        lxc.network.type = phys
-        lxc.network.flags = up
-        lxc.network.link = dummy0
-        lxc.network.hwaddr = 4a:49:43:49:79:ff
-        lxc.network.ipv4 = 10.2.3.6/24
-        lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297
+        lxc.network.0.type = veth
+        lxc.network.0.flags = up
+        lxc.network.0.link = br0
+        lxc.network.0.hwaddr = 4a:49:43:49:79:bf
+        lxc.network.0.ipv4 = 10.2.3.5/24 10.2.3.255
+        lxc.network.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
+        lxc.network.0.ipv6 = 2003:db8:1:0:214:5432:feab:3588
+        lxc.network.1.type = macvlan
+        lxc.network.1.flags = up
+        lxc.network.1.link = eth0
+        lxc.network.1.hwaddr = 4a:49:43:49:79:bd
+        lxc.network.1.ipv4 = 10.2.3.4/24
+        lxc.network.1.ipv4 = 192.168.10.125/24
+        lxc.network.1.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
+        lxc.network.2.type = phys
+        lxc.network.2.flags = up
+        lxc.network.2.link = dummy0
+        lxc.network.2.hwaddr = 4a:49:43:49:79:ff
+        lxc.network.2.ipv4 = 10.2.3.6/24
+        lxc.network.2.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297
         lxc.cgroup.cpuset.cpus = 0,1
         lxc.cgroup.cpu.shares = 1234
         lxc.cgroup.devices.deny = a

--- a/src/lxc/af_unix.h
+++ b/src/lxc/af_unix.h
@@ -24,13 +24,17 @@
 #ifndef __LXC_AF_UNIX_H
 #define __LXC_AF_UNIX_H
 
+#include <stdio.h>
+
 /* does not enforce \0-termination */
 extern int lxc_abstract_unix_open(const char *path, int type, int flags);
 extern int lxc_abstract_unix_close(int fd);
 /* does not enforce \0-termination */
 extern int lxc_abstract_unix_connect(const char *path);
-extern int lxc_abstract_unix_send_fd(int fd, int sendfd, void *data, size_t size);
-extern int lxc_abstract_unix_recv_fd(int fd, int *recvfd, void *data, size_t size);
+extern int lxc_abstract_unix_send_fds(int fd, int *sendfds, int num_sendfds,
+				      void *data, size_t size);
+extern int lxc_abstract_unix_recv_fds(int fd, int *recvfds, int num_recvfds,
+				      void *data, size_t size);
 extern int lxc_abstract_unix_send_credential(int fd, void *data, size_t size);
 extern int lxc_abstract_unix_rcv_credential(int fd, void *data, size_t size);
 

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -986,7 +986,7 @@ int lxc_attach(const char* name, const char* lxcpath, lxc_attach_exec_t exec_fun
 				goto on_error;
 
 			/* Send child fd of the LSM security module to write to. */
-			ret = lxc_abstract_unix_send_fd(ipc_sockets[0], labelfd, NULL, 0);
+			ret = lxc_abstract_unix_send_fds(ipc_sockets[0], &labelfd, 1, NULL, 0);
 			saved_errno = errno;
 			close(labelfd);
 			if (ret <= 0) {
@@ -1273,7 +1273,7 @@ static int attach_child_main(void* data)
 	if ((options->namespaces & CLONE_NEWNS) && (options->attach_flags & LXC_ATTACH_LSM) && init_ctx->lsm_label) {
 		int on_exec;
 		/* Receive fd for LSM security module. */
-		ret = lxc_abstract_unix_recv_fd(ipc_socket, &lsm_labelfd, NULL, 0);
+		ret = lxc_abstract_unix_recv_fds(ipc_socket, &lsm_labelfd, 1, NULL, 0);
 		if (ret <= 0) {
 			ERROR("Expected to receive file descriptor: %s.", strerror(errno));
 			shutdown(ipc_socket, SHUT_RDWR);

--- a/src/lxc/bdev/bdev.c
+++ b/src/lxc/bdev/bdev.c
@@ -854,12 +854,16 @@ static const struct bdev_type *get_bdev_by_name(const char *name)
 	return NULL;
 }
 
-static const struct bdev_type *bdev_query(struct lxc_conf *conf, const char *src)
+static const struct bdev_type *bdev_query(struct lxc_conf *conf,
+					  const char *src)
 {
 	size_t i;
 
-	if (conf->rootfs.bdev_type)
+	if (conf->rootfs.bdev_type) {
+		DEBUG("config file specified rootfs type \"%s\"",
+		      conf->rootfs.bdev_type);
 		return get_bdev_by_name(conf->rootfs.bdev_type);
+	}
 
 	for (i = 0; i < numbdevs; i++) {
 		int r;
@@ -870,6 +874,9 @@ static const struct bdev_type *bdev_query(struct lxc_conf *conf, const char *src
 
 	if (i == numbdevs)
 		return NULL;
+
+	DEBUG("detected rootfs type \"%s\"", bdevs[i].name);
+
 	return &bdevs[i];
 }
 

--- a/src/lxc/bdev/bdev.c
+++ b/src/lxc/bdev/bdev.c
@@ -75,110 +75,110 @@ lxc_log_define(bdev, lxc);
 
 /* aufs */
 static const struct bdev_ops aufs_ops = {
-	.detect = &aufs_detect,
-	.mount = &aufs_mount,
-	.umount = &aufs_umount,
-	.clone_paths = &aufs_clonepaths,
-	.destroy = &aufs_destroy,
-	.create = &aufs_create,
-	.can_snapshot = true,
-	.can_backup = true,
+    .detect = &aufs_detect,
+    .mount = &aufs_mount,
+    .umount = &aufs_umount,
+    .clone_paths = &aufs_clonepaths,
+    .destroy = &aufs_destroy,
+    .create = &aufs_create,
+    .can_snapshot = true,
+    .can_backup = true,
 };
 
 /* btrfs */
 static const struct bdev_ops btrfs_ops = {
-	.detect = &btrfs_detect,
-	.mount = &btrfs_mount,
-	.umount = &btrfs_umount,
-	.clone_paths = &btrfs_clonepaths,
-	.destroy = &btrfs_destroy,
-	.create = &btrfs_create,
-	.can_snapshot = true,
-	.can_backup = true,
+    .detect = &btrfs_detect,
+    .mount = &btrfs_mount,
+    .umount = &btrfs_umount,
+    .clone_paths = &btrfs_clonepaths,
+    .destroy = &btrfs_destroy,
+    .create = &btrfs_create,
+    .can_snapshot = true,
+    .can_backup = true,
 };
 
 /* dir */
 static const struct bdev_ops dir_ops = {
-	.detect = &dir_detect,
-	.mount = &dir_mount,
-	.umount = &dir_umount,
-	.clone_paths = &dir_clonepaths,
-	.destroy = &dir_destroy,
-	.create = &dir_create,
-	.can_snapshot = false,
-	.can_backup = true,
+    .detect = &dir_detect,
+    .mount = &dir_mount,
+    .umount = &dir_umount,
+    .clone_paths = &dir_clonepaths,
+    .destroy = &dir_destroy,
+    .create = &dir_create,
+    .can_snapshot = false,
+    .can_backup = true,
 };
 
 /* loop */
 static const struct bdev_ops loop_ops = {
-	.detect = &loop_detect,
-	.mount = &loop_mount,
-	.umount = &loop_umount,
-	.clone_paths = &loop_clonepaths,
-	.destroy = &loop_destroy,
-	.create = &loop_create,
-	.can_snapshot = false,
-	.can_backup = true,
+    .detect = &loop_detect,
+    .mount = &loop_mount,
+    .umount = &loop_umount,
+    .clone_paths = &loop_clonepaths,
+    .destroy = &loop_destroy,
+    .create = &loop_create,
+    .can_snapshot = false,
+    .can_backup = true,
 };
 
 /* lvm */
 static const struct bdev_ops lvm_ops = {
-	.detect = &lvm_detect,
-	.mount = &lvm_mount,
-	.umount = &lvm_umount,
-	.clone_paths = &lvm_clonepaths,
-	.destroy = &lvm_destroy,
-	.create = &lvm_create,
-	.can_snapshot = true,
-	.can_backup = false,
+    .detect = &lvm_detect,
+    .mount = &lvm_mount,
+    .umount = &lvm_umount,
+    .clone_paths = &lvm_clonepaths,
+    .destroy = &lvm_destroy,
+    .create = &lvm_create,
+    .can_snapshot = true,
+    .can_backup = false,
 };
 
 /* nbd */
 const struct bdev_ops nbd_ops = {
-	.detect = &nbd_detect,
-	.mount = &nbd_mount,
-	.umount = &nbd_umount,
-	.clone_paths = &nbd_clonepaths,
-	.destroy = &nbd_destroy,
-	.create = &nbd_create,
-	.can_snapshot = true,
-	.can_backup = false,
+    .detect = &nbd_detect,
+    .mount = &nbd_mount,
+    .umount = &nbd_umount,
+    .clone_paths = &nbd_clonepaths,
+    .destroy = &nbd_destroy,
+    .create = &nbd_create,
+    .can_snapshot = true,
+    .can_backup = false,
 };
 
 /* overlay */
 static const struct bdev_ops ovl_ops = {
-	.detect = &ovl_detect,
-	.mount = &ovl_mount,
-	.umount = &ovl_umount,
-	.clone_paths = &ovl_clonepaths,
-	.destroy = &ovl_destroy,
-	.create = &ovl_create,
-	.can_snapshot = true,
-	.can_backup = true,
+    .detect = &ovl_detect,
+    .mount = &ovl_mount,
+    .umount = &ovl_umount,
+    .clone_paths = &ovl_clonepaths,
+    .destroy = &ovl_destroy,
+    .create = &ovl_create,
+    .can_snapshot = true,
+    .can_backup = true,
 };
 
 /* rbd */
 static const struct bdev_ops rbd_ops = {
-	.detect = &rbd_detect,
-	.mount = &rbd_mount,
-	.umount = &rbd_umount,
-	.clone_paths = &rbd_clonepaths,
-	.destroy = &rbd_destroy,
-	.create = &rbd_create,
-	.can_snapshot = false,
-	.can_backup = false,
+    .detect = &rbd_detect,
+    .mount = &rbd_mount,
+    .umount = &rbd_umount,
+    .clone_paths = &rbd_clonepaths,
+    .destroy = &rbd_destroy,
+    .create = &rbd_create,
+    .can_snapshot = false,
+    .can_backup = false,
 };
 
 /* zfs */
 static const struct bdev_ops zfs_ops = {
-	.detect = &zfs_detect,
-	.mount = &zfs_mount,
-	.umount = &zfs_umount,
-	.clone_paths = &zfs_clonepaths,
-	.destroy = &zfs_destroy,
-	.create = &zfs_create,
-	.can_snapshot = true,
-	.can_backup = true,
+    .detect = &zfs_detect,
+    .mount = &zfs_mount,
+    .umount = &zfs_umount,
+    .clone_paths = &zfs_clonepaths,
+    .destroy = &zfs_destroy,
+    .create = &zfs_create,
+    .can_snapshot = true,
+    .can_backup = true,
 };
 
 struct bdev_type {
@@ -187,32 +187,33 @@ struct bdev_type {
 };
 
 static const struct bdev_type bdevs[] = {
-	{.name = "zfs", .ops = &zfs_ops,},
-	{.name = "lvm", .ops = &lvm_ops,},
-	{.name = "rbd", .ops = &rbd_ops,},
-	{.name = "btrfs", .ops = &btrfs_ops,},
-	{.name = "dir", .ops = &dir_ops,},
-	{.name = "aufs", .ops = &aufs_ops,},
-	{.name = "overlayfs", .ops = &ovl_ops,},
-	{.name = "loop", .ops = &loop_ops,},
-	{.name = "nbd", .ops = &nbd_ops,},
+	{ .name = "zfs",       .ops = &zfs_ops,   },
+	{ .name = "lvm",       .ops = &lvm_ops,   },
+	{ .name = "rbd",       .ops = &rbd_ops,   },
+	{ .name = "btrfs",     .ops = &btrfs_ops, },
+	{ .name = "dir",       .ops = &dir_ops,   },
+	{ .name = "aufs",      .ops = &aufs_ops,  },
+	{ .name = "overlayfs", .ops = &ovl_ops,   },
+	{ .name = "loop",      .ops = &loop_ops,  },
+	{ .name = "nbd",       .ops = &nbd_ops,   },
 };
 
 static const size_t numbdevs = sizeof(bdevs) / sizeof(struct bdev_type);
 
 /* helpers */
-static const struct bdev_type *bdev_query(struct lxc_conf *conf, const char *src);
+static const struct bdev_type *bdev_query(struct lxc_conf *conf,
+					  const char *src);
 static struct bdev *bdev_get(const char *type);
 static struct bdev *do_bdev_create(const char *dest, const char *type,
-		const char *cname, struct bdev_specs *specs);
+				   const char *cname, struct bdev_specs *specs);
 static int find_fstype_cb(char *buffer, void *data);
 static char *linkderef(char *path, char *dest);
 static bool unpriv_snap_allowed(struct bdev *b, const char *t, bool snap,
-		bool maybesnap);
+				bool maybesnap);
 
 /* the bulk of this needs to become a common helper */
 char *dir_new_path(char *src, const char *oldname, const char *name,
-		const char *oldpath, const char *lxcpath)
+		   const char *oldpath, const char *lxcpath)
 {
 	char *ret, *p, *p2;
 	int l1, l2, nlen;
@@ -244,11 +245,12 @@ char *dir_new_path(char *src, const char *oldname, const char *name,
 
 	while ((p2 = strstr(src, oldname)) != NULL) {
 		strncpy(p, src, p2 - src); // copy text up to oldname
-		p += p2 - src; // move target pointer (p)
-		p += sprintf(p, "%s", name); // print new name in place of oldname
-		src = p2 + l2;  // move src to end of oldname
+		p += p2 - src;		   // move target pointer (p)
+		p += sprintf(p, "%s",
+			     name); // print new name in place of oldname
+		src = p2 + l2;      // move src to end of oldname
 	}
-	sprintf(p, "%s", src);  // copy the rest of src
+	sprintf(p, "%s", src); // copy the rest of src
 	return ret;
 }
 
@@ -264,15 +266,19 @@ bool attach_block_device(struct lxc_conf *conf)
 
 	if (!conf->rootfs.path)
 		return true;
+
 	path = conf->rootfs.path;
 	if (!requires_nbd(path))
 		return true;
+
 	path = strchr(path, ':');
 	if (!path)
 		return false;
+
 	path++;
 	if (!attach_nbd(path, conf))
 		return false;
+
 	return true;
 }
 
@@ -283,6 +289,7 @@ bool bdev_can_backup(struct lxc_conf *conf)
 
 	if (!bdev)
 		return false;
+
 	ret = bdev->ops->can_backup;
 	bdev_put(bdev);
 	return ret;
@@ -293,8 +300,8 @@ bool bdev_can_backup(struct lxc_conf *conf)
  * the original, mount the new, and rsync the contents.
  */
 struct bdev *bdev_copy(struct lxc_container *c0, const char *cname,
-		const char *lxcpath, const char *bdevtype, int flags,
-		const char *bdevdata, uint64_t newsize, int *needs_rdep)
+		       const char *lxcpath, const char *bdevtype, int flags,
+		       const char *bdevdata, uint64_t newsize, int *needs_rdep)
 {
 	struct bdev *orig, *new;
 	pid_t pid;
@@ -311,8 +318,9 @@ struct bdev *bdev_copy(struct lxc_container *c0, const char *cname,
 	 * we don't know how to come up with a new name
 	 */
 	if (strstr(src, oldname) == NULL) {
-		ERROR("original rootfs path %s doesn't include container name %s",
-			src, oldname);
+		ERROR(
+		    "original rootfs path %s doesn't include container name %s",
+		    src, oldname);
 		return NULL;
 	}
 
@@ -334,6 +342,7 @@ struct bdev *bdev_copy(struct lxc_container *c0, const char *cname,
 			bdev_put(orig);
 			return NULL;
 		}
+
 		ret = snprintf(orig->dest, len, "%s/%s/rootfs", oldpath, oldname);
 		if (ret < 0 || (size_t)ret >= len) {
 			ERROR("rootfs path too long");
@@ -341,9 +350,11 @@ struct bdev *bdev_copy(struct lxc_container *c0, const char *cname,
 			return NULL;
 		}
 		ret = stat(orig->dest, &sb);
+
 		if (ret < 0 && errno == ENOENT)
 			if (mkdir_p(orig->dest, 0755) < 0)
-				WARN("Error creating '%s', continuing.", orig->dest);
+				WARN("Error creating '%s', continuing.",
+				     orig->dest);
 	}
 
 	/*
@@ -357,7 +368,8 @@ struct bdev *bdev_copy(struct lxc_container *c0, const char *cname,
 	/*
 	 * If newtype is NULL and snapshot is set, then use overlayfs
 	 */
-	if (!bdevtype && !keepbdevtype && snap && strcmp(orig->type , "dir") == 0)
+	if (!bdevtype && !keepbdevtype && snap &&
+	    strcmp(orig->type, "dir") == 0)
 		bdevtype = "overlayfs";
 
 	if (am_unpriv() && !unpriv_snap_allowed(orig, bdevtype, snap, maybe_snap)) {
@@ -368,23 +380,24 @@ struct bdev *bdev_copy(struct lxc_container *c0, const char *cname,
 
 	*needs_rdep = 0;
 	if (bdevtype && strcmp(orig->type, "dir") == 0 &&
-			(strcmp(bdevtype, "aufs") == 0 ||
-			 strcmp(bdevtype, "overlayfs") == 0)) {
+	    (strcmp(bdevtype, "aufs") == 0 ||
+	     strcmp(bdevtype, "overlayfs") == 0)) {
 		*needs_rdep = 1;
 	} else if (snap && strcmp(orig->type, "lvm") == 0 &&
-			!lvm_is_thin_volume(orig->src)) {
+		   !lvm_is_thin_volume(orig->src)) {
 		*needs_rdep = 1;
 	}
 
 	new = bdev_get(bdevtype ? bdevtype : orig->type);
 	if (!new) {
-		ERROR("no such block device type: %s", bdevtype ? bdevtype : orig->type);
+		ERROR("no such block device type: %s",
+		      bdevtype ? bdevtype : orig->type);
 		bdev_put(orig);
 		return NULL;
 	}
 
 	if (new->ops->clone_paths(orig, new, oldname, cname, oldpath, lxcpath,
-				snap, newsize, c0->lxc_conf) < 0) {
+				  snap, newsize, c0->lxc_conf) < 0) {
 		ERROR("failed getting pathnames for cloned storage: %s", src);
 		goto err;
 	}
@@ -397,11 +410,12 @@ struct bdev *bdev_copy(struct lxc_container *c0, const char *cname,
 
 	/*
 	 * https://github.com/lxc/lxc/issues/131
-	 * Use btrfs snapshot feature instead of rsync to restore if both orig and new are btrfs
+	 * Use btrfs snapshot feature instead of rsync to restore if both orig
+	 * and new are btrfs
 	 */
-	if (bdevtype &&
-			strcmp(orig->type, "btrfs") == 0 && strcmp(new->type, "btrfs") == 0 &&
-			btrfs_same_fs(orig->dest, new->dest) == 0) {
+	if (bdevtype && strcmp(orig->type, "btrfs") == 0 &&
+	    strcmp(new->type, "btrfs") == 0 &&
+	    btrfs_same_fs(orig->dest, new->dest) == 0) {
 		if (btrfs_destroy(new) < 0) {
 			ERROR("Error destroying %s subvolume", new->dest);
 			goto err;
@@ -411,7 +425,8 @@ struct bdev *bdev_copy(struct lxc_container *c0, const char *cname,
 			goto err;
 		}
 		if (btrfs_snapshot(orig->dest, new->dest) < 0) {
-			ERROR("Error restoring %s to %s", orig->dest, new->dest);
+			ERROR("Error restoring %s to %s", orig->dest,
+			      new->dest);
 			goto err;
 		}
 		bdev_put(orig);
@@ -437,7 +452,8 @@ struct bdev *bdev_copy(struct lxc_container *c0, const char *cname,
 	data.orig = orig;
 	data.new = new;
 	if (am_unpriv())
-		ret = userns_exec_1(c0->lxc_conf, rsync_rootfs_wrapper, &data, "rsync_rootfs_wrapper");
+		ret = userns_exec_1(c0->lxc_conf, rsync_rootfs_wrapper, &data,
+				    "rsync_rootfs_wrapper");
 	else
 		ret = rsync_rootfs(&data);
 
@@ -461,7 +477,7 @@ err:
  * @specs: details about the backing store to create, like fstype
  */
 struct bdev *bdev_create(const char *dest, const char *type, const char *cname,
-		struct bdev_specs *specs)
+			 struct bdev_specs *specs)
 {
 	struct bdev *bdev;
 	char *best_options[] = {"btrfs", "zfs", "lvm", "dir", "rbd", NULL};
@@ -474,10 +490,13 @@ struct bdev *bdev_create(const char *dest, const char *type, const char *cname,
 		// try for the best backing store type, according to our
 		// opinionated preferences
 		for (i = 0; best_options[i]; i++) {
-			if ((bdev = do_bdev_create(dest, best_options[i], cname, specs)))
+			if ((bdev = do_bdev_create(dest, best_options[i], cname,
+						   specs)))
 				return bdev;
 		}
-		return NULL;  // 'dir' should never fail, so this shouldn't happen
+
+		return NULL; // 'dir' should never fail, so this shouldn't
+			     // happen
 	}
 
 	// -B lvm,dir
@@ -485,7 +504,7 @@ struct bdev *bdev_create(const char *dest, const char *type, const char *cname,
 		char *dup = alloca(strlen(type) + 1), *saveptr = NULL, *token;
 		strcpy(dup, type);
 		for (token = strtok_r(dup, ",", &saveptr); token;
-				token = strtok_r(NULL, ",", &saveptr)) {
+		     token = strtok_r(NULL, ",", &saveptr)) {
 			if ((bdev = do_bdev_create(dest, token, cname, specs)))
 				return bdev;
 		}
@@ -518,20 +537,23 @@ int bdev_destroy_wrapper(void *data)
 		ERROR("Failed to setgid to 0");
 		return -1;
 	}
+
 	if (setgroups(0, NULL) < 0)
 		WARN("Failed to clear groups");
+
 	if (setuid(0) < 0) {
 		ERROR("Failed to setuid to 0");
 		return -1;
 	}
+
 	if (!bdev_destroy(conf))
 		return -1;
-	else
-		return 0;
+
+	return 0;
 }
 
 struct bdev *bdev_init(struct lxc_conf *conf, const char *src, const char *dst,
-		const char *mntopts)
+		       const char *mntopts)
 {
 	struct bdev *bdev;
 	const struct bdev_type *q;
@@ -549,6 +571,7 @@ struct bdev *bdev_init(struct lxc_conf *conf, const char *src, const char *dst,
 	bdev = malloc(sizeof(struct bdev));
 	if (!bdev)
 		return NULL;
+
 	memset(bdev, 0, sizeof(struct bdev));
 	bdev->ops = q->ops;
 	bdev->type = q->name;
@@ -620,7 +643,7 @@ void detach_block_device(struct lxc_conf *conf)
  */
 int detect_fs(struct bdev *bdev, char *type, int len)
 {
-	int  p[2], ret;
+	int p[2], ret;
 	size_t linelen;
 	pid_t pid;
 	FILE *f;
@@ -637,8 +660,10 @@ int detect_fs(struct bdev *bdev, char *type, int len)
 	ret = pipe(p);
 	if (ret < 0)
 		return -1;
+
 	if ((pid = fork()) < 0)
 		return -1;
+
 	if (pid > 0) {
 		int status;
 		close(p[1]);
@@ -664,7 +689,7 @@ int detect_fs(struct bdev *bdev, char *type, int len)
 		exit(1);
 
 	if (detect_shared_rootfs()) {
-		if (mount(NULL, "/", NULL, MS_SLAVE|MS_REC, NULL)) {
+		if (mount(NULL, "/", NULL, MS_SLAVE | MS_REC, NULL)) {
 			SYSERROR("Failed to make / rslave");
 			ERROR("Continuing...");
 		}
@@ -672,9 +697,11 @@ int detect_fs(struct bdev *bdev, char *type, int len)
 
 	ret = mount_unknown_fs(srcdev, bdev->dest, bdev->mntopts);
 	if (ret < 0) {
-		ERROR("failed mounting %s onto %s to detect fstype", srcdev, bdev->dest);
+		ERROR("failed mounting %s onto %s to detect fstype", srcdev,
+		      bdev->dest);
 		exit(1);
 	}
+
 	// if symlink, get the real dev name
 	char devpath[MAXPATHLEN];
 	char *l = linkderef(srcdev, devpath);
@@ -683,6 +710,7 @@ int detect_fs(struct bdev *bdev, char *type, int len)
 	f = fopen("/proc/self/mounts", "r");
 	if (!f)
 		exit(1);
+
 	while (getline(&line, &linelen, f) != -1) {
 		sp1 = strchr(line, ' ');
 		if (!sp1)
@@ -701,8 +729,10 @@ int detect_fs(struct bdev *bdev, char *type, int len)
 		sp2++;
 		if (write(p[1], sp2, strlen(sp2)) != strlen(sp2))
 			exit(1);
+
 		exit(0);
 	}
+
 	exit(1);
 }
 
@@ -720,9 +750,10 @@ int do_mkfs(const char *path, const char *fstype)
 	// If the file is not a block device, we don't want mkfs to ask
 	// us about whether to proceed.
 	if (null_stdfds() < 0)
-		exit(1);
+		exit(EXIT_FAILURE);
+
 	execlp("mkfs", "mkfs", "-t", fstype, path, (char *)NULL);
-	exit(1);
+	exit(EXIT_FAILURE);
 }
 
 /*
@@ -733,20 +764,23 @@ int is_blktype(struct bdev *b)
 {
 	if (strcmp(b->type, "lvm") == 0)
 		return 1;
+
 	return 0;
 }
 
 int mount_unknown_fs(const char *rootfs, const char *target,
-		const char *options)
+		     const char *options)
 {
+	size_t i;
+	int ret;
 	struct cbarg {
 		const char *rootfs;
 		const char *target;
 		const char *options;
 	} cbarg = {
-		.rootfs = rootfs,
-		.target = target,
-		.options = options,
+	    .rootfs = rootfs,
+	    .target = target,
+	    .options = options,
 	};
 
 	/*
@@ -755,15 +789,11 @@ int mount_unknown_fs(const char *rootfs, const char *target,
 	 * are auto-loaded and fall back to the supported kernel fs
 	 */
 	char *fsfile[] = {
-		"/etc/filesystems",
-		"/proc/filesystems",
+	    "/etc/filesystems",
+	    "/proc/filesystems",
 	};
 
-	size_t i;
 	for (i = 0; i < sizeof(fsfile) / sizeof(fsfile[0]); i++) {
-
-		int ret;
-
 		if (access(fsfile[i], F_OK))
 			continue;
 
@@ -788,34 +818,38 @@ bool rootfs_is_blockdev(struct lxc_conf *conf)
 	int ret;
 
 	if (!conf->rootfs.path || strcmp(conf->rootfs.path, "/") == 0 ||
-		strlen(conf->rootfs.path) == 0)
+	    strlen(conf->rootfs.path) == 0)
 		return false;
 
 	ret = stat(conf->rootfs.path, &st);
 	if (ret == 0 && S_ISBLK(st.st_mode))
 		return true;
+
 	q = bdev_query(conf, conf->rootfs.path);
 	if (!q)
 		return false;
+
 	if (strcmp(q->name, "lvm") == 0 ||
-		strcmp(q->name, "loop") == 0 ||
-		strcmp(q->name, "nbd") == 0)
+	    strcmp(q->name, "loop") == 0 ||
+	    strcmp(q->name, "nbd") == 0)
 		return true;
+
 	return false;
 }
 
 static struct bdev *do_bdev_create(const char *dest, const char *type,
-		const char *cname, struct bdev_specs *specs)
+				   const char *cname, struct bdev_specs *specs)
 {
 
-	struct bdev *bdev = bdev_get(type);
-	if (!bdev) {
+	struct bdev *bdev;
+
+	bdev = bdev_get(type);
+	if (!bdev)
 		return NULL;
-	}
 
 	if (bdev->ops->create(bdev, dest, cname, specs) < 0) {
-		 bdev_put(bdev);
-		 return NULL;
+		bdev_put(bdev);
+		return NULL;
 	}
 
 	return bdev;
@@ -830,14 +864,18 @@ static struct bdev *bdev_get(const char *type)
 		if (strcmp(bdevs[i].name, type) == 0)
 			break;
 	}
+
 	if (i == numbdevs)
 		return NULL;
+
 	bdev = malloc(sizeof(struct bdev));
 	if (!bdev)
 		return NULL;
+
 	memset(bdev, 0, sizeof(struct bdev));
 	bdev->ops = bdevs[i].ops;
 	bdev->type = bdevs[i].name;
+
 	return bdev;
 }
 
@@ -885,7 +923,7 @@ static const struct bdev_type *bdev_query(struct lxc_conf *conf,
  * the callback system, they can be pulled from there eventually, so we
  * don't need to pollute utils.c with these low level functions
  */
-static int find_fstype_cb(char* buffer, void *data)
+static int find_fstype_cb(char *buffer, void *data)
 {
 	struct cbarg {
 		const char *rootfs;
@@ -905,8 +943,8 @@ static int find_fstype_cb(char* buffer, void *data)
 	fstype += lxc_char_left_gc(fstype, strlen(fstype));
 	fstype[lxc_char_right_gc(fstype, strlen(fstype))] = '\0';
 
-	DEBUG("trying to mount '%s'->'%s' with fstype '%s'",
-	      cbarg->rootfs, cbarg->target, fstype);
+	DEBUG("trying to mount '%s'->'%s' with fstype '%s'", cbarg->rootfs,
+	      cbarg->target, fstype);
 
 	if (parse_mntopts(cbarg->options, &mntflags, &mntdata) < 0) {
 		free(mntdata);
@@ -921,8 +959,8 @@ static int find_fstype_cb(char* buffer, void *data)
 
 	free(mntdata);
 
-	INFO("mounted '%s' on '%s', with fstype '%s'",
-	     cbarg->rootfs, cbarg->target, fstype);
+	INFO("mounted '%s' on '%s', with fstype '%s'", cbarg->rootfs,
+	     cbarg->target, fstype);
 
 	return 1;
 }
@@ -935,8 +973,10 @@ static char *linkderef(char *path, char *dest)
 	ret = stat(path, &sbuf);
 	if (ret < 0)
 		return NULL;
+
 	if (!S_ISLNK(sbuf.st_mode))
 		return path;
+
 	ret = readlink(path, dest, MAXPATHLEN);
 	if (ret < 0) {
 		SYSERROR("error reading link %s", path);
@@ -946,6 +986,7 @@ static char *linkderef(char *path, char *dest)
 		return NULL;
 	}
 	dest[ret] = '\0';
+
 	return dest;
 }
 
@@ -953,43 +994,46 @@ static char *linkderef(char *path, char *dest)
  * is an unprivileged user allowed to make this kind of snapshot
  */
 static bool unpriv_snap_allowed(struct bdev *b, const char *t, bool snap,
-		bool maybesnap)
+				bool maybesnap)
 {
 	if (!t) {
 		// new type will be same as original
 		// (unless snap && b->type == dir, in which case it will be
 		// overlayfs -- which is also allowed)
 		if (strcmp(b->type, "dir") == 0 ||
-				strcmp(b->type, "aufs") == 0 ||
-				strcmp(b->type, "overlayfs") == 0 ||
-				strcmp(b->type, "btrfs") == 0 ||
-				strcmp(b->type, "loop") == 0)
+		    strcmp(b->type, "aufs") == 0 ||
+		    strcmp(b->type, "overlayfs") == 0 ||
+		    strcmp(b->type, "btrfs") == 0 ||
+		    strcmp(b->type, "loop") == 0)
 			return true;
+
 		return false;
 	}
 
 	// unprivileged users can copy and snapshot dir, overlayfs,
 	// and loop.  In particular, not zfs, btrfs, or lvm.
 	if (strcmp(t, "dir") == 0 ||
-		strcmp(t, "aufs") == 0 ||
-		strcmp(t, "overlayfs") == 0 ||
-		strcmp(t, "btrfs") == 0 ||
-		strcmp(t, "loop") == 0)
+	    strcmp(t, "aufs") == 0 ||
+	    strcmp(t, "overlayfs") == 0 ||
+	    strcmp(t, "btrfs") == 0 ||
+	    strcmp(t, "loop") == 0)
 		return true;
+
 	return false;
 }
 
 bool is_valid_bdev_type(const char *type)
 {
 	if (strcmp(type, "dir") == 0 ||
-			strcmp(type, "btrfs") == 0 ||
-			strcmp(type, "aufs") == 0 ||
-			strcmp(type, "loop") == 0 ||
-			strcmp(type, "lvm") == 0 ||
-			strcmp(type, "nbd") == 0 ||
-			strcmp(type, "overlayfs") == 0 ||
-			strcmp(type, "rbd") == 0 ||
-			strcmp(type, "zfs") == 0)
+	    strcmp(type, "btrfs") == 0 ||
+	    strcmp(type, "aufs") == 0 ||
+	    strcmp(type, "loop") == 0 ||
+	    strcmp(type, "lvm") == 0 ||
+	    strcmp(type, "nbd") == 0 ||
+	    strcmp(type, "overlayfs") == 0 ||
+	    strcmp(type, "rbd") == 0 ||
+	    strcmp(type, "zfs") == 0)
 		return true;
+
 	return false;
 }

--- a/src/lxc/bdev/bdev.h
+++ b/src/lxc/bdev/bdev.h
@@ -23,17 +23,13 @@
 
 #ifndef __LXC_BDEV_H
 #define __LXC_BDEV_H
-/* blockdev operations for:
- * aufs, dir, raw, btrfs, overlayfs, aufs, lvm, loop, zfs, nbd (qcow2, raw, vdi, qed)
- */
 
-#include <lxc/lxccontainer.h>
+#include "config.h"
 #include <stdint.h>
 #include <sys/mount.h>
 
-#include "config.h"
+#include <lxc/lxccontainer.h>
 
-/* define constants if the kernel/glibc headers don't define them */
 #ifndef MS_DIRSYNC
 #define MS_DIRSYNC 128
 #endif
@@ -71,20 +67,21 @@ struct bdev_ops {
 	int (*umount)(struct bdev *bdev);
 	int (*destroy)(struct bdev *bdev);
 	int (*create)(struct bdev *bdev, const char *dest, const char *n,
-			struct bdev_specs *specs);
+		      struct bdev_specs *specs);
 	/* given original mount, rename the paths for cloned container */
-	int (*clone_paths)(struct bdev *orig, struct bdev *new, const char *oldname,
-			const char *cname, const char *oldpath, const char *lxcpath,
-			int snap, uint64_t newsize, struct lxc_conf *conf);
+	int (*clone_paths)(struct bdev *orig, struct bdev *new,
+			   const char *oldname, const char *cname,
+			   const char *oldpath, const char *lxcpath, int snap,
+			   uint64_t newsize, struct lxc_conf *conf);
 	bool can_snapshot;
 	bool can_backup;
 };
 
 /*
- * When lxc-start (conf.c) is mounting a rootfs, then src will be the
- * 'lxc.rootfs' value, dest will be mount dir (i.e. $libdir/lxc)  When clone
- * or create is doing so, then dest will be $lxcpath/$lxcname/rootfs, since
- * we may need to rsync from one to the other.
+ * When lxc-start is mounting a rootfs, then src will be the "lxc.rootfs" value,
+ * dest will be mount dir (i.e. $libdir/lxc)  When clone or create is doing so,
+ * then dest will be $lxcpath/$lxcname/rootfs, since we may need to rsync from
+ * one to the other.
  * data is so far unused.
  */
 struct bdev {
@@ -93,10 +90,10 @@ struct bdev {
 	char *src;
 	char *dest;
 	char *mntopts;
-	// turn the following into a union if need be
-	// lofd is the open fd for the mounted loopback file
+	/* Turn the following into a union if need be. */
+	/* lofd is the open fd for the mounted loopback file. */
 	int lofd;
-	// index for the connected nbd device
+	/* index for the connected nbd device. */
 	int nbd_idx;
 };
 
@@ -104,27 +101,27 @@ bool bdev_is_dir(struct lxc_conf *conf, const char *path);
 bool bdev_can_backup(struct lxc_conf *conf);
 
 /*
- * Instantiate a bdev object.  The src is used to determine which blockdev
- * type this should be.  The dst and data are optional, and will be used
- * in case of mount/umount.
+ * Instantiate a bdev object. The src is used to determine which blockdev type
+ * this should be. The dst and data are optional, and will be used in case of
+ * mount/umount.
  *
  * Optionally, src can be 'dir:/var/lib/lxc/c1' or 'lvm:/dev/lxc/c1'.  For
- * other backing stores, this will allow additional options.  In particular,
+ * other backing stores, this will allow additional options. In particular,
  * "overlayfs:/var/lib/lxc/canonical/rootfs:/var/lib/lxc/c1/delta" will mean
  * use /var/lib/lxc/canonical/rootfs as lower dir, and /var/lib/lxc/c1/delta
  * as the upper, writeable layer.
  */
 struct bdev *bdev_init(struct lxc_conf *conf, const char *src, const char *dst,
-			const char *data);
+		       const char *data);
 
 struct bdev *bdev_copy(struct lxc_container *c0, const char *cname,
-			const char *lxcpath, const char *bdevtype,
-			int flags, const char *bdevdata, uint64_t newsize,
-			int *needs_rdep);
-struct bdev *bdev_create(const char *dest, const char *type,
-			const char *cname, struct bdev_specs *specs);
+		       const char *lxcpath, const char *bdevtype, int flags,
+		       const char *bdevdata, uint64_t newsize, int *needs_rdep);
+struct bdev *bdev_create(const char *dest, const char *type, const char *cname,
+			 struct bdev_specs *specs);
 void bdev_put(struct bdev *bdev);
 bool bdev_destroy(struct lxc_conf *conf);
+
 /* callback function to be used with userns_exec_1() */
 int bdev_destroy_wrapper(void *data);
 
@@ -139,6 +136,7 @@ int is_blktype(struct bdev *b);
 int mount_unknown_fs(const char *rootfs, const char *target,
 		const char *options);
 bool rootfs_is_blockdev(struct lxc_conf *conf);
+
 /*
  * these are really for qemu-nbd support, as container shutdown
  * must explicitly request device detach.

--- a/src/lxc/bdev/bdev.h
+++ b/src/lxc/bdev/bdev.h
@@ -131,7 +131,7 @@ int bdev_destroy_wrapper(void *data);
  */
 int blk_getsize(struct bdev *bdev, uint64_t *size);
 int detect_fs(struct bdev *bdev, char *type, int len);
-int do_mkfs(const char *path, const char *fstype);
+int do_mkfs_exec_wrapper(void *args);
 int is_blktype(struct bdev *b);
 int mount_unknown_fs(const char *rootfs, const char *target,
 		const char *options);

--- a/src/lxc/bdev/lxcrbd.c
+++ b/src/lxc/bdev/lxcrbd.c
@@ -51,6 +51,8 @@ int rbd_create(struct bdev *bdev, const char *dest, const char *n,
 	int ret, len;
 	char sz[24];
 	pid_t pid;
+	const char *cmd_args[2];
+	char cmd_output[MAXPATHLEN];
 
 	if (!specs)
 		return -1;
@@ -104,11 +106,13 @@ int rbd_create(struct bdev *bdev, const char *dest, const char *n,
 	if (!fstype)
 		fstype = DEFAULT_FSTYPE;
 
-	if (do_mkfs(bdev->src, fstype) < 0) {
-		ERROR("Error creating filesystem type %s on %s", fstype,
-			bdev->src);
+	cmd_args[0] = fstype;
+	cmd_args[1] = bdev->src;
+	ret = run_command(cmd_output, sizeof(cmd_output), do_mkfs_exec_wrapper,
+			  (void *)cmd_args);
+	if (ret < 0)
 		return -1;
-	}
+
 	if (!(bdev->dest = strdup(dest)))
 		return -1;
 

--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -171,7 +171,7 @@ static int lxc_cmd_rsp_recv(int sock, struct lxc_cmd_rr *cmd)
 	int ret,rspfd;
 	struct lxc_cmd_rsp *rsp = &cmd->rsp;
 
-	ret = lxc_abstract_unix_recv_fd(sock, &rspfd, rsp, sizeof(*rsp));
+	ret = lxc_abstract_unix_recv_fds(sock, &rspfd, 1, rsp, sizeof(*rsp));
 	if (ret < 0) {
 		WARN("Command %s failed to receive response: %s.",
 		     lxc_cmd_str(cmd->req.cmd), strerror(errno));
@@ -756,7 +756,7 @@ static int lxc_cmd_console_callback(int fd, struct lxc_cmd_req *req,
 
 	memset(&rsp, 0, sizeof(rsp));
 	rsp.data = INT_TO_PTR(ttynum);
-	if (lxc_abstract_unix_send_fd(fd, masterfd, &rsp, sizeof(rsp)) < 0) {
+	if (lxc_abstract_unix_send_fds(fd, &masterfd, 1, &rsp, sizeof(rsp)) < 0) {
 		ERROR("Failed to send tty to client.");
 		lxc_console_free(handler->conf, fd);
 		goto out_close;

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -172,11 +172,6 @@ static int sethostname(const char * name, size_t len)
 }
 #endif
 
-/* Define __S_ISTYPE if missing from the C library */
-#ifndef __S_ISTYPE
-#define        __S_ISTYPE(mode, mask)  (((mode) & S_IFMT) == (mask))
-#endif
-
 #ifndef MS_PRIVATE
 #define MS_PRIVATE (1<<18)
 #endif

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4093,55 +4093,46 @@ static bool verify_start_hooks(struct lxc_conf *conf)
 	return true;
 }
 
-static int send_fd(int sock, int fd)
+static int lxc_send_ttys_to_parent(struct lxc_handler *handler)
 {
-	int ret = lxc_abstract_unix_send_fd(sock, fd, NULL, 0);
-
-
-	if (ret < 0) {
-		SYSERROR("Error sending tty fd to parent");
-		return -1;
-	}
-
-	return 0;
-}
-
-static int send_ttys_to_parent(struct lxc_handler *handler)
-{
-	int i, ret;
+	int i;
+	int *ttyfds;
+	struct lxc_pty_info *pty_info;
 	struct lxc_conf *conf = handler->conf;
 	const struct lxc_tty_info *tty_info = &conf->tty_info;
 	int sock = handler->ttysock[0];
+	int ret = -1;
+	size_t num_ttyfds = (2 * conf->tty);
 
-	for (i = 0; i < tty_info->nbtty; i++) {
-		struct lxc_pty_info *pty_info = &tty_info->pty_info[i];
-		ret = send_fd(sock, pty_info->slave);
-		if (ret >= 0)
-			send_fd(sock, pty_info->master);
-		TRACE("sending pty \"%s\" with master fd %d and slave fd %d to "
+	ttyfds = malloc(num_ttyfds * sizeof(int));
+	if (!ttyfds)
+		return -1;
+
+	for (i = 0; i < num_ttyfds; i++) {
+		pty_info = &tty_info->pty_info[i / 2];
+		ttyfds[i++] = pty_info->slave;
+		ttyfds[i] = pty_info->master;
+		TRACE("send pty \"%s\" with master fd %d and slave fd %d to "
 		      "parent",
 		      pty_info->name, pty_info->master, pty_info->slave);
-		close(pty_info->slave);
-		pty_info->slave = -1;
-		close(pty_info->master);
-		pty_info->master = -1;
-		if (ret < 0) {
-			ERROR("failed to send pty \"%s\" with master fd %d and "
-			      "slave fd %d to parent : %s",
-			      pty_info->name, pty_info->master, pty_info->slave,
-			      strerror(errno));
-			goto bad;
-		}
 	}
+
+	ret = lxc_abstract_unix_send_fds(sock, ttyfds, num_ttyfds, NULL, 0);
+	if (ret < 0)
+		ERROR("failed to send %d ttys to parent: %s", conf->tty,
+		      strerror(errno));
+	else
+		TRACE("sent %d ttys to parent", conf->tty);
 
 	close(handler->ttysock[0]);
 	close(handler->ttysock[1]);
 
-	return 0;
+	for (i = 0; i < num_ttyfds; i++)
+		close(ttyfds[i]);
 
-bad:
-	ERROR("Error writing tty fd to parent");
-	return -1;
+	free(ttyfds);
+
+	return ret;
 }
 
 int lxc_setup(struct lxc_handler *handler)
@@ -4260,7 +4251,7 @@ int lxc_setup(struct lxc_handler *handler)
 		return -1;
 	}
 
-	if (send_ttys_to_parent(handler) < 0) {
+	if (lxc_send_ttys_to_parent(handler) < 0) {
 		ERROR("failure sending console info to parent");
 		return -1;
 	}

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3831,15 +3831,20 @@ int chown_mapped_root(char *path, struct lxc_conf *conf)
 	return ret;
 }
 
-int ttys_shift_ids(struct lxc_conf *c)
+int lxc_ttys_shift_ids(struct lxc_conf *c)
 {
 	if (lxc_list_empty(&c->id_map))
 		return 0;
 
-	if (strcmp(c->console.name, "") !=0 && chown_mapped_root(c->console.name, c) < 0) {
-		ERROR("Failed to chown %s", c->console.name);
+	if (!strcmp(c->console.name, ""))
+		return 0;
+
+	if (chown_mapped_root(c->console.name, c) < 0) {
+		ERROR("failed to chown console \"%s\"", c->console.name);
 		return -1;
 	}
+
+	TRACE("chowned console \"%s\"", c->console.name);
 
 	return 0;
 }

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -472,7 +472,7 @@ extern void lxc_restore_phys_nics_to_netns(int netnsfd, struct lxc_conf *conf);
 extern int find_unmapped_nsid(struct lxc_conf *conf, enum idtype idtype);
 extern int mapped_hostid(unsigned id, struct lxc_conf *conf, enum idtype idtype);
 extern int chown_mapped_root(char *path, struct lxc_conf *conf);
-extern int ttys_shift_ids(struct lxc_conf *c);
+extern int lxc_ttys_shift_ids(struct lxc_conf *c);
 extern int userns_exec_1(struct lxc_conf *conf, int (*fn)(void *), void *data,
 			 const char *fn_name);
 extern int parse_mntopts(const char *mntopts, unsigned long *mntflags,

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -481,7 +481,7 @@ struct lxc_handler *lxc_init(const char *name, struct lxc_conf *conf, const char
 		goto out_restore_sigmask;
 	}
 
-	if (ttys_shift_ids(conf) < 0) {
+	if (lxc_ttys_shift_ids(conf) < 0) {
 		ERROR("Failed to shift tty into container.");
 		goto out_restore_sigmask;
 	}

--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -315,7 +315,7 @@ static int get_pty_on_host(struct lxc_container *c, struct wrapargs *wrap, int *
 	conf->console.descr = &descr;
 
 	/* Shift ttys to container. */
-	if (ttys_shift_ids(conf) < 0) {
+	if (lxc_ttys_shift_ids(conf) < 0) {
 		ERROR("Failed to shift tty into container");
 		goto err1;
 	}

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -39,6 +39,11 @@
 
 #include "initutils.h"
 
+/* Define __S_ISTYPE if missing from the C library. */
+#ifndef __S_ISTYPE
+#define __S_ISTYPE(mode, mask) (((mode)&S_IFMT) == (mask))
+#endif
+
 /* Useful macros */
 /* Maximum number for 64 bit integer is a string with 21 digits: 2^64 - 1 = 21 */
 #define LXC_NUMSTRLEN64 21


### PR DESCRIPTION
- Enable lxc_abstract_unix_{send,recv}_fd() to send and receive multiple fds at
  once.
- lxc_abstract_unix_{send,recv}_fd() -> lxc_abstract_unix_{send,recv}_fds()
- Send tty fds from child to parent all at once.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>