### PR TITLE
Fix possible buffer overflow / compile failure with gcc 7.1.0

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1370,11 +1370,11 @@ static inline bool cgfsng_create(void *hdata)
 		ERROR("Failed expanding cgroup name pattern");
 		return false;
 	}
-	len = strlen(tmp) + 5; // leave room for -NNN\0
+	len = strlen(tmp) + 6; // leave room for -NNN\0
 	cgname = must_alloc(len);
 	strcpy(cgname, tmp);
 	free(tmp);
-	offset = cgname + len - 5;
+	offset = cgname + len - 6;
 
 again:
 	if (idx == 1000) {
@@ -1382,7 +1382,7 @@ again:
 		goto out_free;
 	}
 	if (idx)
-		snprintf(offset, 5, "-%d", idx);
+		snprintf(offset, 6, "-%d", idx);
 	for (i = 0; hierarchies[i]; i++) {
 		if (!create_path_for_hierarchy(hierarchies[i], cgname)) {
 			int j;


### PR DESCRIPTION
Fix compile failure with gcc 7.1.0 by expanding buffer size by one byte to prevent possible overflow in file src/lxc/cgroups/cgfsng.c.

Fixes gcc 7.1.0 error:

cgroups/cgfsng.c:1381:23: error: ‘snprintf’ output may be truncated before the last format character [-Werror=format-truncation=]
   snprintf(offset, 5, "-%d", idx);
                       ^~~~~
cgroups/cgfsng.c:1381:3: note: ‘snprintf’ output between 3 and 6 bytes into a destination of size 5
   snprintf(offset, 5, "-%d", idx);

Signed-off-by: Lance Ward <ljward10@gmail.com>