### PR TITLE
utils: fix the way to detect blocking signal

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1928,7 +1928,7 @@ bool task_blocking_signal(pid_t pid, int signal)
 				goto out;
 	}
 
-	if (sigblk & signal)
+	if (sigblk & (1 << (signal - 1)))
 		bret = true;
 
 out:


### PR DESCRIPTION
see issue #1625 

"sigblk" is a bitmask, so we use bit shift operators to detect whether the "signal" is blocked.

Signed-off-by: Yifeng Tan <tanyifeng1@huawei.com>