### PR TITLE
wipe all references lxc.network.{[i]}.* and replace with lxc.net.[i].*

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ LXC is configured via a simple set of keys. For example,
 - `lxc.mount.entry`
 
 LXC namespaces configuration keys by using single dots. This means complex
-configuration keys such as `lxc.network` expose various subkeys such as
-`lxc.network.type`, `lxc.network.link`, `lxc.network.ipv6`, and others for even
+configuration keys such as `lxc.net.0` expose various subkeys such as
+`lxc.net.0.type`, `lxc.net.0.link`, `lxc.net.0.ipv6`, and others for even
 more fine-grained configuration.
 
 LXC is used as the default runtime for [LXD](https://github.com/lxc/lxd),

--- a/config/etc/default.conf.libvirt
+++ b/config/etc/default.conf.libvirt
@@ -1,3 +1,3 @@
-lxc.network.type = veth
-lxc.network.link = virbr0
-lxc.network.flags = up
+lxc.net.0.type = veth
+lxc.net.0.link = virbr0
+lxc.net.0.flags = up

--- a/config/etc/default.conf.lxcbr
+++ b/config/etc/default.conf.lxcbr
@@ -1,4 +1,4 @@
-lxc.network.type = veth
-lxc.network.link = lxcbr0
-lxc.network.flags = up
-lxc.network.hwaddr = 00:16:3e:xx:xx:xx
+lxc.net.0.type = veth
+lxc.net.0.link = lxcbr0
+lxc.net.0.flags = up
+lxc.net.0.hwaddr = 00:16:3e:xx:xx:xx

--- a/config/etc/default.conf.unknown
+++ b/config/etc/default.conf.unknown
@@ -1,1 +1,1 @@
-lxc.network.type = empty
+lxc.net.0.type = empty

--- a/config/init/common/lxc-containers.in
+++ b/config/init/common/lxc-containers.in
@@ -56,7 +56,7 @@ wait_for_bridge()
     local BRNAME try flags br
     [ -f "$sysconfdir"/lxc/default.conf ] || { return 0; }
 
-    BRNAME=`grep '^[ 	]*lxc.network.link' "$sysconfdir"/lxc/default.conf | sed 's/^.*=[ 	]*//'`
+    BRNAME=`grep '^[ 	]*lxc.net.0.link' "$sysconfdir"/lxc/default.conf | sed 's/^.*=[ 	]*//'`
     if [ -z "$BRNAME" ]; then
         return 0
     fi

--- a/doc/examples/lxc-complex.conf.in
+++ b/doc/examples/lxc-complex.conf.in
@@ -1,23 +1,23 @@
 # Container with network a complex network mixing macvlan, veth and
 # physical network devices
 lxc.utsname = complex
-lxc.network.type = veth
-lxc.network.flags = up
-lxc.network.link = br0
-lxc.network.hwaddr = 4a:49:43:49:79:bf
-lxc.network.ipv4 = 10.2.3.5/24
-lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
+lxc.net.0.type = veth
+lxc.net.0.flags = up
+lxc.net.0.link = br0
+lxc.net.0.hwaddr = 4a:49:43:49:79:bf
+lxc.net.0.ipv4 = 10.2.3.5/24
+lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
 
-lxc.network.type = macvlan
-lxc.network.flags = up
-lxc.network.link = eth0
-lxc.network.hwaddr = 4a:49:43:49:79:bd
-lxc.network.ipv4 = 10.2.3.4/24
-lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
+lxc.net.0.type = macvlan
+lxc.net.0.flags = up
+lxc.net.0.link = eth0
+lxc.net.0.hwaddr = 4a:49:43:49:79:bd
+lxc.net.0.ipv4 = 10.2.3.4/24
+lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
 
-lxc.network.type = phys
-lxc.network.flags = up
-lxc.network.link = dummy0
-lxc.network.hwaddr = 4a:49:43:49:79:ff
-lxc.network.ipv4 = 10.2.3.6/24
-lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297
+lxc.net.0.type = phys
+lxc.net.0.flags = up
+lxc.net.0.link = dummy0
+lxc.net.0.hwaddr = 4a:49:43:49:79:ff
+lxc.net.0.ipv4 = 10.2.3.6/24
+lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297

--- a/doc/examples/lxc-empty-netns.conf.in
+++ b/doc/examples/lxc-empty-netns.conf.in
@@ -1,4 +1,4 @@
 # Container with new network withtout network devices
 lxc.utsname = omega
-lxc.network.type = empty
-lxc.network.flags = up
+lxc.net.0.type = empty
+lxc.net.0.flags = up

--- a/doc/examples/lxc-macvlan.conf.in
+++ b/doc/examples/lxc-macvlan.conf.in
@@ -1,8 +1,8 @@
 # Container with network virtualized using the macvlan device driver
 lxc.utsname = alpha
-lxc.network.type = macvlan
-lxc.network.flags = up
-lxc.network.link = eth0
-lxc.network.hwaddr = 4a:49:43:49:79:bd
-lxc.network.ipv4 = 10.2.3.4/24
-lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
+lxc.net.0.type = macvlan
+lxc.net.0.flags = up
+lxc.net.0.link = eth0
+lxc.net.0.hwaddr = 4a:49:43:49:79:bd
+lxc.net.0.ipv4 = 10.2.3.4/24
+lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596

--- a/doc/examples/lxc-no-netns.conf.in
+++ b/doc/examples/lxc-no-netns.conf.in
@@ -1,3 +1,3 @@
 # Container with non-virtualized network
-lxc.network.type = none
+lxc.net.0.type = none
 lxc.utsname = delta

--- a/doc/examples/lxc-phys.conf.in
+++ b/doc/examples/lxc-phys.conf.in
@@ -1,9 +1,9 @@
 # Container with network virtualized using a physical network device with name
 # 'eth0'
 lxc.utsname = gamma
-lxc.network.type = phys
-lxc.network.flags = up
-lxc.network.link = eth0
-lxc.network.hwaddr = 4a:49:43:49:79:ff
-lxc.network.ipv4 = 10.2.3.6/24
-lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297
+lxc.net.0.type = phys
+lxc.net.0.flags = up
+lxc.net.0.link = eth0
+lxc.net.0.hwaddr = 4a:49:43:49:79:ff
+lxc.net.0.ipv4 = 10.2.3.6/24
+lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297

--- a/doc/examples/lxc-veth.conf.in
+++ b/doc/examples/lxc-veth.conf.in
@@ -1,9 +1,9 @@
 # Container with network virtualized using a pre-configured bridge named br0 and
 # veth pair virtual network devices
 lxc.utsname = beta
-lxc.network.type = veth
-lxc.network.flags = up
-lxc.network.link = br0
-lxc.network.hwaddr = 4a:49:43:49:79:bf
-lxc.network.ipv4 = 10.2.3.5/24
-lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
+lxc.net.0.type = veth
+lxc.net.0.flags = up
+lxc.net.0.link = br0
+lxc.net.0.hwaddr = 4a:49:43:49:79:bf
+lxc.net.0.ipv4 = 10.2.3.5/24
+lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597

--- a/doc/examples/lxc-vlan.conf.in
+++ b/doc/examples/lxc-vlan.conf.in
@@ -1,9 +1,9 @@
 # Container with network virtualized using the vlan device driver
 lxc.utsname = alpha
-lxc.network.type = vlan
-lxc.network.vlan.id = 1234
-lxc.network.flags = up
-lxc.network.link = eth0
-lxc.network.hwaddr = 4a:49:43:49:79:bd
-lxc.network.ipv4 = 10.2.3.4/24
-lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
+lxc.net.0.type = vlan
+lxc.net.0.vlan.id = 1234
+lxc.net.0.flags = up
+lxc.net.0.link = eth0
+lxc.net.0.hwaddr = 4a:49:43:49:79:bd
+lxc.net.0.ipv4 = 10.2.3.4/24
+lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596

--- a/doc/ja/lxc-info.sgml.in
+++ b/doc/ja/lxc-info.sgml.in
@@ -220,7 +220,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       </varlistentry>
 
       <varlistentry>
-        <term>lxc-info -n foo -c lxc.network.0.veth.pair</term>
+        <term>lxc-info -n foo -c lxc.net.0.veth.pair</term>
         <listitem>
           <para>
             <!--

--- a/doc/ja/lxc.container.conf.sgml.in
+++ b/doc/ja/lxc.container.conf.sgml.in
@@ -126,12 +126,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     <para>
       <!--
       LXC namespaces configuration keys by using single dots. This means complex
-      configuration keys such as <option>lxc.network</option> expose various
-      subkeys such as <option>lxc.network.type</option>,
-      <option>lxc.network.link</option>, <option>lxc.network.ipv6</option>, and
+      configuration keys such as <option>lxc.net.0</option> expose various
+      subkeys such as <option>lxc.net.0.type</option>,
+      <option>lxc.net.0.link</option>, <option>lxc.net.0.ipv6</option>, and
       others for even more fine-grained configuration.
       -->
-      LXC は、シングルドットを使って設定キーの名前空間を表します。<option>lxc.network</option> のような複雑な設定キーは、<option>lxc.network.type</option>、<option>lxc.network.link</option>、<option>lxc.network.ipv6</option> や、さらに細分化された設定向けの色々なサブキーを持つことを意味します。
+      LXC は、シングルドットを使って設定キーの名前空間を表します。<option>lxc.net.0</option> のような複雑な設定キーは、<option>lxc.net.0.type</option>、<option>lxc.net.0.link</option>、<option>lxc.net.0.ipv6</option> や、さらに細分化された設定向けの色々なサブキーを持つことを意味します。
     </para>
 
     <refsect2>
@@ -455,7 +455,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.network</option>
+            <option>lxc.net</option>
           </term>
           <listitem>
             <para>
@@ -468,7 +468,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         </varlistentry>
         <varlistentry>
           <term>
-            <option>lxc.network.[i].type</option>
+            <option>lxc.net.[i].type</option>
           </term>
           <listitem>
             <para>
@@ -477,17 +477,17 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               for the container.
               Multiple networks can be specified by using an additional index
               <option>i</option>
-              after all <option>lxc.network.*</option> keys. For example,
-              <option>lxc.network.0.type = veth</option> and
-              <option>lxc.network.1.type = veth</option> specify two different
+              after all <option>lxc.net.*</option> keys. For example,
+              <option>lxc.net.0.type = veth</option> and
+              <option>lxc.net.1.type = veth</option> specify two different
               networks of the same type. All keys sharing the same index
               <option>i</option> will be treated as belonging to the same
-              network. For example, <option>lxc.network.0.link = br0</option>
-              will belong to <option>lxc.network.0.type</option>.
+              network. For example, <option>lxc.net.0.link = br0</option>
+              will belong to <option>lxc.net.0.type</option>.
               Currently, the different virtualization types can be:
               -->
-              コンテナがどの種類のネットワーク仮想化を使うかを指定します。すべての <option>lxc.network.*</option> キーに、追加のインデックス <option>i</option> を使うと、複数のネットワークを指定できます。例えば、<option>lxc.network.0.type = veth</option> と <option>lxc.network.1.type = veth</option> は、同じタイプの異なるネットワークを 2 つ指定します。
-              同じインデックスを指定したキーはすべて同じネットワークの指定になります。例えば、<option>lxc.network.0.link = br0</option> は <option>lxc.network.0.type</option> と同じネットワークの設定になります。
+              コンテナがどの種類のネットワーク仮想化を使うかを指定します。すべての <option>lxc.net.*</option> キーに、追加のインデックス <option>i</option> を使うと、複数のネットワークを指定できます。例えば、<option>lxc.net.0.type = veth</option> と <option>lxc.net.1.type = veth</option> は、同じタイプの異なるネットワークを 2 つ指定します。
+              同じインデックスを指定したキーはすべて同じネットワークの指定になります。例えば、<option>lxc.net.0.link = br0</option> は <option>lxc.net.0.type</option> と同じネットワークの設定になります。
               現時点では、以下のネットワーク仮想化のタイプが使えます:
             </para>
 
@@ -518,7 +518,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               <option>veth:</option> a virtual ethernet pair
               device is created with one side assigned to the container
               and the other side attached to a bridge specified by
-              the <option>lxc.network.link</option> option.
+              the <option>lxc.net.[i].link</option> option.
               If the bridge is not specified, then the veth pair device
               will be created but not attached to any bridge.
               Otherwise, the bridge has to be created on the system
@@ -530,37 +530,37 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               container, but if you wish to handle
               this name yourselves, you can tell <command>lxc</command>
               to set a specific name with
-              the <option>lxc.network.veth.pair</option> option (except for
+              the <option>lxc.net.[i].veth.pair</option> option (except for
               unprivileged containers where this option is ignored for security
               reasons).
               -->
-              <option>veth:</option > 一方がコンテナに、もう一方が <option>lxc.network.link</option> オプションで指定されたブリッジに接続されるペアの仮想イーサネットデバイスを作成します。
+              <option>veth:</option > 一方がコンテナに、もう一方が <option>lxc.net.[i].link</option> オプションで指定されたブリッジに接続されるペアの仮想イーサネットデバイスを作成します。
               もし、ブリッジが指定されていない場合、veth ペアデバイスは作成されますが、ブリッジには接続されません。
               ブリッジはコンテナが開始する前にシステムで事前に設定しておく必要があります。
               <command>lxc</command> はコンテナ外の設定を扱うことはありません。
               デフォルトでは、<command>lxc</command> がコンテナの外部に属するネットワークデバイスに対する名前を決定します。
-              しかし、もしこの名前を自分で指定したい場合、<option>lxc.network.veth.pair</option> オプションを使って名前を設定し、lxc に対して指定をすることができます (非特権コンテナの場合をのぞきます。セキュリティ上の理由からこのオプションは無視されます)。
+              しかし、もしこの名前を自分で指定したい場合、<option>lxc.net.[i].veth.pair</option> オプションを使って名前を設定し、lxc に対して指定をすることができます (非特権コンテナの場合をのぞきます。セキュリティ上の理由からこのオプションは無視されます)。
             </para>
 
             <para>
               <!--
               <option>vlan:</option> a vlan interface is linked with
               the interface specified by
-              the <option>lxc.network.link</option> and assigned to
+              the <option>lxc.net.[i].link</option> and assigned to
               the container. The vlan identifier is specified with the
-              option <option>lxc.network.vlan.id</option>.
+              option <option>lxc.net.[i].vlan.id</option>.
               -->
-              <option>vlan:</option> vlan インターフェースは <option>lxc.network.link</option> で指定されたインターフェースとリンクし、コンテナに割り当てられます。
-              vlan の指定は <option>lxc.network.vlan.id</option> オプションで指定します。
+              <option>vlan:</option> vlan インターフェースは <option>lxc.net.[i].link</option> で指定されたインターフェースとリンクし、コンテナに割り当てられます。
+              vlan の指定は <option>lxc.net.[i].vlan.id</option> オプションで指定します。
             </para>
 
             <para>
               <!--
               <option>macvlan:</option> a macvlan interface is linked
               with the interface specified by
-              the <option>lxc.network.link</option> and assigned to
+              the <option>lxc.net.[i].link</option> and assigned to
               the container.
-              <option>lxc.network.macvlan.mode</option> specifies the
+              <option>lxc.net.[i].macvlan.mode</option> specifies the
               mode the macvlan will use to communicate between
               different macvlan on the same upper device. The accepted
               modes are <option>private</option>, <option>vepa</option>,
@@ -589,8 +589,8 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               interface. Only one macvlan interface in <option>passthru</option>
               mode is possible for one physical interface.
               -->
-              <option>macvlan:</option> macvlan インターフェースは <option>lxc.network.link</option> により指定されるインターフェースとリンクし、コンテナに割り当てられます。
-              <option>lxc.network.macvlan.mode</option> でモードを指定すると、その macvlan の指定を、同じ上位デバイスで異なる macvlan の間の通信をする時に使います。
+              <option>macvlan:</option> macvlan インターフェースは <option>lxc.net.[i].link</option> により指定されるインターフェースとリンクし、コンテナに割り当てられます。
+              <option>lxc.net.[i].macvlan.mode</option> でモードを指定すると、その macvlan の指定を、同じ上位デバイスで異なる macvlan の間の通信をする時に使います。
               指定できるモードは <option>private</option>、<option>vepa</option>、<option>bridge</option>、<option>passthru</option> のいずれかです。
               <option>private</option> モードの場合、デバイスは同じ上位デバイスの他のデバイスとの通信を行いません (デフォルト)。
               新しい仮想イーサネットポート集約モード (Virtual Ethernet Port Aggregator (VEPA)) である <option>vepa</option> モードの場合、隣接したポートが、ソースとデスティネーションの両方が macvlan ポートに対してローカルであるフレームを全て返すと仮定します。
@@ -608,17 +608,17 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
             <para>
               <!--
               <option>phys:</option> an already existing interface
-              specified by the <option>lxc.network.link</option> is
+              specified by the <option>lxc.net.[i].link</option> is
               assigned to the container.
               -->
-              <option>phys:</option> <option>lxc.network.link</option> で指定された、すでに存在しているインターフェースがコンテナに割り当てられます。
+              <option>phys:</option> <option>lxc.net.[i].link</option> で指定された、すでに存在しているインターフェースがコンテナに割り当てられます。
             </para>
           </listitem>
           </varlistentry>
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].flags</option>
+            <option>lxc.net.[i].flags</option>
           </term>
           <listitem>
             <para>
@@ -639,7 +639,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].link</option>
+            <option>lxc.net.[i].link</option>
           </term>
           <listitem>
             <para>
