### PR TITLE
configure.ac: clear libtoolize's complaining

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,8 @@ m4_define([lxc_version],
 
 AC_INIT([lxc], [lxc_version])
 
+AC_CONFIG_MACRO_DIRS([config])
+
 # We need pkg-config
 PKG_PROG_PKG_CONFIG
 


### PR DESCRIPTION
the libtoolize give the following complaints.

```
libtoolize: Consider adding 'AC_CONFIG_MACRO_DIRS([config])' to
configure.ac,
libtoolize: and rerunning libtoolize and aclocal.
```
Signed-off-by: 0x0916 <w@laoqinren.net>