### PR TITLE
start: kill lxc-monitord

### DIFF
--- a/src/lxc/commands.h
+++ b/src/lxc/commands.h
@@ -43,6 +43,7 @@ typedef enum {
 	LXC_CMD_GET_CONFIG_ITEM,
 	LXC_CMD_GET_NAME,
 	LXC_CMD_GET_LXCPATH,
+	LXC_CMD_STATE_SERVER,
 	LXC_CMD_MAX,
 } lxc_cmd_t;
 
@@ -82,8 +83,10 @@ extern char *lxc_cmd_get_config_item(const char *name, const char *item, const c
 extern char *lxc_cmd_get_name(const char *hashed_sock);
 extern char *lxc_cmd_get_lxcpath(const char *hashed_sock);
 extern pid_t lxc_cmd_get_init_pid(const char *name, const char *lxcpath);
-extern lxc_state_t lxc_cmd_get_state(const char *name, const char *lxcpath);
+extern int lxc_cmd_get_state(const char *name, const char *lxcpath);
 extern int lxc_cmd_stop(const char *name, const char *lxcpath);
+extern int lxc_cmd_state_server(const char *name, const char *lxcpath,
+				lxc_state_t states[MAX_STATE]);
 
 struct lxc_epoll_descr;
 struct lxc_handler;

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3771,11 +3771,15 @@ int chown_mapped_root(char *path, struct lxc_conf *conf)
 		return 0;
 	}
 
-	// save the current gid of "path"
+	/* save the current gid of "path" */
 	if (stat(path, &sb) < 0) {
 		ERROR("Error stat %s", path);
 		return -1;
 	}
+
+	/* Update the path argument in case this was overlayfs. */
+	args1[sizeof(args1) / sizeof(args1[0]) - 2] = path;
+	args2[sizeof(args2) / sizeof(args2[0]) - 2] = path;
 
 	/*
 	 * A file has to be group-owned by a gid mapped into the

--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -797,8 +797,11 @@ static void do_restore(struct lxc_container *c, int status_pipe, struct migrate_
 		close(fd);
 	}
 
-	handler = lxc_init(c->name, c->lxc_conf, c->config_path);
+	handler = lxc_init_handler(c->name, c->lxc_conf, c->config_path);
 	if (!handler)
+		goto out;
+
+	if (lxc_init(c->name, handler) < 0)
 		goto out;
 
 	if (!cgroup_init(handler)) {

--- a/src/lxc/execute.c
+++ b/src/lxc/execute.c
@@ -111,16 +111,15 @@ static struct lxc_operations execute_start_ops = {
 };
 
 int lxc_execute(const char *name, char *const argv[], int quiet,
-		struct lxc_conf *conf, const char *lxcpath, bool backgrounded)
+		struct lxc_handler *handler, const char *lxcpath,
+		bool backgrounded)
 {
-	struct execute_args args = {
-		.argv = argv,
-		.quiet = quiet
-	};
+	struct execute_args args = {.argv = argv, .quiet = quiet};
 
-	if (lxc_check_inherited(conf, false, -1))
+	if (lxc_check_inherited(handler->conf, false, handler->conf->maincmd_fd))
 		return -1;
 
-	conf->is_execute = 1;
-	return __lxc_start(name, conf, &execute_start_ops, &args, lxcpath, backgrounded);
+	handler->conf->is_execute = 1;
+	return __lxc_start(name, handler, &execute_start_ops, &args, lxcpath,
+			   backgrounded);
 }

--- a/src/lxc/lxc.h
+++ b/src/lxc/lxc.h
@@ -36,6 +36,7 @@ extern "C" {
 struct lxc_msg;
 struct lxc_conf;
 struct lxc_arguments;
+struct lxc_handler;
 
 /**
  Following code is for liblxc.
@@ -51,8 +52,9 @@ struct lxc_arguments;
  * @backgrounded : whether or not the container is daemonized
  * Returns 0 on success, < 0 otherwise
  */