@@ -653,7 +653,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].mtu</option>
+            <option>lxc.net.[i].mtu</option>
           </term>
           <listitem>
             <para>
@@ -667,7 +667,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].name</option>
+            <option>lxc.net.[i].name</option>
           </term>
           <listitem>
             <para>
@@ -684,7 +684,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].hwaddr</option>
+            <option>lxc.net.[i].hwaddr</option>
           </term>
           <listitem>
             <para>
@@ -702,7 +702,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].ipv4</option>
+            <option>lxc.net.[i].ipv4</option>
           </term>
           <listitem>
             <para>
@@ -718,7 +718,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].ipv4.gateway</option>
+            <option>lxc.net.[i].ipv4.gateway</option>
           </term>
           <listitem>
             <para>
@@ -729,13 +729,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               Can also have the special value <option>auto</option>,
               which means to take the primary address from the bridge
               interface (as specified by the
-              <option>lxc.network.link</option> option) and use that as
+              <option>lxc.net.[i].link</option> option) and use that as
               the gateway. <option>auto</option> is only available when
               using the <option>veth</option> and
               <option>macvlan</option> network types.
               -->
               コンテナでゲートウェイとして使う IPv4 アドレスを指定します。アドレスは x.y.z.t というフォーマットです。例) 192.168.1.123
-              <option>auto</option> という特別な値を指定できます。これは (<option>lxc.network.link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し、それをゲートウェイに使うという意味になります。<option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります。
+              <option>auto</option> という特別な値を指定できます。これは (<option>lxc.net.[i].link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し、それをゲートウェイに使うという意味になります。<option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります。
             </para>
           </listitem>
         </varlistentry>
@@ -743,7 +743,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].ipv6</option>
+            <option>lxc.net.[i].ipv6</option>
           </term>
           <listitem>
             <para>
@@ -760,7 +760,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].ipv6.gateway</option>
+            <option>lxc.net.[i].ipv6.gateway</option>
           </term>
           <listitem>
             <para>
@@ -771,20 +771,20 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
               Can also have the special value <option>auto</option>,
               which means to take the primary address from the bridge
               interface (as specified by the
-              <option>lxc.network.link</option> option) and use that as
+              <option>lxc.net.[i].link</option> option) and use that as
               the gateway. <option>auto</option> is only available when
               using the <option>veth</option> and
               <option>macvlan</option> network types.
               -->
               コンテナでゲートウェイとして使う IPv6 アドレスを指定します。アドレスは x::y というフォーマットです。例) 2003:db8:1:0::1
-              <option>auto</option> という特別な値を記述する事も可能です。これは (<option>lxc.network.link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し、それをゲートウェイに使うという意味になります。<option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります。
+              <option>auto</option> という特別な値を記述する事も可能です。これは (<option>lxc.net.[i].link</option> で指定した) ブリッジインターフェースの最初のアドレスを使用し、それをゲートウェイに使うという意味になります。<option>auto</option> はネットワークタイプとして <option>veth</option> と <option>macvlan</option> を指定している時だけ有効となります。
             </para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].script.up</option>
+            <option>lxc.net.[i].script.up</option>
           </term>
           <listitem>
             <para>
@@ -817,7 +817,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].script.down</option>
+            <option>lxc.net.[i].script.down</option>
           </term>
           <listitem>
             <para>
@@ -2668,13 +2668,13 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       </para>
       <programlisting>
         lxc.utsname = myhostname
-        lxc.network.type = veth
-        lxc.network.flags = up
-        lxc.network.link = br0
-        lxc.network.name = eth0
-        lxc.network.hwaddr = 4a:49:43:49:79:bf
-        lxc.network.ipv4 = 1.2.3.5/24 1.2.3.255
-        lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
+        lxc.net.0.type = veth
+        lxc.net.0.flags = up
+        lxc.net.0.link = br0
+        lxc.net.0.name = eth0
+        lxc.net.0.hwaddr = 4a:49:43:49:79:bf
+        lxc.net.0.ipv4 = 1.2.3.5/24 1.2.3.255
+        lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
       </programlisting>
     </refsect2>
 
@@ -2721,26 +2721,26 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       </para>
       <programlisting>
         lxc.utsname = complex
-        lxc.network.0.type = veth
-        lxc.network.0.flags = up
-        lxc.network.0.link = br0
-        lxc.network.0.hwaddr = 4a:49:43:49:79:bf
-        lxc.network.0.ipv4 = 10.2.3.5/24 10.2.3.255
-        lxc.network.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
-        lxc.network.0.ipv6 = 2003:db8:1:0:214:5432:feab:3588
-        lxc.network.1.type = macvlan
-        lxc.network.1.flags = up
-        lxc.network.1.link = eth0
-        lxc.network.1.hwaddr = 4a:49:43:49:79:bd
-        lxc.network.1.ipv4 = 10.2.3.4/24
-        lxc.network.1.ipv4 = 192.168.10.125/24
-        lxc.network.1.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
-        lxc.network.2.type = phys
-        lxc.network.2.flags = up
-        lxc.network.2.link = dummy0
-        lxc.network.2.hwaddr = 4a:49:43:49:79:ff
-        lxc.network.2.ipv4 = 10.2.3.6/24
-        lxc.network.2.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297
+        lxc.net.0.type = veth
+        lxc.net.0.flags = up
+        lxc.net.0.link = br0
+        lxc.net.0.hwaddr = 4a:49:43:49:79:bf
+        lxc.net.0.ipv4 = 10.2.3.5/24 10.2.3.255
+        lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
+        lxc.net.0.ipv6 = 2003:db8:1:0:214:5432:feab:3588
+        lxc.net.1.type = macvlan
+        lxc.net.1.flags = up
+        lxc.net.1.link = eth0
+        lxc.net.1.hwaddr = 4a:49:43:49:79:bd
+        lxc.net.1.ipv4 = 10.2.3.4/24
+        lxc.net.1.ipv4 = 192.168.10.125/24
+        lxc.net.1.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
+        lxc.net.2.type = phys
+        lxc.net.2.flags = up
+        lxc.net.2.link = dummy0
+        lxc.net.2.hwaddr = 4a:49:43:49:79:ff
+        lxc.net.2.ipv4 = 10.2.3.6/24
+        lxc.net.2.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297
         lxc.cgroup.cpuset.cpus = 0,1
         lxc.cgroup.cpu.shares = 1234
         lxc.cgroup.devices.deny = a

