### PR TITLE
lxc: let it compile ok for gcc7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -686,7 +686,7 @@ LXC_CHECK_TLS
 if test "x$GCC" = "xyes"; then
 	CFLAGS="$CFLAGS -Wall"
 	if test "x$enable_werror" = "xyes"; then
-		CFLAGS="$CFLAGS -Werror"
+		CFLAGS="$CFLAGS -Werror -Wno-error=format-truncation"
 	fi
 fi
 


### PR DESCRIPTION
After gcc upgrade to 7.1, gcc7 contains a number of enhancements that help
detect buffer overflow and other forms of invalid memory accesses.

When compiling lxc with gcc7, the system outputs errors:

   ../../../lxc-2.0.4/src/lxc/bdev/lxcloop.c:297:30: error: '%s' directive
   output may be truncated writing up to 255 bytes into a region of size 95
   [-Werror=format-truncation=]

This is because in configure.ac, the flag "-Werror" let the compiler treat
the warnings as errors, in order to compile successfully, we should add the
following to the configure.ac:

   -Wno-error=format-truncation

Signed-off-by: Dengke Du <dengke.du@windriver.com>