-extern int lxc_start(const char *name, char *const argv[], struct lxc_conf *conf,
-		     const char *lxcpath, bool backgrounded);
+extern int lxc_start(const char *name, char *const argv[],
+		     struct lxc_handler *handler, const char *lxcpath,
+		     bool backgrounded);
 
 /*
  * Start the specified command inside an application container
@@ -64,7 +66,7 @@ extern int lxc_start(const char *name, char *const argv[], struct lxc_conf *conf
  * Returns 0 on success, < 0 otherwise
  */
 extern int lxc_execute(const char *name, char *const argv[], int quiet,
-		       struct lxc_conf *conf, const char *lxcpath,
+		       struct lxc_handler *handler, const char *lxcpath,
 		       bool backgrounded);
 
 /*

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -758,10 +758,10 @@ static bool do_lxcapi_start(struct lxc_container *c, int useinit, char * const a
 		return false;
 	conf = c->lxc_conf;
 	daemonize = c->daemonize;
-	container_mem_unlock(c);
 
 	/* initialize handler */
 	handler = lxc_init_handler(c->name, conf, c->config_path);
+	container_mem_unlock(c);
 	if (!handler)
 		return false;
 
@@ -800,7 +800,7 @@ static bool do_lxcapi_start(struct lxc_container *c, int useinit, char * const a
 			 * the PID file, child will do the free and unlink.
 			 */
 			c->pidfile = NULL;
-			close(c->lxc_conf->maincmd_fd);
+			close(handler->conf->maincmd_fd);
 			return wait_on_daemonized_start(c, pid);
 		}
 

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -790,7 +790,6 @@ static bool do_lxcapi_start(struct lxc_container *c, int useinit, char * const a
 	*/
 	if (daemonize) {
 		char title[2048];
-		lxc_monitord_spawn(c->config_path);
 
 		pid_t pid = fork();
 		if (pid < 0)

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -384,6 +384,7 @@ int lxc_poll(const char *name, struct lxc_handler *handler)
 			DEBUG("Not starting utmp handler as CAP_SYS_BOOT cannot be dropped without capabilities support.");
 		#endif
 	}
+	TRACE("lxc mainloop is ready");
 
 	return lxc_mainloop(&descr, -1);
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -341,10 +341,64 @@ static int signal_handler(int fd, uint32_t events, void *data,
 	return 1;
 }
 
-int lxc_set_state(const char *name, struct lxc_handler *handler, lxc_state_t state)
+int lxc_set_state(const char *name, struct lxc_handler *handler,
+		  lxc_state_t state)
 {
+	ssize_t ret;
+	struct lxc_list *cur, *next;
+	struct state_client *client;
+	struct lxc_msg msg = {.type = lxc_msg_state, .value = state};
+
+	process_lock();
+	/* Only set state under process lock held so that we don't cause
+	 * lxc_cmd_state_server() to miss a state.
+	 */
 	handler->state = state;
+	TRACE("set container state to %s", lxc_state2str(state));
+
+	if (lxc_list_empty(&handler->state_clients)) {
+		TRACE("no state clients registered");
+		process_unlock();
+		return 0;
+	}
+
+	strncpy(msg.name, name, sizeof(msg.name));
+	msg.name[sizeof(msg.name) - 1] = 0;
+
+	lxc_list_for_each_safe(cur, &handler->state_clients, next) {
+		client = cur->elem;
+
+		if (!client->states[state]) {
+			TRACE("state %s not registered for state client %d",
+			      lxc_state2str(state), client->clientfd);
+			continue;
+		}
+
+		TRACE("sending state %s to state client %d",
+		      lxc_state2str(state), client->clientfd);
+
+	again:
+		ret = send(client->clientfd, &msg, sizeof(msg), 0);
+		if (ret < 0) {
+			if (errno == EINTR)
+				goto again;
+
+			ERROR("failed to send message to client");
+		}
+
+		/* kick client from list */
+		close(client->clientfd);
+		lxc_list_del(cur);
+		free(cur->elem);
+		free(cur);
+	}
+	process_unlock();
+
+	/* This function will try to connect to the legacy lxc-monitord state
+	 * server and only exists for backwards compatibility.
+	 */
 	lxc_monitor_send_state(name, state, handler->lxcpath);
+
 	return 0;
 }
 
@@ -415,6 +469,7 @@ struct lxc_handler *lxc_init_handler(const char *name, struct lxc_conf *conf,
 	handler->conf = conf;
 	handler->lxcpath = lxcpath;
 	handler->pinfd = -1;
+	lxc_list_init(&handler->state_clients);
 
 	for (i = 0; i < LXC_NS_MAX; i++)
 		handler->nsfd[i] = -1;
@@ -455,12 +510,14 @@ int lxc_init(const char *name, struct lxc_handler *handler)
 		ERROR("Failed loading seccomp policy.");
 		goto out_close_maincmd_fd;
 	}
+	TRACE("read seccomp policy");
 
 	/* Begin by setting the state to STARTING. */
 	if (lxc_set_state(name, handler, STARTING)) {
 		ERROR("Failed to set state for container \"%s\" to \"%s\".", name, lxc_state2str(STARTING));
 		goto out_close_maincmd_fd;
 	}
+	TRACE("set container state to \"STARTING\"");
 
 	/* Start of environment variable setup for hooks. */
 	if (name && setenv("LXC_NAME", name, 1))
@@ -485,10 +542,13 @@ int lxc_init(const char *name, struct lxc_handler *handler)
 		SYSERROR("Failed to set environment variable LXC_CGNS_AWARE=1.");
 	/* End of environment variable setup for hooks. */
 
+	TRACE("set environment variables");
+
 	if (run_lxc_hooks(name, "pre-start", conf, handler->lxcpath, NULL)) {
 		ERROR("Failed to run lxc.hook.pre-start for container \"%s\".", name);
 		goto out_aborting;
 	}
+	TRACE("ran pre-start hooks");
 
 	/* The signal fd has to be created before forking otherwise if the child
 	 * process exits before we setup the signal fd, the event will be lost
@@ -499,19 +559,22 @@ int lxc_init(const char *name, struct lxc_handler *handler)
 		ERROR("Failed to setup SIGCHLD fd handler.");
 		goto out_delete_tty;
 	}
+	TRACE("set up signal fd");
 
 	/* Do this after setting up signals since it might unblock SIGWINCH. */
 	if (lxc_console_create(conf)) {
 		ERROR("Failed to create console for container \"%s\".", name);
 		goto out_restore_sigmask;
 	}
+	TRACE("created console");
 
 	if (lxc_ttys_shift_ids(conf) < 0) {
 		ERROR("Failed to shift tty into container.");
 		goto out_restore_sigmask;
 	}
+	TRACE("shifted tty ids");
 
-	INFO("Container \"%s\" is initialized.", name);
+	INFO("container \"%s\" is initialized", name);
 	return 0;
 
 out_restore_sigmask:
@@ -529,8 +592,9 @@ out_close_maincmd_fd:
 void lxc_fini(const char *name, struct lxc_handler *handler)
 {
 	int i, rc;
+	struct lxc_list *cur, *next;
 	pid_t self = getpid();
-	char *namespaces[LXC_NS_MAX+1];
+	char *namespaces[LXC_NS_MAX + 1];
 	size_t namespace_count = 0;
 
 	/* The STOPPING state is there for future cleanup code which can take
@@ -592,8 +656,23 @@ void lxc_fini(const char *name, struct lxc_handler *handler)
 
 	lxc_console_delete(&handler->conf->console);
 	lxc_delete_tty(&handler->conf->tty_info);
+
+	/* close the command socket */
 	close(handler->conf->maincmd_fd);
 	handler->conf->maincmd_fd = -1;
+
+	/* The command socket is now closed, no more state clients can register
+	 * themselves from now on. So free the list of state clients.
+	 */
+	lxc_list_for_each_safe(cur, &handler->state_clients, next) {
+		struct state_client *client = cur->elem;
+		/* close state client socket */
+		close(client->clientfd);
+		lxc_list_del(cur);
+		free(cur->elem);
+		free(cur);
+	}
+
 	free(handler->name);
 	if (handler->ttysock[0] != -1) {
 		close(handler->ttysock[0]);

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -396,14 +396,17 @@ out_sigfd:
 	return -1;
 }
 
-struct lxc_handler *lxc_init(const char *name, struct lxc_conf *conf, const char *lxcpath)
+struct lxc_handler *lxc_init_handler(const char *name, struct lxc_conf *conf,
+				     const char *lxcpath)
 {
 	int i;
 	struct lxc_handler *handler;
 
 	handler = malloc(sizeof(*handler));
-	if (!handler)
+	if (!handler) {
+		ERROR("failed to allocate memory");
 		return NULL;
+	}
 
 	memset(handler, 0, sizeof(*handler));
 
@@ -415,16 +418,37 @@ struct lxc_handler *lxc_init(const char *name, struct lxc_conf *conf, const char
 	for (i = 0; i < LXC_NS_MAX; i++)
 		handler->nsfd[i] = -1;
 
-	lsm_init();
-
 	handler->name = strdup(name);
 	if (!handler->name) {
-		ERROR("Failed to allocate memory.");
-		goto out_free;
+		ERROR("failed to allocate memory");
+		goto do_partial_cleanup;
 	}
 
-	if (lxc_cmd_init(name, handler, lxcpath))
-		goto out_free_name;
+	if (lxc_cmd_init(name, handler, lxcpath)) {
+		ERROR("failed to set up command socket");
+		goto do_full_cleanup;
+	}
+
+	TRACE("unix domain socket %d for command server is ready",
+	      handler->conf->maincmd_fd);
+
+	return handler;
+
+do_full_cleanup:
+	free(handler->name);
+
+do_partial_cleanup:
+	free(handler);
+
+	return NULL;
+}
+
+int lxc_init(const char *name, struct lxc_handler *handler)
+{
+	struct lxc_conf *conf = handler->conf;
+
+	lsm_init();
+	TRACE("initialized LSM");
 
 	if (lxc_read_seccomp_config(conf) != 0) {
 		ERROR("Failed loading seccomp policy.");
@@ -487,7 +511,7 @@ struct lxc_handler *lxc_init(const char *name, struct lxc_conf *conf, const char
 	}
 
 	INFO("Container \"%s\" is initialized.", name);
-	return handler;
+	return 0;
 
 out_restore_sigmask:
 	sigprocmask(SIG_SETMASK, &handler->oldmask, NULL);
@@ -498,12 +522,7 @@ out_aborting:
 out_close_maincmd_fd:
 	close(conf->maincmd_fd);
 	conf->maincmd_fd = -1;
-out_free_name:
-	free(handler->name);
-	handler->name = NULL;
-out_free:
-	free(handler);
-	return NULL;
+	return -1;
 }
 
 void lxc_fini(const char *name, struct lxc_handler *handler)
@@ -1337,17 +1356,16 @@ out_abort:
 	return -1;
 }
 
-int __lxc_start(const char *name, struct lxc_conf *conf,
+int __lxc_start(const char *name, struct lxc_handler *handler,
 		struct lxc_operations* ops, void *data, const char *lxcpath,
 		bool backgrounded)
 {
-	struct lxc_handler *handler;
-	int err = -1;
 	int status;
+	int err = -1;
 	bool removed_all_netdevs = true;
+	struct lxc_conf *conf = handler->conf;
 
-	handler = lxc_init(name, conf, lxcpath);
-	if (!handler) {
+	if (lxc_init(name, handler) < 0) {
 		ERROR("Failed to initialize container \"%s\".", name);
 		return -1;
 	}
@@ -1494,15 +1512,15 @@ static struct lxc_operations start_ops = {
 	.post_start = post_start
 };
 
-int lxc_start(const char *name, char *const argv[], struct lxc_conf *conf,
+int lxc_start(const char *name, char *const argv[], struct lxc_handler *handler,
 	      const char *lxcpath, bool backgrounded)
 {
 	struct start_args start_arg = {
 		.argv = argv,
 	};
 
-	conf->need_utmp_watch = 1;
-	return __lxc_start(name, conf, &start_ops, &start_arg, lxcpath, backgrounded);
+	handler->conf->need_utmp_watch = 1;
+	return __lxc_start(name, handler, &start_ops, &start_arg, lxcpath, backgrounded);
 }
 
 static void lxc_destroy_container_on_signal(struct lxc_handler *handler,

--- a/src/lxc/start.h
+++ b/src/lxc/start.h
@@ -69,6 +69,7 @@ extern void lxc_abort(const char *name, struct lxc_handler *handler);
 extern struct lxc_handler *lxc_init_handler(const char *name,
 					    struct lxc_conf *conf,
 					    const char *lxcpath);
+extern void lxc_free_handler(struct lxc_handler *handler);
 extern int lxc_init(const char *name, struct lxc_handler *handler);
 extern void lxc_fini(const char *name, struct lxc_handler *handler);
 

--- a/src/lxc/start.h
+++ b/src/lxc/start.h
@@ -32,16 +32,6 @@
 #include "state.h"
 #include "namespace.h"
 
-
-struct lxc_handler;
-
-struct lxc_operations {
-	int (*start)(struct lxc_handler *, void *);
-	int (*post_start)(struct lxc_handler *, void *);
-};
-
-struct cgroup_desc;
-
 struct lxc_handler {
 	pid_t pid;
 	char *name;
@@ -60,8 +50,18 @@ struct lxc_handler {
 	bool backgrounded; // indicates whether should we close std{in,out,err} on start
 	int nsfd[LXC_NS_MAX];
 	int netnsfd;
+	struct lxc_list state_clients;
 };
 
+struct lxc_operations {
+	int (*start)(struct lxc_handler *, void *);
+	int (*post_start)(struct lxc_handler *, void *);
+};
+
+struct state_client {
+	int clientfd;
+	lxc_state_t states[MAX_STATE];
+};
 
 extern int lxc_poll(const char *name, struct lxc_handler *handler);
 extern int lxc_set_state(const char *name, struct lxc_handler *handler, lxc_state_t state);

--- a/src/lxc/start.h
+++ b/src/lxc/start.h
@@ -27,11 +27,11 @@
 #include <sys/param.h>
 #include <stdbool.h>
 
+#include "conf.h"
 #include "config.h"
 #include "state.h"
 #include "namespace.h"
 
-struct lxc_conf;
 
 struct lxc_handler;
 
@@ -66,11 +66,14 @@ struct lxc_handler {
 extern int lxc_poll(const char *name, struct lxc_handler *handler);
 extern int lxc_set_state(const char *name, struct lxc_handler *handler, lxc_state_t state);
 extern void lxc_abort(const char *name, struct lxc_handler *handler);
-extern struct lxc_handler *lxc_init(const char *name, struct lxc_conf *, const char *);
+extern struct lxc_handler *lxc_init_handler(const char *name,
+					    struct lxc_conf *conf,
+					    const char *lxcpath);
+extern int lxc_init(const char *name, struct lxc_handler *handler);
 extern void lxc_fini(const char *name, struct lxc_handler *handler);
 
 extern int lxc_check_inherited(struct lxc_conf *conf, bool closeall, int fd_to_ignore);
-int __lxc_start(const char *, struct lxc_conf *, struct lxc_operations *,
+int __lxc_start(const char *, struct lxc_handler *, struct lxc_operations *,
 		void *, const char *, bool);
 
 extern void resolve_clone_flags(struct lxc_handler *handler);

--- a/src/lxc/state.c
+++ b/src/lxc/state.c
@@ -79,7 +79,7 @@ lxc_state_t lxc_getstate(const char *name, const char *lxcpath)
 	return state;
 }
 
-static int fillwaitedstates(const char *strstates, int *states)
+static int fillwaitedstates(const char *strstates, lxc_state_t *states)
 {
 	char *token, *saveptr = NULL;
 	char *strstates_dup = strdup(strstates);
@@ -108,90 +108,21 @@ static int fillwaitedstates(const char *strstates, int *states)
 extern int lxc_wait(const char *lxcname, const char *states, int timeout,
 		    const char *lxcpath)
 {
-	struct lxc_msg msg;
 	int state;
-	int s[MAX_STATE] = {0}, fd = -1, ret = -1;
+	lxc_state_t s[MAX_STATE] = {0};
 
 	if (fillwaitedstates(states, s))
 		return -1;
 
-	/*
-	 * if container present,
-	 * then check if already in requested state
-	 */
-	state = lxc_getstate(lxcname, lxcpath);
+	state = lxc_cmd_state_server(lxcname, lxcpath, s);
 	if (state < 0) {
-		goto out_close;
-	} else if ((state >= 0) && (s[state])) {
-		ret = 0;
-		goto out_close;
+		SYSERROR("failed to receive state from monitor");
+		return -1;
 	}
 
-	if (lxc_monitord_spawn(lxcpath))
+	TRACE("retrieved state of container %s", lxc_state2str(state));
+	if (!s[state])
 		return -1;
 
-	fd = lxc_monitor_open(lxcpath);
-	if (fd < 0)
-		return -1;
-
-	for (;;) {
-		int64_t elapsed_time, curtime = 0;
-		struct timespec tspec;
-		int stop = 0;
-		int retval;
-
-		if (timeout != -1) {
-			retval = clock_gettime(CLOCK_REALTIME, &tspec);
-			if (retval)
-				goto out_close;
-			curtime = tspec.tv_sec;
-		}
-		if (lxc_monitor_read_timeout(fd, &msg, timeout) < 0) {
-			/* try again if select interrupted by signal */
-			if (errno != EINTR)
-				goto out_close;
-		}
-
-		if (timeout != -1) {
-			retval = clock_gettime(CLOCK_REALTIME, &tspec);
-			if (retval)
-				goto out_close;
-			elapsed_time = tspec.tv_sec - curtime;
-			if (timeout - elapsed_time <= 0)
-				stop = 1;
-			timeout -= elapsed_time;
-		}
-
-		if (strcmp(lxcname, msg.name)) {
-			if (stop) {
-				ret = -2;
-				goto out_close;
-			}
-			continue;
-		}
-
-		switch (msg.type) {
-		case lxc_msg_state:
-			if (msg.value < 0 || msg.value >= MAX_STATE)
-				goto out_close;
-
-			if (s[msg.value]) {
-				ret = 0;
-				goto out_close;
-			}
-			break;
-		default:
-			if (stop) {
-				ret = -2;
-				goto out_close;
-			}
-			/* just ignore garbage */
-			break;
-		}
-	}
-
-out_close:
-	if (fd >= 0)
-		lxc_monitor_close(fd);
-	return ret;
+	return 0;
 }

--- a/src/lxc/state.h
+++ b/src/lxc/state.h
@@ -24,8 +24,15 @@
 #define __LXC_STATE_H
 
 typedef enum {
-	STOPPED, STARTING, RUNNING, STOPPING,
-	ABORTING, FREEZING, FROZEN, THAWED, MAX_STATE,
+	STOPPED,
+	STARTING,
+	RUNNING,
+	STOPPING,
+	ABORTING,
+	FREEZING,
+	FROZEN,
+	THAWED,
+	MAX_STATE,
 } lxc_state_t;
 
 extern int lxc_rmstate(const char *name);

--- a/src/tests/lxc-test-apparmor-mount
+++ b/src/tests/lxc-test-apparmor-mount
@@ -50,7 +50,7 @@ cleanup() {
 	run_cmd lxc-destroy -f -n $cname || true
 	umount -l $MOUNTSR || true
 	rmdir $dnam || true
-	pkill -u $(id -u $TUSER) -9
+	pkill -u $(id -u $TUSER) -9 || true
 	sed -i '/lxcunpriv/d' /run/lxc/nics /etc/lxc/lxc-usernet
 	sed -i '/^lxcunpriv:/d' /etc/subuid /etc/subgid
 	rm -Rf $HDIR /run/user/$(id -u $TUSER)

--- a/src/tests/lxc-test-unpriv
+++ b/src/tests/lxc-test-unpriv
@@ -71,7 +71,7 @@ cleanup() {
 
 	run_cmd lxc-stop -n c2 -k || true
 	run_cmd lxc-stop -n c1 -k || true
-	pkill -u $(id -u $TUSER) -9
+	pkill -u $(id -u $TUSER) -9 || true
 
 	sed -i '/lxcunpriv/d' /run/lxc/nics /etc/lxc/lxc-usernet
 	sed -i '/^lxcunpriv:/d' /etc/subuid /etc/subgid


### PR DESCRIPTION
#### Introduction

A LXC container's lifecycle is regulated by the states STARTING, RUNNING, STOPPING, STOPPED, ABORTING. These states are tracked in the LXC handler and can be checked via approriate functions in the command socket callback system. (The freezer stages are not part of a container's lifecycle since they are not recorded in the LXC handler. This might change in the future but given that the freezer controller will be removed from future cgroup implementations it is unlikely.) So far, LXC was using an external helper to track the states of a container (lxc-monitord). This solution was error prone. For example, the external state server would hang in various scenarios that seemed to be caused by either very subtle internal races or irritation of the external state server by signals.

#### Proposal
LXC will switch from an external state monitor (lxc-monitord) which serves as a state server for state clients to a native implementation using the individual container's command socket. This solution was discussed and outlined by @stgraber and @brauner during the Denver, CO LX{C,D} sprint.

#### Outline
The LXC handler will gain an additional field to track state clients. In order for a state client to receive state notifications from the command server he will need to register himself via the lxc_cmd_state_server() function in the state client list. The state client list will be served by lxc_set_state() during the container's lifecycle. lxc_set_state() will also take care of removing any clients from the state list in the LXC handler once the requested state has been reached and sent to the client.
In order to prevent races between adding and serving new state clients the state client list and the state field in the LXC handler will be protected by a lock.

#### Corner Cases
- Adding new clients when the container is in STARTING state:
  Assume that lxc_cmd_state_server() acquires the lock on the states client list and detects that the current state is STARTING. In this case lxc_cmd_state_server() will only add clients that want to wait on the RUNNING, STOPPING, or STOPPED states. (Clients that want to wait on STARTING state will be immediately served by lxc_cmd_state_server() without adding them to the state client list.)
- Registering clients that want to wait on RUNNING state when the container already is in RUNNING state: This shouldn't be a problem. If the container is already in RUNNING state and lxc_cmd_state_server() holds the lock on the state clients lists it will detect that the container is already running and immediately report back to the caller without adding a new client to the list. If lxc_set_state() succeeds in taking the lock and setting a new state the only possible states that can follow RUNNING are STOPPING, STOPPED, or ABORTING. In all cases the container will eventually be shut down, the command socket closed, and the client list free()ed. So there's no danger of accumulating zombie clients. Furthermore, the implementation updates the state field in the lxc handler with the process lock held which should prevent moving on to another state while lxc_cmd_state_server() acquires the lock.
- Adding new clients when the container is in STOPPING state: Assume that lxc_cmd_state_server() acquires the lock on the states client list and detects that the current state is STOPPING. In this case
  lxc_cmd_state_server() will only add clients that want to wait on the STOPPED state.
  (Clients that want to wait on STOPPING will be immediately served by lxc_cmd_state_server() without adding them to the state client list.)
- Adding new clients when the container is in STOPPED state: Assume that lxc_cmd_state_server() acquires the lock on the states client list and detects that the current state is STOPPED. In this case  lxc_cmd_state_server() will not add new clients. (Clients that want to wait on STOPPED will be immediately served by lxc_cmd_state_server() without adding them to the state client list.)
- Adding new clients when the container is in STOPPED state: Assume that lxc_cmd_state_server() acquires the lock on the states client list and detects that the current state is ABORTING. In this case
  lxc_cmd_state_server() will not add new clients. (Clients that want to wait on ABORTING will be immediately served by lxc_cmd_state_server() without adding them to the state client list.)

#### Implementation Details
- The lock is always taken on the whole list and the state field in the lxc handler struct while lxc_cmd_state_server() or lxc_set_state() are adding or serving clients. This prevents a bunch of weird races.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>