### PR TITLE
remove the `__func__` macro

### DIFF
--- a/src/lxc/bdev/lxcbtrfs.c
+++ b/src/lxc/bdev/lxcbtrfs.c
@@ -68,13 +68,13 @@ char *get_btrfs_subvol_path(int fd, u64 dir_id, u64 objid, char *name,
 	ret = ioctl(fd, BTRFS_IOC_INO_LOOKUP, &args);
 	e = errno;
 	if (ret) {
-		ERROR("%s: ERROR: Failed to lookup path for %llu %llu %s - %s\n",
-				 __func__, (unsigned long long) dir_id,
+		ERROR("Failed to lookup path for %llu %llu %s - %s\n",
+				 (unsigned long long) dir_id,
 				 (unsigned long long) objid,
 				 name, strerror(e));
 		return NULL;
 	} else
-		INFO("%s: got path for %llu %llu - %s\n", __func__,
+		INFO("Got path for %llu %llu - %s\n",
 			(unsigned long long) objid, (unsigned long long) dir_id,
 			name);
 

--- a/src/lxc/cgroups/cgfs.c
+++ b/src/lxc/cgroups/cgfs.c
@@ -165,7 +165,7 @@ static int cgroup_rmdir(char *dirname)
 
 	dir = opendir(dirname);
 	if (!dir) {
-		ERROR("%s: failed to open %s", __func__, dirname);
+		ERROR("Failed to open %s", dirname);
 		return -1;
 	}
 
@@ -190,7 +190,7 @@ static int cgroup_rmdir(char *dirname)
 		}
 		ret = lstat(pathname, &mystat);
 		if (ret) {
-			SYSERROR("%s: failed to stat %s", __func__, pathname);
+			SYSERROR("Failed to stat %s", pathname);
 			failed=1;
 			if (!saved_errno)
 				saved_errno = errno;
@@ -206,7 +206,7 @@ static int cgroup_rmdir(char *dirname)
 	}
 
 	if (rmdir(dirname) < 0) {
-		SYSERROR("%s: failed to delete %s", __func__, dirname);
+		SYSERROR("Failed to delete %s", dirname);
 		if (!saved_errno)
 			saved_errno = errno;
 		failed=1;
@@ -214,7 +214,7 @@ static int cgroup_rmdir(char *dirname)
 
 	ret = closedir(dir);
 	if (ret) {
-		SYSERROR("%s: failed to close directory %s", __func__, dirname);
+		SYSERROR("Failed to close directory %s", dirname);
 		if (!saved_errno)
 			saved_errno = errno;
 		failed=1;
@@ -2229,7 +2229,7 @@ static int cgroup_read_from_file(const char *fn, char buf[], size_t bufsize)
 			return ret;
 		}
 		/* Callers don't do this, but regression/sanity check */
-		ERROR("%s: was not expecting 0 bufsize", __func__);
+		ERROR("was not expecting 0 bufsize");
 		return -1;
 	}
 	buf[ret] = '\0';

--- a/src/lxc/cgroups/cgmanager.c
+++ b/src/lxc/cgroups/cgmanager.c
@@ -395,7 +395,7 @@ static int do_chown_cgroup(const char *controller, const char *cgroup_path,
 		goto out;
 	}
 	if (send_creds(sv[0], getpid(), getuid(), getgid())) {
-		SYSERROR("%s: Error sending pid over SCM_CREDENTIAL", __func__);
+		SYSERROR("Error sending pid over SCM_CREDENTIAL");
 		goto out;
 	}
 	fds.fd = sv[0];
@@ -410,7 +410,7 @@ static int do_chown_cgroup(const char *controller, const char *cgroup_path,
 		goto out;
 	}
 	if (send_creds(sv[0], getpid(), newuid, 0)) {
-		SYSERROR("%s: Error sending pid over SCM_CREDENTIAL", __func__);
+		SYSERROR("Error sending pid over SCM_CREDENTIAL");
 		goto out;
 	}
 	fds.fd = sv[0];

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3812,7 +3812,7 @@ int chown_mapped_root(char *path, struct lxc_conf *conf)
 
 	if (rootuid == hostuid) {
 		// nothing to do
-		INFO("%s: container root is our uid;  no need to chown" ,__func__);
+		INFO("Container root is our uid; no need to chown");
 		return 0;
 	}
 

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -99,7 +99,7 @@ static int _recursive_rmdir(char *dirname, dev_t pdev,
 
 	dir = opendir(dirname);
 	if (!dir) {
-		ERROR("%s: failed to open %s", __func__, dirname);
+		ERROR("failed to open %s", dirname);
 		return -1;
 	}
 
@@ -132,10 +132,10 @@ static int _recursive_rmdir(char *dirname, dev_t pdev,
 				case ENOTDIR:
 					ret = unlink(pathname);
 					if (ret)
-						INFO("%s: failed to remove %s", __func__, pathname);
+						INFO("Failed to remove %s", pathname);
 					break;
 				default:
-					SYSERROR("%s: failed to rmdir %s", __func__, pathname);
+					SYSERROR("Failed to rmdir %s", pathname);
 					failed = 1;
 					break;
 				}
@@ -145,7 +145,7 @@ static int _recursive_rmdir(char *dirname, dev_t pdev,
 
 		ret = lstat(pathname, &mystat);
 		if (ret) {
-			ERROR("%s: failed to stat %s", __func__, pathname);
+			ERROR("Failed to stat %s", pathname);
 			failed = 1;
 			continue;
 		}
@@ -161,20 +161,20 @@ static int _recursive_rmdir(char *dirname, dev_t pdev,
 				failed=1;
 		} else {
 			if (unlink(pathname) < 0) {
-				SYSERROR("%s: failed to delete %s", __func__, pathname);
+				SYSERROR("Failed to delete %s", pathname);
 				failed=1;
 			}
 		}
 	}
 
 	if (rmdir(dirname) < 0 && !btrfs_try_remove_subvol(dirname) && !hadexclude) {
-		ERROR("%s: failed to delete %s", __func__, dirname);
+		ERROR("Failed to delete %s", dirname);
 		failed=1;
 	}
 
 	ret = closedir(dir);
 	if (ret) {
-		ERROR("%s: failed to close directory %s", __func__, dirname);
+		ERROR("Failed to close directory %s", dirname);
 		failed=1;
 	}
 
@@ -213,7 +213,7 @@ extern int lxc_rmdir_onedev(char *path, const char *exclude)
 	if (lstat(path, &mystat) < 0) {
 		if (errno == ENOENT)
 			return 0;
-		ERROR("%s: failed to stat %s", __func__, path);
+		ERROR("Failed to stat %s", path);
 		return -1;
 	}
 


### PR DESCRIPTION
Our logging function will always spew out the function name.

Signed-off-by: 0x0916 <w@laoqinren.net>