### PR TITLE
network: new network parser part II

### DIFF
--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -21,6 +21,7 @@ noinst_HEADERS = \
 	caps.h \
 	conf.h \
 	confile.h \
+	confile_network_legacy.h \
 	confile_utils.h \
 	console.h \
 	error.h \
@@ -103,6 +104,7 @@ liblxc_la_SOURCES = \
 	namespace.h namespace.c \
 	conf.c conf.h \
 	confile.c confile.h \
+	confile_network_legacy.c confile_network_legacy.h \
 	confile_utils.c confile_utils.h \
 	list.h \
 	state.c state.h \

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2533,6 +2533,13 @@ static int lxc_setup_networks_in_child_namespaces(const struct lxc_conf *conf,
 	lxc_list_for_each(iterator, network) {
 		netdev = iterator->elem;
 
+		/* REMOVE in LXC 3.0 */
+		if (netdev->idx < 0) {
+			ERROR("WARNING: using \"lxc.network.*\" keys to define "
+			      "networks is DEPRECATED, please switch to using "
+			      "\"lxc.net.[i].* keys\"");
+		}
+
 		if (lxc_setup_netdev_in_child_namespaces(netdev)) {
 			ERROR("failed to setup netdev");
 			return -1;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -45,6 +45,7 @@
 #include "parse.h"
 #include "config.h"
 #include "confile.h"
+#include "confile_network_legacy.h"
 #include "confile_utils.h"
 #include "utils.h"
 #include "log.h"
@@ -195,113 +196,106 @@ static int get_config_hooks(const char *, char *, int, struct lxc_conf *,
 			    void *);
 static int clr_config_hooks(const char *, struct lxc_conf *, void *);
 
-static int set_config_network_type(const char *, const char *,
-				   struct lxc_conf *, void *);
-static int get_config_network_type(const char *, char *, int, struct lxc_conf *,
-				   void *);
-static int clr_config_network_type(const char *, struct lxc_conf *, void *);
+static int set_config_net_type(const char *, const char *, struct lxc_conf *,
+			       void *);
+static int get_config_net_type(const char *, char *, int, struct lxc_conf *,
+			       void *);
+static int clr_config_net_type(const char *, struct lxc_conf *, void *);
 
-static int set_config_network_flags(const char *, const char *,
+static int set_config_net_flags(const char *, const char *, struct lxc_conf *,
+				void *);
+static int get_config_net_flags(const char *, char *, int, struct lxc_conf *,
+				void *);
+static int clr_config_net_flags(const char *, struct lxc_conf *, void *);
+
+static int set_config_net_link(const char *, const char *, struct lxc_conf *,
+			       void *);
+static int get_config_net_link(const char *, char *, int, struct lxc_conf *,
+			       void *);
+static int clr_config_net_link(const char *, struct lxc_conf *, void *);
+
+static int set_config_net_name(const char *, const char *, struct lxc_conf *,
+			       void *);
+static int get_config_net_name(const char *, char *, int, struct lxc_conf *,
+			       void *);
+static int clr_config_net_name(const char *, struct lxc_conf *, void *);
+
+static int set_config_net_veth_pair(const char *, const char *,
 				    struct lxc_conf *, void *);
-static int get_config_network_flags(const char *, char *, int,
+static int get_config_net_veth_pair(const char *, char *, int,
 				    struct lxc_conf *, void *);
-static int clr_config_network_flags(const char *, struct lxc_conf *, void *);
+static int clr_config_net_veth_pair(const char *, struct lxc_conf *, void *);
 
-static int set_config_network_link(const char *, const char *,
-				   struct lxc_conf *, void *);
-static int get_config_network_link(const char *, char *, int, struct lxc_conf *,
-				   void *);
-static int clr_config_network_link(const char *, struct lxc_conf *, void *);
+static int set_config_net_macvlan_mode(const char *, const char *,
+				       struct lxc_conf *, void *);
+static int get_config_net_macvlan_mode(const char *, char *, int,
+				       struct lxc_conf *, void *);
+static int clr_config_net_macvlan_mode(const char *, struct lxc_conf *, void *);
 
-static int set_config_network_name(const char *, const char *,
-				   struct lxc_conf *, void *);
-static int get_config_network_name(const char *, char *, int, struct lxc_conf *,
-				   void *);
-static int clr_config_network_name(const char *, struct lxc_conf *, void *);
+static int set_config_net_hwaddr(const char *, const char *, struct lxc_conf *,
+				 void *);
+static int get_config_net_hwaddr(const char *, char *, int, struct lxc_conf *,
+				 void *);
+static int clr_config_net_hwaddr(const char *, struct lxc_conf *, void *);
 
-static int set_config_network_veth_pair(const char *, const char *,
-					struct lxc_conf *, void *);
-static int get_config_network_veth_pair(const char *, char *, int,
-					struct lxc_conf *, void *);
-static int clr_config_network_veth_pair(const char *, struct lxc_conf *,
-					void *);
-
-static int set_config_network_macvlan_mode(const char *, const char *,
-					   struct lxc_conf *, void *);
-static int get_config_network_macvlan_mode(const char *, char *, int,
-					   struct lxc_conf *, void *);
-static int clr_config_network_macvlan_mode(const char *, struct lxc_conf *,
-					   void *);
-
-static int set_config_network_hwaddr(const char *, const char *,
-				     struct lxc_conf *, void *);
-static int get_config_network_hwaddr(const char *, char *, int,
-				     struct lxc_conf *, void *);
-static int clr_config_network_hwaddr(const char *, struct lxc_conf *, void *);
-
-static int set_config_network_vlan_id(const char *, const char *,
-				      struct lxc_conf *, void *);
-static int get_config_network_vlan_id(const char *, char *, int,
-				      struct lxc_conf *, void *);
-static int clr_config_network_vlan_id(const char *, struct lxc_conf *, void *);
-
-static int set_config_network_mtu(const char *, const char *, struct lxc_conf *,
+static int set_config_net_vlan_id(const char *, const char *, struct lxc_conf *,
 				  void *);
-static int get_config_network_mtu(const char *, char *, int, struct lxc_conf *,
+static int get_config_net_vlan_id(const char *, char *, int, struct lxc_conf *,
 				  void *);
-static int clr_config_network_mtu(const char *, struct lxc_conf *, void *);
+static int clr_config_net_vlan_id(const char *, struct lxc_conf *, void *);
 
-static int set_config_network_ipv4(const char *, const char *,
-				   struct lxc_conf *, void *);
-static int get_config_network_ipv4(const char *, char *, int, struct lxc_conf *,
-				   void *);
-static int clr_config_network_ipv4(const char *, struct lxc_conf *, void *);
-
-static int set_config_network_ipv4_gateway(const char *, const char *,
-					   struct lxc_conf *, void *);
-static int get_config_network_ipv4_gateway(const char *, char *, int,
-					   struct lxc_conf *, void *);
-static int clr_config_network_ipv4_gateway(const char *, struct lxc_conf *,
-					   void *);
-
-static int set_config_network_script_up(const char *, const char *,
-					struct lxc_conf *, void *);
-static int get_config_network_script_up(const char *, char *, int,
-					struct lxc_conf *, void *);
-static int clr_config_network_script_up(const char *, struct lxc_conf *,
-					void *);
-
-static int set_config_network_script_down(const char *, const char *,
-					  struct lxc_conf *, void *);
-static int get_config_network_script_down(const char *, char *, int,
-					  struct lxc_conf *, void *);
-static int clr_config_network_script_down(const char *, struct lxc_conf *,
-					  void *);
-
-static int set_config_network_ipv6(const char *, const char *,
-				   struct lxc_conf *, void *);
-static int get_config_network_ipv6(const char *, char *, int, struct lxc_conf *,
-				   void *);
-static int clr_config_network_ipv6(const char *, struct lxc_conf *, void *);
-
-static int set_config_network_ipv6_gateway(const char *, const char *,
-					   struct lxc_conf *, void *);
-static int get_config_network_ipv6_gateway(const char *, char *, int,
-					   struct lxc_conf *, void *);
-static int clr_config_network_ipv6_gateway(const char *, struct lxc_conf *,
-					   void *);
-
-static int set_config_network_nic(const char *, const char *, struct lxc_conf *,
-				  void *);
-static int get_config_network_nic(const char *, char *, int, struct lxc_conf *,
-				  void *);
-static int clr_config_network_nic(const char *, struct lxc_conf *, void *);
-
-static int set_config_network(const char *, const char *, struct lxc_conf *,
+static int set_config_net_mtu(const char *, const char *, struct lxc_conf *,
 			      void *);
-static int get_config_network(const char *, char *, int, struct lxc_conf *,
+static int get_config_net_mtu(const char *, char *, int, struct lxc_conf *,
 			      void *);
-static int clr_config_network(const char *, struct lxc_conf *, void *);
+static int clr_config_net_mtu(const char *, struct lxc_conf *, void *);
+
+static int set_config_net_ipv4(const char *, const char *, struct lxc_conf *,
+			       void *);
+static int get_config_net_ipv4(const char *, char *, int, struct lxc_conf *,
+			       void *);
+static int clr_config_net_ipv4(const char *, struct lxc_conf *, void *);
+
+static int set_config_net_ipv4_gateway(const char *, const char *,
+				       struct lxc_conf *, void *);
+static int get_config_net_ipv4_gateway(const char *, char *, int,
+				       struct lxc_conf *, void *);
+static int clr_config_net_ipv4_gateway(const char *, struct lxc_conf *, void *);
+
+static int set_config_net_script_up(const char *, const char *,
+				    struct lxc_conf *, void *);
+static int get_config_net_script_up(const char *, char *, int,
+				    struct lxc_conf *, void *);
+static int clr_config_net_script_up(const char *, struct lxc_conf *, void *);
+
+static int set_config_net_script_down(const char *, const char *,
+				      struct lxc_conf *, void *);
+static int get_config_net_script_down(const char *, char *, int,
+				      struct lxc_conf *, void *);
+static int clr_config_net_script_down(const char *, struct lxc_conf *, void *);
+
+static int set_config_net_ipv6(const char *, const char *, struct lxc_conf *,
+			       void *);
+static int get_config_net_ipv6(const char *, char *, int, struct lxc_conf *,
+			       void *);
+static int clr_config_net_ipv6(const char *, struct lxc_conf *, void *);
+
+static int set_config_net_ipv6_gateway(const char *, const char *,
+				       struct lxc_conf *, void *);
+static int get_config_net_ipv6_gateway(const char *, char *, int,
+				       struct lxc_conf *, void *);
+static int clr_config_net_ipv6_gateway(const char *, struct lxc_conf *, void *);
+
+static int set_config_net_nic(const char *, const char *, struct lxc_conf *,
+			      void *);
+static int get_config_net_nic(const char *, char *, int, struct lxc_conf *,
+			      void *);
+static int clr_config_net_nic(const char *, struct lxc_conf *, void *);
+
+static int set_config_net(const char *, const char *, struct lxc_conf *,
+			  void *);
+static int get_config_net(const char *, char *, int, struct lxc_conf *, void *);
+static int clr_config_net(const char *, struct lxc_conf *, void *);
 
 static int set_config_cap_drop(const char *, const char *, struct lxc_conf *,
 			       void *);
@@ -430,77 +424,98 @@ static int get_config_limit(const char *, char *, int, struct lxc_conf *,
 static int clr_config_limit(const char *, struct lxc_conf *, void *);
 
 static struct lxc_config_t config[] = {
-	{ "lxc.arch",                 set_config_personality,          get_config_personality,          clr_config_personality,          },
-	{ "lxc.pts",                  set_config_pts,                  get_config_pts,                  clr_config_pts,                  },
-	{ "lxc.tty",                  set_config_tty,                  get_config_tty,                  clr_config_tty,                  },
-	{ "lxc.devttydir",            set_config_ttydir,               get_config_ttydir,               clr_config_ttydir,               },
-	{ "lxc.kmsg",                 set_config_kmsg,                 get_config_kmsg,                 clr_config_kmsg,                 },
-	{ "lxc.aa_profile",           set_config_lsm_aa_profile,       get_config_lsm_aa_profile,       clr_config_lsm_aa_profile,       },
-	{ "lxc.aa_allow_incomplete",  set_config_lsm_aa_incomplete,    get_config_lsm_aa_incomplete,    clr_config_lsm_aa_incomplete,    },
-	{ "lxc.se_context",           set_config_lsm_se_context,       get_config_lsm_se_context,       clr_config_lsm_se_context,       },
-	{ "lxc.cgroup",               set_config_cgroup,               get_config_cgroup,               clr_config_cgroup,               },
-	{ "lxc.id_map",               set_config_idmaps,               get_config_idmaps,               clr_config_idmaps,               },
-	{ "lxc.loglevel",             set_config_loglevel,             get_config_loglevel,             clr_config_loglevel,             },
-	{ "lxc.logfile",              set_config_logfile,              get_config_logfile,              clr_config_logfile,              },
-	{ "lxc.mount.entry",          set_config_mount,                get_config_mount,                clr_config_mount,                },
-	{ "lxc.mount.auto",           set_config_mount_auto,           get_config_mount_auto,           clr_config_mount_auto,           },
-	{ "lxc.mount",                set_config_fstab,	               get_config_fstab,                clr_config_fstab,                },
-	{ "lxc.rootfs.mount",         set_config_rootfs_mount,         get_config_rootfs_mount,         clr_config_rootfs_mount,         },
-	{ "lxc.rootfs.options",       set_config_rootfs_options,       get_config_rootfs_options,       clr_config_rootfs_options,       },
-	{ "lxc.rootfs.backend",       set_config_rootfs_backend,       get_config_rootfs_backend,       clr_config_rootfs_backend,       },
-	{ "lxc.rootfs",               set_config_rootfs,               get_config_rootfs,               clr_config_rootfs,               },
-	{ "lxc.pivotdir",             set_config_pivotdir,             get_config_pivotdir,             clr_config_pivotdir,             },
-	{ "lxc.utsname",              set_config_utsname,              get_config_utsname,              clr_config_utsname,              },
-	{ "lxc.hook.pre-start",       set_config_hooks,                get_config_hooks,                clr_config_hooks,                },
-	{ "lxc.hook.pre-mount",       set_config_hooks,                get_config_hooks,                clr_config_hooks,                },
-	{ "lxc.hook.mount",           set_config_hooks,                get_config_hooks,                clr_config_hooks,                },
-	{ "lxc.hook.autodev",         set_config_hooks,                get_config_hooks,                clr_config_hooks,                },
-	{ "lxc.hook.start",           set_config_hooks,                get_config_hooks,                clr_config_hooks,                },
-	{ "lxc.hook.stop",            set_config_hooks,                get_config_hooks,                clr_config_hooks,                },
-	{ "lxc.hook.post-stop",       set_config_hooks,                get_config_hooks,                clr_config_hooks,                },
-	{ "lxc.hook.clone",           set_config_hooks,                get_config_hooks,                clr_config_hooks,                },
-	{ "lxc.hook.destroy",         set_config_hooks,                get_config_hooks,                clr_config_hooks,                },
-	{ "lxc.hook",                 set_config_hooks,                get_config_hooks,                clr_config_hooks,                },
-	{ "lxc.network.type",         set_config_network_type,         get_config_network_type,         clr_config_network_type,         },
-	{ "lxc.network.flags",        set_config_network_flags,        get_config_network_flags,        clr_config_network_flags,        },
-	{ "lxc.network.link",         set_config_network_link,         get_config_network_link,         clr_config_network_link,         },
-	{ "lxc.network.name",         set_config_network_name,         get_config_network_name,         clr_config_network_name,         },
-	{ "lxc.network.macvlan.mode", set_config_network_macvlan_mode, get_config_network_macvlan_mode, clr_config_network_macvlan_mode, },
-	{ "lxc.network.veth.pair",    set_config_network_veth_pair,    get_config_network_veth_pair,    clr_config_network_veth_pair,    },
-	{ "lxc.network.script.up",    set_config_network_script_up,    get_config_network_script_up,    clr_config_network_script_up,    },
-	{ "lxc.network.script.down",  set_config_network_script_down,  get_config_network_script_down,  clr_config_network_script_down,  },
-	{ "lxc.network.hwaddr",       set_config_network_hwaddr,       get_config_network_hwaddr,       clr_config_network_hwaddr,       },
-	{ "lxc.network.mtu",          set_config_network_mtu,          get_config_network_mtu,          clr_config_network_mtu,          },
-	{ "lxc.network.vlan.id",      set_config_network_vlan_id,      get_config_network_vlan_id,      clr_config_network_vlan_id,      },
-	{ "lxc.network.ipv4.gateway", set_config_network_ipv4_gateway, get_config_network_ipv4_gateway, clr_config_network_ipv4_gateway, },
-	{ "lxc.network.ipv4",         set_config_network_ipv4,         get_config_network_ipv4,         clr_config_network_ipv4,         },
-	{ "lxc.network.ipv6.gateway", set_config_network_ipv6_gateway, get_config_network_ipv6_gateway, clr_config_network_ipv6_gateway, },
-	{ "lxc.network.ipv6",         set_config_network_ipv6,         get_config_network_ipv6,         clr_config_network_ipv6,         },
-	{ "lxc.network.",             set_config_network_nic,          get_config_network_nic,          clr_config_network_nic,          },
-	{ "lxc.network",              set_config_network,              get_config_network,              clr_config_network,              },
-	{ "lxc.cap.drop",             set_config_cap_drop,             get_config_cap_drop,             clr_config_cap_drop,             },
-	{ "lxc.cap.keep",             set_config_cap_keep,             get_config_cap_keep,             clr_config_cap_keep,             },
-	{ "lxc.console.logfile",      set_config_console_logfile,      get_config_console_logfile,      clr_config_console_logfile,      },
-	{ "lxc.console",              set_config_console,              get_config_console,              clr_config_console,              },
-	{ "lxc.seccomp",              set_config_seccomp,              get_config_seccomp,              clr_config_seccomp,              },
-	{ "lxc.include",              set_config_includefiles,         get_config_includefiles,         clr_config_includefiles,         },
-	{ "lxc.autodev",              set_config_autodev,              get_config_autodev,              clr_config_autodev,              },
-	{ "lxc.haltsignal",           set_config_haltsignal,           get_config_haltsignal,           clr_config_haltsignal,           },
-	{ "lxc.rebootsignal",         set_config_rebootsignal,         get_config_rebootsignal,         clr_config_rebootsignal,         },
-	{ "lxc.stopsignal",           set_config_stopsignal,           get_config_stopsignal,           clr_config_stopsignal,           },
-	{ "lxc.start.auto",           set_config_start,                get_config_start,                clr_config_start,                },
-	{ "lxc.start.delay",          set_config_start,                get_config_start,                clr_config_start,                },
-	{ "lxc.start.order",          set_config_start,                get_config_start,                clr_config_start,                },
-	{ "lxc.monitor.unshare",      set_config_monitor,              get_config_monitor,              clr_config_monitor,              },
-	{ "lxc.group",                set_config_group,                get_config_group,                clr_config_group,                },
-	{ "lxc.environment",          set_config_environment,          get_config_environment,          clr_config_environment,          },
-	{ "lxc.init_cmd",             set_config_init_cmd,             get_config_init_cmd,             clr_config_init_cmd,             },
-	{ "lxc.init_uid",             set_config_init_uid,             get_config_init_uid,             clr_config_init_uid,             },
-	{ "lxc.init_gid",             set_config_init_gid,             get_config_init_gid,             clr_config_init_gid,             },
-	{ "lxc.ephemeral",            set_config_ephemeral,            get_config_ephemeral,            clr_config_ephemeral,            },
-	{ "lxc.syslog",               set_config_syslog,               get_config_syslog,               clr_config_syslog,               },
-	{ "lxc.no_new_privs",	      set_config_no_new_privs,         get_config_no_new_privs,         clr_config_no_new_privs,         },
-	{ "lxc.limit",                set_config_limit,                get_config_limit,                clr_config_limit,                },
+	{ "lxc.arch",                 set_config_personality,          get_config_personality,          clr_config_personality,       },
+	{ "lxc.pts",                  set_config_pts,                  get_config_pts,                  clr_config_pts,               },
+	{ "lxc.tty",                  set_config_tty,                  get_config_tty,                  clr_config_tty,               },
+	{ "lxc.devttydir",            set_config_ttydir,               get_config_ttydir,               clr_config_ttydir,            },
+	{ "lxc.kmsg",                 set_config_kmsg,                 get_config_kmsg,                 clr_config_kmsg,              },
+	{ "lxc.aa_profile",           set_config_lsm_aa_profile,       get_config_lsm_aa_profile,       clr_config_lsm_aa_profile,    },
+	{ "lxc.aa_allow_incomplete",  set_config_lsm_aa_incomplete,    get_config_lsm_aa_incomplete,    clr_config_lsm_aa_incomplete, },
+	{ "lxc.se_context",           set_config_lsm_se_context,       get_config_lsm_se_context,       clr_config_lsm_se_context,    },
+	{ "lxc.cgroup",               set_config_cgroup,               get_config_cgroup,               clr_config_cgroup,            },
+	{ "lxc.id_map",               set_config_idmaps,               get_config_idmaps,               clr_config_idmaps,            },
+	{ "lxc.loglevel",             set_config_loglevel,             get_config_loglevel,             clr_config_loglevel,          },
+	{ "lxc.logfile",              set_config_logfile,              get_config_logfile,              clr_config_logfile,           },
+	{ "lxc.mount.entry",          set_config_mount,                get_config_mount,                clr_config_mount,             },
+	{ "lxc.mount.auto",           set_config_mount_auto,           get_config_mount_auto,           clr_config_mount_auto,        },
+	{ "lxc.mount",                set_config_fstab,	               get_config_fstab,                clr_config_fstab,             },
+	{ "lxc.rootfs.mount",         set_config_rootfs_mount,         get_config_rootfs_mount,         clr_config_rootfs_mount,      },
+	{ "lxc.rootfs.options",       set_config_rootfs_options,       get_config_rootfs_options,       clr_config_rootfs_options,    },
+	{ "lxc.rootfs.backend",       set_config_rootfs_backend,       get_config_rootfs_backend,       clr_config_rootfs_backend,    },
+	{ "lxc.rootfs",               set_config_rootfs,               get_config_rootfs,               clr_config_rootfs,            },
+	{ "lxc.pivotdir",             set_config_pivotdir,             get_config_pivotdir,             clr_config_pivotdir,          },
+	{ "lxc.utsname",              set_config_utsname,              get_config_utsname,              clr_config_utsname,           },
+	{ "lxc.hook.pre-start",       set_config_hooks,                get_config_hooks,                clr_config_hooks,             },
+	{ "lxc.hook.pre-mount",       set_config_hooks,                get_config_hooks,                clr_config_hooks,             },
+	{ "lxc.hook.mount",           set_config_hooks,                get_config_hooks,                clr_config_hooks,             },
+	{ "lxc.hook.autodev",         set_config_hooks,                get_config_hooks,                clr_config_hooks,             },
+	{ "lxc.hook.start",           set_config_hooks,                get_config_hooks,                clr_config_hooks,             },
+	{ "lxc.hook.stop",            set_config_hooks,                get_config_hooks,                clr_config_hooks,             },
+	{ "lxc.hook.post-stop",       set_config_hooks,                get_config_hooks,                clr_config_hooks,             },
+	{ "lxc.hook.clone",           set_config_hooks,                get_config_hooks,                clr_config_hooks,             },
+	{ "lxc.hook.destroy",         set_config_hooks,                get_config_hooks,                clr_config_hooks,             },
+	{ "lxc.hook",                 set_config_hooks,                get_config_hooks,                clr_config_hooks,             },
+	/* legacy network keys */
+	{ "lxc.network.type",         set_config_network_legacy_type,         get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.flags",        set_config_network_legacy_flags,        get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.link",         set_config_network_legacy_link,         get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.name",         set_config_network_legacy_name,         get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.macvlan.mode", set_config_network_legacy_macvlan_mode, get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.veth.pair",    set_config_network_legacy_veth_pair,    get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.script.up",    set_config_network_legacy_script_up,    get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.script.down",  set_config_network_legacy_script_down,  get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.hwaddr",       set_config_network_legacy_hwaddr,       get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.mtu",          set_config_network_legacy_mtu,          get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.vlan.id",      set_config_network_legacy_vlan_id,      get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.ipv4.gateway", set_config_network_legacy_ipv4_gateway, get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.ipv4",         set_config_network_legacy_ipv4,         get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.ipv6.gateway", set_config_network_legacy_ipv6_gateway, get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.ipv6",         set_config_network_legacy_ipv6,         get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network.",             set_config_network_legacy_nic,          get_config_network_legacy_item,         clr_config_network_legacy_item, },
+	{ "lxc.network",              set_config_network_legacy,              get_config_network_legacy,              clr_config_network_legacy,      },
+
+	{ "lxc.net.type",             set_config_net_type,             get_config_net_type,             clr_config_net_type,          },
+	{ "lxc.net.flags",            set_config_net_flags,            get_config_net_flags,            clr_config_net_flags,         },
+	{ "lxc.net.link",             set_config_net_link,             get_config_net_link,             clr_config_net_link,          },
+	{ "lxc.net.name",             set_config_net_name,             get_config_net_name,             clr_config_net_name,          },
+	{ "lxc.net.macvlan.mode",     set_config_net_macvlan_mode,     get_config_net_macvlan_mode,     clr_config_net_macvlan_mode,  },
+	{ "lxc.net.veth.pair",        set_config_net_veth_pair,        get_config_net_veth_pair,        clr_config_net_veth_pair,     },
+	{ "lxc.net.script.up",        set_config_net_script_up,        get_config_net_script_up,        clr_config_net_script_up,     },
+	{ "lxc.net.script.down",      set_config_net_script_down,      get_config_net_script_down,      clr_config_net_script_down,   },
+	{ "lxc.net.hwaddr",           set_config_net_hwaddr,           get_config_net_hwaddr,           clr_config_net_hwaddr,        },
+	{ "lxc.net.mtu",              set_config_net_mtu,              get_config_net_mtu,              clr_config_net_mtu,           },
+	{ "lxc.net.vlan.id",          set_config_net_vlan_id,          get_config_net_vlan_id,          clr_config_net_vlan_id,       },
+	{ "lxc.net.ipv4.gateway",     set_config_net_ipv4_gateway,     get_config_net_ipv4_gateway,     clr_config_net_ipv4_gateway,  },
+	{ "lxc.net.ipv4",             set_config_net_ipv4,             get_config_net_ipv4,             clr_config_net_ipv4,          },
+	{ "lxc.net.ipv6.gateway",     set_config_net_ipv6_gateway,     get_config_net_ipv6_gateway,     clr_config_net_ipv6_gateway,  },
+	{ "lxc.net.ipv6",             set_config_net_ipv6,             get_config_net_ipv6,             clr_config_net_ipv6,          },
+	{ "lxc.net.",                 set_config_net_nic,              get_config_net_nic,              clr_config_net_nic,           },
+	{ "lxc.net",                  set_config_net,                  get_config_net,                  clr_config_net,               },
+
+
+	{ "lxc.cap.drop",             set_config_cap_drop,             get_config_cap_drop,             clr_config_cap_drop,          },
+	{ "lxc.cap.keep",             set_config_cap_keep,             get_config_cap_keep,             clr_config_cap_keep,          },
+	{ "lxc.console.logfile",      set_config_console_logfile,      get_config_console_logfile,      clr_config_console_logfile,   },
+	{ "lxc.console",              set_config_console,              get_config_console,              clr_config_console,           },
+	{ "lxc.seccomp",              set_config_seccomp,              get_config_seccomp,              clr_config_seccomp,           },
+	{ "lxc.include",              set_config_includefiles,         get_config_includefiles,         clr_config_includefiles,      },
+	{ "lxc.autodev",              set_config_autodev,              get_config_autodev,              clr_config_autodev,           },
+	{ "lxc.haltsignal",           set_config_haltsignal,           get_config_haltsignal,           clr_config_haltsignal,        },
+	{ "lxc.rebootsignal",         set_config_rebootsignal,         get_config_rebootsignal,         clr_config_rebootsignal,      },
+	{ "lxc.stopsignal",           set_config_stopsignal,           get_config_stopsignal,           clr_config_stopsignal,        },
+	{ "lxc.start.auto",           set_config_start,                get_config_start,                clr_config_start,             },
+	{ "lxc.start.delay",          set_config_start,                get_config_start,                clr_config_start,             },
+	{ "lxc.start.order",          set_config_start,                get_config_start,                clr_config_start,             },
+	{ "lxc.monitor.unshare",      set_config_monitor,              get_config_monitor,              clr_config_monitor,           },
+	{ "lxc.group",                set_config_group,                get_config_group,                clr_config_group,             },
+	{ "lxc.environment",          set_config_environment,          get_config_environment,          clr_config_environment,       },
+	{ "lxc.init_cmd",             set_config_init_cmd,             get_config_init_cmd,             clr_config_init_cmd,          },
+	{ "lxc.init_uid",             set_config_init_uid,             get_config_init_uid,             clr_config_init_uid,          },
+	{ "lxc.init_gid",             set_config_init_gid,             get_config_init_gid,             clr_config_init_gid,          },
+	{ "lxc.ephemeral",            set_config_ephemeral,            get_config_ephemeral,            clr_config_ephemeral,         },
+	{ "lxc.syslog",               set_config_syslog,               get_config_syslog,               clr_config_syslog,            },
+	{ "lxc.no_new_privs",	      set_config_no_new_privs,         get_config_no_new_privs,         clr_config_no_new_privs,      },
+	{ "lxc.limit",                set_config_limit,                get_config_limit,                clr_config_limit,             },
 };
 
 struct signame {
@@ -599,23 +614,6 @@ extern struct lxc_config_t *lxc_getconfig(const char *key)
 	return NULL;
 }
 
-#define strprint(str, inlen, ...)                                              \
-	do {                                                                   \
-		len = snprintf(str, inlen, ##__VA_ARGS__);                     \
-		if (len < 0) {                                                 \
-			SYSERROR("failed to create string");                   \
-			return -1;                                             \
-		};                                                             \
-		fulllen += len;                                                \
-		if (inlen > 0) {                                               \
-			if (str)                                               \
-				str += len;                                    \
-			inlen -= len;                                          \
-			if (inlen < 0)                                         \
-				inlen = 0;                                     \
-		}                                                              \
-	} while (0);
-
 int lxc_listconfigs(char *retv, int inlen)
 {
 	size_t i;
@@ -637,90 +635,29 @@ int lxc_listconfigs(char *retv, int inlen)
 	return fulllen;
 }
 
-static int set_config_string_item(char **conf_item, const char *value)
-{
-	char *new_value;
-
-	if (lxc_config_value_empty(value)) {
-		free(*conf_item);
-		*conf_item = NULL;
-		return 0;
-	}
-
-	new_value = strdup(value);
-	if (!new_value) {
-		SYSERROR("failed to duplicate string \"%s\"", value);
-		return -1;
-	}
-
-	free(*conf_item);
-	*conf_item = new_value;
-	return 0;
-}
-
-static int set_config_string_item_max(char **conf_item, const char *value,
-				      size_t max)
-{
-	if (strlen(value) >= max) {
-		ERROR("%s is too long (>= %lu)", value, (unsigned long)max);
-		return -1;
-	}
-
-	return set_config_string_item(conf_item, value);
-}
-
-static int set_config_path_item(char **conf_item, const char *value)
-{
-	return set_config_string_item_max(conf_item, value, PATH_MAX);
-}
-
-static int set_config_network(const char *key, const char *value,
-			      struct lxc_conf *lxc_conf, void *data)
+static int set_config_net(const char *key, const char *value,
+			  struct lxc_conf *lxc_conf, void *data)
 {
 	if (!lxc_config_value_empty(value)) {
-		ERROR("lxc.network must not have a value");
+		ERROR("lxc.net must not have a value");
 		return -1;
 	}
 
-	return clr_config_network(key, lxc_conf, data);
+	return clr_config_net(key, lxc_conf, data);
 }
 
-static int set_config_network_type(const char *key, const char *value,
-				   struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_type(const char *key, const char *value,
+			       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_type(key, lxc_conf, data);
+		return clr_config_net_type(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-
-		/* We maintain a negative count for legacy network devices. */
-		ssize_t negidx = -1;
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.type\" without an index "
-		     "(e.g.\"lxc.network.0.type\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		if (!lxc_list_empty(&lxc_conf->network)) {
-			struct lxc_netdev *ndv;
-			ndv = lxc_list_first_elem(&lxc_conf->network);
-			if (ndv->idx < 0) {
-				negidx = ndv->idx;
-				negidx--;
-			}
-		}
-		if (negidx == INT_MIN) {
-			SYSERROR("number of configured networks would overflow "
-				 "the counter... what are you doing?");
-			return -1;
-		}
-		netdev = lxc_network_add(&lxc_conf->network, negidx, false);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -746,20 +683,8 @@ static int set_config_network_type(const char *key, const char *value,
 	return 0;
 }
 
-static int config_ip_prefix(struct in_addr *addr)
-{
-	if (IN_CLASSA(addr->s_addr))
-		return 32 - IN_CLASSA_NSHIFT;
-	if (IN_CLASSB(addr->s_addr))
-		return 32 - IN_CLASSB_NSHIFT;
-	if (IN_CLASSC(addr->s_addr))
-		return 32 - IN_CLASSC_NSHIFT;
-
-	return 0;
-}
-
 /*
- * If you have p="lxc.network.0.link", pass it p+12
+ * If you have p="lxc.net.0.link", pass it p+12
  * to get back '0' (the index of the nic).
  */
 static int get_network_netdev_idx(const char *key)
@@ -777,7 +702,7 @@ static int get_network_netdev_idx(const char *key)
 }
 
 /*
- * If you have p="lxc.network.0", pass this p+12 and it will return
+ * If you have p="lxc.net.0", pass this p+12 and it will return
  * the netdev of the first configured nic.
  */
 static struct lxc_netdev *get_netdev_from_key(const char *key,
@@ -809,7 +734,7 @@ extern int lxc_list_nicconfigs(struct lxc_conf *c, const char *key, char *retv,
 	int len;
 	int fulllen = 0;
 
-	netdev = get_netdev_from_key(key + 12, &c->network);
+	netdev = get_netdev_from_key(key + 8, &c->network);
 	if (!netdev)
 		return -1;
 
@@ -850,63 +775,18 @@ extern int lxc_list_nicconfigs(struct lxc_conf *c, const char *key, char *retv,
 	return fulllen;
 }
 
-static int network_ifname(char **valuep, const char *value)
-{
-	return set_config_string_item_max(valuep, value, IFNAMSIZ);
-}
-
-static int rand_complete_hwaddr(char *hwaddr)
-{
-	const char hex[] = "0123456789abcdef";
-	char *curs = hwaddr;
-
-#ifndef HAVE_RAND_R
-	randseed(true);
-#else
-	unsigned int seed;
-
-	seed = randseed(false);
-#endif
-	while (*curs != '\0' && *curs != '\n') {
-		if (*curs == 'x' || *curs == 'X') {
-			if (curs - hwaddr == 1) {
-				/* ensure address is unicast */
-#ifdef HAVE_RAND_R
-				*curs = hex[rand_r(&seed) & 0x0E];
-			} else {
-				*curs = hex[rand_r(&seed) & 0x0F];
-#else
-				*curs = hex[rand() & 0x0E];
-			} else {
-				*curs = hex[rand() & 0x0F];
-#endif
-			}
-		}
-		curs++;
-	}
-	return 0;
-}
-
-static int set_config_network_flags(const char *key, const char *value,
-				    struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_flags(const char *key, const char *value,
+				struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_flags(key, lxc_conf, data);
+		return clr_config_net_flags(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.flags\" without an index "
-		     "(e.g.\"lxc.network.0.flags\"). LET US KNOW IF YOU NEED "
-		     "TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -916,13 +796,13 @@ static int set_config_network_flags(const char *key, const char *value,
 }
 
 static int create_matched_ifnames(const char *value, struct lxc_conf *lxc_conf,
-				  struct lxc_netdev *netdev)
+			   struct lxc_netdev *netdev)
 {
 	struct ifaddrs *ifaddr, *ifa;
 	int n;
 	int ret = 0;
-	const char *type_key = "lxc.network.type";
-	const char *link_key = "lxc.network.link";
+	const char *type_key = "lxc.net.type";
+	const char *link_key = "lxc.net.link";
 	const char *tmpvalue = "phys";
 
 	if (getifaddrs(&ifaddr) == -1) {
@@ -937,10 +817,10 @@ static int create_matched_ifnames(const char *value, struct lxc_conf *lxc_conf,
 			continue;
 
 		if (!strncmp(value, ifa->ifa_name, strlen(value) - 1)) {
-			ret = set_config_network_type(type_key, tmpvalue,
-						      lxc_conf, netdev);
+			ret = set_config_net_type(type_key, tmpvalue, lxc_conf,
+						  netdev);
 			if (!ret) {
-				ret = set_config_network_link(
+				ret = set_config_net_link(
 				    link_key, ifa->ifa_name, lxc_conf, netdev);
 				if (ret) {
 					ERROR("failed to create matched ifnames");
@@ -959,27 +839,19 @@ static int create_matched_ifnames(const char *value, struct lxc_conf *lxc_conf,
 	return ret;
 }
 
-static int set_config_network_link(const char *key, const char *value,
-				   struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_link(const char *key, const char *value,
+			       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 	int ret = 0;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_link(key, lxc_conf, data);
+		return clr_config_net_link(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.link\" without an index "
-		     "(e.g.\"lxc.network.0.link\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -991,107 +863,73 @@ static int set_config_network_link(const char *key, const char *value,
 	return ret;
 }
 
-static int set_config_network_name(const char *key, const char *value,
-				   struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_name(const char *key, const char *value,
+			       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_name(key, lxc_conf, data);
+		return clr_config_net_name(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.name\" without an index "
-		     "(e.g.\"lxc.network.0.name\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
 	return network_ifname(&netdev->name, value);
 }
 
-static int set_config_network_veth_pair(const char *key, const char *value,
-					struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_veth_pair(const char *key, const char *value,
+				    struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_veth_pair(key, lxc_conf, data);
+		return clr_config_net_veth_pair(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.veth.pair\" without an index "
-		     "(e.g.\"lxc.network.0.veth.pair\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
 	return network_ifname(&netdev->priv.veth_attr.pair, value);
 }
 
-static int set_config_network_macvlan_mode(const char *key, const char *value,
-					   struct lxc_conf *lxc_conf,
-					   void *data)
+static int set_config_net_macvlan_mode(const char *key, const char *value,
+				       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_macvlan_mode(key, lxc_conf, data);
+		return clr_config_net_macvlan_mode(key, lxc_conf, data);
 
-	/* lxc.network.* without an index */
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.macvlan.mode\" without an index "
-		     "(e.g.\"lxc.network.0.macvlan.mode\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
 	return lxc_macvlan_mode_to_flag(&netdev->priv.macvlan_attr.mode, value);
 }
 
-static int set_config_network_hwaddr(const char *key, const char *value,
-				     struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_hwaddr(const char *key, const char *value,
+				 struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 	char *new_value;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_hwaddr(key, lxc_conf, data);
+		return clr_config_net_hwaddr(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.hwaddr\" without an index "
-		     "(e.g.\"lxc.network.0.hwaddr\"). LET US KNOW IF YOU NEED "
-		     "TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -1112,26 +950,18 @@ static int set_config_network_hwaddr(const char *key, const char *value,
 	return 0;
 }
 
-static int set_config_network_vlan_id(const char *key, const char *value,
-				      struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_vlan_id(const char *key, const char *value,
+				  struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_vlan_id(key, lxc_conf, data);
+		return clr_config_net_vlan_id(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.vlan.id\" without an index "
-		     "(e.g.\"lxc.network.0.vlan.id\"). LET US KNOW IF YOU NEED "
-		     "TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -1141,34 +971,26 @@ static int set_config_network_vlan_id(const char *key, const char *value,
 	return 0;
 }
 
-static int set_config_network_mtu(const char *key, const char *value,
-				  struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_mtu(const char *key, const char *value,
+			      struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_mtu(key, lxc_conf, data);
+		return clr_config_net_mtu(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.mtu\" without an index "
-		     "(e.g.\"lxc.network.0.mtu\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
 	return set_config_string_item(&netdev->mtu, value);
 }
 
-static int set_config_network_ipv4(const char *key, const char *value,
-				   struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_ipv4(const char *key, const char *value,
+			       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 	struct lxc_inetdev *inetdev;
@@ -1177,20 +999,12 @@ static int set_config_network_ipv4(const char *key, const char *value,
 	char *addr = NULL, *bcast = NULL, *prefix = NULL;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_ipv4(key, lxc_conf, data);
+		return clr_config_net_ipv4(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv4\" without an index "
-		     "(e.g.\"lxc.network.0.ipv4\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -1270,27 +1084,18 @@ static int set_config_network_ipv4(const char *key, const char *value,
 	return 0;
 }
 
-static int set_config_network_ipv4_gateway(const char *key, const char *value,
-					   struct lxc_conf *lxc_conf,
-					   void *data)
+static int set_config_net_ipv4_gateway(const char *key, const char *value,
+				       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_ipv4_gateway(key, lxc_conf, data);
+		return clr_config_net_ipv4_gateway(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv4.gateway\" without an index "
-		     "(e.g.\"lxc.network.0.ipv4.gateway\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -1323,8 +1128,8 @@ static int set_config_network_ipv4_gateway(const char *key, const char *value,
 	return 0;
 }
 
-static int set_config_network_ipv6(const char *key, const char *value,
-				   struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_ipv6(const char *key, const char *value,
+			       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 	struct lxc_inet6dev *inet6dev;
@@ -1332,20 +1137,12 @@ static int set_config_network_ipv6(const char *key, const char *value,
 	char *slash, *valdup, *netmask;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_ipv6(key, lxc_conf, data);
+		return clr_config_net_ipv6(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv6\" without an index "
-		     "(e.g.\"lxc.network.0.ipv6\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -1397,27 +1194,18 @@ static int set_config_network_ipv6(const char *key, const char *value,
 	return 0;
 }
 
-static int set_config_network_ipv6_gateway(const char *key, const char *value,
-					   struct lxc_conf *lxc_conf,
-					   void *data)
+static int set_config_net_ipv6_gateway(const char *key, const char *value,
+				       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_ipv6_gateway(key, lxc_conf, data);
+		return clr_config_net_ipv6_gateway(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv6.gateway\" without an index "
-		     "(e.g.\"lxc.network.0.ipv6.gateway\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -1450,52 +1238,36 @@ static int set_config_network_ipv6_gateway(const char *key, const char *value,
 	return 0;
 }
 
-static int set_config_network_script_up(const char *key, const char *value,
-					struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_script_up(const char *key, const char *value,
+				    struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_script_up(key, lxc_conf, data);
+		return clr_config_net_script_up(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.script.up\" without an index "
-		     "(e.g.\"lxc.network.0.script.up\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
 	return set_config_string_item(&netdev->upscript, value);
 }
 
-static int set_config_network_script_down(const char *key, const char *value,
-					  struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_script_down(const char *key, const char *value,
+				      struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_script_down(key, lxc_conf, data);
+		return clr_config_net_script_down(key, lxc_conf, data);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.script.down\" without an index "
-		     "(e.g.\"lxc.network.0.script.down\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -2459,40 +2231,6 @@ static int set_config_console_logfile(const char *key, const char *value,
 	return set_config_path_item(&lxc_conf->console.log_path, value);
 }
 
-/*
- * If we find a lxc.network.hwaddr in the original config file, we expand it in
- * the unexpanded_config, so that after a save_config we store the hwaddr for
- * re-use.
- * This is only called when reading the config file, not when executing a
- * lxc.include.
- * 'x' and 'X' are substituted in-place.
- */
-static void update_hwaddr(const char *line)
-{
-	char *p;
-
-	line += lxc_char_left_gc(line, strlen(line));
-	if (line[0] == '#')
-		return;
-
-	if (strncmp(line, "lxc.network.hwaddr", 18) != 0)
-		return;
-
-	/* Let config_network_hwaddr raise the error. */
-	p = strchr(line, '=');
-	if (!p)
-		return;
-	p++;
-
-	while (isblank(*p))
-		p++;
-
-	if (!*p)
-		return;
-
-	rand_complete_hwaddr(p);
-}
-
 int append_unexp_config_line(const char *line, struct lxc_conf *conf)
 {
 	size_t len = conf->unexpanded_len, linelen = strlen(line);
@@ -3177,22 +2915,6 @@ bool clone_update_unexp_hooks(struct lxc_conf *conf, const char *oldpath,
 		}                                                              \
 	}
 
-static bool new_hwaddr(char *hwaddr)
-{
-	int ret;
-
-	(void)randseed(true);
-
-	ret = snprintf(hwaddr, 18, "00:16:3e:%02x:%02x:%02x", rand() % 255,
-		       rand() % 255, rand() % 255);
-	if (ret < 0 || ret >= 18) {
-		SYSERROR("Failed to call snprintf().");
-		return false;
-	}
-
-	return true;
-}
-
 /*
  * This is called only from clone.  We wish to update all hwaddrs in the
  * unexpanded config file.  We can't/don't want to update any which come from
@@ -3711,8 +3433,8 @@ static int get_config_hooks(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
-static int get_config_network(const char *key, char *retv, int inlen,
-			      struct lxc_conf *c, void *data)
+static int get_config_net(const char *key, char *retv, int inlen,
+			  struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
 	struct lxc_list *it;
@@ -4114,8 +3836,8 @@ static inline int clr_config_hooks(const char *key, struct lxc_conf *c,
 	return lxc_clear_hooks(c, key);
 }
 
-static inline int clr_config_network(const char *key, struct lxc_conf *c,
-				     void *data)
+static inline int clr_config_net(const char *key, struct lxc_conf *c,
+				 void *data)
 {
 	lxc_free_networks(&c->network);
 
@@ -4288,25 +4010,25 @@ get_network_config_ops(const char *key, struct lxc_conf *lxc_conf, ssize_t *idx)
 	struct lxc_config_t *config = NULL;
 
 	/* check that this is a sensible network key */
-	if (strncmp("lxc.network.", key, 12))
+	if (strncmp("lxc.net.", key, 8))
 		return NULL;
 
 	copy = strdup(key);
 	if (!copy)
 		return NULL;
 
-	/* lxc.network.<n> */
-	if (isdigit(*(key + 12))) {
+	/* lxc.net.<n> */
+	if (isdigit(*(key + 8))) {
 		int ret;
 		unsigned int tmpidx;
 		size_t numstrlen;
 
 		/* beginning of index string */
-		idx_start = (copy + 11);
+		idx_start = (copy + 7);
 		*idx_start = '\0';
 
 		/* end of index string */
-		idx_end = strchr((copy + 12), '.');
+		idx_end = strchr((copy + 8), '.');
 		if (!idx_end)
 			goto on_error;
 		*idx_end = '\0';
@@ -4336,7 +4058,7 @@ get_network_config_ops(const char *key, struct lxc_conf *lxc_conf, ssize_t *idx)
 		*idx_start = '.';
 		*idx_end = '.';
 
-		memmove(copy + 12, idx_end + 1, strlen(idx_end + 1));
+		memmove(copy + 8, idx_end + 1, strlen(idx_end + 1));
 		copy[strlen(key) - numstrlen + 1] = '\0';
 	}
 
@@ -4350,19 +4072,19 @@ on_error:
 }
 
 /*
- * Config entry is something like "lxc.network.0.ipv4" the key 'lxc.network.'
+ * Config entry is something like "lxc.net.0.ipv4" the key 'lxc.net.'
  * was found.  So we make sure next comes an integer, find the right callback
  * (by rewriting the key), and call it.
  */
-static int set_config_network_nic(const char *key, const char *value,
-				  struct lxc_conf *lxc_conf, void *data)
+static int set_config_net_nic(const char *key, const char *value,
+			      struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_config_t *config;
 	struct lxc_netdev *netdev;
 	ssize_t idx = -1;
 
 	if (lxc_config_value_empty(value))
-		return clr_config_network_nic(key, lxc_conf, data);
+		return clr_config_net_nic(key, lxc_conf, data);
 
 	config = get_network_config_ops(key, lxc_conf, &idx);
 	if (!config || idx < 0)
@@ -4376,23 +4098,23 @@ static int set_config_network_nic(const char *key, const char *value,
 }
 
 /*
- * Config entry is something like "lxc.network.0.ipv4" the key 'lxc.network.'
+ * Config entry is something like "lxc.net.0.ipv4" the key 'lxc.net.'
  * was found.  So we make sure next comes an integer, find the right callback
  * (by rewriting the key), and call it.
  */
-static int clr_config_network_nic(const char *key, struct lxc_conf *lxc_conf,
-				  void *data)
+static int clr_config_net_nic(const char *key, struct lxc_conf *lxc_conf,
+			      void *data)
 {
 	const char *idxstring;
 	struct lxc_config_t *config;
 	struct lxc_netdev *netdev;
 	ssize_t idx;
 
-	/* If we get passed "lxc.network.<n>" we clear the whole network. */
-	if (strncmp("lxc.network.", key, 12))
+	/* If we get passed "lxc.net.<n>" we clear the whole network. */
+	if (strncmp("lxc.net.", key, 8))
 		return -1;
 
-	idxstring = key + 12;
+	idxstring = key + 8;
 	/* The left conjunct is pretty self-explanatory. The right conjunct
 	 * checks whether the two pointers are equal. If they are we now that
 	 * this is not a key that is namespaced any further and so we are
@@ -4420,23 +4142,15 @@ static int clr_config_network_nic(const char *key, struct lxc_conf *lxc_conf,
 	return config->clr(key, lxc_conf, netdev);
 }
 
-static int clr_config_network_type(const char *key, struct lxc_conf *lxc_conf,
-				   void *data)
+static int clr_config_net_type(const char *key, struct lxc_conf *lxc_conf,
+			       void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.type\" without an index "
-		     "(e.g.\"lxc.network.0.type\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4445,23 +4159,15 @@ static int clr_config_network_type(const char *key, struct lxc_conf *lxc_conf,
 	return 0;
 }
 
-static int clr_config_network_name(const char *key, struct lxc_conf *lxc_conf,
-				   void *data)
+static int clr_config_net_name(const char *key, struct lxc_conf *lxc_conf,
+			       void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.name\" without an index "
-		     "(e.g.\"lxc.network.0.name\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4471,24 +4177,15 @@ static int clr_config_network_name(const char *key, struct lxc_conf *lxc_conf,
 	return 0;
 }
 
-
-static int clr_config_network_flags(const char *key, struct lxc_conf *lxc_conf,
-				    void *data)
+static int clr_config_net_flags(const char *key, struct lxc_conf *lxc_conf,
+				void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.flags\" without an index "
-		     "(e.g.\"lxc.network.0.flags\"). LET US KNOW IF YOU NEED "
-		     "TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4497,23 +4194,15 @@ static int clr_config_network_flags(const char *key, struct lxc_conf *lxc_conf,
 	return 0;
 }
 
-static int clr_config_network_link(const char *key, struct lxc_conf *lxc_conf,
-				   void *data)
+static int clr_config_net_link(const char *key, struct lxc_conf *lxc_conf,
+			       void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.link\" without an index "
-		     "(e.g.\"lxc.network.0.link\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4523,24 +4212,15 @@ static int clr_config_network_link(const char *key, struct lxc_conf *lxc_conf,
 	return 0;
 }
 
-static int clr_config_network_macvlan_mode(const char *key,
-					   struct lxc_conf *lxc_conf,
-					   void *data)
+static int clr_config_net_macvlan_mode(const char *key,
+				       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.macvlan.mode\" without an index "
-		     "(e.g.\"lxc.network.0.macvlan.mode\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4552,23 +4232,15 @@ static int clr_config_network_macvlan_mode(const char *key,
 	return 0;
 }
 
-static int clr_config_network_veth_pair(const char *key,
-					struct lxc_conf *lxc_conf, void *data)
+static int clr_config_net_veth_pair(const char *key, struct lxc_conf *lxc_conf,
+				    void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.veth.pair\" without an index "
-		     "(e.g.\"lxc.network.0.veth.pair\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4578,23 +4250,15 @@ static int clr_config_network_veth_pair(const char *key,
 	return 0;
 }
 
-static int clr_config_network_script_up(const char *key,
-					struct lxc_conf *lxc_conf, void *data)
+static int clr_config_net_script_up(const char *key, struct lxc_conf *lxc_conf,
+				    void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.script.up\" without an index "
-		     "(e.g.\"lxc.network.0.script.up\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4604,23 +4268,15 @@ static int clr_config_network_script_up(const char *key,
 	return 0;
 }
 
-static int clr_config_network_script_down(const char *key,
-					  struct lxc_conf *lxc_conf, void *data)
+static int clr_config_net_script_down(const char *key,
+				      struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.script.down\" without an index "
-		     "(e.g.\"lxc.network.0.script.down\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4630,23 +4286,15 @@ static int clr_config_network_script_down(const char *key,
 	return 0;
 }
 
-static int clr_config_network_hwaddr(const char *key, struct lxc_conf *lxc_conf,
-				     void *data)
+static int clr_config_net_hwaddr(const char *key, struct lxc_conf *lxc_conf,
+				 void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.hwaddr\" without an index "
-		     "(e.g.\"lxc.network.0.hwaddr\"). LET US KNOW IF YOU NEED "
-		     "TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4656,23 +4304,15 @@ static int clr_config_network_hwaddr(const char *key, struct lxc_conf *lxc_conf,
 	return 0;
 }
 
-static int clr_config_network_mtu(const char *key, struct lxc_conf *lxc_conf,
-				  void *data)
+static int clr_config_net_mtu(const char *key, struct lxc_conf *lxc_conf,
+			      void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.mtu\" without an index "
-		     "(e.g.\"lxc.network.0.mtu\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4682,23 +4322,15 @@ static int clr_config_network_mtu(const char *key, struct lxc_conf *lxc_conf,
 	return 0;
 }
 
-static int clr_config_network_vlan_id(const char *key,
-				      struct lxc_conf *lxc_conf, void *data)
+static int clr_config_net_vlan_id(const char *key, struct lxc_conf *lxc_conf,
+				  void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.vlan.id\" without an index "
-		     "(e.g.\"lxc.network.0.vlan.id\"). LET US KNOW IF YOU NEED "
-		     "TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4707,24 +4339,15 @@ static int clr_config_network_vlan_id(const char *key,
 	return 0;
 }
 
-static int clr_config_network_ipv4_gateway(const char *key,
-					   struct lxc_conf *lxc_conf,
-					   void *data)
+static int clr_config_net_ipv4_gateway(const char *key,
+				       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv4.gateway\" without an index "
-		     "(e.g.\"lxc.network.0.ipv4.gateway\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4734,24 +4357,16 @@ static int clr_config_network_ipv4_gateway(const char *key,
 	return 0;
 }
 
-static int clr_config_network_ipv4(const char *key, struct lxc_conf *lxc_conf,
-				   void *data)
+static int clr_config_net_ipv4(const char *key, struct lxc_conf *lxc_conf,
+			       void *data)
 {
 	struct lxc_netdev *netdev;
 	struct lxc_list *cur, *next;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv4\" without an index "
-		     "(e.g.\"lxc.network.0.ipv4\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4764,24 +4379,15 @@ static int clr_config_network_ipv4(const char *key, struct lxc_conf *lxc_conf,
 	return 0;
 }
 
-static int clr_config_network_ipv6_gateway(const char *key,
-					   struct lxc_conf *lxc_conf,
-					   void *data)
+static int clr_config_net_ipv6_gateway(const char *key,
+				       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv6.gateway\" without an index "
-		     "(e.g.\"lxc.network.0.ipv6.gateway\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4791,24 +4397,16 @@ static int clr_config_network_ipv6_gateway(const char *key,
 	return 0;
 }
 
-static int clr_config_network_ipv6(const char *key, struct lxc_conf *lxc_conf,
-				   void *data)
+static int clr_config_net_ipv6(const char *key, struct lxc_conf *lxc_conf,
+			       void *data)
 {
 	struct lxc_netdev *netdev;
 	struct lxc_list *cur, *next;
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv6\" without an index "
-		     "(e.g.\"lxc.network.0.ipv6\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&lxc_conf->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4821,8 +4419,8 @@ static int clr_config_network_ipv6(const char *key, struct lxc_conf *lxc_conf,
 	return 0;
 }
 
-static int get_config_network_nic(const char *key, char *retv, int inlen,
-				  struct lxc_conf *c, void *data)
+static int get_config_net_nic(const char *key, char *retv, int inlen,
+			      struct lxc_conf *c, void *data)
 {
 	struct lxc_config_t *config;
 	struct lxc_netdev *netdev;
@@ -4839,8 +4437,8 @@ static int get_config_network_nic(const char *key, char *retv, int inlen,
 	return config->get(key, retv, inlen, c, netdev);
 }
 
-static int get_config_network_type(const char *key, char *retv, int inlen,
-				   struct lxc_conf *c, void *data)
+static int get_config_net_type(const char *key, char *retv, int inlen,
+			       struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
 	struct lxc_netdev *netdev;
@@ -4850,18 +4448,10 @@ static int get_config_network_type(const char *key, char *retv, int inlen,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.type\" without an index "
-		     "(e.g.\"lxc.network.0.type\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4870,8 +4460,8 @@ static int get_config_network_type(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
-static int get_config_network_flags(const char *key, char *retv, int inlen,
-				    struct lxc_conf *c, void *data)
+static int get_config_net_flags(const char *key, char *retv, int inlen,
+				struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
 	struct lxc_netdev *netdev;
@@ -4881,18 +4471,10 @@ static int get_config_network_flags(const char *key, char *retv, int inlen,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.flags\" without an index "
-		     "(e.g.\"lxc.network.0.flags\"). LET US KNOW IF YOU NEED "
-		     "TO USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4902,8 +4484,8 @@ static int get_config_network_flags(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
-static int get_config_network_link(const char *key, char *retv, int inlen,
-				   struct lxc_conf *c, void *data)
+static int get_config_net_link(const char *key, char *retv, int inlen,
+			       struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
 	struct lxc_netdev *netdev;
@@ -4913,18 +4495,10 @@ static int get_config_network_link(const char *key, char *retv, int inlen,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.link\" without an index "
-		     "(e.g.\"lxc.network.0.link\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4934,8 +4508,8 @@ static int get_config_network_link(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
-static int get_config_network_name(const char *key, char *retv, int inlen,
-				   struct lxc_conf *c, void *data)
+static int get_config_net_name(const char *key, char *retv, int inlen,
+			       struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
 	struct lxc_netdev *netdev;
@@ -4945,18 +4519,10 @@ static int get_config_network_name(const char *key, char *retv, int inlen,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.name\" without an index "
-		     "(e.g.\"lxc.network.0.name\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -4966,9 +4532,8 @@ static int get_config_network_name(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
-static int get_config_network_macvlan_mode(const char *key, char *retv,
-					   int inlen, struct lxc_conf *c,
-					   void *data)
+static int get_config_net_macvlan_mode(const char *key, char *retv, int inlen,
+				       struct lxc_conf *c, void *data)
 {
 	const char *mode;
 	int len, fulllen = 0;
@@ -4979,18 +4544,10 @@ static int get_config_network_macvlan_mode(const char *key, char *retv,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.macvlan.mode\" without an index "
-		     "(e.g.\"lxc.network.0.macvlan.mode\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -5020,8 +4577,8 @@ static int get_config_network_macvlan_mode(const char *key, char *retv,
 	return fulllen;
 }
 
-static int get_config_network_veth_pair(const char *key, char *retv, int inlen,
-					struct lxc_conf *c, void *data)
+static int get_config_net_veth_pair(const char *key, char *retv, int inlen,
+				    struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
 	struct lxc_netdev *netdev;
@@ -5031,18 +4588,10 @@ static int get_config_network_veth_pair(const char *key, char *retv, int inlen,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.veth.pair\" without an index "
-		     "(e.g.\"lxc.network.0.veth.pair\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -5056,8 +4605,8 @@ static int get_config_network_veth_pair(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
-static int get_config_network_script_up(const char *key, char *retv, int inlen,
-					struct lxc_conf *c, void *data)
+static int get_config_net_script_up(const char *key, char *retv, int inlen,
+				    struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
 	struct lxc_netdev *netdev;
@@ -5067,18 +4616,10 @@ static int get_config_network_script_up(const char *key, char *retv, int inlen,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.script.up\" without an index "
-		     "(e.g.\"lxc.network.0.script.up\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -5088,104 +4629,7 @@ static int get_config_network_script_up(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
-static int get_config_network_script_down(const char *key, char *retv,
-					  int inlen, struct lxc_conf *c,
-					  void *data)
-{
-	int len, fulllen = 0;
-	struct lxc_netdev *netdev;
-
-	if (!retv)
-		inlen = 0;
-	else
-		memset(retv, 0, inlen);
-
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.script.down\" without an index "
-		     "(e.g.\"lxc.network.0.script.down\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
-		netdev = data;
-	}
-	if (!netdev)
-		return -1;
-
-	if (netdev->downscript)
-		strprint(retv, inlen, "%s", netdev->downscript);
-
-	return fulllen;
-}
-
-static int get_config_network_hwaddr(const char *key, char *retv, int inlen,
-				     struct lxc_conf *c, void *data)
-{
-	int len, fulllen = 0;
-	struct lxc_netdev *netdev;
-
-	if (!retv)
-		inlen = 0;
-	else
-		memset(retv, 0, inlen);
-
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.hwaddr\" without an index "
-		     "(e.g.\"lxc.network.0.hwaddr\"). LET US KNOW IF YOU NEED "
-		     "TO USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
-		netdev = data;
-	}
-	if (!netdev)
-		return -1;
-
-	if (netdev->hwaddr)
-		strprint(retv, inlen, "%s", netdev->hwaddr);
-
-	return fulllen;
-}
-
-static int get_config_network_mtu(const char *key, char *retv, int inlen,
-				  struct lxc_conf *c, void *data)
-{
-	int len, fulllen = 0;
-	struct lxc_netdev *netdev;
-
-	if (!retv)
-		inlen = 0;
-	else
-		memset(retv, 0, inlen);
-
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.mtu\" without an index "
-		     "(e.g.\"lxc.network.0.mtu\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
-		netdev = data;
-	}
-	if (!netdev)
-		return -1;
-
-	if (netdev->mtu)
-		strprint(retv, inlen, "%s", netdev->mtu);
-
-	return fulllen;
-}
-
-static int get_config_network_vlan_id(const char *key, char *retv, int inlen,
+static int get_config_net_script_down(const char *key, char *retv, int inlen,
 				      struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
@@ -5196,18 +4640,82 @@ static int get_config_network_vlan_id(const char *key, char *retv, int inlen,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.vlan.id\" without an index "
-		     "(e.g.\"lxc.network.0.vlan.id\"). LET US KNOW IF YOU NEED "
-		     "TO USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
+	if (!netdev)
+		return -1;
+
+	if (netdev->downscript)
+		strprint(retv, inlen, "%s", netdev->downscript);
+
+	return fulllen;
+}
+
+static int get_config_net_hwaddr(const char *key, char *retv, int inlen,
+				 struct lxc_conf *c, void *data)
+{
+	int len, fulllen = 0;
+	struct lxc_netdev *netdev;
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	if (!data)
+		return -1;
+	else
+		netdev = data;
+	if (!netdev)
+		return -1;
+
+	if (netdev->hwaddr)
+		strprint(retv, inlen, "%s", netdev->hwaddr);
+
+	return fulllen;
+}
+
+static int get_config_net_mtu(const char *key, char *retv, int inlen,
+			      struct lxc_conf *c, void *data)
+{
+	int len, fulllen = 0;
+	struct lxc_netdev *netdev;
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	if (!data)
+		return -1;
+	else
+		netdev = data;
+	if (!netdev)
+		return -1;
+
+	if (netdev->mtu)
+		strprint(retv, inlen, "%s", netdev->mtu);
+
+	return fulllen;
+}
+
+static int get_config_net_vlan_id(const char *key, char *retv, int inlen,
+				  struct lxc_conf *c, void *data)
+{
+	int len, fulllen = 0;
+	struct lxc_netdev *netdev;
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	if (!data)
+		return -1;
+	else
+		netdev = data;
 	if (!netdev)
 		return -1;
 
@@ -5219,9 +4727,8 @@ static int get_config_network_vlan_id(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
-static int get_config_network_ipv4_gateway(const char *key, char *retv,
-					   int inlen, struct lxc_conf *c,
-					   void *data)
+static int get_config_net_ipv4_gateway(const char *key, char *retv, int inlen,
+				       struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
 	char buf[INET_ADDRSTRLEN];
@@ -5232,18 +4739,10 @@ static int get_config_network_ipv4_gateway(const char *key, char *retv,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv4.gateway\" without an index "
-		     "(e.g.\"lxc.network.0.ipv4.gateway\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -5257,8 +4756,8 @@ static int get_config_network_ipv4_gateway(const char *key, char *retv,
 	return fulllen;
 }
 
-static int get_config_network_ipv4(const char *key, char *retv, int inlen,
-				   struct lxc_conf *c, void *data)
+static int get_config_net_ipv4(const char *key, char *retv, int inlen,
+			       struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
 	size_t listlen;
@@ -5271,18 +4770,10 @@ static int get_config_network_ipv4(const char *key, char *retv, int inlen,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv4\" without an index "
-		     "(e.g.\"lxc.network.0.ipv4\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -5297,9 +4788,8 @@ static int get_config_network_ipv4(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
-static int get_config_network_ipv6_gateway(const char *key, char *retv,
-					   int inlen, struct lxc_conf *c,
-					   void *data)
+static int get_config_net_ipv6_gateway(const char *key, char *retv, int inlen,
+				       struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
 	char buf[INET6_ADDRSTRLEN];
@@ -5310,18 +4800,10 @@ static int get_config_network_ipv6_gateway(const char *key, char *retv,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv6.gateway\" without an index "
-		     "(e.g.\"lxc.network.0.ipv6.gateway\"). LET US KNOW IF YOU "
-		     "NEED TO USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 
@@ -5335,8 +4817,8 @@ static int get_config_network_ipv6_gateway(const char *key, char *retv,
 	return fulllen;
 }
 
-static int get_config_network_ipv6(const char *key, char *retv, int inlen,
-				   struct lxc_conf *c, void *data)
+static int get_config_net_ipv6(const char *key, char *retv, int inlen,
+			       struct lxc_conf *c, void *data)
 {
 	int len, fulllen = 0;
 	size_t listlen;
@@ -5349,18 +4831,10 @@ static int get_config_network_ipv6(const char *key, char *retv, int inlen,
 	else
 		memset(retv, 0, inlen);
 
-	if (!data) {
-		/* REMOVE IN LXC 3.0:
-		 * lxc.network.* without an index
-		 */
-		WARN("WARNING: We're considering DEPRECATING "
-		     "\"lxc.network.ipv6\" without an index "
-		     "(e.g.\"lxc.network.0.ipv6\"). LET US KNOW IF YOU NEED TO "
-		     "USE THIS!");
-		netdev = lxc_list_first_elem(&c->network);
-	} else {
+	if (!data)
+		return -1;
+	else
 		netdev = data;
-	}
 	if (!netdev)
 		return -1;
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1101,9 +1101,7 @@ static int set_config_net_ipv4_gateway(const char *key, const char *value,
 
 	free(netdev->ipv4_gateway);
 
-	if (lxc_config_value_empty(value)) {
-		netdev->ipv4_gateway = NULL;
-	} else if (!strcmp(value, "auto")) {
+	if (!strcmp(value, "auto")) {
 		netdev->ipv4_gateway = NULL;
 		netdev->ipv4_gateway_auto = true;
 	} else {
@@ -1211,9 +1209,7 @@ static int set_config_net_ipv6_gateway(const char *key, const char *value,
 
 	free(netdev->ipv6_gateway);
 
-	if (lxc_config_value_empty(value)) {
-		netdev->ipv6_gateway = NULL;
-	} else if (!strcmp(value, "auto")) {
+	if (!strcmp(value, "auto")) {
 		netdev->ipv6_gateway = NULL;
 		netdev->ipv6_gateway_auto = true;
 	} else {

--- a/src/lxc/confile_network_legacy.c
+++ b/src/lxc/confile_network_legacy.c
@@ -1,0 +1,1002 @@
+/*
+ * lxc: linux Container library
+ * (C) Copyright IBM Corp. 2007, 2008
+ *
+ * Authors:
+ * Daniel Lezcano <daniel.lezcano at free.fr>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#define _GNU_SOURCE
+#define __STDC_FORMAT_MACROS /* Required for PRIu64 to work. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <ctype.h>
+#include <inttypes.h> /* Required for PRIu64 to work. */
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/utsname.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <net/if.h>
+#include <time.h>
+#include <dirent.h>
+#include <syslog.h>
+
+#include "bdev.h"
+#include "parse.h"
+#include "config.h"
+#include "confile.h"
+#include "confile_utils.h"
+#include "confile_network_legacy.h"
+#include "utils.h"
+#include "log.h"
+#include "conf.h"
+#include "network.h"
+#include "lxcseccomp.h"
+
+#if HAVE_IFADDRS_H
+#include <ifaddrs.h>
+#else
+#include <../include/ifaddrs.h>
+#endif
+
+lxc_log_define(lxc_confile_network_legacy, lxc);
+
+/*
+ * Config entry is something like "lxc.network.0.ipv4" the key 'lxc.network.'
+ * was found.  So we make sure next comes an integer, find the right callback
+ * (by rewriting the key), and call it.
+ */
+int set_config_network_legacy_nic(const char *key, const char *value,
+				  struct lxc_conf *lxc_conf, void *data)
+{
+	char *copy = strdup(key), *p;
+	int ret = -1;
+	struct lxc_config_t *config;
+
+	if (!copy) {
+		SYSERROR("failed to allocate memory");
+		return -1;
+	}
+	/*
+	 * Ok we know that to get here we've got "lxc.network."
+	 * and it isn't any of the other network entries.  So
+	 * after the second . Should come an integer (# of defined
+	 * nic) followed by a valid entry.
+	 */
+	if (*(key + 12) < '0' || *(key + 12) > '9')
+		goto out;
+
+	p = strchr(key + 12, '.');
+	if (!p)
+		goto out;
+
+	strcpy(copy + 12, p + 1);
+	config = lxc_getconfig(copy);
+	if (!config) {
+		ERROR("unknown key %s", key);
+		goto out;
+	}
+	ret = config->set(key, value, lxc_conf, NULL);
+
+out:
+	free(copy);
+	return ret;
+}
+
+static void lxc_remove_nic(struct lxc_list *it)
+{
+	struct lxc_netdev *netdev = it->elem;
+	struct lxc_list *it2,*next;
+
+	lxc_list_del(it);
+
+	free(netdev->link);
+	free(netdev->name);
+	if (netdev->type == LXC_NET_VETH)
+		free(netdev->priv.veth_attr.pair);
+	free(netdev->upscript);
+	free(netdev->hwaddr);
+	free(netdev->mtu);
+	free(netdev->ipv4_gateway);
+	free(netdev->ipv6_gateway);
+	lxc_list_for_each_safe(it2, &netdev->ipv4, next) {
+		lxc_list_del(it2);
+		free(it2->elem);
+		free(it2);
+	}
+	lxc_list_for_each_safe(it2, &netdev->ipv6, next) {
+		lxc_list_del(it2);
+		free(it2->elem);
+		free(it2);
+	}
+	free(netdev);
+	free(it);
+}
+
+static int lxc_clear_config_network(struct lxc_conf *c)
+{
+	struct lxc_list *it,*next;
+	lxc_list_for_each_safe(it, &c->network, next) {
+		lxc_remove_nic(it);
+	}
+	return 0;
+}
+
+int set_config_network_legacy(const char *key, const char *value,
+		       struct lxc_conf *lxc_conf, void *data)
+{
+	if (!lxc_config_value_empty(value)) {
+		ERROR("lxc.network must not have a value");
+		return -1;
+	}
+
+	return lxc_clear_config_network(lxc_conf);
+}
+
+int set_config_network_legacy_type(const char *key, const char *value,
+				   struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_list *network = &lxc_conf->network;
+	struct lxc_netdev *netdev, *prevnetdev;
+	struct lxc_list *list;
+
+	if (lxc_config_value_empty(value))
+		return lxc_clear_config_network(lxc_conf);
+
+	netdev = malloc(sizeof(*netdev));
+	if (!netdev) {
+		SYSERROR("failed to allocate memory");
+		return -1;
+	}
+
+	memset(netdev, 0, sizeof(*netdev));
+	lxc_list_init(&netdev->ipv4);
+	lxc_list_init(&netdev->ipv6);
+
+	list = malloc(sizeof(*list));
+	if (!list) {
+		SYSERROR("failed to allocate memory");
+		free(netdev);
+		return -1;
+	}
+
+	lxc_list_init(list);
+	list->elem = netdev;
+
+	/* We maintain a negative count for legacy networks. */
+	netdev->idx = -1;
+	if (!lxc_list_empty(network)) {
+		prevnetdev = lxc_list_last_elem(network);
+		netdev->idx = prevnetdev->idx;
+		if (netdev->idx == INT_MIN) {
+			ERROR("number of requested networks would underflow "
+			      "counter");
+			free(netdev);
+			free(list);
+			return -1;
+		}
+		netdev->idx--;
+	}
+
+	lxc_list_add_tail(network, list);
+
+	if (!strcmp(value, "veth"))
+		netdev->type = LXC_NET_VETH;
+	else if (!strcmp(value, "macvlan")) {
+		netdev->type = LXC_NET_MACVLAN;
+		lxc_macvlan_mode_to_flag(&netdev->priv.macvlan_attr.mode, "private");
+	} else if (!strcmp(value, "vlan"))
+		netdev->type = LXC_NET_VLAN;
+	else if (!strcmp(value, "phys"))
+		netdev->type = LXC_NET_PHYS;
+	else if (!strcmp(value, "empty"))
+		netdev->type = LXC_NET_EMPTY;
+	else if (!strcmp(value, "none"))
+		netdev->type = LXC_NET_NONE;
+	else {
+		ERROR("invalid network type %s", value);
+		return -1;
+	}
+	return 0;
+}
+
+/*
+ * If you have p="lxc.network.0.link", pass it p+12
+ * to get back '0' (the index of the nic).
+ */
+static int get_network_netdev_idx(const char *key)
+{
+	int ret, idx;
+
+	if (*key < '0' || *key > '9')
+		return -1;
+
+	ret = sscanf(key, "%d", &idx);
+	if (ret != 1)
+		return -1;
+
+	return idx;
+}
+
+/*
+ * If you have p="lxc.network.0", pass this p+12 and it will return
+ * the netdev of the first configured nic.
+ */
+static struct lxc_netdev *get_netdev_from_key(const char *key,
+					      struct lxc_list *network)
+{
+	int idx;
+	struct lxc_list *it;
+	int i = 0;
+	struct lxc_netdev *netdev = NULL;
+
+	idx = get_network_netdev_idx(key);
+	if (idx == -1)
+		return NULL;
+
+	lxc_list_for_each(it, network) {
+		if (idx == i++) {
+			netdev = it->elem;
+			break;
+		}
+	}
+
+	return netdev;
+}
+
+int lxc_list_nicconfigs_legacy(struct lxc_conf *c, const char *key, char *retv,
+			       int inlen)
+{
+	struct lxc_netdev *netdev;
+	int len;
+	int fulllen = 0;
+
+	netdev = get_netdev_from_key(key + 12, &c->network);
+	if (!netdev)
+		return -1;
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	strprint(retv, inlen, "type\n");
+	strprint(retv, inlen, "script.up\n");
+	strprint(retv, inlen, "script.down\n");
+	if (netdev->type != LXC_NET_EMPTY) {
+		strprint(retv, inlen, "flags\n");
+		strprint(retv, inlen, "link\n");
+		strprint(retv, inlen, "name\n");
+		strprint(retv, inlen, "hwaddr\n");
+		strprint(retv, inlen, "mtu\n");
+		strprint(retv, inlen, "ipv6\n");
+		strprint(retv, inlen, "ipv6.gateway\n");
+		strprint(retv, inlen, "ipv4\n");
+		strprint(retv, inlen, "ipv4.gateway\n");
+	}
+
+	switch (netdev->type) {
+	case LXC_NET_VETH:
+		strprint(retv, inlen, "veth.pair\n");
+		break;
+	case LXC_NET_MACVLAN:
+		strprint(retv, inlen, "macvlan.mode\n");
+		break;
+	case LXC_NET_VLAN:
+		strprint(retv, inlen, "vlan.id\n");
+		break;
+	case LXC_NET_PHYS:
+		break;
+	}
+
+	return fulllen;
+}
+
+static struct lxc_netdev *network_netdev(const char *key, const char *value,
+					 struct lxc_list *network)
+{
+	struct lxc_netdev *netdev = NULL;
+
+	if (lxc_list_empty(network)) {
+		ERROR("network is not created for '%s' = '%s' option", key,
+		      value);
+		return NULL;
+	}
+
+	if (get_network_netdev_idx(key + 12) == -1)
+		netdev = lxc_list_last_elem(network);
+	else
+		netdev = get_netdev_from_key(key + 12, network);
+
+	if (!netdev) {
+		ERROR("no network device defined for '%s' = '%s' option", key,
+		      value);
+		return NULL;
+	}
+
+	return netdev;
+}
+
+int set_config_network_legacy_flags(const char *key, const char *value,
+				    struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	netdev->flags |= IFF_UP;
+
+	return 0;
+}
+
+static int create_matched_ifnames(const char *value, struct lxc_conf *lxc_conf,
+			   struct lxc_netdev *netdev)
+{
+	struct ifaddrs *ifaddr, *ifa;
+	int n;
+	int ret = 0;
+	const char *type_key = "lxc.network.type";
+	const char *link_key = "lxc.network.link";
+	const char *tmpvalue = "phys";
+
+	if (getifaddrs(&ifaddr) == -1) {
+		SYSERROR("Get network interfaces failed");
+		return -1;
+	}
+
+	for (ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++) {
+		if (!ifa->ifa_addr)
+			continue;
+		if (ifa->ifa_addr->sa_family != AF_PACKET)
+			continue;
+
+		if (!strncmp(value, ifa->ifa_name, strlen(value) - 1)) {
+			ret = set_config_network_legacy_type(type_key, tmpvalue,
+							     lxc_conf, netdev);
+			if (!ret) {
+				ret = set_config_network_legacy_link(
+				    link_key, ifa->ifa_name, lxc_conf, netdev);
+				if (ret) {
+					ERROR("failed to create matched ifnames");
+					break;
+				}
+			} else {
+				ERROR("failed to create matched ifnames");
+				break;
+			}
+		}
+	}
+
+	freeifaddrs(ifaddr);
+	ifaddr = NULL;
+
+	return ret;
+}
+
+int set_config_network_legacy_link(const char *key, const char *value,
+				   struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev;
+	struct lxc_list *it;
+	int ret = 0;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	if (value[strlen(value) - 1] == '+' && netdev->type == LXC_NET_PHYS) {
+		/* Get the last network list and remove it. */
+		it = lxc_conf->network.prev;
+		if (((struct lxc_netdev *)(it->elem))->type != LXC_NET_PHYS) {
+			ERROR("lxc config cannot support string pattern "
+			      "matching for this link type");
+			return -1;
+		}
+
+		lxc_list_del(it);
+		free(it);
+		ret = create_matched_ifnames(value, lxc_conf, NULL);
+	} else {
+		ret = network_ifname(&netdev->link, value);
+	}
+
+	return ret;
+}
+
+int set_config_network_legacy_name(const char *key, const char *value,
+				   struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	return network_ifname(&netdev->name, value);
+}
+
+int set_config_network_legacy_veth_pair(const char *key, const char *value,
+					struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	if (netdev->type != LXC_NET_VETH) {
+		ERROR("Invalid veth pair for a non-veth netdev");
+		return -1;
+	}
+
+	return network_ifname(&netdev->priv.veth_attr.pair, value);
+}
+
+int set_config_network_legacy_macvlan_mode(const char *key, const char *value,
+					   struct lxc_conf *lxc_conf,
+					   void *data)
+{
+	struct lxc_netdev *netdev;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	if (netdev->type != LXC_NET_MACVLAN) {
+		ERROR("Invalid macvlan.mode for a non-macvlan netdev");
+		return -1;
+	}
+
+	return lxc_macvlan_mode_to_flag(&netdev->priv.macvlan_attr.mode, value);
+}
+
+int set_config_network_legacy_hwaddr(const char *key, const char *value,
+				     struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev;
+	char *new_value;
+
+	new_value = strdup(value);
+	if (!new_value) {
+		SYSERROR("failed to strdup \"%s\"", value);
+		return -1;
+	}
+	rand_complete_hwaddr(new_value);
+
+	netdev = network_netdev(key, new_value, &lxc_conf->network);
+	if (!netdev) {
+		free(new_value);
+		return -1;
+	};
+
+	if (lxc_config_value_empty(new_value)) {
+		free(new_value);
+		netdev->hwaddr = NULL;
+		return 0;
+	}
+
+	netdev->hwaddr = new_value;
+	return 0;
+}
+
+int set_config_network_legacy_vlan_id(const char *key, const char *value,
+				      struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	if (netdev->type != LXC_NET_VLAN) {
+		ERROR("Invalid vlan.id for a non-macvlan netdev");
+		return -1;
+	}
+
+	if (get_u16(&netdev->priv.vlan_attr.vid, value, 0))
+		return -1;
+
+	return 0;
+}
+
+int set_config_network_legacy_mtu(const char *key, const char *value,
+				  struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	return set_config_string_item(&netdev->mtu, value);
+}
+
+int set_config_network_legacy_ipv4(const char *key, const char *value,
+				   struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev;
+	struct lxc_inetdev *inetdev;
+	struct lxc_list *list;
+	char *cursor, *slash;
+	char *addr = NULL, *bcast = NULL, *prefix = NULL;
+
+	if (lxc_config_value_empty(value))
+		return clr_config_network_legacy_item(key, lxc_conf, NULL);
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	inetdev = malloc(sizeof(*inetdev));
+	if (!inetdev) {
+		SYSERROR("failed to allocate ipv4 address");
+		return -1;
+	}
+	memset(inetdev, 0, sizeof(*inetdev));
+
+	list = malloc(sizeof(*list));
+	if (!list) {
+		SYSERROR("failed to allocate memory");
+		free(inetdev);
+		return -1;
+	}
+
+	lxc_list_init(list);
+	list->elem = inetdev;
+
+	addr = strdup(value);
+	if (!addr) {
+		ERROR("no address specified");
+		free(inetdev);
+		free(list);
+		return -1;
+	}
+
+	cursor = strstr(addr, " ");
+	if (cursor) {
+		*cursor = '\0';
+		bcast = cursor + 1;
+	}
+
+	slash = strstr(addr, "/");
+	if (slash) {
+		*slash = '\0';
+		prefix = slash + 1;
+	}
+
+	if (!inet_pton(AF_INET, addr, &inetdev->addr)) {
+		SYSERROR("invalid ipv4 address: %s", value);
+		free(inetdev);
+		free(addr);
+		free(list);
+		return -1;
+	}
+
+	if (bcast && !inet_pton(AF_INET, bcast, &inetdev->bcast)) {
+		SYSERROR("invalid ipv4 broadcast address: %s", value);
+		free(inetdev);
+		free(list);
+		free(addr);
+		return -1;
+	}
+
+	/* No prefix specified, determine it from the network class. */
+	if (prefix) {
+		if (lxc_safe_uint(prefix, &inetdev->prefix) < 0)
+			return -1;
+	} else {
+		inetdev->prefix = config_ip_prefix(&inetdev->addr);
+	}
+
+	/* If no broadcast address, let compute one from the
+	 * prefix and address.
+	 */
+	if (!bcast) {
+		inetdev->bcast.s_addr = inetdev->addr.s_addr;
+		inetdev->bcast.s_addr |=
+		    htonl(INADDR_BROADCAST >> inetdev->prefix);
+	}
+
+	lxc_list_add_tail(&netdev->ipv4, list);
+
+	free(addr);
+	return 0;
+}
+
+int set_config_network_legacy_ipv4_gateway(const char *key, const char *value,
+					   struct lxc_conf *lxc_conf,
+					   void *data)
+{
+	struct lxc_netdev *netdev;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	free(netdev->ipv4_gateway);
+
+	if (lxc_config_value_empty(value)) {
+		netdev->ipv4_gateway = NULL;
+	} else if (!strcmp(value, "auto")) {
+		netdev->ipv4_gateway = NULL;
+		netdev->ipv4_gateway_auto = true;
+	} else {
+		struct in_addr *gw;
+
+		gw = malloc(sizeof(*gw));
+		if (!gw) {
+			SYSERROR("failed to allocate ipv4 gateway address");
+			return -1;
+		}
+
+		if (!inet_pton(AF_INET, value, gw)) {
+			SYSERROR("invalid ipv4 gateway address: %s", value);
+			free(gw);
+			return -1;
+		}
+
+		netdev->ipv4_gateway = gw;
+		netdev->ipv4_gateway_auto = false;
+	}
+
+	return 0;
+}
+
+int set_config_network_legacy_ipv6(const char *key, const char *value,
+				   struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev;
+	struct lxc_inet6dev *inet6dev;
+	struct lxc_list *list;
+	char *slash, *valdup, *netmask;
+
+	if (lxc_config_value_empty(value))
+		return clr_config_network_legacy_item(key, lxc_conf, NULL);
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	inet6dev = malloc(sizeof(*inet6dev));
+	if (!inet6dev) {
+		SYSERROR("failed to allocate ipv6 address");
+		return -1;
+	}
+	memset(inet6dev, 0, sizeof(*inet6dev));
+
+	list = malloc(sizeof(*list));
+	if (!list) {
+		SYSERROR("failed to allocate memory");
+		free(inet6dev);
+		return -1;
+	}
+
+	lxc_list_init(list);
+	list->elem = inet6dev;
+
+	valdup = strdup(value);
+	if (!valdup) {
+		ERROR("no address specified");
+		free(list);
+		free(inet6dev);
+		return -1;
+	}
+
+	inet6dev->prefix = 64;
+	slash = strstr(valdup, "/");
+	if (slash) {
+		*slash = '\0';
+		netmask = slash + 1;
+		if (lxc_safe_uint(netmask, &inet6dev->prefix) < 0)
+			return -1;
+	}
+
+	if (!inet_pton(AF_INET6, valdup, &inet6dev->addr)) {
+		SYSERROR("invalid ipv6 address: %s", valdup);
+		free(list);
+		free(inet6dev);
+		free(valdup);
+		return -1;
+	}
+
+	lxc_list_add_tail(&netdev->ipv6, list);
+
+	free(valdup);
+	return 0;
+}
+
+int set_config_network_legacy_ipv6_gateway(const char *key, const char *value,
+					   struct lxc_conf *lxc_conf,
+					   void *data)
+{
+	struct lxc_netdev *netdev;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	free(netdev->ipv6_gateway);
+
+	if (lxc_config_value_empty(value)) {
+		netdev->ipv6_gateway = NULL;
+	} else if (!strcmp(value, "auto")) {
+		netdev->ipv6_gateway = NULL;
+		netdev->ipv6_gateway_auto = true;
+	} else {
+		struct in6_addr *gw;
+
+		gw = malloc(sizeof(*gw));
+		if (!gw) {
+			SYSERROR("failed to allocate ipv6 gateway address");
+			return -1;
+		}
+
+		if (!inet_pton(AF_INET6, value, gw)) {
+			SYSERROR("invalid ipv6 gateway address: %s", value);
+			free(gw);
+			return -1;
+		}
+
+		netdev->ipv6_gateway = gw;
+		netdev->ipv6_gateway_auto = false;
+	}
+
+	return 0;
+}
+
+int set_config_network_legacy_script_up(const char *key, const char *value,
+					struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	return set_config_string_item(&netdev->upscript, value);
+}
+
+int set_config_network_legacy_script_down(const char *key, const char *value,
+					  struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev;
+
+	netdev = network_netdev(key, value, &lxc_conf->network);
+	if (!netdev)
+		return -1;
+
+	return set_config_string_item(&netdev->downscript, value);
+}
+
+int get_config_network_legacy(const char *key, char *retv, int inlen,
+			      struct lxc_conf *c, void *data)
+{
+	int len, fulllen = 0;
+	struct lxc_list *it;
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	lxc_list_for_each(it, &c->network) {
+		struct lxc_netdev *n = it->elem;
+		const char *t = lxc_net_type_to_str(n->type);
+		strprint(retv, inlen, "%s\n", t ? t : "(invalid)");
+	}
+
+	return fulllen;
+}
+
+/*
+ * lxc.network.0.XXX, where XXX can be: name, type, link, flags, type,
+ * macvlan.mode, veth.pair, vlan, ipv4, ipv6, script.up, hwaddr, mtu,
+ * ipv4.gateway, ipv6.gateway.  ipvX.gateway can return 'auto' instead
+ * of an address.  ipv4 and ipv6 return lists (newline-separated).
+ * things like veth.pair return '' if invalid (i.e. if called for vlan
+ * type).
+ */
+int get_config_network_legacy_item(const char *key, char *retv, int inlen,
+				   struct lxc_conf *c, void *data)
+{
+	char *p1;
+	int len, fulllen = 0;
+	struct lxc_netdev *netdev;
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	if (!strncmp(key, "lxc.network.", 12))
+		key += 12;
+	else
+		return -1;
+
+	p1 = strchr(key, '.');
+	if (!p1 || *(p1 + 1) == '\0')
+		return -1;
+	p1++;
+
+	netdev = get_netdev_from_key(key, &c->network);
+	if (!netdev)
+		return -1;
+	if (strcmp(p1, "name") == 0) {
+		if (netdev->name)
+			strprint(retv, inlen, "%s", netdev->name);
+	} else if (strcmp(p1, "type") == 0) {
+		strprint(retv, inlen, "%s", lxc_net_type_to_str(netdev->type));
+	} else if (strcmp(p1, "link") == 0) {
+		if (netdev->link)
+			strprint(retv, inlen, "%s", netdev->link);
+	} else if (strcmp(p1, "flags") == 0) {
+		if (netdev->flags & IFF_UP)
+			strprint(retv, inlen, "up");
+	} else if (strcmp(p1, "script.up") == 0) {
+		if (netdev->upscript)
+			strprint(retv, inlen, "%s", netdev->upscript);
+	} else if (strcmp(p1, "script.down") == 0) {
+		if (netdev->downscript)
+			strprint(retv, inlen, "%s", netdev->downscript);
+	} else if (strcmp(p1, "hwaddr") == 0) {
+		if (netdev->hwaddr)
+			strprint(retv, inlen, "%s", netdev->hwaddr);
+	} else if (strcmp(p1, "mtu") == 0) {
+		if (netdev->mtu)
+			strprint(retv, inlen, "%s", netdev->mtu);
+	} else if (strcmp(p1, "macvlan.mode") == 0) {
+		if (netdev->type == LXC_NET_MACVLAN) {
+			const char *mode;
+			switch (netdev->priv.macvlan_attr.mode) {
+			case MACVLAN_MODE_PRIVATE:
+				mode = "private";
+				break;
+			case MACVLAN_MODE_VEPA:
+				mode = "vepa";
+				break;
+			case MACVLAN_MODE_BRIDGE:
+				mode = "bridge";
+				break;
+			case MACVLAN_MODE_PASSTHRU:
+				mode = "passthru";
+				break;
+			default:
+				mode = "(invalid)";
+				break;
+			}
+			strprint(retv, inlen, "%s", mode);
+		}
+	} else if (strcmp(p1, "veth.pair") == 0) {
+		if (netdev->type == LXC_NET_VETH) {
+			strprint(retv, inlen, "%s",
+				 netdev->priv.veth_attr.pair
+				     ? netdev->priv.veth_attr.pair
+				     : netdev->priv.veth_attr.veth1);
+		}
+	} else if (strcmp(p1, "vlan") == 0) {
+		if (netdev->type == LXC_NET_VLAN) {
+			strprint(retv, inlen, "%d", netdev->priv.vlan_attr.vid);
+		}
+	} else if (strcmp(p1, "ipv4.gateway") == 0) {
+		if (netdev->ipv4_gateway_auto) {
+			strprint(retv, inlen, "auto");
+		} else if (netdev->ipv4_gateway) {
+			char buf[INET_ADDRSTRLEN];
+			inet_ntop(AF_INET, netdev->ipv4_gateway, buf,
+				  sizeof(buf));
+			strprint(retv, inlen, "%s", buf);
+		}
+	} else if (strcmp(p1, "ipv4") == 0) {
+		struct lxc_list *it2;
+		lxc_list_for_each(it2, &netdev->ipv4) {
+			struct lxc_inetdev *i = it2->elem;
+			char buf[INET_ADDRSTRLEN];
+			inet_ntop(AF_INET, &i->addr, buf, sizeof(buf));
+			strprint(retv, inlen, "%s/%d\n", buf, i->prefix);
+		}
+	} else if (strcmp(p1, "ipv6.gateway") == 0) {
+		if (netdev->ipv6_gateway_auto) {
+			strprint(retv, inlen, "auto");
+		} else if (netdev->ipv6_gateway) {
+			char buf[INET6_ADDRSTRLEN];
+			inet_ntop(AF_INET6, netdev->ipv6_gateway, buf,
+				  sizeof(buf));
+			strprint(retv, inlen, "%s", buf);
+		}
+	} else if (strcmp(p1, "ipv6") == 0) {
+		struct lxc_list *it2;
+		lxc_list_for_each(it2, &netdev->ipv6) {
+			struct lxc_inet6dev *i = it2->elem;
+			char buf[INET6_ADDRSTRLEN];
+			inet_ntop(AF_INET6, &i->addr, buf, sizeof(buf));
+			strprint(retv, inlen, "%s/%d\n", buf, i->prefix);
+		}
+	}
+	return fulllen;
+}
+
+/* we get passed in something like '0', '0.ipv4' or '1.ipv6' */
+static int lxc_clear_nic(struct lxc_conf *c, const char *key)
+{
+	char *p1;
+	int ret, idx, i;
+	struct lxc_list *it;
+	struct lxc_netdev *netdev;
+
+	p1 = strchr(key, '.');
+	if (!p1 || *(p1+1) == '\0')
+		p1 = NULL;
+
+	ret = sscanf(key, "%d", &idx);
+	if (ret != 1) return -1;
+	if (idx < 0)
+		return -1;
+
+	i = 0;
+	lxc_list_for_each(it, &c->network) {
+		if (i == idx)
+			break;
+		i++;
+	}
+	if (i < idx)  // we don't have that many nics defined
+		return -1;
+
+	if (!it || !it->elem)
+		return -1;
+
+	netdev = it->elem;
+
+	if (!p1) {
+		lxc_remove_nic(it);
+	} else if (strcmp(p1, ".ipv4") == 0) {
+		struct lxc_list *it2,*next;
+		lxc_list_for_each_safe(it2, &netdev->ipv4, next) {
+			lxc_list_del(it2);
+			free(it2->elem);
+			free(it2);
+		}
+	} else if (strcmp(p1, ".ipv6") == 0) {
+		struct lxc_list *it2,*next;
+		lxc_list_for_each_safe(it2, &netdev->ipv6, next) {
+			lxc_list_del(it2);
+			free(it2->elem);
+			free(it2);
+		}
+	}
+		else return -1;
+
+	return 0;
+}
+
+inline int clr_config_network_legacy_item(const char *key, struct lxc_conf *c,
+					  void *data)
+{
+	return lxc_clear_nic(c, key + 12);
+}
+
+inline int clr_config_network_legacy(const char *key, struct lxc_conf *c, void *data)
+{
+	return lxc_clear_config_network(c);
+}

--- a/src/lxc/confile_network_legacy.h
+++ b/src/lxc/confile_network_legacy.h
@@ -1,0 +1,81 @@
+/*
+ * lxc: linux Container library
+ *
+ * (C) Copyright IBM Corp. 2007, 2008
+ *
+ * Authors:
+ * Daniel Lezcano <daniel.lezcano at free.fr>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __LXC_CONFILE_NETWORK_LEGACY_H
+#define __LXC_CONFILE_NETWORK_LEGACY_H
+
+#include <stdio.h>
+#include <lxc/attach_options.h>
+#include <stdbool.h>
+
+struct lxc_conf;
+struct lxc_list;
+
+extern int set_config_network_legacy_type(const char *, const char *,
+					  struct lxc_conf *, void *);
+extern int set_config_network_legacy_flags(const char *, const char *,
+					   struct lxc_conf *, void *);
+extern int set_config_network_legacy_link(const char *, const char *,
+					  struct lxc_conf *, void *);
+extern int set_config_network_legacy_name(const char *, const char *,
+					  struct lxc_conf *, void *);
+extern int set_config_network_legacy_veth_pair(const char *, const char *,
+					       struct lxc_conf *, void *);
+extern int set_config_network_legacy_macvlan_mode(const char *, const char *,
+						  struct lxc_conf *, void *);
+extern int set_config_network_legacy_hwaddr(const char *, const char *,
+					    struct lxc_conf *, void *);
+extern int set_config_network_legacy_vlan_id(const char *, const char *,
+					     struct lxc_conf *, void *);
+extern int set_config_network_legacy_mtu(const char *, const char *,
+					 struct lxc_conf *, void *);
+extern int set_config_network_legacy_ipv4(const char *, const char *,
+					  struct lxc_conf *, void *);
+extern int set_config_network_legacy_ipv4_gateway(const char *, const char *,
+						  struct lxc_conf *, void *);
+extern int set_config_network_legacy_script_up(const char *, const char *,
+					       struct lxc_conf *, void *);
+extern int set_config_network_legacy_script_down(const char *, const char *,
+						 struct lxc_conf *, void *);
+extern int set_config_network_legacy_ipv6(const char *, const char *,
+					  struct lxc_conf *, void *);
+extern int set_config_network_legacy_ipv6_gateway(const char *, const char *,
+						  struct lxc_conf *, void *);
+extern int set_config_network_legacy_nic(const char *, const char *,
+					 struct lxc_conf *, void *);
+extern int get_config_network_legacy_item(const char *, char *, int,
+					  struct lxc_conf *, void *);
+extern int clr_config_network_legacy_item(const char *, struct lxc_conf *,
+					  void *);
+
+extern int set_config_network_legacy(const char *, const char *,
+				     struct lxc_conf *, void *);
+extern int get_config_network_legacy(const char *, char *, int,
+				     struct lxc_conf *, void *);
+extern int clr_config_network_legacy(const char *, struct lxc_conf *, void *);
+extern int lxc_list_nicconfigs_legacy(struct lxc_conf *c, const char *key,
+				      char *retv, int inlen);
+extern int lxc_listconfigs(char *retv, int inlen);
+
+extern bool network_new_hwaddrs(struct lxc_conf *conf);
+#endif

--- a/src/lxc/confile_utils.h
+++ b/src/lxc/confile_utils.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 
 #include "conf.h"
+#include "confile_utils.h"
 
 #ifndef MACVLAN_MODE_PRIVATE
 #define MACVLAN_MODE_PRIVATE 1
@@ -40,6 +41,23 @@
 #define MACVLAN_MODE_PASSTHRU 8
 #endif
 
+#define strprint(str, inlen, ...)                                              \
+	do {                                                                   \
+		len = snprintf(str, inlen, ##__VA_ARGS__);                     \
+		if (len < 0) {                                                 \
+			SYSERROR("failed to create string");                   \
+			return -1;                                             \
+		};                                                             \
+		fulllen += len;                                                \
+		if (inlen > 0) {                                               \
+			if (str)                                               \
+				str += len;                                    \
+			inlen -= len;                                          \
+			if (inlen < 0)                                         \
+				inlen = 0;                                     \
+		}                                                              \
+	} while (0);
+
 extern int parse_idmaps(const char *idmap, char *type, unsigned long *nsid,
 			unsigned long *hostid, unsigned long *range);
 
@@ -53,5 +71,15 @@ extern bool lxc_remove_nic_by_idx(struct lxc_conf *conf, unsigned int idx);
 extern void lxc_free_networks(struct lxc_list *networks);
 extern int lxc_macvlan_mode_to_flag(int *mode, const char *value);
 extern char *lxc_macvlan_flag_to_mode(int mode);
+
+extern int set_config_string_item(char **conf_item, const char *value);
+extern int set_config_string_item_max(char **conf_item, const char *value,
+				      size_t max);
+extern int set_config_path_item(char **conf_item, const char *value);
+extern int config_ip_prefix(struct in_addr *addr);
+extern int network_ifname(char **valuep, const char *value);
+extern int rand_complete_hwaddr(char *hwaddr);
+extern void update_hwaddr(const char *line);
+extern bool new_hwaddr(char *hwaddr);
 
 #endif /* __LXC_CONFILE_UTILS_H */

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -47,6 +47,7 @@
 #include "config.h"
 #include "commands.h"
 #include "confile.h"
+#include "confile_network_legacy.h"
 #include "console.h"
 #include "criu.h"
 #include "log.h"
@@ -1697,6 +1698,8 @@ static void do_clear_unexp_config_line(struct lxc_conf *conf, const char *key)
 		clear_unexp_config_line(conf, key, true);
 	else if (strcmp(key, "lxc.network") == 0)
 		clear_unexp_config_line(conf, key, true);
+	else if (strcmp(key, "lxc.net") == 0)
+		clear_unexp_config_line(conf, key, true);
 	else if (strcmp(key, "lxc.hook") == 0)
 		clear_unexp_config_line(conf, key, true);
 	else
@@ -2075,8 +2078,10 @@ static int do_lxcapi_get_keys(struct lxc_container *c, const char *key, char *re
 	if (container_mem_lock(c))
 		return -1;
 	int ret = -1;
-	if (strncmp(key, "lxc.network.", 12) == 0)
+	if (strncmp(key, "lxc.net.", 8) == 0)
 		ret = lxc_list_nicconfigs(c->lxc_conf, key, retv, inlen);
+	else if (strncmp(key, "lxc.network.", 12) == 0)
+		ret = lxc_list_nicconfigs_legacy(c->lxc_conf, key, retv, inlen);
 	container_mem_unlock(c);
 	return ret;
 }

--- a/src/tests/get_item.c
+++ b/src/tests/get_item.c
@@ -298,7 +298,7 @@ int main(int argc, char *argv[])
 	}
 	printf("%d: get_config_item(lxc.network) returned %d %s\n", __LINE__, ret, v2);
 
-	if (!c->set_config_item(c, "lxc.network.0.ipv4", "10.2.3.4")) {
+	if (!c->set_config_item(c, "lxc.network.ipv4", "10.2.3.4")) {
 		fprintf(stderr, "%d: failed to set ipv4\n", __LINE__);
 		goto out;
 	}
@@ -318,7 +318,7 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.0.ipv4.gateway", "10.2.3.254")) {
+	if (!c->set_config_item(c, "lxc.network.ipv4.gateway", "10.2.3.254")) {
 		fprintf(stderr, "%d: failed to set ipv4.gateway\n", __LINE__);
 		goto out;
 	}

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -90,61 +90,61 @@ static int set_get_compare_clear_save_load(struct lxc_container *c,
 
 static int set_and_clear_complete_netdev(struct lxc_container *c)
 {
-	if (!c->set_config_item(c, "lxc.network.1.type", "veth")) {
-		lxc_error("%s\n", "lxc.network.1.type");
+	if (!c->set_config_item(c, "lxc.net.1.type", "veth")) {
+		lxc_error("%s\n", "lxc.net.1.type");
 		return -1;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.1.ipv4", "10.0.2.3/24")) {
-		lxc_error("%s\n", "lxc.network.1.ipv4");
+	if (!c->set_config_item(c, "lxc.net.1.ipv4", "10.0.2.3/24")) {
+		lxc_error("%s\n", "lxc.net.1.ipv4");
 		return -1;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.1.ipv4_gateway", "10.0.2.2")) {
-		lxc_error("%s\n", "lxc.network.1.ipv4");
+	if (!c->set_config_item(c, "lxc.net.1.ipv4_gateway", "10.0.2.2")) {
+		lxc_error("%s\n", "lxc.net.1.ipv4");
 		return -1;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.1.ipv6",
+	if (!c->set_config_item(c, "lxc.net.1.ipv6",
 				"2003:db8:1:0:214:1234:fe0b:3596/64")) {
-		lxc_error("%s\n", "lxc.network.1.ipv6");
+		lxc_error("%s\n", "lxc.net.1.ipv6");
 		return -1;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.1.ipv6_gateway",
+	if (!c->set_config_item(c, "lxc.net.1.ipv6_gateway",
 				"2003:db8:1:0::1")) {
-		lxc_error("%s\n", "lxc.network.1.ipv6");
+		lxc_error("%s\n", "lxc.net.1.ipv6");
 		return -1;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.1.flags", "up")) {
-		lxc_error("%s\n", "lxc.network.1.flags");
+	if (!c->set_config_item(c, "lxc.net.1.flags", "up")) {
+		lxc_error("%s\n", "lxc.net.1.flags");
 		return -1;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.1.link", "br0")) {
-		lxc_error("%s\n", "lxc.network.1.link");
+	if (!c->set_config_item(c, "lxc.net.1.link", "br0")) {
+		lxc_error("%s\n", "lxc.net.1.link");
 		return -1;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.1.veth.pair", "bla")) {
-		lxc_error("%s\n", "lxc.network.1.veth.pair");
+	if (!c->set_config_item(c, "lxc.net.1.veth.pair", "bla")) {
+		lxc_error("%s\n", "lxc.net.1.veth.pair");
 		return -1;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.1.hwaddr",
+	if (!c->set_config_item(c, "lxc.net.1.hwaddr",
 				"52:54:00:80:7a:5d")) {
-		lxc_error("%s\n", "lxc.network.1.hwaddr");
+		lxc_error("%s\n", "lxc.net.1.hwaddr");
 		return -1;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.1.mtu", "2000")) {
-		lxc_error("%s\n", "lxc.network.1.mtu");
+	if (!c->set_config_item(c, "lxc.net.1.mtu", "2000")) {
+		lxc_error("%s\n", "lxc.net.1.mtu");
 		return -1;
 	}
 
-	if (!c->clear_config_item(c, "lxc.network.1")) {
-		lxc_error("%s", "failed to clear \"lxc.network.1\"\n");
+	if (!c->clear_config_item(c, "lxc.net.1")) {
+		lxc_error("%s", "failed to clear \"lxc.net.1\"\n");
 		return -1;
 	}
 
@@ -212,8 +212,8 @@ static int set_get_compare_clear_save_load_network(
 	char retval[4096] = {0};
 	int ret;
 
-	if (!c->set_config_item(c, "lxc.network.0.type", network_type)) {
-		lxc_error("%s\n", "lxc.network.0.type");
+	if (!c->set_config_item(c, "lxc.net.0.type", network_type)) {
+		lxc_error("%s\n", "lxc.net.0.type");
 		return -1;
 	}
 
@@ -260,8 +260,8 @@ static int set_get_compare_clear_save_load_network(
 		return -1;
 	}
 
-	if (!c->clear_config_item(c, "lxc.network.0.type")) {
-		lxc_error("%s\n", "lxc.network.0.type");
+	if (!c->clear_config_item(c, "lxc.net.0.type")) {
+		lxc_error("%s\n", "lxc.net.0.type");
 		return -1;
 	}
 
@@ -714,140 +714,140 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.type", "veth",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.type", "veth",
 					    tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.type");
+		lxc_error("%s\n", "lxc.net.0.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.2.type", "none",
+	if (set_get_compare_clear_save_load(c, "lxc.net.2.type", "none",
 					    tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.2.type");
+		lxc_error("%s\n", "lxc.net.2.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.3.type", "empty",
+	if (set_get_compare_clear_save_load(c, "lxc.net.3.type", "empty",
 					    tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.3.type");
+		lxc_error("%s\n", "lxc.net.3.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.4.type", "vlan",
+	if (set_get_compare_clear_save_load(c, "lxc.net.4.type", "vlan",
 					    tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.4.type");
+		lxc_error("%s\n", "lxc.net.4.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.type", "macvlan",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.type", "macvlan",
 					    tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.type");
+		lxc_error("%s\n", "lxc.net.0.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.1000.type", "phys",
+	if (set_get_compare_clear_save_load(c, "lxc.net.1000.type", "phys",
 					    tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.1000.type");
+		lxc_error("%s\n", "lxc.net.1000.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.flags", "up",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.flags", "up",
 					    tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.flags");
+		lxc_error("%s\n", "lxc.net.0.flags");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.name", "eth0",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.name", "eth0",
 					    tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.name");
+		lxc_error("%s\n", "lxc.net.0.name");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.link", "bla",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.link", "bla",
 					    tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.link");
+		lxc_error("%s\n", "lxc.net.0.link");
 		goto non_test_error;
 	}
 
 	if (set_get_compare_clear_save_load_network(
-		c, "lxc.network.0.macvlan.mode", "private", tmpf, true,
+		c, "lxc.net.0.macvlan.mode", "private", tmpf, true,
 		"macvlan")) {
-		lxc_error("%s\n", "lxc.network.0.macvlan.mode");
+		lxc_error("%s\n", "lxc.net.0.macvlan.mode");
 		goto non_test_error;
 	}
 
 	if (set_get_compare_clear_save_load_network(
-		c, "lxc.network.0.macvlan.mode", "vepa", tmpf, true,
+		c, "lxc.net.0.macvlan.mode", "vepa", tmpf, true,
 		"macvlan")) {
-		lxc_error("%s\n", "lxc.network.0.macvlan.mode");
+		lxc_error("%s\n", "lxc.net.0.macvlan.mode");
 		goto non_test_error;
 	}
 
 	if (set_get_compare_clear_save_load_network(
-		c, "lxc.network.0.macvlan.mode", "bridge", tmpf, true,
+		c, "lxc.net.0.macvlan.mode", "bridge", tmpf, true,
 		"macvlan")) {
-		lxc_error("%s\n", "lxc.network.0.macvlan.mode");
+		lxc_error("%s\n", "lxc.net.0.macvlan.mode");
 		goto non_test_error;
 	}
 
 	if (set_get_compare_clear_save_load_network(
-		c, "lxc.network.0.veth.pair", "clusterfuck", tmpf, true,
+		c, "lxc.net.0.veth.pair", "clusterfuck", tmpf, true,
 		"veth")) {
-		lxc_error("%s\n", "lxc.network.0.veth.pair");
+		lxc_error("%s\n", "lxc.net.0.veth.pair");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.script.up",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.script.up",
 					    "/some/up/path", tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.script.up");
+		lxc_error("%s\n", "lxc.net.0.script.up");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.script.down",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.script.down",
 					    "/some/down/path", tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.script.down");
+		lxc_error("%s\n", "lxc.net.0.script.down");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.hwaddr",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.hwaddr",
 					    "52:54:00:80:7a:5d", tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.hwaddr");
+		lxc_error("%s\n", "lxc.net.0.hwaddr");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.mtu", "2000",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.mtu", "2000",
 					    tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.mtu");
+		lxc_error("%s\n", "lxc.net.0.mtu");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load_network(c, "lxc.network.0.vlan.id",
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.vlan.id",
 						    "2", tmpf, true, "vlan")) {
-		lxc_error("%s\n", "lxc.network.0.vlan.id");
+		lxc_error("%s\n", "lxc.net.0.vlan.id");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.ipv4.gateway",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv4.gateway",
 					    "10.0.2.2", tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.ipv4.gateway");
+		lxc_error("%s\n", "lxc.net.0.ipv4.gateway");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.ipv6.gateway",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv6.gateway",
 					    "2003:db8:1::1", tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.ipv6.gateway");
+		lxc_error("%s\n", "lxc.net.0.ipv6.gateway");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.network.0.ipv4",
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv4",
 					    "10.0.2.3/24", tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.ipv4");
+		lxc_error("%s\n", "lxc.net.0.ipv4");
 		goto non_test_error;
 	}
 
 	if (set_get_compare_clear_save_load(
-		c, "lxc.network.0.ipv6", "2003:db8:1:0:214:1234:fe0b:3596/64",
+		c, "lxc.net.0.ipv6", "2003:db8:1:0:214:1234:fe0b:3596/64",
 		tmpf, true)) {
-		lxc_error("%s\n", "lxc.network.0.ipv6");
+		lxc_error("%s\n", "lxc.net.0.ipv6");
 		goto non_test_error;
 	}
 


### PR DESCRIPTION
Serge and I discussed the new network parser we've merge a couple of days ago.
He pointed out that a bunch of use-cases we're currently supporting in the old
network parser would be broken by the new parser. As we've pointed out many
times before, we're strongly commited to backwards compatibility and not
breaking existing use-cases. That's why we decided to take a new approach.
Instead of trying to mangle the old parser and new parser to come up with
something that allows a smooth transition we will simply deprecate the old
configuration keys with LXC 3.0. In the meantime we will support the full-blown
old legacy parser and the new network parser. Specifically, this means that
we're deprecating:

    lxc.network.*

in favor of

    lxc.net.*

With LXC 2.1. defining networks using lxc.network.* keys will cause a
deprecation warning to be shown/logged. We strongly suggest that users upgrade
their existing configuration files to switch to the new network configuration
parser. Starting with LXC 3.0 we will remove all lxc.network.* keys and will
only support lxc.net.* style network configurations.

Note that the new network configuration parser will only accept index based
configuration keys, i.e. we are only supporting lxc.net.[i].*. Keys without an
index such as lxc.net.type are not supported anymore. The advantages of this
approach are vast. Not just internally, but also user-facing since it is much
clearer what configuration key belongs to what network.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>