--- a/doc/ko/lxc-info.sgml.in
+++ b/doc/ko/lxc-info.sgml.in
@@ -220,7 +220,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
       </varlistentry>
 
       <varlistentry>
-        <term>lxc-info -n foo -c lxc.network.0.veth.pair</term>
+        <term>lxc-info -n foo -c lxc.net.0.veth.pair</term>
         <listitem>
           <para>
             <!--

--- a/doc/ko/lxc.container.conf.sgml.in
+++ b/doc/ko/lxc.container.conf.sgml.in
@@ -415,7 +415,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.network</option>
+            <option>lxc.net</option>
           </term>
           <listitem>
             <para>
@@ -428,14 +428,14 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
         </varlistentry>
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.type</option>
+	    <option>lxc.net.[i].type</option>
 	  </term>
 	  <listitem>
 	    <para>
               <!--
 	      specify what kind of network virtualization to be used
 	      for the container. Each time
-	      a <option>lxc.network.type</option> field is found a new
+	      a <option>lxc.net.[i].type</option> field is found a new
 	      round of network configuration begins. In this way,
 	      several network virtualization types can be specified
 	      for the same container, as well as assigning several
@@ -443,7 +443,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 	      virtualization types can be:
               -->
               컨테이너가 어떤 종류의 네트워크 가상화를 사용할지 지정한다.
-              <option>lxc.network.type</option> 필드부터 새로운 네트워크 설정이 시작된다. 이 방법으로 여러개의 네트워크 가상화 형태를 같은 컨테이너에 지정할 수 있다. 그리고 여러개의 네트워크 인터페이스를 하나의 컨테이너에 지정할 수도 있다.
+              <option>lxc.net.[i].type</option> 필드부터 새로운 네트워크 설정이 시작된다. 이 방법으로 여러개의 네트워크 가상화 형태를 같은 컨테이너에 지정할 수 있다. 그리고 여러개의 네트워크 인터페이스를 하나의 컨테이너에 지정할 수도 있다.
               지정 가능한 형태는 아래와 같다.
 	    </para>
 
@@ -473,7 +473,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
               <option>veth:</option> a virtual ethernet pair
               device is created with one side assigned to the container
               and the other side attached to a bridge specified by
-              the <option>lxc.network.link</option> option.
+              the <option>lxc.net.[i].link</option> option.
               If the bridge is not specified, then the veth pair device
               will be created but not attached to any bridge.
               Otherwise, the bridge has to be created on the system
@@ -485,33 +485,33 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
               container, but if you wish to handle
               this name yourselves, you can tell <command>lxc</command>
               to set a specific name with
-              the <option>lxc.network.veth.pair</option> option (except for
+              the <option>lxc.net.[i].veth.pair</option> option (except for
               unprivileged containers where this option is ignored for security
               reasons).
               -->
-              <option>veth:</option> 한 쪽은 컨테이너로, 다른 한쪽은 <option>lxc.network.link</option> 옵션으로 지정한 브리지로 붙은 가상 이더넷(veth) 장치 쌍을 생성한다.
+              <option>veth:</option> 한 쪽은 컨테이너로, 다른 한쪽은 <option>lxc.net.[i].link</option> 옵션으로 지정한 브리지로 붙은 가상 이더넷(veth) 장치 쌍을 생성한다.
               만약 브리지가 지정되지 않았다면, 어떤 브리지에도 붙지 않은  veth 장치 쌍을 만든다. 브리지는 컨테이너 시작전에 시스템에서 생성해야 한다.
-              <command>lxc</command>는 컨테이너 이외의 설정에 대해서는 다루지 않는다. 기본값으로 <command>lxc</command>는 컨테이너 바깥에 속할 네트워크 디바이스의 이름을 정해준다. 이름을 변경하기 원한다면, <command>lxc</command>가 지정한 이름으로 설정하도록 <option>lxc.network.veth.pair</option> 옵션을 사용하여야 한다. (비특권 컨테이너는 불가능하다. 이 옵션은 보안상의 이유로 무시될 것이다)
+              <command>lxc</command>는 컨테이너 이외의 설정에 대해서는 다루지 않는다. 기본값으로 <command>lxc</command>는 컨테이너 바깥에 속할 네트워크 디바이스의 이름을 정해준다. 이름을 변경하기 원한다면, <command>lxc</command>가 지정한 이름으로 설정하도록 <option>lxc.net.[i].veth.pair</option> 옵션을 사용하여야 한다. (비특권 컨테이너는 불가능하다. 이 옵션은 보안상의 이유로 무시될 것이다)
             </para>
 
 	    <para>
               <!--
 	      <option>vlan:</option> a vlan interface is linked with
 	      the interface specified by
-	      the <option>lxc.network.link</option> and assigned to
+	      the <option>lxc.net.[i].link</option> and assigned to
 	      the container. The vlan identifier is specified with the
-	      option <option>lxc.network.vlan.id</option>.
+	      option <option>lxc.net.[i].vlan.id</option>.
               -->
-              <option>vlan:</option> vlan 인터페이스는 <option>lxc.network.link</option>로 지정한 인터페이스에 연결되고, 컨테이너로 할당된다. vlan의 식별자는 <option>lxc.network.vlan.id</option> 옵션으로 지정한다.
+              <option>vlan:</option> vlan 인터페이스는 <option>lxc.net.[i].link</option>로 지정한 인터페이스에 연결되고, 컨테이너로 할당된다. vlan의 식별자는 <option>lxc.net.[i].vlan.id</option> 옵션으로 지정한다.
 	    </para>
 
 	    <para>
               <!--
 	      <option>macvlan:</option> a macvlan interface is linked
 	      with the interface specified by
-	      the <option>lxc.network.link</option> and assigned to
+	      the <option>lxc.net.[i].link</option> and assigned to
 	      the container.
-	      <option>lxc.network.macvlan.mode</option> specifies the
+	      <option>lxc.net.[i].macvlan.mode</option> specifies the
 	      mode the macvlan will use to communicate between
 	      different macvlan on the same upper device. The accepted
               modes are <option>private</option>, <option>vepa</option>,
@@ -540,8 +540,8 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
               interface. Only one macvlan interface in <option>passthru</option>
               mode is possible for one physical interface.
               -->
-              <option>macvlan:</option> macvlan 인터페이스는 <option>lxc.network.link</option>로 지정한 인터페이스에 연결되고, 컨테이너로 할당된다.
-              <option>lxc.network.macvlan.mode</option>은 같은 상위 디바이스에 있는 다른 macvlan과 통신할 때 사용하는 모드를 지정한다.
+              <option>macvlan:</option> macvlan 인터페이스는 <option>lxc.net.[i].link</option>로 지정한 인터페이스에 연결되고, 컨테이너로 할당된다.
+              <option>lxc.net.[i].macvlan.mode</option>은 같은 상위 디바이스에 있는 다른 macvlan과 통신할 때 사용하는 모드를 지정한다.
               지정할 수 있는 모드는 <option>private</option>、<option>vepa</option>、<option>bridge</option>、<option>passthru</option>이다.
               <option>private</option>모드는 디바이스가 같은 상위디바이스의 어떤 장치와도 통신하지 않는다. (기본값)
               새로운 가상 이더넷 포트 통합모드(Virtual Ethernet Port Aggregator), 즉 <option>vepa</option> 모드는 인접한 브리지가 소스와 목적지가 로컬인 모든 프레임들을 macvlan 포트로 반환한다고 가정한다. 즉,  브리지가 reflective relay로 설정되어 있다는 것이다.
@@ -558,17 +558,17 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 	    <para>
               <!--
 	      <option>phys:</option> an already existing interface
-	      specified by the <option>lxc.network.link</option> is
+	      specified by the <option>lxc.net.[i].link</option> is
 	      assigned to the container.
               -->
-              <option>phys:</option> <option>lxc.network.link</option>로 지정한 이미 존재하는 인터페이스를 컨테이너로 할당된다.
+              <option>phys:</option> <option>lxc.net.[i].link</option>로 지정한 이미 존재하는 인터페이스를 컨테이너로 할당된다.
 	    </para>
 	  </listitem>
 	  </varlistentry>
 
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.flags</option>
+	    <option>lxc.net.[i].flags</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -590,7 +590,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.link</option>
+	    <option>lxc.net.[i].link</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -605,7 +605,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.mtu</option>
+	    <option>lxc.net.[i].mtu</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -619,7 +619,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.name</option>
+	    <option>lxc.net.[i].name</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -638,7 +638,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.hwaddr</option>
+	    <option>lxc.net.[i].hwaddr</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -658,7 +658,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.ipv4</option>
+	    <option>lxc.net.[i].ipv4</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -679,7 +679,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.ipv4.gateway</option>
+	    <option>lxc.net.[i].ipv4.gateway</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -691,7 +691,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 	      Can also have the special value <option>auto</option>,
 	      which means to take the primary address from the bridge
 	      interface (as specified by the
-	      <option>lxc.network.link</option> option) and use that as
+	      <option>lxc.net.[i].link</option> option) and use that as
 	      the gateway. <option>auto</option> is only available when
 	      using the <option>veth</option> and
 	      <option>macvlan</option> network types.
@@ -700,7 +700,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
               주소 형식은 x.y.z.t로, 예를 들면 192.168.1.123이다.
 
               <option>auto</option>라는 특별한 값을 지정할 수있다.
-              이것은 (<option>lxc.network.link</option> 에서 지정된) 브리지 인터페이스의 첫번째 주소를 가져와 게이트 주소로 사용한다.
+              이것은 (<option>lxc.net.[i].link</option> 에서 지정된) 브리지 인터페이스의 첫번째 주소를 가져와 게이트 주소로 사용한다.
               <option>auto</option>는 네트워크 형태가 <option>veth</option>나 <option>macvlan</option>일 때만 지정 가능하다.
 	    </para>
 	  </listitem>
@@ -709,7 +709,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.ipv6</option>
+	    <option>lxc.net.[i].ipv6</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -728,7 +728,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.ipv6.gateway</option>
+	    <option>lxc.net.[i].ipv6.gateway</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -740,7 +740,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 	      Can also have the special value <option>auto</option>,
 	      which means to take the primary address from the bridge
 	      interface (as specified by the
-	      <option>lxc.network.link</option> option) and use that as
+	      <option>lxc.net.[i].link</option> option) and use that as
 	      the gateway. <option>auto</option> is only available when
 	      using the <option>veth</option> and
 	      <option>macvlan</option> network types.
@@ -749,7 +749,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
               주소 형식은 x::y로, 예를 들면 2003:db8:1:0::1이다.
 
               <option>auto</option>라는 특별한 값을 지정할 수있다.
-              이것은 (<option>lxc.network.link</option> 에서 지정된) 브리지 인터페이스의 첫번째 주소를 가져와 게이트 주소로 사용한다.
+              이것은 (<option>lxc.net.[i].link</option> 에서 지정된) 브리지 인터페이스의 첫번째 주소를 가져와 게이트 주소로 사용한다.
 <option>auto</option>는 네트워크 형태가 <option>veth</option>나 <option>macvlan</option>일 때만 지정 가능하다.
 	    </para>
 	  </listitem>
@@ -757,7 +757,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.script.up</option>
+	    <option>lxc.net.[i].script.up</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -790,7 +790,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
 
 	<varlistentry>
 	  <term>
-	    <option>lxc.network.script.down</option>
+	    <option>lxc.net.[i].script.down</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -2564,13 +2564,13 @@ mknod errno 0
       </para>
       <programlisting>
 	lxc.utsname = myhostname
