### PR TITLE
Revert "Add a prefix to the lxc.pc"

### DIFF
--- a/lxc.pc.in
+++ b/lxc.pc.in
@@ -1,8 +1,7 @@
-prefix=@prefix@
 bindir=@BINDIR@
-libdir=${prefix}/@LIBDIR@
+libdir=@LIBDIR@
 localstatedir=@LOCALSTATEDIR@
-includedir=${prefix}/@INCLUDEDIR@
+includedir=@INCLUDEDIR@
 rootfsmountdir=@LXCROOTFSMOUNT@
 
 Name: lxc


### PR DESCRIPTION
Fix: https://github.com/lxc/lxc/issues/1636

This reverts commit 758243d8af0406e63cc5446c65d415298fa3cef2.

Signed-off-by: 0x0916 <w@laoqinren.net>