### PR TITLE
tree-wide: priority -> level

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2621,7 +2621,7 @@ struct lxc_conf *lxc_conf_init(void)
 	}
 	memset(new, 0, sizeof(*new));
 
-	new->loglevel = LXC_LOG_PRIORITY_NOTSET;
+	new->loglevel = LXC_LOG_LEVEL_NOTSET;
 	new->personality = -1;
 	new->autodev = 1;
 	new->console.log_path = NULL;
@@ -4844,8 +4844,8 @@ int userns_exec_1(struct lxc_conf *conf, int (*fn)(void *), void *data,
 	/* idmap will now keep track of that memory. */
 	host_gid_map = NULL;
 
-	if (lxc_log_get_level() == LXC_LOG_PRIORITY_TRACE ||
-	    conf->loglevel == LXC_LOG_PRIORITY_TRACE) {
+	if (lxc_log_get_level() == LXC_LOG_LEVEL_TRACE ||
+	    conf->loglevel == LXC_LOG_LEVEL_TRACE) {
 		lxc_list_for_each(it, idmap) {
 			map = it->elem;
 			TRACE("establishing %cid mapping for \"%d\" in new "

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1663,7 +1663,7 @@ static int set_config_loglevel(const char *key, const char *value,
 
 	/* Set config value to default. */
 	if (config_value_empty(value)) {
-		lxc_conf->loglevel = LXC_LOG_PRIORITY_NOTSET;
+		lxc_conf->loglevel = LXC_LOG_LEVEL_NOTSET;
 		return 0;
 	}
 
@@ -3932,7 +3932,7 @@ static inline int clr_config_idmaps(const char *key, struct lxc_conf *c)
 
 static inline int clr_config_loglevel(const char *key, struct lxc_conf *c)
 {
-	c->loglevel = LXC_LOG_PRIORITY_NOTSET;
+	c->loglevel = LXC_LOG_LEVEL_NOTSET;
 	return 0;
 }
 

--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -67,23 +67,23 @@ lxc_log_define(lxc_log, lxc);
 static int lxc_log_priority_to_syslog(int priority)
 {
 	switch (priority) {
-	case LXC_LOG_PRIORITY_FATAL:
+	case LXC_LOG_LEVEL_FATAL:
 		return LOG_EMERG;
-	case LXC_LOG_PRIORITY_ALERT:
+	case LXC_LOG_LEVEL_ALERT:
 		return LOG_ALERT;
-	case LXC_LOG_PRIORITY_CRIT:
+	case LXC_LOG_LEVEL_CRIT:
 		return LOG_CRIT;
-	case LXC_LOG_PRIORITY_ERROR:
+	case LXC_LOG_LEVEL_ERROR:
 		return LOG_ERR;
-	case LXC_LOG_PRIORITY_WARN:
+	case LXC_LOG_LEVEL_WARN:
 		return LOG_WARNING;
-	case LXC_LOG_PRIORITY_NOTICE:
-	case LXC_LOG_PRIORITY_NOTSET:
+	case LXC_LOG_LEVEL_NOTICE:
+	case LXC_LOG_LEVEL_NOTSET:
 		return LOG_NOTICE;
-	case LXC_LOG_PRIORITY_INFO:
+	case LXC_LOG_LEVEL_INFO:
 		return LOG_INFO;
-	case LXC_LOG_PRIORITY_TRACE:
-	case LXC_LOG_PRIORITY_DEBUG:
+	case LXC_LOG_LEVEL_TRACE:
+	case LXC_LOG_LEVEL_DEBUG:
 		return LOG_DEBUG;
 	}
 
@@ -130,7 +130,7 @@ static int log_append_syslog(const struct lxc_log_appender *appender,
 static int log_append_stderr(const struct lxc_log_appender *appender,
 			     struct lxc_log_event *event)
 {
-	if (event->priority < LXC_LOG_PRIORITY_ERROR)
+	if (event->priority < LXC_LOG_LEVEL_ERROR)
 		return 0;
 
 	fprintf(stderr, "%s: %s%s", log_prefix, log_vmname ? log_vmname : "", log_vmname ? ": " : "");
@@ -325,14 +325,14 @@ static struct lxc_log_appender log_appender_logfile = {
 
 static struct lxc_log_category log_root = {
 	.name		= "root",
-	.priority	= LXC_LOG_PRIORITY_ERROR,
+	.priority	= LXC_LOG_LEVEL_ERROR,
 	.appender	= NULL,
 	.parent		= NULL,
 };
 
 struct lxc_log_category lxc_log_category_lxc = {
 	.name		= "lxc",
-	.priority	= LXC_LOG_PRIORITY_ERROR,
+	.priority	= LXC_LOG_LEVEL_ERROR,
 	.appender	= &log_appender_logfile,
 	.parent		= &log_root
 };
@@ -546,7 +546,7 @@ extern void lxc_log_enable_syslog(void)
  */
 extern int lxc_log_init(struct lxc_log *log)
 {
-	int lxc_priority = LXC_LOG_PRIORITY_ERROR;
+	int lxc_priority = LXC_LOG_LEVEL_ERROR;
 	int ret;
 
 	if (lxc_log_fd != -1) {
@@ -554,8 +554,8 @@ extern int lxc_log_init(struct lxc_log *log)
 		return 0;
 	}
 
-	if (log->priority)
-		lxc_priority = lxc_log_priority_to_int(log->priority);
+	if (log->level)
+		lxc_priority = lxc_log_priority_to_int(log->level);
 
 	if (!lxc_loglevel_specified) {
 		lxc_log_category_lxc.priority = lxc_priority;
@@ -620,7 +620,7 @@ extern int lxc_log_init(struct lxc_log *log)
  */
 extern int lxc_log_set_level(int *dest, int level)
 {
-	if (level < 0 || level >= LXC_LOG_PRIORITY_NOTSET) {
+	if (level < 0 || level >= LXC_LOG_LEVEL_NOTSET) {
 		ERROR("invalid log priority %d", level);
 		return -1;
 	}
@@ -636,7 +636,7 @@ extern int lxc_log_get_level(void)
 extern bool lxc_log_has_valid_level(void)
 {
 	int log_level = lxc_log_get_level();
-	if (log_level < 0 || log_level >= LXC_LOG_PRIORITY_NOTSET)
+	if (log_level < 0 || log_level >= LXC_LOG_LEVEL_NOTSET)
 		return false;
 	return true;
 }

--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -58,16 +58,16 @@
 
 /* predefined lxc log priorities. */
 enum lxc_loglevel {
-	LXC_LOG_PRIORITY_TRACE,
-	LXC_LOG_PRIORITY_DEBUG,
-	LXC_LOG_PRIORITY_INFO,
-	LXC_LOG_PRIORITY_NOTICE,
-	LXC_LOG_PRIORITY_WARN,
-	LXC_LOG_PRIORITY_ERROR,
-	LXC_LOG_PRIORITY_CRIT,
-	LXC_LOG_PRIORITY_ALERT,
-	LXC_LOG_PRIORITY_FATAL,
-	LXC_LOG_PRIORITY_NOTSET,
+	LXC_LOG_LEVEL_TRACE,
+	LXC_LOG_LEVEL_DEBUG,
+	LXC_LOG_LEVEL_INFO,
+	LXC_LOG_LEVEL_NOTICE,
+	LXC_LOG_LEVEL_WARN,
+	LXC_LOG_LEVEL_ERROR,
+	LXC_LOG_LEVEL_CRIT,
+	LXC_LOG_LEVEL_ALERT,
+	LXC_LOG_LEVEL_FATAL,
+	LXC_LOG_LEVEL_NOTSET,
 };
 
 /* location information of the logging event */
@@ -121,14 +121,14 @@ static inline int
 lxc_log_priority_is_enabled(const struct lxc_log_category* category,
 			   int priority)
 {
-	while (category->priority == LXC_LOG_PRIORITY_NOTSET &&
+	while (category->priority == LXC_LOG_LEVEL_NOTSET &&
 	       category->parent)
 		category = category->parent;
 
 	int cmp_prio = category->priority;
 #ifndef NO_LXC_CONF
 	if (!lxc_log_use_global_fd && current_config &&
-			current_config->loglevel != LXC_LOG_PRIORITY_NOTSET)
+			current_config->loglevel != LXC_LOG_LEVEL_NOTSET)
 		cmp_prio = current_config->loglevel;
 #endif
 
@@ -141,15 +141,15 @@ lxc_log_priority_is_enabled(const struct lxc_log_category* category,
 static inline const char* lxc_log_priority_to_string(int priority)
 {
 	switch (priority) {
-	case LXC_LOG_PRIORITY_TRACE:	return "TRACE";
-	case LXC_LOG_PRIORITY_DEBUG:	return "DEBUG";
-	case LXC_LOG_PRIORITY_INFO:	return "INFO";
-	case LXC_LOG_PRIORITY_NOTICE:	return "NOTICE";
-	case LXC_LOG_PRIORITY_WARN:	return "WARN";
-	case LXC_LOG_PRIORITY_ERROR:	return "ERROR";
-	case LXC_LOG_PRIORITY_CRIT:	return "CRIT";
-	case LXC_LOG_PRIORITY_ALERT:	return "ALERT";
-	case LXC_LOG_PRIORITY_FATAL:	return "FATAL";
+	case LXC_LOG_LEVEL_TRACE:	return "TRACE";
+	case LXC_LOG_LEVEL_DEBUG:	return "DEBUG";
+	case LXC_LOG_LEVEL_INFO:	return "INFO";
+	case LXC_LOG_LEVEL_NOTICE:	return "NOTICE";
+	case LXC_LOG_LEVEL_WARN:	return "WARN";
+	case LXC_LOG_LEVEL_ERROR:	return "ERROR";
+	case LXC_LOG_LEVEL_CRIT:	return "CRIT";
+	case LXC_LOG_LEVEL_ALERT:	return "ALERT";
+	case LXC_LOG_LEVEL_FATAL:	return "FATAL";
 	default:
 		return "NOTSET";
 	}
@@ -177,17 +177,17 @@ static inline const char* lxc_syslog_priority_to_string(int priority)
  */
 static inline int lxc_log_priority_to_int(const char* name)
 {
-	if (!strcasecmp("TRACE",  name)) return LXC_LOG_PRIORITY_TRACE;
-	if (!strcasecmp("DEBUG",  name)) return LXC_LOG_PRIORITY_DEBUG;
-	if (!strcasecmp("INFO",   name)) return LXC_LOG_PRIORITY_INFO;
-	if (!strcasecmp("NOTICE", name)) return LXC_LOG_PRIORITY_NOTICE;
-	if (!strcasecmp("WARN",   name)) return LXC_LOG_PRIORITY_WARN;
-	if (!strcasecmp("ERROR",  name)) return LXC_LOG_PRIORITY_ERROR;
-	if (!strcasecmp("CRIT",   name)) return LXC_LOG_PRIORITY_CRIT;
-	if (!strcasecmp("ALERT",  name)) return LXC_LOG_PRIORITY_ALERT;
-	if (!strcasecmp("FATAL",  name)) return LXC_LOG_PRIORITY_FATAL;
+	if (!strcasecmp("TRACE",  name)) return LXC_LOG_LEVEL_TRACE;
+	if (!strcasecmp("DEBUG",  name)) return LXC_LOG_LEVEL_DEBUG;
+	if (!strcasecmp("INFO",   name)) return LXC_LOG_LEVEL_INFO;
+	if (!strcasecmp("NOTICE", name)) return LXC_LOG_LEVEL_NOTICE;
+	if (!strcasecmp("WARN",   name)) return LXC_LOG_LEVEL_WARN;
+	if (!strcasecmp("ERROR",  name)) return LXC_LOG_LEVEL_ERROR;
+	if (!strcasecmp("CRIT",   name)) return LXC_LOG_LEVEL_CRIT;
+	if (!strcasecmp("ALERT",  name)) return LXC_LOG_LEVEL_ALERT;
+	if (!strcasecmp("FATAL",  name)) return LXC_LOG_LEVEL_FATAL;
 
-	return LXC_LOG_PRIORITY_NOTSET;
+	return LXC_LOG_LEVEL_NOTSET;
 }
 
 static inline int lxc_syslog_priority_to_int(const char* name)
@@ -234,19 +234,19 @@ __lxc_log(const struct lxc_log_category* category,
 /*
  * Helper macro to define log functions.
  */
-#define lxc_log_priority_define(acategory, PRIORITY)			\
+#define lxc_log_priority_define(acategory, LEVEL)			\
 									\
-ATTR_UNUSED static inline void LXC_##PRIORITY(struct lxc_log_locinfo *,		\
+ATTR_UNUSED static inline void LXC_##LEVEL(struct lxc_log_locinfo *,		\
 	const char *, ...) __attribute__ ((format (printf, 2, 3)));	\
 									\
-ATTR_UNUSED static inline void LXC_##PRIORITY(struct lxc_log_locinfo* locinfo,	\
+ATTR_UNUSED static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 				  const char* format, ...)		\
 {									\
 	if (lxc_log_priority_is_enabled(acategory, 			\
-					LXC_LOG_PRIORITY_##PRIORITY)) {	\
+					LXC_LOG_LEVEL_##LEVEL)) {	\
 		struct lxc_log_event evt = {				\
 			.category	= (acategory)->name,		\
-			.priority	= LXC_LOG_PRIORITY_##PRIORITY,	\
+			.priority	= LXC_LOG_LEVEL_##LEVEL,	\
 			.fmt		= format,			\
 			.locinfo	= locinfo			\
 		};							\
@@ -271,7 +271,7 @@ ATTR_UNUSED static inline void LXC_##PRIORITY(struct lxc_log_locinfo* locinfo,	\
 	extern struct lxc_log_category lxc_log_category_##parent;	\
 	struct lxc_log_category lxc_log_category_##name = {		\
 		#name,							\
-		LXC_LOG_PRIORITY_NOTSET,				\
+		LXC_LOG_LEVEL_NOTSET,				\
 		NULL,							\
 		&lxc_log_category_##parent				\
 	};

--- a/src/lxc/lxc_monitord.c
+++ b/src/lxc/lxc_monitord.c
@@ -368,7 +368,7 @@ int main(int argc, char *argv[])
 
 	log.name = NULL;
 	log.file = logpath;
-	log.priority = "DEBUG";
+	log.level = "DEBUG";
 	log.prefix = "lxc-monitord";
 	log.quiet = 0;
 	log.lxcpath = lxcpath;

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -1021,7 +1021,7 @@ struct lxc_log {
 	const char *name;
 	const char *lxcpath;
 	const char *file;
-	const char *priority;
+	const char *level;
 	const char *prefix;
 	bool quiet;
 };

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -795,7 +795,7 @@ int lxc_seccomp_load(struct lxc_conf *conf)
 /* After load seccomp filter into the kernel successfully, export the current seccomp
  * filter to log file */
 #if HAVE_SCMP_FILTER_CTX
-	if ((lxc_log_get_level() <= LXC_LOG_PRIORITY_TRACE || conf->loglevel <= LXC_LOG_PRIORITY_TRACE) &&
+	if ((lxc_log_get_level() <= LXC_LOG_LEVEL_TRACE || conf->loglevel <= LXC_LOG_LEVEL_TRACE) &&
 	    lxc_log_fd >= 0) {
 		ret = seccomp_export_pfc(conf->seccomp_ctx, lxc_log_fd);
 		/* Just give an warning when export error */

--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -389,7 +389,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_autostart.c
+++ b/src/lxc/tools/lxc_autostart.c
@@ -359,7 +359,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_cgroup.c
+++ b/src/lxc/tools/lxc_cgroup.c
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_checkpoint.c
+++ b/src/lxc/tools/lxc_checkpoint.c
@@ -245,7 +245,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_console.c
+++ b/src/lxc/tools/lxc_console.c
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_copy.c
+++ b/src/lxc/tools/lxc_copy.c
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_create.c
+++ b/src/lxc/tools/lxc_create.c
@@ -219,7 +219,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_destroy.c
+++ b/src/lxc/tools/lxc_destroy.c
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_device.c
+++ b/src/lxc/tools/lxc_device.c
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_freeze.c
+++ b/src/lxc/tools/lxc_freeze.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_info.c
+++ b/src/lxc/tools/lxc_info.c
@@ -404,7 +404,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_init.c
+++ b/src/lxc/tools/lxc_init.c
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 
 	log.name = name;
 	log.file = name ? NULL : "none";
-	log.priority = logpriority;
+	log.level = logpriority;
 	log.prefix = basename(argv[0]);
 	log.quiet = quiet;
 	log.lxcpath = lxcpath;

--- a/src/lxc/tools/lxc_ls.c
+++ b/src/lxc/tools/lxc_ls.c
@@ -221,7 +221,7 @@ int main(int argc, char *argv[])
 	 */
 	log.name = NULL;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_monitor.c
+++ b/src/lxc/tools/lxc_monitor.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_snapshot.c
+++ b/src/lxc/tools/lxc_snapshot.c
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_start.c
+++ b/src/lxc/tools/lxc_start.c
@@ -229,7 +229,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_stop.c
+++ b/src/lxc/tools/lxc_stop.c
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_unfreeze.c
+++ b/src/lxc/tools/lxc_unfreeze.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];

--- a/src/lxc/tools/lxc_wait.c
+++ b/src/lxc/tools/lxc_wait.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 
 	log.name = my_args.name;
 	log.file = my_args.log_file;
-	log.priority = my_args.log_priority;
+	log.level = my_args.log_priority;
 	log.prefix = my_args.progname;
 	log.quiet = my_args.quiet;
 	log.lxcpath = my_args.lxcpath[0];


### PR DESCRIPTION
When we merged the new logging function for the api we exposed the log level
argument in the struct as "priority" which we actually requested to be changed
to "level" which somehow didn't happen and we missed it. Given the fact there
has been no new liblxc release let's fix it right now before it hits users.
Also, take the chance to change the terminology in the log from "priority" to
"level" globally. This is to prevent confusion with syslog's "priority"
argument which we also support.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>