-	lxc.network.type = veth
-	lxc.network.flags = up
-	lxc.network.link = br0
-	lxc.network.name = eth0
-	lxc.network.hwaddr = 4a:49:43:49:79:bf
-	lxc.network.ipv4 = 1.2.3.5/24 1.2.3.255
-	lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
+	lxc.net.0.type = veth
+	lxc.net.0.flags = up
+	lxc.net.0.link = br0
+	lxc.net.0.name = eth0
+	lxc.net.0.hwaddr = 4a:49:43:49:79:bf
+	lxc.net.0.ipv4 = 1.2.3.5/24 1.2.3.255
+	lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
       </programlisting>
     </refsect2>
 
@@ -2614,26 +2614,26 @@ mknod errno 0
       </para>
       <programlisting>
 	lxc.utsname = complex
-	lxc.network.type = veth
-	lxc.network.flags = up
-	lxc.network.link = br0
-	lxc.network.hwaddr = 4a:49:43:49:79:bf
-	lxc.network.ipv4 = 10.2.3.5/24 10.2.3.255
-	lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
-	lxc.network.ipv6 = 2003:db8:1:0:214:5432:feab:3588
-	lxc.network.type = macvlan
-	lxc.network.flags = up
-	lxc.network.link = eth0
-	lxc.network.hwaddr = 4a:49:43:49:79:bd
-	lxc.network.ipv4 = 10.2.3.4/24
-	lxc.network.ipv4 = 192.168.10.125/24
-	lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
-	lxc.network.type = phys
-	lxc.network.flags = up
-	lxc.network.link = dummy0
-	lxc.network.hwaddr = 4a:49:43:49:79:ff
-	lxc.network.ipv4 = 10.2.3.6/24
-	lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297
+	lxc.net.0.type = veth
+	lxc.net.0.flags = up
+	lxc.net.0.link = br0
+	lxc.net.0.hwaddr = 4a:49:43:49:79:bf
+	lxc.net.0.ipv4 = 10.2.3.5/24 10.2.3.255
+	lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
+	lxc.net.0.ipv6 = 2003:db8:1:0:214:5432:feab:3588
+	lxc.net.1.type = macvlan
+	lxc.net.1.flags = up
+	lxc.net.1.link = eth0
+	lxc.net.1.hwaddr = 4a:49:43:49:79:bd
+	lxc.net.1.ipv4 = 10.2.3.4/24
+	lxc.net.1.ipv4 = 192.168.10.125/24
+	lxc.net.1.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
+	lxc.net.2.type = phys
+	lxc.net.2.flags = up
+	lxc.net.2.link = dummy0
+	lxc.net.2.hwaddr = 4a:49:43:49:79:ff
+	lxc.net.2.ipv4 = 10.2.3.6/24
+	lxc.net.2.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297
 	lxc.cgroup.cpuset.cpus = 0,1
 	lxc.cgroup.cpu.shares = 1234
 	lxc.cgroup.devices.deny = a

--- a/doc/lxc-info.sgml.in
+++ b/doc/lxc-info.sgml.in
@@ -175,7 +175,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       </varlistentry>
 
       <varlistentry>
-        <term>lxc-info -n foo -c lxc.network.0.veth.pair</term>
+        <term>lxc-info -n foo -c lxc.net.0.veth.pair</term>
         <listitem>
           <para>
             prints the veth pair name of foo.

--- a/doc/lxc.container.conf
+++ b/doc/lxc.container.conf
@@ -12,25 +12,25 @@ lxc.utsname = virtnode
 #              should be an existing interface, usually it is eth0
 #  * phys    : the network will use a physical network device, the specified
 #              link should be an existing interface
-lxc.network.type = macvlan
+lxc.net.0.type = macvlan
 
 # specify the flags to be used for the network, actually only <up> is allowed
 # which mean the network should be set up when created. If the network is set
 # up, the loopback is automatically set up too.
-lxc.network.flags = up
+lxc.net.0.flags = up
 
 # specify the physical network device which will communicate with the
 # outside world
-lxc.network.link = eth0
+lxc.net.0.link = eth0
 
 # NIC ethernet mac address
-lxc.network.hwaddr = 4a:49:43:49:79:bd
+lxc.net.0.hwaddr = 4a:49:43:49:79:bd
 
 # specify the ipv4 address of the container. Several lines are allowed and
 # will mean several addresses will be assigned to the interface
-lxc.network.ipv4 = 1.2.3.5/24
+lxc.net.0.ipv4 = 1.2.3.5/24
 
 # specify the ipv6 address of the container. Several lines are allowed and
 # will mean several addresses will be assigned to the interface
-lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
+lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
 

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -100,9 +100,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
     <para>
       LXC namespaces configuration keys by using single dots. This means complex
-      configuration keys such as <option>lxc.network</option> expose various
-      subkeys such as <option>lxc.network.type</option>,
-      <option>lxc.network.link</option>, <option>lxc.network.ipv6</option>, and
+      configuration keys such as <option>lxc.net.0</option> expose various
+      subkeys such as <option>lxc.net.0.type</option>,
+      <option>lxc.net.0.link</option>, <option>lxc.net.0.ipv6</option>, and
       others for even more fine-grained configuration.
     </para>
 
@@ -342,7 +342,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.network</option>
+            <option>lxc.net</option>
           </term>
           <listitem>
             <para>
@@ -352,7 +352,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         </varlistentry>
         <varlistentry>
           <term>
-            <option>lxc.network.[i].type</option>
+            <option>lxc.net.[i].type</option>
           </term>
           <listitem>
             <para>
@@ -360,13 +360,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               for the container.
               Multiple networks can be specified by using an additional index
               <option>i</option>
-              after all <option>lxc.network.*</option> keys. For example,
-              <option>lxc.network.0.type = veth</option> and
-              <option>lxc.network.1.type = veth</option> specify two different
+              after all <option>lxc.net.*</option> keys. For example,
+              <option>lxc.net.0.type = veth</option> and
+              <option>lxc.net.1.type = veth</option> specify two different
               networks of the same type. All keys sharing the same index
               <option>i</option> will be treated as belonging to the same
-              network. For example, <option>lxc.network.0.link = br0</option>
-              will belong to <option>lxc.network.0.type</option>.
+              network. For example, <option>lxc.net.0.link = br0</option>
+              will belong to <option>lxc.net.0.type</option>.
               Currently, the different virtualization types can be:
             </para>
 
@@ -388,7 +388,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               <option>veth:</option> a virtual ethernet pair
               device is created with one side assigned to the container
               and the other side attached to a bridge specified by
-              the <option>lxc.network.link</option> option.
+              the <option>lxc.net.[i].link</option> option.
               If the bridge is not specified, then the veth pair device
               will be created but not attached to any bridge.
               Otherwise, the bridge has to be created on the system
@@ -400,7 +400,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               container, but if you wish to handle
               this name yourselves, you can tell <command>lxc</command>
               to set a specific name with
-              the <option>lxc.network.veth.pair</option> option (except for
+              the <option>lxc.net.[i].veth.pair</option> option (except for
               unprivileged containers where this option is ignored for security
               reasons).
             </para>
@@ -408,17 +408,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             <para>
               <option>vlan:</option> a vlan interface is linked with
               the interface specified by
-              the <option>lxc.network.link</option> and assigned to
+              the <option>lxc.net.[i].link</option> and assigned to
               the container. The vlan identifier is specified with the
-              option <option>lxc.network.vlan.id</option>.
+              option <option>lxc.net.[i].vlan.id</option>.
             </para>
 
             <para>
               <option>macvlan:</option> a macvlan interface is linked
               with the interface specified by
-              the <option>lxc.network.link</option> and assigned to
+              the <option>lxc.net.[i].link</option> and assigned to
               the container.
-              <option>lxc.network.macvlan.mode</option> specifies the
+              <option>lxc.net.[i].macvlan.mode</option> specifies the
               mode the macvlan will use to communicate between
               different macvlan on the same upper device. The accepted
               modes are <option>private</option>, <option>vepa</option>,
@@ -450,7 +450,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
             <para>
               <option>phys:</option> an already existing interface
-              specified by the <option>lxc.network.link</option> is
+              specified by the <option>lxc.net.[i].link</option> is
               assigned to the container.
             </para>
           </listitem>
@@ -458,7 +458,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].flags</option>
+            <option>lxc.net.[i].flags</option>
           </term>
           <listitem>
             <para>
@@ -472,7 +472,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].link</option>
+            <option>lxc.net.[i].link</option>
           </term>
           <listitem>
             <para>
@@ -483,7 +483,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].mtu</option>
+            <option>lxc.net.[i].mtu</option>
           </term>
           <listitem>
             <para>
@@ -494,7 +494,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].name</option>
+            <option>lxc.net.[i].name</option>
           </term>
           <listitem>
             <para>
@@ -508,7 +508,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].hwaddr</option>
+            <option>lxc.net.[i].hwaddr</option>
           </term>
           <listitem>
             <para>
@@ -523,7 +523,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].ipv4</option>
+            <option>lxc.net.[i].ipv4</option>
           </term>
           <listitem>
             <para>
@@ -536,7 +536,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].ipv4.gateway</option>
+            <option>lxc.net.[i].ipv4.gateway</option>
           </term>
           <listitem>
             <para>
@@ -546,7 +546,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               Can also have the special value <option>auto</option>,
               which means to take the primary address from the bridge
               interface (as specified by the
-              <option>lxc.network.link</option> option) and use that as
+              <option>lxc.net.[i].link</option> option) and use that as
               the gateway. <option>auto</option> is only available when
               using the <option>veth</option> and
               <option>macvlan</option> network types.
@@ -557,7 +557,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].ipv6</option>
+            <option>lxc.net.[i].ipv6</option>
           </term>
           <listitem>
             <para>
@@ -571,7 +571,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].ipv6.gateway</option>
+            <option>lxc.net.[i].ipv6.gateway</option>
           </term>
           <listitem>
             <para>
@@ -581,7 +581,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               Can also have the special value <option>auto</option>,
               which means to take the primary address from the bridge
               interface (as specified by the
-              <option>lxc.network.link</option> option) and use that as
+              <option>lxc.net.[i].link</option> option) and use that as
               the gateway. <option>auto</option> is only available when
               using the <option>veth</option> and
               <option>macvlan</option> network types.
@@ -591,7 +591,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].script.up</option>
+            <option>lxc.net.[i].script.up</option>
           </term>
           <listitem>
             <para>
@@ -616,7 +616,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
-            <option>lxc.network.[i].script.down</option>
+            <option>lxc.net.[i].script.down</option>
           </term>
           <listitem>
             <para>
@@ -1933,13 +1933,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         eth0.</para>
       <programlisting>
         lxc.utsname = myhostname
-        lxc.network.type = veth
-        lxc.network.flags = up
-        lxc.network.link = br0
-        lxc.network.name = eth0
-        lxc.network.hwaddr = 4a:49:43:49:79:bf
-        lxc.network.ipv4 = 10.2.3.5/24 10.2.3.255
-        lxc.network.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
+        lxc.net.0.type = veth
+        lxc.net.0.flags = up
+        lxc.net.0.link = br0
+        lxc.net.0.name = eth0
+        lxc.net.0.hwaddr = 4a:49:43:49:79:bf
+        lxc.net.0.ipv4 = 10.2.3.5/24 10.2.3.255
+        lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
       </programlisting>
     </refsect2>
 
@@ -1976,26 +1976,26 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       mounting some locations and a changing root file system.</para>
       <programlisting>
         lxc.utsname = complex
-        lxc.network.0.type = veth
-        lxc.network.0.flags = up
-        lxc.network.0.link = br0
-        lxc.network.0.hwaddr = 4a:49:43:49:79:bf
-        lxc.network.0.ipv4 = 10.2.3.5/24 10.2.3.255
-        lxc.network.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
-        lxc.network.0.ipv6 = 2003:db8:1:0:214:5432:feab:3588
-        lxc.network.1.type = macvlan
-        lxc.network.1.flags = up
-        lxc.network.1.link = eth0
-        lxc.network.1.hwaddr = 4a:49:43:49:79:bd
-        lxc.network.1.ipv4 = 10.2.3.4/24
-        lxc.network.1.ipv4 = 192.168.10.125/24
-        lxc.network.1.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
-        lxc.network.2.type = phys
-        lxc.network.2.flags = up
-        lxc.network.2.link = dummy0
-        lxc.network.2.hwaddr = 4a:49:43:49:79:ff
-        lxc.network.2.ipv4 = 10.2.3.6/24
-        lxc.network.2.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297
+        lxc.net.0.type = veth
+        lxc.net.0.flags = up
+        lxc.net.0.link = br0
+        lxc.net.0.hwaddr = 4a:49:43:49:79:bf
+        lxc.net.0.ipv4 = 10.2.3.5/24 10.2.3.255
+        lxc.net.0.ipv6 = 2003:db8:1:0:214:1234:fe0b:3597
+        lxc.net.0.ipv6 = 2003:db8:1:0:214:5432:feab:3588
+        lxc.net.1.type = macvlan
+        lxc.net.1.flags = up
+        lxc.net.1.link = eth0
+        lxc.net.1.hwaddr = 4a:49:43:49:79:bd
+        lxc.net.1.ipv4 = 10.2.3.4/24
+        lxc.net.1.ipv4 = 192.168.10.125/24
+        lxc.net.1.ipv6 = 2003:db8:1:0:214:1234:fe0b:3596
+        lxc.net.2.type = phys
+        lxc.net.2.flags = up
+        lxc.net.2.link = dummy0
+        lxc.net.2.hwaddr = 4a:49:43:49:79:ff
+        lxc.net.2.ipv4 = 10.2.3.6/24
+        lxc.net.2.ipv6 = 2003:db8:1:0:214:1234:fe0b:3297
         lxc.cgroup.cpuset.cpus = 0,1
         lxc.cgroup.cpu.shares = 1234
         lxc.cgroup.devices.deny = a

--- a/src/lua-lxc/test/apitest.lua
+++ b/src/lua-lxc/test/apitest.lua
@@ -225,7 +225,7 @@ end
 
 function test_container_cmd()
     log(0, "Test get config from running container...")
-    veth_pair = lxc.cmd_get_config_item(optarg["n"], "lxc.network.0.veth.pair")
+    veth_pair = lxc.cmd_get_config_item(optarg["n"], "lxc.net.0.veth.pair")
     log(0, "  veth.pair:%s", veth_pair)
 end
 
@@ -281,7 +281,7 @@ function test_config_network(net_nr)
     log(0, "Test network %d config...", net_nr)
     local netcfg
 
-    netcfg = container:get_keys("lxc.network." .. net_nr)
+    netcfg = container:get_keys("lxc.net." .. net_nr)
     if (netcfg == nil) then
 	return
     end
@@ -289,7 +289,7 @@ function test_config_network(net_nr)
 	log(0, "  %s = %s", k, v or "")
     end
     assert(netcfg["flags"] == "up")
-    assert(container:get_config_item("lxc.network."..net_nr..".type") == "veth")
+    assert(container:get_config_item("lxc.net."..net_nr..".type") == "veth")
 end
 
 

--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -523,7 +523,7 @@ static int lxc_cmd_get_cgroup_callback(int fd, struct lxc_cmd_req *req,
  * lxc_cmd_get_config_item: Get config item the running container
  *
  * @name     : name of container to connect to
- * @item     : the configuration item to retrieve (ex: lxc.network.0.veth.pair)
+ * @item     : the configuration item to retrieve (ex: lxc.net.0.veth.pair)
  * @lxcpath  : the lxcpath in which the container is running
  *
  * Returns the item on success, NULL on failure. The caller must free() the

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -114,8 +114,8 @@ union netdev_p {
 
 /*
  * Defines a structure to configure a network device
- * @link       : lxc.network.link, name of bridge or host iface to attach if any
- * @name       : lxc.network.name, name of iface on the container side
+ * @link       : lxc.net.[i].link, name of bridge or host iface to attach if any
+ * @name       : lxc.net.[i].name, name of iface on the container side
  * @flags      : flag of the network device (IFF_UP, ... )
  * @ipv4       : a list of ipv4 addresses to be set on the network device
  * @ipv6       : a list of ipv6 addresses to be set on the network device

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -2606,7 +2606,6 @@ bool network_new_hwaddrs(struct lxc_conf *conf)
 {
 	char *lend, *p, *p2;
 	struct lxc_list *it;
-	const char *key = "lxc.network.hwaddr";
 	char *lstart = conf->unexpanded_config;
 
 	if (!conf->unexpanded_config)
@@ -2621,12 +2620,12 @@ bool network_new_hwaddrs(struct lxc_conf *conf)
 		else
 			lend++;
 
-		if (strncmp(lstart, key, strlen(key)) != 0) {
+		if (!lxc_config_net_hwaddr(lstart)) {
 			lstart = lend;
 			continue;
 		}
 
-		p = strchr(lstart + strlen(key), '=');
+		p = strchr(lstart, '=');
 		if (!p) {
 			lstart = lend;
 			continue;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -401,7 +401,7 @@ static int set_config_net_type(const char *key, const char *value,
 }
 
 /*
- * If you have p="lxc.net.0.link", pass it p+12
+ * If you have p="lxc.net.0.link", pass it p+8
  * to get back '0' (the index of the nic).
  */
 static int get_network_netdev_idx(const char *key)
@@ -419,7 +419,7 @@ static int get_network_netdev_idx(const char *key)
 }
 
 /*
- * If you have p="lxc.net.0", pass this p+12 and it will return
+ * If you have p="lxc.net.0", pass this p+8 and it will return
  * the netdev of the first configured nic.
  */
 static struct lxc_netdev *get_netdev_from_key(const char *key,

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -593,9 +593,9 @@ bool lxc_config_net_hwaddr(const char *line)
 }
 
 /*
- * If we find a lxc.net.hwaddr in the original config file, we expand it in
- * the unexpanded_config, so that after a save_config we store the hwaddr for
- * re-use.
+ * If we find a lxc.net.[i].hwaddr or lxc.network.hwaddr in the original config
+ * file, we expand it in the unexpanded_config, so that after a save_config we
+ * store the hwaddr for re-use.
  * This is only called when reading the config file, not when executing a
  * lxc.include.
  * 'x' and 'X' are substituted in-place.
@@ -608,8 +608,7 @@ void update_hwaddr(const char *line)
 	if (line[0] == '#')
 		return;
 
-	if ((strncmp(line, "lxc.network.hwaddr", 18) != 0) &&
-	    (strncmp(line, "lxc.net.hwaddr", 14) != 0))
+	if (!lxc_config_net_hwaddr(line))
 		return;
 
 	/* Let config_net_hwaddr raise the error. */

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -532,6 +532,66 @@ int rand_complete_hwaddr(char *hwaddr)
 	return 0;
 }
 
+bool lxc_config_net_hwaddr(const char *line)
+{
+	char *copy, *p;
+
+	if (strncmp(line, "lxc.net", 7) != 0)
+		return false;
+	if (strncmp(line, "lxc.network.hwaddr", 18) == 0)
+		return true;
+
+	/* We have to dup the line, if line is something like
+	 * "lxc.net.[i].xxx = xxxxx ", we need to remove
+	 * '[i]' and compare its key with 'lxc.net.hwaddr'*/
+	copy = strdup(line);
+	if (!copy) {
+		SYSERROR("failed to allocate memory");
+		return false;
+	}
+	if (*(copy + 8) >= '0' && *(copy + 8) <= '9') {
+		p = strchr(copy + 8, '.');
+		if (!p) {
+			free(copy);
+			return false;
+		}
+		/* strlen("hwaddr") = 6 */
+		strncpy(copy + 8, p + 1, 6);
+		copy[8 + 6] = '\0';
+	}
+	if (strncmp(copy, "lxc.net.hwaddr", 14) == 0) {
+		free(copy);
+		return true;
+	}
+	free(copy);
+
+	/* We have to dup the line second time, if line is something like
+	 * "lxc.network.[i].xxx = xxxxx ", we need to remove
+	 * '[i]' and compare its key with 'lxc.network.hwaddr'*/
+	copy = strdup(line);
+	if (!copy) {
+		SYSERROR("failed to allocate memory");
+		return false;
+	}
+	if (*(copy + 12) >= '0' && *(copy + 12) <= '9') {
+		p = strchr(copy + 12, '.');
+		if (!p) {
+			free(copy);
+			return false;
+		}
+		/* strlen("hwaddr") = 6 */
+		strncpy(copy + 12, p + 1, 6);
+		copy[12 + 6] = '\0';
+	}
+	if (strncmp(copy, "lxc.network.hwaddr", 18) == 0) {
+		free(copy);
+		return true;
+	}
+
+	free(copy);
+	return false;
+}
+
 /*
  * If we find a lxc.net.hwaddr in the original config file, we expand it in
  * the unexpanded_config, so that after a save_config we store the hwaddr for

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -533,7 +533,7 @@ int rand_complete_hwaddr(char *hwaddr)
 }
 
 /*
- * If we find a lxc.network.hwaddr in the original config file, we expand it in
+ * If we find a lxc.net.hwaddr in the original config file, we expand it in
  * the unexpanded_config, so that after a save_config we store the hwaddr for
  * re-use.
  * This is only called when reading the config file, not when executing a

--- a/src/lxc/confile_utils.h
+++ b/src/lxc/confile_utils.h
@@ -79,6 +79,7 @@ extern int set_config_path_item(char **conf_item, const char *value);
 extern int config_ip_prefix(struct in_addr *addr);
 extern int network_ifname(char **valuep, const char *value);
 extern int rand_complete_hwaddr(char *hwaddr);
+extern bool lxc_config_net_hwaddr(const char *line);
 extern void update_hwaddr(const char *line);
 extern bool new_hwaddr(char *hwaddr);
 extern int lxc_get_conf_str(char *retv, int inlen, const char *value);

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2069,7 +2069,7 @@ static int do_lxcapi_get_keys(struct lxc_container *c, const char *key, char *re
 	if (!key)
 		return lxc_listconfigs(retv, inlen);
 	/*
-	 * Support 'lxc.network.<idx>', i.e. 'lxc.network.0'
+	 * Support 'lxc.net.<idx>', i.e. 'lxc.net.0'
 	 * This is an intelligent result to show which keys are valid given
 	 * the type of nic it is
 	 */

--- a/src/lxc/tools/lxc_info.c
+++ b/src/lxc/tools/lxc_info.c
@@ -155,15 +155,15 @@ static void print_net_stats(struct lxc_container *c)
 	char buf[256];
 
 	for(netnr = 0; ;netnr++) {
-		sprintf(buf, "lxc.network.%d.type", netnr);
+		sprintf(buf, "lxc.net.%d.type", netnr);
 		type = c->get_running_config_item(c, buf);
 		if (!type)
 			break;
 
 		if (!strcmp(type, "veth")) {
-			sprintf(buf, "lxc.network.%d.veth.pair", netnr);
+			sprintf(buf, "lxc.net.%d.veth.pair", netnr);
 		} else {
-			sprintf(buf, "lxc.network.%d.link", netnr);
+			sprintf(buf, "lxc.net.%d.link", netnr);
 		}
 		free(type);
 		ifname = c->get_running_config_item(c, buf);

--- a/src/python-lxc/examples/api_test.py
+++ b/src/python-lxc/examples/api_test.py
@@ -90,7 +90,7 @@ assert(capdrop == container.get_config_item("lxc.cap.drop"))
 print("Testing the networking")
 
 # A few basic checks of the current state
-assert("name" in container.get_keys("lxc.network.0"))
+assert("name" in container.get_keys("lxc.net.0"))
 assert(len(container.network) == 1)
 
 ## Starting the container

--- a/src/python-lxc/lxc/__init__.py
+++ b/src/python-lxc/lxc/__init__.py
@@ -40,7 +40,7 @@ class ContainerNetwork(object):
         self.container = container
         self.index = index
 
-        for key in self.container.get_keys("lxc.network.%s" % self.index):
+        for key in self.container.get_keys("lxc.net.%s" % self.index):
             if "." in key:
                 self.props[key.replace(".", "_")] = key
             else:
@@ -98,18 +98,18 @@ class ContainerNetwork(object):
 
     def __clear_network_item(self, key):
         if key in ("ipv4", "ipv6"):
-            return self.container.clear_config_item("lxc.network.%s.%s" % (
+            return self.container.clear_config_item("lxc.net.%s.%s" % (
                                                     self.index, key))
         else:
-            return self.container.set_config_item("lxc.network.%s.%s" % (
+            return self.container.set_config_item("lxc.net.%s.%s" % (
                                                     self.index, key), "")
 
     def __get_network_item(self, key):
-        return self.container.get_config_item("lxc.network.%s.%s" % (
+        return self.container.get_config_item("lxc.net.%s.%s" % (
                                               self.index, key))
 
     def __set_network_item(self, key, value):
-        return self.container.set_config_item("lxc.network.%s.%s" % (
+        return self.container.set_config_item("lxc.net.%s.%s" % (
                                               self.index, key), value)
 
 
@@ -124,7 +124,7 @@ class ContainerNetworkList():
         return ContainerNetwork(self.container, index)
 
     def __len__(self):
-        values = self.container.get_config_item("lxc.network")
+        values = self.container.get_config_item("lxc.net")
 
         if values:
             return len(values)
@@ -134,7 +134,7 @@ class ContainerNetworkList():
     def add(self, network_type):
         index = len(self)
 
-        return self.container.set_config_item("lxc.network.%s.type" % index,
+        return self.container.set_config_item("lxc.net.%s.type" % index,
                                               network_type)
 
     def remove(self, index):
@@ -142,7 +142,7 @@ class ContainerNetworkList():
         if index >= count:
             raise IndexError("list index out of range")
 
-        return self.container.clear_config_item("lxc.network.%s" % index)
+        return self.container.clear_config_item("lxc.net.%s" % index)
 
 
 class Container(_lxc.Container):

--- a/src/tests/aa.c
+++ b/src/tests/aa.c
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "%d: %s thought it was defined\n", __LINE__, MYNAME);
 		goto err;
 	}
-	if (!c->set_config_item(c, "lxc.network.type", "empty")) {
+	if (!c->set_config_item(c, "lxc.net.0.type", "empty")) {
 		fprintf(stderr, "%s: %d: failed to set network type\n", __FILE__, __LINE__);
 		goto err;
 	}

--- a/src/tests/cgpath.c
+++ b/src/tests/cgpath.c
@@ -143,7 +143,7 @@ static int test_container(const char *lxcpath,
 		c->destroy(c);
 		c = lxc_container_new(name, lxcpath);
 	}
-	c->set_config_item(c, "lxc.network.type", "empty");
+	c->set_config_item(c, "lxc.net.0.type", "empty");
 	if (!c->createl(c, template, NULL, NULL, 0, NULL)) {
 		TSTERR("creating container %s", name);
 		goto out2;

--- a/src/tests/createtest.c
+++ b/src/tests/createtest.c
@@ -44,12 +44,12 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.type", "veth")) {
+	if (!c->set_config_item(c, "lxc.net.0.type", "veth")) {
 		fprintf(stderr, "%d: failed to set network type\n", __LINE__);
 		goto out;
 	}
-	c->set_config_item(c, "lxc.network.link", "lxcbr0");
-	c->set_config_item(c, "lxc.network.flags", "up");
+	c->set_config_item(c, "lxc.net.0.link", "lxcbr0");
+	c->set_config_item(c, "lxc.net.0.flags", "up");
 	if (!c->createl(c, "busybox", NULL, NULL, 0, NULL)) {
 		fprintf(stderr, "%d: failed to create a trusty container\n", __LINE__);
 		goto out;

--- a/src/tests/get_item.c
+++ b/src/tests/get_item.c
@@ -298,6 +298,22 @@ int main(int argc, char *argv[])
 	}
 	printf("%d: get_config_item(lxc.network) returned %d %s\n", __LINE__, ret, v2);
 
+	if (!c->set_config_item(c, "lxc.network.type", "veth")) {
+		fprintf(stderr, "%d: failed to set network.type\n", __LINE__);
+		goto out;
+	}
+	if (!c->set_config_item(c, "lxc.network.link", "lxcbr0")) {
+		fprintf(stderr, "%d: failed to set network.link\n", __LINE__);
+		goto out;
+	}
+	if (!c->set_config_item(c, "lxc.network.flags", "up")) {
+		fprintf(stderr, "%d: failed to set network.flags\n", __LINE__);
+		goto out;
+	}
+	if (!c->set_config_item(c, "lxc.network.hwaddr", "00:16:3e:xx:xx:xx")) {
+		fprintf(stderr, "%d: failed to set network.hwaddr\n", __LINE__);
+		goto out;
+	}
 	if (!c->set_config_item(c, "lxc.network.ipv4", "10.2.3.4")) {
 		fprintf(stderr, "%d: failed to set ipv4\n", __LINE__);
 		goto out;

--- a/src/tests/get_item.c
+++ b/src/tests/get_item.c
@@ -293,7 +293,7 @@ int main(int argc, char *argv[])
 	printf("%d: get_config_item(lxc.cap.drop) returned %d %s\n", __LINE__, ret, v2);
 	ret = c->get_config_item(c, "lxc.network", v2, 255);
 	if (ret < 0) {
-		fprintf(stderr, "%d: get_config_item returned %d\n", __LINE__, ret);
+		fprintf(stderr, "%d: get_config_item(lxc.network) returned %d\n", __LINE__, ret);
 		goto out;
 	}
 	printf("%d: get_config_item(lxc.network) returned %d %s\n", __LINE__, ret, v2);

--- a/src/tests/lxc-test-apparmor-mount
+++ b/src/tests/lxc-test-apparmor-mount
@@ -100,8 +100,8 @@ usermod -v 910000-919999 -w 910000-919999 $TUSER
 
 mkdir -p $HDIR/.config/lxc/
 cat > $HDIR/.config/lxc/default.conf << EOF
-lxc.network.type = veth
-lxc.network.link = lxcbr0
+lxc.net.0.type = veth
+lxc.net.0.link = lxcbr0
 lxc.id_map = u 0 910000 9999
 lxc.id_map = g 0 910000 9999
 EOF

--- a/src/tests/lxc-test-cloneconfig
+++ b/src/tests/lxc-test-cloneconfig
@@ -48,12 +48,12 @@ cleanup() {
 }
 
 verify_numnics() {
-	verify_unchanged_number lxc.network.type "network defs"
+	verify_unchanged_number lxc.net.0.type "network defs"
 }
 
 verify_hwaddr() {
-	verify_unchanged_number lxc.network.hwaddr "hwaddr defs"
-	grep ^lxc.network.hwaddr $CONTAINER_PATH/config | while read line; do
+	verify_unchanged_number lxc.net.0.hwaddr "hwaddr defs"
+	grep ^lxc.net.0.hwaddr $CONTAINER_PATH/config | while read line; do
 		addr=`echo $line | awk -F= { print $2 }`
 		echo "looking for $addr in $CONTAINER2_PATH/config"
 		if grep -q $addr $CONTAINER2_PATH/config; then
@@ -80,20 +80,20 @@ trap cleanup EXIT
 
 # Simple nic
 cat > $s/1.conf << EOF
-lxc.network.type = veth
-lxc.network.link = lxcbr0
+lxc.net.0.type = veth
+lxc.net.0.link = lxcbr0
 EOF
 
 # Simple nic with hwaddr; verify hwaddr changed
 cat > $s/2.conf << EOF
-lxc.network.type = veth
-lxc.network.link = lxcbr0
+lxc.net.0.type = veth
+lxc.net.0.link = lxcbr0
 EOF
 
 # No nics, but nic from include
 cat > $s/1.include << EOF
-lxc.network.type = veth
-lxc.network.link = lxcbr0
+lxc.net.0.type = veth
+lxc.net.0.link = lxcbr0
 lxc.hook.start = /bin/bash
 EOF
 cat > $s/3.conf << EOF

--- a/src/tests/lxc-test-createconfig
+++ b/src/tests/lxc-test-createconfig
@@ -34,8 +34,8 @@ cleanup() {
 trap cleanup EXIT
 
 cat > $f << EOF
-lxc.network.type = veth
-lxc.network.hwaddr = 00:16:3e:xx:xx:xx
+lxc.net.0.type = veth
+lxc.net.0.hwaddr = 00:16:3e:xx:xx:xx
 EOF
 lxc-create -t busybox -f $f -n lxctestc
 grep -q "xx:xx" /var/lib/lxc/lxctestc/config && { echo "hwaddr not expanded"; exit 1; }

--- a/src/tests/lxc-test-no-new-privs
+++ b/src/tests/lxc-test-no-new-privs
@@ -38,8 +38,8 @@ trap cleanup EXIT SIGHUP SIGINT SIGTERM
 
 mkdir -p /etc/lxc/
 cat > /etc/lxc/default.conf << EOF
-lxc.network.type = veth
-lxc.network.link = lxcbr0
+lxc.net.0.type = veth
+lxc.net.0.link = lxcbr0
 EOF
 
 ARCH=i386

--- a/src/tests/lxc-test-unpriv
+++ b/src/tests/lxc-test-unpriv
@@ -116,8 +116,8 @@ usermod -v 910000-919999 -w 910000-919999 $TUSER
 
 mkdir -p $HDIR/.config/lxc/
 cat > $HDIR/.config/lxc/default.conf << EOF
-lxc.network.type = veth
-lxc.network.link = lxcbr0
+lxc.net.0.type = veth
+lxc.net.0.link = lxcbr0
 lxc.id_map = u 0 910000 9999
 lxc.id_map = g 0 910000 9999
 EOF

--- a/src/tests/lxc-test-usernic.in
+++ b/src/tests/lxc-test-usernic.in
@@ -80,7 +80,7 @@ usermod -v 910000-919999 -w 910000-919999 usernic-user
 
 mkdir -p /home/usernic-user/.config/lxc/
 cat > /home/usernic-user/.config/lxc/default.conf << EOF
-lxc.network.type = empty
+lxc.net.0.type = empty
 lxc.id_map = u 0 910000 10000
 lxc.id_map = g 0 910000 10000
 EOF

--- a/src/tests/shutdowntest.c
+++ b/src/tests/shutdowntest.c
@@ -45,12 +45,12 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	if (!c->set_config_item(c, "lxc.network.type", "veth")) {
+	if (!c->set_config_item(c, "lxc.net.0.type", "veth")) {
 		fprintf(stderr, "%d: failed to set network type\n", __LINE__);
 		goto out;
 	}
-	c->set_config_item(c, "lxc.network.link", "lxcbr0");
-	c->set_config_item(c, "lxc.network.flags", "up");
+	c->set_config_item(c, "lxc.net.0.link", "lxcbr0");
+	c->set_config_item(c, "lxc.net.0.flags", "up");
 	if (!c->createl(c, "busybox", NULL, NULL, 0, NULL)) {
 		fprintf(stderr, "%d: failed to create a container\n", __LINE__);
 		goto out;

--- a/src/tests/snapshot.c
+++ b/src/tests/snapshot.c
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "%d: %s thought it was defined\n", __LINE__, MYNAME);
 		(void) c->destroy_with_snapshots(c);
 	}
-	if (!c->set_config_item(c, "lxc.network.type", "empty")) {
+	if (!c->set_config_item(c, "lxc.net.0.type", "empty")) {
 		fprintf(stderr, "%s: %d: failed to set network type\n", __FILE__, __LINE__);
 		goto err;
 	}

--- a/templates/lxc-altlinux.in
+++ b/templates/lxc-altlinux.in
@@ -276,30 +276,30 @@ lxc.cap.drop = sys_module mac_admin mac_override sys_time
 #lxc.aa_profile = unconfined
 
 #networking
-#lxc.network.type = $lxc_network_type
-#lxc.network.flags = up
-#lxc.network.link = $lxc_network_link
-#lxc.network.name = veth0
-#lxc.network.mtu = 1500
+#lxc.net.0.type = $lxc_network_type
+#lxc.net.0.flags = up
+#lxc.net.0.link = $lxc_network_link
+#lxc.net.0.name = veth0
+#lxc.net.0.mtu = 1500
 EOF
 if [ ! -z ${ipv4} ]; then
     cat <<EOF >> $config_path/config
-lxc.network.ipv4 = $ipv4
+lxc.net.0.ipv4 = $ipv4
 EOF
 fi
 if [ ! -z ${gw} ]; then
     cat <<EOF >> $config_path/config
-lxc.network.ipv4.gateway = $gw
+lxc.net.0.ipv4.gateway = $gw
 EOF
 fi
 if [ ! -z ${ipv6} ]; then
     cat <<EOF >> $config_path/config
-lxc.network.ipv6 = $ipv6
+lxc.net.0.ipv6 = $ipv6
 EOF
 fi
 if [ ! -z ${gw6} ]; then
     cat <<EOF >> $config_path/config
-lxc.network.ipv6.gateway = $gw6
+lxc.net.0.ipv6.gateway = $gw6
 EOF
 fi
     cat <<EOF >> $config_path/config

--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -618,13 +618,13 @@ lxc.rootfs = $rootfs_path
         # Seems that \s doesn't work in brackets.
         KEY=$(expr "${LINE}" : '\s*\([^	 ]*\)\s*=')
 
-        if [[ "${KEY}" != "lxc.network.hwaddr" ]]
+        if [[ "${KEY}" != "lxc.net.0.hwaddr" ]]
         then
             echo ${LINE} >> $config_path/config
 
-            if [[ "${KEY}" == "lxc.network.link" ]]
+            if [[ "${KEY}" == "lxc.net.0.link" ]]
             then
-                echo "lxc.network.hwaddr = $(create_hwaddr)" >> $config_path/config
+                echo "lxc.net.0.hwaddr = $(create_hwaddr)" >> $config_path/config
             fi
         fi
     done < $config_path/config.def
@@ -647,16 +647,16 @@ lxc.utsname = $utsname
 #lxc.aa_profile = unconfined
 
 # example simple networking setup, uncomment to enable
-#lxc.network.type = $lxc_network_type
-#lxc.network.flags = up
-#lxc.network.link = $lxc_network_link
-#lxc.network.name = eth0
+#lxc.net.0.type = $lxc_network_type
+#lxc.net.0.flags = up
+#lxc.net.0.link = $lxc_network_link
+#lxc.net.0.name = eth0
 # Additional example for veth network type
 #    static MAC address,
-#lxc.network.hwaddr = 00:16:3e:77:52:20
+#lxc.net.0.hwaddr = 00:16:3e:77:52:20
 #    persistent veth device name on host side
 #        Note: This may potentially collide with other containers of same name!
-#lxc.network.veth.pair = v-$name-e0
+#lxc.net.0.veth.pair = v-$name-e0
 
 EOF
 

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -493,9 +493,9 @@ copy_configuration()
     # Generate the configuration file
     # if there is exactly one veth network entry, make sure it has an
     # associated hwaddr.
-    nics=$(grep -ce '^lxc\.network\.type[ \t]*=[ \t]*veth' "$path/config")
+    nics=$(grep -ce '^lxc\.net\.0\.type[ \t]*=[ \t]*veth' "$path/config")
     if [ "$nics" -eq 1 ]; then
-        grep -q "^lxc.network.hwaddr" "$path/config" || sed -i -e "/^lxc\.network\.type[ \t]*=[ \t]*veth/a lxc.network.hwaddr = 00:16:3e:$(openssl rand -hex 3| sed 's/\(..\)/\1:/g; s/.$//')" "$path/config"
+        grep -q "^lxc.net.0.hwaddr" "$path/config" || sed -i -e "/^lxc\.net\.0\.type[ \t]*=[ \t]*veth/a lxc.net.0.hwaddr = 00:16:3e:$(openssl rand -hex 3| sed 's/\(..\)/\1:/g; s/.$//')" "$path/config"
     fi
 
     ## Add all the includes

--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -526,7 +526,7 @@ if [ ! -e $configfile ]; then
 fi
 
 ## Extract all the network config entries
-sed -i -e "/lxc.network/{w ${LXC_PATH}/config-network" -e "d}" \
+sed -i -e "/lxc.net.0/{w ${LXC_PATH}/config-network" -e "d}" \
     ${LXC_PATH}/config
 
 ## Extract any other config entry

--- a/templates/lxc-fedora-legacy.in
+++ b/templates/lxc-fedora-legacy.in
@@ -1104,13 +1104,13 @@ lxc.rootfs = $rootfs_path
         # Seems that \s doesn't work in brackets.
         KEY=$(expr "${LINE}" : '\s*\([^	 ]*\)\s*=')
 
-        if [[ "${KEY}" != "lxc.network.hwaddr" ]]
+        if [[ "${KEY}" != "lxc.net.0.hwaddr" ]]
         then
             echo "${LINE}" >> $config_path/config
 
-            if [[ "${KEY}" == "lxc.network.link" ]]
+            if [[ "${KEY}" == "lxc.net.0.link" ]]
             then
-                echo "lxc.network.hwaddr = $(create_hwaddr)" >> $config_path/config
+                echo "lxc.net.0.hwaddr = $(create_hwaddr)" >> $config_path/config
             fi
         fi
     done < $config_path/config.def
@@ -1133,16 +1133,16 @@ lxc.utsname = $utsname
 #lxc.aa_profile = unconfined
 
 # example simple networking setup, uncomment to enable
-#lxc.network.type = $lxc_network_type
-#lxc.network.flags = up
-#lxc.network.link = $lxc_network_link
-#lxc.network.name = eth0
+#lxc.net.0.type = $lxc_network_type
+#lxc.net.0.flags = up
+#lxc.net.0.link = $lxc_network_link
+#lxc.net.0.name = eth0
 # Additional example for veth network type
 #    static MAC address,
-#lxc.network.hwaddr = 00:16:3e:77:52:20
+#lxc.net.0.hwaddr = 00:16:3e:77:52:20
 #    persistent veth device name on host side
 #        Note: This may potentially collide with other containers of same name!
-#lxc.network.veth.pair = v-$name-e0
+#lxc.net.0.veth.pair = v-$name-e0
 
 EOF
 

--- a/templates/lxc-fedora.in
+++ b/templates/lxc-fedora.in
@@ -463,13 +463,13 @@ lxc.rootfs = ${rootfs}
         # Seems that \s doesn't work in brackets.
         key=$(expr "${line}" : '\s*\([^	 ]*\)\s*=')
 
-        if [ "${key}" != "lxc.network.hwaddr" ]
+        if [ "${key}" != "lxc.net.0.hwaddr" ]
         then
             echo "${line}" >> "${config}"
 
-            if [ "${key}" == "lxc.network.link" ]
+            if [ "${key}" == "lxc.net.0.link" ]
             then
-                echo "lxc.network.hwaddr = $(create_hwaddr)" >> "${config}"
+                echo "lxc.net.0.hwaddr = $(create_hwaddr)" >> "${config}"
             fi
         fi
     done < "${config}.orig"
@@ -492,16 +492,16 @@ lxc.utsname = ${utsname}
 #lxc.aa_profile = unconfined
 
 # example simple networking setup, uncomment to enable
-#lxc.network.type = ${lxc_network_type}
-#lxc.network.flags = up
-#lxc.network.link = ${lxc_network_link}
-#lxc.network.name = eth0
+#lxc.net.0.type = ${lxc_network_type}
+#lxc.net.0.flags = up
+#lxc.net.0.link = ${lxc_network_link}
+#lxc.net.0.name = eth0
 # Additional example for veth network type
 #    static MAC address,
-#lxc.network.hwaddr = $(create_hwaddr)
+#lxc.net.0.hwaddr = $(create_hwaddr)
 #    persistent veth device name on host side
 #        Note: This may potentially collide with other containers of same name!
-#lxc.network.veth.pair = v-${name}-e0
+#lxc.net.0.veth.pair = v-${name}-e0
 EOF
 
     if [ $? -ne 0 ]

--- a/templates/lxc-gentoo.in
+++ b/templates/lxc-gentoo.in
@@ -517,7 +517,7 @@ container_conf_net()
         value=$(echo "${line}" | sed 's/^.*_real_ugly_sep_42_//')
 
         #new nic !
-        if [[ "${key}" == "lxc.network.type" ]]; then
+        if [[ "${key}" == "lxc.net.0.type" ]]; then
             #we don't know what to do with it.
             [[ "${value}" == "empty" ]] && continue
 
@@ -535,15 +535,15 @@ container_conf_net()
             nic_type="${value}"
         fi
 
-                if [[ "${key}" == "lxc.network.hwaddr" ]]; then
+                if [[ "${key}" == "lxc.net.0.hwaddr" ]]; then
                 nic_hwaddr=1
         fi
 
-        if [[ "${key}" =~ ^lxc.network.ipv(4|6) ]]; then
+        if [[ "${key}" =~ ^lxc.net.0.ipv(4|6) ]]; then
             #tell openrc to not manage this NIC as LXC set there address
             nic_conf="null"
         fi
-        if [[ "${key}" =~ ^lxc.network.name ]]; then
+        if [[ "${key}" =~ ^lxc.net.0.name ]]; then
             nic_name="${value}"
             let nic_named=nic_named+1
         fi
@@ -583,10 +583,10 @@ container_net()
                         store_user_message "No network interface for this container
 It's a pitty, you have bridge, ${bridge}.
 If it is for Lxc, use it next time by adding this to your default.conf :
-lxc.network.type = veth
-lxc.network.link = ${bridge}
-lxc.network.flags = up
-lxc.network.hwaddr = fe:xx:xx:xx:xx:xx"
+lxc.net.0.type = veth
+lxc.net.0.link = ${bridge}
+lxc.net.0.flags = up
+lxc.net.0.hwaddr = fe:xx:xx:xx:xx:xx"
                         return 0
         else
                 store_user_message "No network interface for this container"
@@ -681,9 +681,9 @@ container_conf()
 
     # if there is exactly one veth network entry, make sure it has an
     # associated hwaddr.
-    nics=`grep -e '^lxc\.network\.type[ \t]*=[ \t]*veth' ${conf_file} | wc -l`
+    nics=`grep -e '^lxc\.net\.0\.type[ \t]*=[ \t]*veth' ${conf_file} | wc -l`
     if [ $nics -eq 1 ]; then
-        grep -q "^lxc.network.hwaddr" ${conf_file} || sed -i -e "/^lxc\.network\.type[ \t]*=[ \t]*veth/a lxc.network.hwaddr = 00:16:3e:$(openssl rand -hex 3| sed 's/\(..\)/\1:/g; s/.$//')" ${conf_file}
+        grep -q "^lxc.net.0.hwaddr" ${conf_file} || sed -i -e "/^lxc\.net\.0\.type[ \t]*=[ \t]*veth/a lxc.net.0.hwaddr = 00:16:3e:$(openssl rand -hex 3| sed 's/\(..\)/\1:/g; s/.$//')" ${conf_file}
     fi
 
     if grep -q "^lxc.rootfs" "${conf_file}" ; then

--- a/templates/lxc-openmandriva.in
+++ b/templates/lxc-openmandriva.in
@@ -238,30 +238,30 @@ lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed
 #lxc.aa_profile = unconfined
 
 #networking
-lxc.network.type = $lxc_network_type
-lxc.network.flags = up
-lxc.network.link = $lxc_network_link
-lxc.network.name = eth0
-lxc.network.mtu = 1500
+lxc.net.0.type = $lxc_network_type
+lxc.net.0.flags = up
+lxc.net.0.link = $lxc_network_link
+lxc.net.0.name = eth0
+lxc.net.0.mtu = 1500
 EOF
 if [ ! -z ${ipv4} ]; then
     cat <<EOF >> $config_path/config
-lxc.network.ipv4 = $ipv4
+lxc.net.0.ipv4 = $ipv4
 EOF
 fi
 if [ ! -z ${gw} ]; then
     cat <<EOF >> $config_path/config
-lxc.network.ipv4.gateway = $gw
+lxc.net.0.ipv4.gateway = $gw
 EOF
 fi
 if [ ! -z ${ipv6} ]; then
     cat <<EOF >> $config_path/config
-lxc.network.ipv6 = $ipv6
+lxc.net.0.ipv6 = $ipv6
 EOF
 fi
 if [ ! -z ${gw6} ]; then
     cat <<EOF >> $config_path/config
-lxc.network.ipv6.gateway = $gw6
+lxc.net.0.ipv6.gateway = $gw6
 EOF
 fi
     cat <<EOF >> $config_path/config

--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -327,13 +327,13 @@ lxc.rootfs = $rootfs_path
         # Seems that \s doesn't work in brackets.
         KEY=$(expr "${LINE}" : '\s*\([^	 ]*\)\s*=')
 
-        if [[ "${KEY}" != "lxc.network.hwaddr" ]]
+        if [[ "${KEY}" != "lxc.net.0.hwaddr" ]]
         then
             echo "${LINE}" >> $path/config
 
-            if [[ "${KEY}" == "lxc.network.link" ]]
+            if [[ "${KEY}" == "lxc.net.0.link" ]]
             then
-                echo "lxc.network.hwaddr = $(create_hwaddr)" >> $path/config
+                echo "lxc.net.0.hwaddr = $(create_hwaddr)" >> $path/config
             fi
         fi
     done < $path/config.def
@@ -358,16 +358,16 @@ lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed
 lxc.aa_profile = unconfined
 
 # example simple networking setup, uncomment to enable
-#lxc.network.type = $lxc_network_type
-#lxc.network.flags = up
-#lxc.network.link = $lxc_network_link
-#lxc.network.name = eth0
+#lxc.net.0.type = $lxc_network_type
+#lxc.net.0.flags = up
+#lxc.net.0.link = $lxc_network_link
+#lxc.net.0.name = eth0
 # Additional example for veth network type
 #    static MAC address,
-#lxc.network.hwaddr = 00:16:3e:77:52:20
+#lxc.net.0.hwaddr = 00:16:3e:77:52:20
 #    persistent veth device name on host side
 #        Note: This may potentially collide with other containers of same name!
-#lxc.network.veth.pair = v-$name-e0
+#lxc.net.0.veth.pair = v-$name-e0
 
 EOF
 

--- a/templates/lxc-oracle.in
+++ b/templates/lxc-oracle.in
@@ -497,36 +497,36 @@ EOF
 
     echo "# Networking" >>$cfg_dir/config
     # see if the default network settings were already specified
-    lxc_network_type=`grep '^lxc.network.type' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
+    lxc_network_type=`grep '^lxc.net.0.type' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
     if [ -z "$lxc_network_type" ]; then
-        echo "lxc.network.type = veth" >>$cfg_dir/config
+        echo "lxc.net.0.type = veth" >>$cfg_dir/config
         lxc_network_type=veth
     fi
 
-    lxc_network_link=`grep '^lxc.network.link' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
+    lxc_network_link=`grep '^lxc.net.0.link' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
     if [ -z "$lxc_network_link" ]; then
-        echo "lxc.network.link = lxcbr0" >>$cfg_dir/config
+        echo "lxc.net.0.link = lxcbr0" >>$cfg_dir/config
         lxc_network_link=lxcbr0
     fi
 
-    lxc_network_hwaddr=`grep '^lxc.network.hwaddr' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
+    lxc_network_hwaddr=`grep '^lxc.net.0.hwaddr' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
     if [ -z "$lxc_network_hwaddr" ]; then
 	# generate a hwaddr for the container
         # see http://sourceforge.net/tracker/?func=detail&aid=3411497&group_id=163076&atid=826303
         local hwaddr="00:16:3e:`dd if=/dev/urandom bs=8 count=1 2>/dev/null |od -t x8 | \
                         head -n1 | awk '{print $2}' | cut -c1-6 | \
                         sed 's/\(..\)/\1:/g; s/.$//'`"
-        echo "lxc.network.hwaddr = $hwaddr" >>$cfg_dir/config
+        echo "lxc.net.0.hwaddr = $hwaddr" >>$cfg_dir/config
     fi
 
-    lxc_network_flags=`grep '^lxc.network.flags' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
+    lxc_network_flags=`grep '^lxc.net.0.flags' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
     if [ -z "$lxc_network_flags" ]; then
-        echo "lxc.network.flags = up" >>$cfg_dir/config
+        echo "lxc.net.0.flags = up" >>$cfg_dir/config
     fi
 
     cat <<EOF >> $cfg_dir/config || die "unable to create $cfg_dir/config"
-lxc.network.name = eth0
-lxc.network.mtu = 1500
+lxc.net.0.name = eth0
+lxc.net.0.mtu = 1500
 EOF
 }
 

--- a/templates/lxc-sparclinux.in
+++ b/templates/lxc-sparclinux.in
@@ -326,36 +326,36 @@ EOF
 
     echo "# Networking" >>$cfg_dir/config
     # see if the default network settings were already specified
-    lxc_network_type=`grep '^lxc.network.type' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
+    lxc_network_type=`grep '^lxc.net.0.type' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
     if [ -z "$lxc_network_type" ]; then
-        echo "lxc.network.type = veth" >>$cfg_dir/config
+        echo "lxc.net.0.type = veth" >>$cfg_dir/config
         lxc_network_type=veth
     fi
 
-    lxc_network_link=`grep '^lxc.network.link' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
+    lxc_network_link=`grep '^lxc.net.0.link' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
     if [ -z "$lxc_network_link" ]; then
-        echo "lxc.network.link = lxcbr0" >>$cfg_dir/config
+        echo "lxc.net.0.link = lxcbr0" >>$cfg_dir/config
         lxc_network_link=lxcbr0
     fi
 
-    lxc_network_hwaddr=`grep '^lxc.network.hwaddr' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
+    lxc_network_hwaddr=`grep '^lxc.net.0.hwaddr' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
     if [ -z "$lxc_network_hwaddr" ]; then
         # generate a hwaddr for the container
         # see http://sourceforge.net/tracker/?func=detail&aid=3411497&group_id=163076&atid=826303
         local hwaddr="00:16:3e:`dd if=/dev/urandom bs=8 count=1 2>/dev/null |od -t x8 | \
                         head -n1 | awk '{print $2}' | cut -c1-6 | \
                         sed 's/\(..\)/\1:/g; s/.$//'`"
-        echo "lxc.network.hwaddr = $hwaddr" >>$cfg_dir/config
+        echo "lxc.net.0.hwaddr = $hwaddr" >>$cfg_dir/config
     fi
 
-    lxc_network_flags=`grep '^lxc.network.flags' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
+    lxc_network_flags=`grep '^lxc.net.0.flags' $cfg_dir/config | awk -F'[= \t]+' '{ print $2 }'`
     if [ -z "$lxc_network_flags" ]; then
-        echo "lxc.network.flags = up" >>$cfg_dir/config
+        echo "lxc.net.0.flags = up" >>$cfg_dir/config
     fi
 
     cat <<EOF >> $cfg_dir/config || die "unable to create $cfg_dir/config"
-lxc.network.name = eth0
-lxc.network.mtu = 1500
+lxc.net.0.name = eth0
+lxc.net.0.mtu = 1500
 EOF
 }
 

--- a/templates/lxc-sshd.in
+++ b/templates/lxc-sshd.in
@@ -162,7 +162,7 @@ EOF
     fi
 
     # if no .ipv4 section in config, then have the container run dhcp
-    grep -q "^lxc.network.ipv4" $path/config || touch $rootfs/run-dhcp
+    grep -q "^lxc.net.0.ipv4" $path/config || touch $rootfs/run-dhcp
 
     if [ "$(uname -m)" = "x86_64" ]; then
         cat <<EOF >> $path/config

--- a/templates/lxc-ubuntu-cloud.in
+++ b/templates/lxc-ubuntu-cloud.in
@@ -60,14 +60,14 @@ copy_configuration()
 
     # if there is exactly one veth network entry, make sure it has an
     # associated hwaddr.
-    nics=`grep -e '^lxc\.network\.type[ \t]*=[ \t]*veth' $path/config | wc -l`
+    nics=`grep -e '^lxc\.net\.0\.type[ \t]*=[ \t]*veth' $path/config | wc -l`
     if [ $nics -eq 1 ]; then
-        grep -q "^lxc.network.hwaddr" $path/config || sed -i -e "/^lxc\.network\.type[ \t]*=[ \t]*veth/a lxc.network.hwaddr = 00:16:3e:$(openssl rand -hex 3| sed 's/\(..\)/\1:/g; s/.$//')" $path/config
+        grep -q "^lxc.net.0.hwaddr" $path/config || sed -i -e "/^lxc\.net\.0\.type[ \t]*=[ \t]*veth/a lxc.net.0.hwaddr = 00:16:3e:$(openssl rand -hex 3| sed 's/\(..\)/\1:/g; s/.$//')" $path/config
     fi
 
     # Generate the configuration file
     ## Relocate all the network config entries
-    sed -i -e "/lxc.network/{w ${path}/config-network" -e "d}" $path/config
+    sed -i -e "/lxc.net.0/{w ${path}/config-network" -e "d}" $path/config
 
     ## Relocate any other config entries
     sed -i -e "/lxc./{w ${path}/config-auto" -e "d}" $path/config

--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -503,14 +503,14 @@ copy_configuration()
 
     # if there is exactly one veth network entry, make sure it has an
     # associated hwaddr.
-    nics=`grep -e '^lxc\.network\.type[ \t]*=[ \t]*veth' $path/config | wc -l`
+    nics=`grep -e '^lxc\.net\.0\.type[ \t]*=[ \t]*veth' $path/config | wc -l`
     if [ $nics -eq 1 ]; then
-        grep -q "^lxc.network.hwaddr" $path/config || sed -i -e "/^lxc\.network\.type[ \t]*=[ \t]*veth/a lxc.network.hwaddr = 00:16:3e:$(openssl rand -hex 3| sed 's/\(..\)/\1:/g; s/.$//')" $path/config
+        grep -q "^lxc.net.0.hwaddr" $path/config || sed -i -e "/^lxc\.net\.0\.type[ \t]*=[ \t]*veth/a lxc.net.0.hwaddr = 00:16:3e:$(openssl rand -hex 3| sed 's/\(..\)/\1:/g; s/.$//')" $path/config
     fi
 
     # Generate the configuration file
     ## Relocate all the network config entries
-    sed -i -e "/lxc.network/{w ${path}/config-network" -e "d}" $path/config
+    sed -i -e "/lxc.net.0/{w ${path}/config-network" -e "d}" $path/config
 
     ## Relocate any other config entries
     sed -i -e "/lxc./{w ${path}/config-auto" -e "d}" $path/config


### PR DESCRIPTION
Fix: https://github.com/lxc/lxc/issues/1641

This pr also add the new `lxc.net` key support for function `network_new_hwaddrs`.