### PR TITLE
new configuration keys

### DIFF
--- a/config/templates/alpine.common.conf.in
+++ b/config/templates/alpine.common.conf.in
@@ -2,7 +2,7 @@
 lxc.include = @LXCTEMPLATECONFIG@/common.conf
 
 # Doesn't support consoles in /dev/lxc/.
-lxc.devttydir =
+lxc.tty.dir =
 
 # Drop another (potentially) harmful capabilities.
 lxc.cap.drop = audit_write

--- a/config/templates/archlinux.common.conf.in
+++ b/config/templates/archlinux.common.conf.in
@@ -9,7 +9,7 @@ lxc.signal.halt=SIGRTMIN+4
 lxc.signal.stop=SIGRTMIN+14
 
 # Uncomment to disable creating tty devices subdirectory in /dev
-# lxc.devttydir =
+# lxc.tty.dir =
 
 # Capabilities
 # Uncomment these if you don't run anything that needs the capability, and

--- a/config/templates/archlinux.common.conf.in
+++ b/config/templates/archlinux.common.conf.in
@@ -5,8 +5,8 @@ lxc.include = @LXCTEMPLATECONFIG@/common.conf
 lxc.tty = 6
 
 # Set the halt/stop signals
-lxc.haltsignal=SIGRTMIN+4
-lxc.stopsignal=SIGRTMIN+14
+lxc.signal.halt=SIGRTMIN+4
+lxc.signal.stop=SIGRTMIN+14
 
 # Uncomment to disable creating tty devices subdirectory in /dev
 # lxc.devttydir =

--- a/config/templates/common.conf.in
+++ b/config/templates/common.conf.in
@@ -1,7 +1,7 @@
 # Default configuration shared by all containers
 
 # Setup the LXC devices in /dev/lxc/
-lxc.devttydir = lxc
+lxc.tty.dir = lxc
 
 # Allow for 1024 pseudo terminals
 lxc.pts = 1024

--- a/config/templates/debian.common.conf.in
+++ b/config/templates/debian.common.conf.in
@@ -2,7 +2,7 @@
 lxc.include = @LXCTEMPLATECONFIG@/common.conf
 
 # Doesn't support consoles in /dev/lxc/
-lxc.devttydir =
+lxc.tty.dir =
 
 # When using LXC with apparmor, the container will be confined by default.
 # If you wish for it to instead run unconfined, copy the following line

--- a/config/templates/gentoo.common.conf.in
+++ b/config/templates/gentoo.common.conf.in
@@ -7,7 +7,7 @@ lxc.include = @LXCTEMPLATECONFIG@/common.conf
 # Looking for more security, see gentoo.moresecure.conf
 
 # Doesn't support consoles in /dev/lxc/
-lxc.devttydir =
+lxc.tty.dir =
 
 # Extra cgroup device access
 ## rtc

--- a/config/templates/openwrt.common.conf.in
+++ b/config/templates/openwrt.common.conf.in
@@ -1,5 +1,5 @@
 # Default console settings
-lxc.devttydir = lxc
+lxc.tty.dir = lxc
 lxc.tty = 4
 lxc.pts = 1024
 

--- a/config/templates/plamo.common.conf.in
+++ b/config/templates/plamo.common.conf.in
@@ -2,7 +2,7 @@
 lxc.include = @LXCTEMPLATECONFIG@/common.conf
 
 # Doesn't support consoles in /dev/lxc/
-lxc.devttydir =
+lxc.tty.dir =
 
 # Extra cgroup device access
 ## rtc

--- a/config/templates/sabayon.common.conf.in
+++ b/config/templates/sabayon.common.conf.in
@@ -13,7 +13,7 @@ lxc.tty = 1
 lxc.autodev = 1
 
 # Doesn't support consoles in /dev/lxc/
-lxc.devttydir =
+lxc.tty.dir =
 
 # CGroup whitelist
 lxc.cgroup.devices.deny = a

--- a/config/templates/slackware.common.conf.in
+++ b/config/templates/slackware.common.conf.in
@@ -2,7 +2,7 @@
 lxc.include = @LXCTEMPLATECONFIG@/common.conf
 
 # Doesn't support consoles in /dev/lxc/
-lxc.devttydir =
+lxc.tty.dir =
 
 # Extra cgroup device access
 ## rtc

--- a/config/templates/ubuntu.lucid.conf.in
+++ b/config/templates/ubuntu.lucid.conf.in
@@ -1,2 +1,2 @@
 # Ubuntu 10.04 LTS doesn't have /dev/lxc/
-lxc.devttydir =
+lxc.tty.dir =

--- a/config/templates/userns.conf.in
+++ b/config/templates/userns.conf.in
@@ -3,7 +3,7 @@ lxc.cgroup.devices.deny =
 lxc.cgroup.devices.allow =
 
 # We can't move bind-mounts, so don't use /dev/lxc/
-lxc.devttydir =
+lxc.tty.dir =
 
 # Extra bind-mounts for userns
 lxc.mount.entry = /dev/full dev/full none bind,create=file 0 0

--- a/config/templates/voidlinux.common.conf.in
+++ b/config/templates/voidlinux.common.conf.in
@@ -8,7 +8,7 @@ lxc.tty = 6
 lxc.environment=VIRTUALIZATION=lxc
 
 # Set the halt/stop signals
-lxc.haltsignal=SIGCONT
+lxc.signal.halt=SIGCONT
 
 
 # Uncomment to disable creating tty devices subdirectory in /dev

--- a/config/templates/voidlinux.common.conf.in
+++ b/config/templates/voidlinux.common.conf.in
@@ -12,7 +12,7 @@ lxc.signal.halt=SIGCONT
 
 
 # Uncomment to disable creating tty devices subdirectory in /dev
-# lxc.devttydir =
+# lxc.tty.dir =
 
 # Capabilities
 # Uncomment these if you don't run anything that needs the capability, and

--- a/config/templates/voidlinux.userns.conf.in
+++ b/config/templates/voidlinux.userns.conf.in
@@ -5,4 +5,4 @@ lxc.include = @LXCTEMPLATECONFIG@/userns.conf
 lxc.environment=VIRTUALIZATION=lxc
 
 # Set the halt/stop signals
-lxc.haltsignal=SIGCONT
+lxc.signal.halt=SIGCONT

--- a/doc/examples/lxc-complex.conf.in
+++ b/doc/examples/lxc-complex.conf.in
@@ -1,6 +1,6 @@
 # Container with network a complex network mixing macvlan, veth and
 # physical network devices
-lxc.utsname = complex
+lxc.uts.name = complex
 lxc.net.0.type = veth
 lxc.net.0.flags = up
 lxc.net.0.link = br0

--- a/doc/examples/lxc-empty-netns.conf.in
+++ b/doc/examples/lxc-empty-netns.conf.in
@@ -1,4 +1,4 @@
 # Container with new network withtout network devices
-lxc.utsname = omega
+lxc.uts.name = omega
 lxc.net.0.type = empty
 lxc.net.0.flags = up

--- a/doc/examples/lxc-macvlan.conf.in
+++ b/doc/examples/lxc-macvlan.conf.in
@@ -1,5 +1,5 @@
 # Container with network virtualized using the macvlan device driver
-lxc.utsname = alpha
+lxc.uts.name = alpha
 lxc.net.0.type = macvlan
 lxc.net.0.flags = up
 lxc.net.0.link = eth0

--- a/doc/examples/lxc-no-netns.conf.in
+++ b/doc/examples/lxc-no-netns.conf.in
@@ -1,3 +1,3 @@
 # Container with non-virtualized network
 lxc.net.0.type = none
-lxc.utsname = delta
+lxc.uts.name = delta

--- a/doc/examples/lxc-phys.conf.in
+++ b/doc/examples/lxc-phys.conf.in
@@ -1,6 +1,6 @@
 # Container with network virtualized using a physical network device with name
 # 'eth0'
-lxc.utsname = gamma
+lxc.uts.name = gamma
 lxc.net.0.type = phys
 lxc.net.0.flags = up
 lxc.net.0.link = eth0

--- a/doc/examples/lxc-veth.conf.in
+++ b/doc/examples/lxc-veth.conf.in
@@ -1,6 +1,6 @@
 # Container with network virtualized using a pre-configured bridge named br0 and
 # veth pair virtual network devices
-lxc.utsname = beta
+lxc.uts.name = beta
 lxc.net.0.type = veth
 lxc.net.0.flags = up
 lxc.net.0.link = br0

--- a/doc/examples/lxc-vlan.conf.in
+++ b/doc/examples/lxc-vlan.conf.in
@@ -1,5 +1,5 @@
 # Container with network virtualized using the vlan device driver
-lxc.utsname = alpha
+lxc.uts.name = alpha
 lxc.net.0.type = vlan
 lxc.net.0.vlan.id = 1234
 lxc.net.0.flags = up

--- a/doc/ja/lxc-start.sgml.in
+++ b/doc/ja/lxc-start.sgml.in
@@ -94,12 +94,12 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
     <para>
       <!--
       If no command is specified, <command>lxc-start</command> will
-      use the command defined in lxc.init_cmd or if not set, the default
+      use the command defined in lxc.init.cmd or if not set, the default
       <command>"/sbin/init"</command> command to run a system
       container.
       -->
-      もし command が指定されない場合は、<command>lxc-start</command> はシステムコンテナを実行するためのコマンドとして、lxc.init_cmd で設定されたコマンドを使用します。
-      もし lxc.init_cmd が設定されていない場合は、デフォルトで <command>"/sbin/init"</command> を使用します。
+      もし command が指定されない場合は、<command>lxc-start</command> はシステムコンテナを実行するためのコマンドとして、lxc.init.cmd で設定されたコマンドを使用します。
+      もし lxc.init.cmd が設定されていない場合は、デフォルトで <command>"/sbin/init"</command> を使用します。
     </para>
 
   </refsect1>

--- a/doc/ja/lxc-stop.sgml.in
+++ b/doc/ja/lxc-stop.sgml.in
@@ -73,18 +73,18 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <command>lxc-stop</command> reboots, cleanly shuts down, or kills
       all the processes inside the container.  By default, it will
       request a clean shutdown of the container by sending
-      <command>lxc.haltsignal</command> (defaults to SIGPWR) to
+      <command>lxc.signal.halt</command> (defaults to SIGPWR) to
       the container's init process, waiting up to 60 seconds for the container
       to exit, and then returning. If the container fails to cleanly exit in
-      60 seconds, it will be sent the <command>lxc.stopsignal</command>
+      60 seconds, it will be sent the <command>lxc.signal.stop</command>
       (defaults to SIGKILL) to force it to shut down. A request to reboot will
-      send the <command>lxc.rebootsignal</command> (defaults to SIGINT) to the
+      send the <command>lxc.signal.reboot</command> (defaults to SIGINT) to the
       container's init process.
       -->
       <command>lxc-stop</command> は、リブート、クリーンシャットダウン、コンテナ内の全てのプロセスの kill のどれかを行います。
-      デフォルトでは、コンテナのクリーンなシャットダウンを <command>lxc.haltsignal</command> (デフォルトでは SIGPWR) をコンテナの init プロセスに送ることでリクエストし、コンテナの終了を 60 秒待ち、return します。
-      コンテナが 60 秒の間にクリーンに終了するのに失敗した場合、<command>lxc.stopsignal</command> (デフォルトは SIGKILL です) を送り、強制的にシャットダウンします。
-      リブートのリクエストは <command>lxc.rebootsignal</command> に設定されたシグナルをコンテナの init プロセスに送ります (デフォルトは SIGINT です)。
+      デフォルトでは、コンテナのクリーンなシャットダウンを <command>lxc.signal.halt</command> (デフォルトでは SIGPWR) をコンテナの init プロセスに送ることでリクエストし、コンテナの終了を 60 秒待ち、return します。
+      コンテナが 60 秒の間にクリーンに終了するのに失敗した場合、<command>lxc.signal.stop</command> (デフォルトは SIGKILL です) を送り、強制的にシャットダウンします。
+      リブートのリクエストは <command>lxc.signal.reboot</command> に設定されたシグナルをコンテナの init プロセスに送ります (デフォルトは SIGINT です)。
     </para>
 
     <para>

--- a/doc/ja/lxc.container.conf.sgml.in
+++ b/doc/ja/lxc.container.conf.sgml.in
@@ -260,7 +260,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.haltsignal</option>
+            <option>lxc.signal.halt</option>
           </term>
           <listitem>
             <para>
@@ -289,7 +289,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
           <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.rebootsignal</option>
+            <option>lxc.signal.reboot</option>
           </term>
           <listitem>
             <para>
@@ -318,7 +318,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.stopsignal</option>
+            <option>lxc.signal.stop</option>
           </term>
           <listitem>
             <para>

--- a/doc/ja/lxc.container.conf.sgml.in
+++ b/doc/ja/lxc.container.conf.sgml.in
@@ -2410,7 +2410,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.loglevel</option>
+            <option>lxc.log.level</option>
           </term>
           <listitem>
             <para>
@@ -2440,7 +2440,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         </varlistentry>
         <varlistentry>
           <term>
-            <option>lxc.logfile</option>
+            <option>lxc.log</option>
           </term>
           <listitem>
             <para>
@@ -2453,17 +2453,17 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         </varlistentry>
         <varlistentry>
           <term>
-            <option>lxc.syslog</option>
+            <option>lxc.log.syslog</option>
           </term>
           <listitem>
             <para>
               <!--
             Send logging info to syslog. It respects the log level defined in
-            <command>lxc.loglevel</command>. The argument should be the syslog
+            <command>lxc.log.level</command>. The argument should be the syslog
             facility to use, valid ones are: daemon, local0, local1, local2,
             local3, local4, local5, local5, local7.
             -->
-              ログ情報を syslog に送ります。ログレベルとして <command>lxc.loglevel</command> の値を使用します。指定する値は使用する syslog の facility です。有効な値は daemon, local0, local1, local2, local3, local4, local5, local5, local6, local7 のいずれかです。
+              ログ情報を syslog に送ります。ログレベルとして <command>lxc.log.level</command> の値を使用します。指定する値は使用する syslog の facility です。有効な値は daemon, local0, local1, local2, local3, local4, local5, local5, local6, local7 のいずれかです。
             </para>
           </listitem>
         </varlistentry>

--- a/doc/ja/lxc.container.conf.sgml.in
+++ b/doc/ja/lxc.container.conf.sgml.in
@@ -1684,7 +1684,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.limit.[limit name]</option>
+            <option>lxc.prlimit.[limit name]</option>
           </term>
           <listitem>
             <para>

--- a/doc/ja/lxc.container.conf.sgml.in
+++ b/doc/ja/lxc.container.conf.sgml.in
@@ -349,7 +349,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.init_cmd</option>
+            <option>lxc.init.cmd</option>
           </term>
           <listitem>
             <para>
@@ -381,7 +381,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.init_uid</option>
+            <option>lxc.init.uid</option>
           </term>
           <listitem>
             <para>
@@ -394,7 +394,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         </varlistentry>
         <varlistentry>
           <term>
-            <option>lxc.init_gid</option>
+            <option>lxc.init.gid</option>
           </term>
           <listitem>
             <para>

--- a/doc/ja/lxc.container.conf.sgml.in
+++ b/doc/ja/lxc.container.conf.sgml.in
@@ -229,7 +229,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.utsname</option>
+            <option>lxc.uts.name</option>
           </term>
           <listitem>
             <para>
@@ -2667,7 +2667,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         仮想ネットワークデバイスは、コンテナ内では eth0 とリネームされます。
       </para>
       <programlisting>
-        lxc.utsname = myhostname
+        lxc.uts.name = myhostname
         lxc.net.0.type = veth
         lxc.net.0.flags = up
         lxc.net.0.link = br0
@@ -2720,7 +2720,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
         この例は、control group を使って、複雑なネットワークスタックを作成し、新しいホスト名を指定し、いくつかの場所をマウントし、ルートファイルシステムを変更するような複雑な設定を示します。
       </para>
       <programlisting>
-        lxc.utsname = complex
+        lxc.uts.name = complex
         lxc.net.0.type = veth
         lxc.net.0.flags = up
         lxc.net.0.link = br0

--- a/doc/ja/lxc.sgml.in
+++ b/doc/ja/lxc.sgml.in
@@ -556,12 +556,12 @@ rootfs
 	command into the container.
 	The pid of the first process is 1. If no command is
 	specified <command>lxc-start</command> will
-	run the command defined in lxc.init_cmd or if not set,
+	run the command defined in lxc.init.cmd or if not set,
 	<filename>/sbin/init</filename> .
         -->
         <command>lxc-start</command> コマンドは、コンテナ内の特定のコマンドを直接実行します。
         最初のプロセスの pid が 1 となります。
-        もし、実行するコマンドが指定されない場合は、<command>lxc-start</command> は lxc.init_cmd で設定されたコマンドを実行します。もし lxc.init_cmd が設定されていない場合は <filename>/sbin/init</filename> を実行します。
+        もし、実行するコマンドが指定されない場合は、<command>lxc-start</command> は lxc.init.cmd で設定されたコマンドを実行します。もし lxc.init.cmd が設定されていない場合は <filename>/sbin/init</filename> を実行します。
       </para>
 
       <para>

--- a/doc/ko/lxc-start.sgml.in
+++ b/doc/ko/lxc-start.sgml.in
@@ -95,11 +95,11 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
     <para>
       <!--
       If no command is specified, <command>lxc-start</command> will
-      use the command defined in lxc.init_cmd or if not set, the default
+      use the command defined in lxc.init.cmd or if not set, the default
       <command>"/sbin/init"</command> command to run a system
       container.
       -->
-      만약 명령어가 지정되지 않았다면, <command>lxc-start</command>는 lxc.init_cmd에 정의된 명령어를 사용한다. 만약 그마저도 없다면 <command>"/sbin/init"</command>명령어를 사용한다.
+      만약 명령어가 지정되지 않았다면, <command>lxc-start</command>는 lxc.init.cmd에 정의된 명령어를 사용한다. 만약 그마저도 없다면 <command>"/sbin/init"</command>명령어를 사용한다.
     </para>
 
   </refsect1>

--- a/doc/ko/lxc-stop.sgml.in
+++ b/doc/ko/lxc-stop.sgml.in
@@ -73,16 +73,16 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
       <command>lxc-stop</command> reboots, cleanly shuts down, or kills
       all the processes inside the container.  By default, it will
       request a clean shutdown of the container by sending
-      <command>lxc.haltsignal</command> (defaults to SIGPWR) to
+      <command>lxc.signal.halt</command> (defaults to SIGPWR) to
       the container's init process, waiting up to 60 seconds for the container
       to exit, and then returning. If the container fails to cleanly exit in
-      60 seconds, it will be sent the <command>lxc.stopsignal</command>
+      60 seconds, it will be sent the <command>lxc.signal.stop</command>
       (defaults to SIGKILL) to force it to shut down. A request to reboot will
-      send the <command>lxc.rebootsignal</command> (defaults to SIGINT) to the
+      send the <command>lxc.signal.reboot</command> (defaults to SIGINT) to the
       container's init process.
       -->
-      <command>lxc-stop</command> 는 재뷰탕, 종료, 또는 컨테이너 내의 모든 프로세스를 강제종료 시킨다. 기본 동작은 컨테이너에게 <command>lxc.haltsignal</command> 시그널(기본값은 SIGPWR)을 컨테이너 init 프로세스에게 날려, 컨테이너가 종료되게 요청하는 것이다. 60초 동안 컨테이너가 종료되는 것을 기다리고 리턴된다.
-만약 컨테이너가 60초안에 종료되지 않는다면 <command>lxc.stopsignal</command> 시그널(기본값은 SIGKILL)을 날려 강제로 종료시킨다. 재부팅 요청시에는 <command>lxc.rebootsignal</command> 시그널(기본값은 SIGINT)를 컨테이너 init 프로세스에게 날린다.
+      <command>lxc-stop</command> 는 재뷰탕, 종료, 또는 컨테이너 내의 모든 프로세스를 강제종료 시킨다. 기본 동작은 컨테이너에게 <command>lxc.signal.halt</command> 시그널(기본값은 SIGPWR)을 컨테이너 init 프로세스에게 날려, 컨테이너가 종료되게 요청하는 것이다. 60초 동안 컨테이너가 종료되는 것을 기다리고 리턴된다.
+만약 컨테이너가 60초안에 종료되지 않는다면 <command>lxc.signal.stop</command> 시그널(기본값은 SIGKILL)을 날려 강제로 종료시킨다. 재부팅 요청시에는 <command>lxc.signal.reboot</command> 시그널(기본값은 SIGINT)를 컨테이너 init 프로세스에게 날린다.
     </para>
 
     <para>

--- a/doc/ko/lxc.container.conf.sgml.in
+++ b/doc/ko/lxc.container.conf.sgml.in
@@ -187,7 +187,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
       <variablelist>
 	<varlistentry>
 	  <term>
-	    <option>lxc.utsname</option>
+	    <option>lxc.uts.name</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -2563,7 +2563,7 @@ mknod errno 0
         이 설정은 컨테이너가 한 쪽은 (이전에 시스템에 이미 생성된) br0 브리지에 연결되어 있는 veth 장치 쌍을 사용하도록 세팅한다. 가상 네트워크 장치는 컨테이너 내에서 eth0라는 이름을 갖는다.
       </para>
       <programlisting>
-	lxc.utsname = myhostname
+	lxc.uts.name = myhostname
 	lxc.net.0.type = veth
 	lxc.net.0.flags = up
 	lxc.net.0.link = br0
@@ -2613,7 +2613,7 @@ mknod errno 0
         아래의 예제는 복잡한 네트워크 스택, 컨트롤 그룹 사용, 호스트 이름 설정, 몇몇 장소 마운트, 루트 파일시스템 변경 등의 복잡한 설정을 보여준다.
       </para>
       <programlisting>
-	lxc.utsname = complex
+	lxc.uts.name = complex
 	lxc.net.0.type = veth
 	lxc.net.0.flags = up
 	lxc.net.0.link = br0

--- a/doc/ko/lxc.container.conf.sgml.in
+++ b/doc/ko/lxc.container.conf.sgml.in
@@ -219,7 +219,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.haltsignal</option>
+            <option>lxc.signal.halt</option>
           </term>
           <listitem>
             <para>
@@ -248,7 +248,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
           <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.rebootsignal</option>
+            <option>lxc.signal.reboot</option>
           </term>
           <listitem>
             <para>
@@ -277,7 +277,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.stopsignal</option>
+            <option>lxc.signal.stop</option>
           </term>
           <listitem>
             <para>

--- a/doc/ko/lxc.container.conf.sgml.in
+++ b/doc/ko/lxc.container.conf.sgml.in
@@ -308,7 +308,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.init_cmd</option>
+            <option>lxc.init.cmd</option>
           </term>
           <listitem>
             <para>
@@ -343,7 +343,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.init_uid</option>
+            <option>lxc.init.uid</option>
           </term>
           <listitem>
             <para>
@@ -356,7 +356,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
         </varlistentry>
         <varlistentry>
           <term>
-            <option>lxc.init_gid</option>
+            <option>lxc.init.gid</option>
           </term>
           <listitem>
             <para>

--- a/doc/ko/lxc.container.conf.sgml.in
+++ b/doc/ko/lxc.container.conf.sgml.in
@@ -2308,7 +2308,7 @@ mknod errno 0
       <variablelist>
 	<varlistentry>
 	  <term>
-	    <option>lxc.loglevel</option>
+	    <option>lxc.log.level</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -2338,7 +2338,7 @@ mknod errno 0
 	</varlistentry>
 	<varlistentry>
 	  <term>
-	    <option>lxc.logfile</option>
+	    <option>lxc.log</option>
 	  </term>
 	  <listitem>
 	    <para>
@@ -2351,17 +2351,17 @@ mknod errno 0
 	</varlistentry>
 	<varlistentry>
 	  <term>
-	    <option>lxc.syslog</option>
+	    <option>lxc.log.syslog</option>
 	  </term>
 	  <listitem>
 	    <para>
 	      <!--
 		  Send logging info to syslog. It respects the log level defined in
-		  <command>lxc.loglevel</command>. The argument should be the syslog
+		  <command>lxc.log.level</command>. The argument should be the syslog
 		  facility to use, valid ones are: daemon, local0, local1, local2,
 		  local3, local4, local5, local5, local7.
 	      -->
-	      로그정보를 syslog에 보낸다. 로그 수준은 <command>lxc.loglevel</command>로 지정할 수 있다. 인자는 syslog에 정의된 값으로만 지정할 수 있다. 사용 가능한 값은 다음과 같다 : daemon, local0, local1, local2, local3, local4, local5, local5, local7 
+	      로그정보를 syslog에 보낸다. 로그 수준은 <command>lxc.log.level</command>로 지정할 수 있다. 인자는 syslog에 정의된 값으로만 지정할 수 있다. 사용 가능한 값은 다음과 같다 : daemon, local0, local1, local2, local3, local4, local5, local5, local7 
 	    </para>
 	  </listitem>
 	</varlistentry>

--- a/doc/ko/lxc.sgml.in
+++ b/doc/ko/lxc.sgml.in
@@ -542,10 +542,10 @@ rootfs
 	command into the container.
 	The pid of the first process is 1. If no command is
 	specified <command>lxc-start</command> will
-	run the command defined in lxc.init_cmd or if not set,
+	run the command defined in lxc.init.cmd or if not set,
 	<filename>/sbin/init</filename> .
         -->
-        <command>lxc-start</command> 명령어는 지정한 명령어를 컨테이너 내에서 직접 실행한다. 첫 프로세스의 pid는 1번이다. 만약 어떤 명령어도 지정되지 않으면, lxc.init_cmd에 지정된 명령어를 실행한다. 이마저도 지정되있지 않으면, <filename>/sbin/init</filename>를 실행한다.
+        <command>lxc-start</command> 명령어는 지정한 명령어를 컨테이너 내에서 직접 실행한다. 첫 프로세스의 pid는 1번이다. 만약 어떤 명령어도 지정되지 않으면, lxc.init.cmd에 지정된 명령어를 실행한다. 이마저도 지정되있지 않으면, <filename>/sbin/init</filename>를 실행한다.
       </para>
 
       <para>

--- a/doc/lxc-start.sgml.in
+++ b/doc/lxc-start.sgml.in
@@ -80,7 +80,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
     </para>
     <para>
       If no command is specified, <command>lxc-start</command> will
-      use the command defined in lxc.init_cmd or if not set, the default
+      use the command defined in lxc.init.cmd or if not set, the default
       <command>"/sbin/init"</command> command to run a system
       container.
     </para>

--- a/doc/lxc-stop.sgml.in
+++ b/doc/lxc-stop.sgml.in
@@ -66,12 +66,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <command>lxc-stop</command> reboots, cleanly shuts down, or kills
       all the processes inside the container.  By default, it will
       request a clean shutdown of the container by sending
-      <command>lxc.haltsignal</command> (defaults to SIGPWR) to
+      <command>lxc.signal.halt</command> (defaults to SIGPWR) to
       the container's init process, waiting up to 60 seconds for the container
       to exit, and then returning. If the container fails to cleanly exit in
-      60 seconds, it will be sent the <command>lxc.stopsignal</command>
+      60 seconds, it will be sent the <command>lxc.signal.stop</command>
       (defaults to SIGKILL) to force it to shut down. A request to reboot will
-      send the <command>lxc.rebootsignal</command> (defaults to SIGINT) to the
+      send the <command>lxc.signal.reboot</command> (defaults to SIGINT) to the
       container's init process.
     </para>
 	<para>

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -263,7 +263,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.init_cmd</option>
+            <option>lxc.init.cmd</option>
           </term>
           <listitem>
             <para>
@@ -287,7 +287,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.init_uid</option>
+            <option>lxc.init.uid</option>
           </term>
           <listitem>
             <para>
@@ -297,7 +297,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         </varlistentry>
         <varlistentry>
           <term>
-            <option>lxc.init_gid</option>
+            <option>lxc.init.gid</option>
           </term>
           <listitem>
             <para>

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -1201,7 +1201,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.limit.[limit name]</option>
+            <option>lxc.prlimit.[limit name]</option>
           </term>
           <listitem>
             <para>

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -172,7 +172,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.utsname</option>
+            <option>lxc.uts.name</option>
           </term>
           <listitem>
             <para>
@@ -1932,7 +1932,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         virtual network device visible in the container is renamed to
         eth0.</para>
       <programlisting>
-        lxc.utsname = myhostname
+        lxc.uts.name = myhostname
         lxc.net.0.type = veth
         lxc.net.0.flags = up
         lxc.net.0.link = br0
@@ -1975,7 +1975,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       network stack, using the control groups, setting a new hostname,
       mounting some locations and a changing root file system.</para>
       <programlisting>
-        lxc.utsname = complex
+        lxc.uts.name = complex
         lxc.net.0.type = veth
         lxc.net.0.flags = up
         lxc.net.0.link = br0

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -196,7 +196,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.haltsignal</option>
+            <option>lxc.signal.halt</option>
           </term>
           <listitem>
             <para>
@@ -218,7 +218,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
           <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.rebootsignal</option>
+            <option>lxc.signal.reboot</option>
           </term>
           <listitem>
             <para>
@@ -240,7 +240,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
           <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.stopsignal</option>
+            <option>lxc.signal.stop</option>
           </term>
           <listitem>
             <para>

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -1741,7 +1741,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <variablelist>
         <varlistentry>
           <term>
-            <option>lxc.loglevel</option>
+            <option>lxc.log.level</option>
           </term>
           <listitem>
             <para>
@@ -1761,7 +1761,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         </varlistentry>
         <varlistentry>
           <term>
-            <option>lxc.logfile</option>
+            <option>lxc.log</option>
           </term>
           <listitem>
             <para>
@@ -1771,12 +1771,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         </varlistentry>
         <varlistentry>
           <term>
-            <option>lxc.syslog</option>
+            <option>lxc.log.syslog</option>
           </term>
           <listitem>
             <para>
             Send logging info to syslog. It respects the log level defined in
-            <command>lxc.loglevel</command>. The argument should be the syslog
+            <command>lxc.log.level</command>. The argument should be the syslog
             facility to use, valid ones are: daemon, local0, local1, local2,
             local3, local4, local5, local5, local6, local7.
             </para>

--- a/doc/lxc.sgml.in
+++ b/doc/lxc.sgml.in
@@ -376,7 +376,7 @@ rootfs
 	command into the container.
 	The pid of the first process is 1. If no command is
 	specified <command>lxc-start</command> will
-	run the command defined in lxc.init_cmd or if not set,
+	run the command defined in lxc.init.cmd or if not set,
 	<filename>/sbin/init</filename> .
       </para>
 

--- a/src/lua-lxc/test/apitest.lua
+++ b/src/lua-lxc/test/apitest.lua
@@ -233,11 +233,11 @@ function test_config_items()
     log(0, "Test set/clear configuration items...")
 
     -- test setting a 'single type' item
-    assert(container:get_config_item("lxc.utsname") == optarg["n"])
-    container:set_config_item("lxc.utsname", "foobar")
-    assert(container:get_config_item("lxc.utsname") == "foobar")
-    container:set_config_item("lxc.utsname", optarg["n"])
-    assert(container:get_config_item("lxc.utsname") == optarg["n"])
+    assert(container:get_config_item("lxc.uts.name") == optarg["n"])
+    container:set_config_item("lxc.uts.name", "foobar")
+    assert(container:get_config_item("lxc.uts.name") == "foobar")
+    container:set_config_item("lxc.uts.name", optarg["n"])
+    assert(container:get_config_item("lxc.uts.name") == optarg["n"])
 
     -- test clearing/setting a 'list type' item
     container:clear_config_item("lxc.cap.drop")

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4350,10 +4350,13 @@ int lxc_clear_limits(struct lxc_conf *c, const char *key)
 	bool all = false;
 	const char *k = NULL;
 
-	if (strcmp(key, "lxc.limit") == 0)
+	if (strcmp(key, "lxc.limit") == 0
+	    || strcmp(key, "lxc.prlimit"))
 		all = true;
 	else if (strncmp(key, "lxc.limit.", sizeof("lxc.limit.")-1) == 0)
 		k = key + sizeof("lxc.limit.")-1;
+	else if (strncmp(key, "lxc.prlimit.", sizeof("lxc.prlimit.")-1) == 0)
+		k = key + sizeof("lxc.prlimit.")-1;
 	else
 		return -1;
 
@@ -4515,7 +4518,7 @@ void lxc_conf_free(struct lxc_conf *conf)
 	lxc_clear_includes(conf);
 	lxc_clear_aliens(conf);
 	lxc_clear_environment(conf);
-	lxc_clear_limits(conf, "lxc.limit");
+	lxc_clear_limits(conf, "lxc.prlimit");
 	free(conf);
 }
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -118,9 +118,9 @@ lxc_config_define(console);
 lxc_config_define(seccomp);
 lxc_config_define(includefiles);
 lxc_config_define(autodev);
-lxc_config_define(haltsignal);
-lxc_config_define(rebootsignal);
-lxc_config_define(stopsignal);
+lxc_config_define(signal_halt);
+lxc_config_define(signal_reboot);
+lxc_config_define(signal_stop);
 lxc_config_define(start);
 lxc_config_define(monitor);
 lxc_config_define(group);
@@ -215,9 +215,17 @@ static struct lxc_config_t config[] = {
 	{ "lxc.seccomp",                   set_config_seccomp,                     get_config_seccomp,                     clr_config_seccomp,                   },
 	{ "lxc.include",                   set_config_includefiles,                get_config_includefiles,                clr_config_includefiles,              },
 	{ "lxc.autodev",                   set_config_autodev,                     get_config_autodev,                     clr_config_autodev,                   },
-	{ "lxc.haltsignal",                set_config_haltsignal,                  get_config_haltsignal,                  clr_config_haltsignal,                },
-	{ "lxc.rebootsignal",              set_config_rebootsignal,                get_config_rebootsignal,                clr_config_rebootsignal,              },
-	{ "lxc.stopsignal",                set_config_stopsignal,                  get_config_stopsignal,                  clr_config_stopsignal,                },
+
+	/* REMOVE IN LXC 3.0
+	   legacy singal keys
+	 */
+	{ "lxc.haltsignal",                set_config_signal_halt,                 get_config_signal_halt,                 clr_config_signal_halt,               },
+	{ "lxc.rebootsignal",              set_config_signal_reboot,               get_config_signal_reboot,               clr_config_signal_reboot,             },
+	{ "lxc.stopsignal",                set_config_signal_stop,                 get_config_signal_stop,                 clr_config_signal_stop,               },
+
+	{ "lxc.signal.halt",               set_config_signal_halt,                 get_config_signal_halt,                 clr_config_signal_halt,               },
+	{ "lxc.signal.reboot",             set_config_signal_reboot,               get_config_signal_reboot,               clr_config_signal_reboot,             },
+	{ "lxc.signal.stop",               set_config_signal_stop,                 get_config_signal_stop,                 clr_config_signal_stop,               },
 	{ "lxc.start.auto",                set_config_start,                       get_config_start,                       clr_config_start,                     },
 	{ "lxc.start.delay",               set_config_start,                       get_config_start,                       clr_config_start,                     },
 	{ "lxc.start.order",               set_config_start,                       get_config_start,                       clr_config_start,                     },
@@ -1446,7 +1454,7 @@ static int sig_parse(const char *signame)
 	return -1;
 }
 
-static int set_config_haltsignal(const char *key, const char *value,
+static int set_config_signal_halt(const char *key, const char *value,
 				 struct lxc_conf *lxc_conf, void *data)
 {
 	int sig_n;
@@ -1467,7 +1475,7 @@ static int set_config_haltsignal(const char *key, const char *value,
 	return 0;
 }
 
-static int set_config_rebootsignal(const char *key, const char *value,
+static int set_config_signal_reboot(const char *key, const char *value,
 				   struct lxc_conf *lxc_conf, void *data)
 {
 	int sig_n;
@@ -1487,7 +1495,7 @@ static int set_config_rebootsignal(const char *key, const char *value,
 	return 0;
 }
 
-static int set_config_stopsignal(const char *key, const char *value,
+static int set_config_signal_stop(const char *key, const char *value,
 				 struct lxc_conf *lxc_conf, void *data)
 {
 	int sig_n;
@@ -3159,19 +3167,19 @@ static int get_config_autodev(const char *key, char *retv, int inlen,
 	return lxc_get_conf_int(c, retv, inlen, c->autodev);
 }
 
-static int get_config_haltsignal(const char *key, char *retv, int inlen,
+static int get_config_signal_halt(const char *key, char *retv, int inlen,
 				 struct lxc_conf *c, void *data)
 {
 	return lxc_get_conf_int(c, retv, inlen, c->haltsignal);
 }
 
-static int get_config_rebootsignal(const char *key, char *retv, int inlen,
+static int get_config_signal_reboot(const char *key, char *retv, int inlen,
 				   struct lxc_conf *c, void *data)
 {
 	return lxc_get_conf_int(c, retv, inlen, c->rebootsignal);
 }
 
-static int get_config_stopsignal(const char *key, char *retv, int inlen,
+static int get_config_signal_stop(const char *key, char *retv, int inlen,
 				 struct lxc_conf *c, void *data)
 {
 	return lxc_get_conf_int(c, retv, inlen, c->stopsignal);
@@ -3523,21 +3531,21 @@ static inline int clr_config_autodev(const char *key, struct lxc_conf *c,
 	return 0;
 }
 
-static inline int clr_config_haltsignal(const char *key, struct lxc_conf *c,
+static inline int clr_config_signal_halt(const char *key, struct lxc_conf *c,
 					void *data)
 {
 	c->haltsignal = 0;
 	return 0;
 }
 
-static inline int clr_config_rebootsignal(const char *key, struct lxc_conf *c,
+static inline int clr_config_signal_reboot(const char *key, struct lxc_conf *c,
 					  void *data)
 {
 	c->rebootsignal = 0;
 	return 0;
 }
 
-static inline int clr_config_stopsignal(const char *key, struct lxc_conf *c,
+static inline int clr_config_signal_stop(const char *key, struct lxc_conf *c,
 					void *data)
 {
 	c->stopsignal = 0;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -77,7 +77,7 @@ lxc_log_define(lxc_confile, lxc);
 lxc_config_define(personality);
 lxc_config_define(pts);
 lxc_config_define(tty);
-lxc_config_define(ttydir);
+lxc_config_define(tty_dir);
 lxc_config_define(apparmor_profile);
 lxc_config_define(apparmor_allow_incomplete);
 lxc_config_define(selinux_context);
@@ -136,8 +136,14 @@ lxc_config_define(prlimit);
 static struct lxc_config_t config[] = {
 	{ "lxc.arch",                      set_config_personality,                 get_config_personality,                 clr_config_personality,               },
 	{ "lxc.pts",                       set_config_pts,                         get_config_pts,                         clr_config_pts,                       },
+	{ "lxc.tty.dir",                   set_config_tty_dir,                     get_config_tty_dir,                     clr_config_tty_dir,                   },
+
+	/* REMOVE IN LXC 3.0
+	   legacy devttydir key
+	 */
+	{ "lxc.devttydir",                 set_config_tty_dir,                     get_config_tty_dir,                     clr_config_tty_dir,                   },
+
 	{ "lxc.tty",                       set_config_tty,                         get_config_tty,                         clr_config_tty,                       },
-	{ "lxc.devttydir",                 set_config_ttydir,                      get_config_ttydir,                      clr_config_ttydir,                    },
 	{ "lxc.apparmor.profile",          set_config_apparmor_profile,            get_config_apparmor_profile,            clr_config_apparmor_profile,          },
 	{ "lxc.apparmor.allow_incomplete", set_config_apparmor_allow_incomplete,   get_config_apparmor_allow_incomplete,   clr_config_apparmor_allow_incomplete, },
 	{ "lxc.selinux.context",           set_config_selinux_context,             get_config_selinux_context,             clr_config_selinux_context,           },
@@ -1295,7 +1301,7 @@ static int set_config_tty(const char *key, const char *value,
 	return lxc_safe_uint(value, &lxc_conf->tty);
 }
 
-static int set_config_ttydir(const char *key, const char *value,
+static int set_config_tty_dir(const char *key, const char *value,
 			     struct lxc_conf *lxc_conf, void *data)
 {
 	return set_config_string_item_max(&lxc_conf->ttydir, value,
@@ -2781,7 +2787,7 @@ static int get_config_tty(const char *key, char *retv, int inlen,
 	return lxc_get_conf_int(c, retv, inlen, c->tty);
 }
 
-static int get_config_ttydir(const char *key, char *retv, int inlen,
+static int get_config_tty_dir(const char *key, char *retv, int inlen,
 			     struct lxc_conf *c, void *data)
 {
 	return lxc_get_conf_str(retv, inlen, c->ttydir);
@@ -3355,7 +3361,7 @@ static inline int clr_config_tty(const char *key, struct lxc_conf *c,
 	return 0;
 }
 
-static inline int clr_config_ttydir(const char *key, struct lxc_conf *c,
+static inline int clr_config_tty_dir(const char *key, struct lxc_conf *c,
 				    void *data)
 {
 	free(c->ttydir);

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -92,7 +92,7 @@ lxc_config_define(rootfs_mount);
 lxc_config_define(rootfs_options);
 lxc_config_define(rootfs_backend);
 lxc_config_define(rootfs);
-lxc_config_define(utsname);
+lxc_config_define(uts_name);
 lxc_config_define(hooks);
 lxc_config_define(net_type);
 lxc_config_define(net_flags);
@@ -164,7 +164,13 @@ static struct lxc_config_t config[] = {
 	{ "lxc.rootfs.options",            set_config_rootfs_options,              get_config_rootfs_options,              clr_config_rootfs_options,            },
 	{ "lxc.rootfs.backend",            set_config_rootfs_backend,              get_config_rootfs_backend,              clr_config_rootfs_backend,            },
 	{ "lxc.rootfs",                    set_config_rootfs,                      get_config_rootfs,                      clr_config_rootfs,                    },
-	{ "lxc.utsname",                   set_config_utsname,                     get_config_utsname,                     clr_config_utsname,                   },
+
+	/* REMOVE IN LXC 3.0
+	   legacy utsname key
+	 */
+	{ "lxc.utsname",                   set_config_uts_name,                    get_config_uts_name,                    clr_config_uts_name,                   },
+
+	{ "lxc.uts.name",                  set_config_uts_name,                    get_config_uts_name,                    clr_config_uts_name,                   },
 	{ "lxc.hook.pre-start",            set_config_hooks,                       get_config_hooks,                       clr_config_hooks,                     },
 	{ "lxc.hook.pre-mount",            set_config_hooks,                       get_config_hooks,                       clr_config_hooks,                     },
 	{ "lxc.hook.mount",                set_config_hooks,                       get_config_hooks,                       clr_config_hooks,                     },
@@ -2059,13 +2065,13 @@ static int set_config_rootfs_backend(const char *key, const char *value,
 	return set_config_string_item(&lxc_conf->rootfs.bdev_type, value);
 }
 
-static int set_config_utsname(const char *key, const char *value,
+static int set_config_uts_name(const char *key, const char *value,
 			      struct lxc_conf *lxc_conf, void *data)
 {
 	struct utsname *utsname;
 
 	if (lxc_config_value_empty(value)) {
-		clr_config_utsname(key, lxc_conf, NULL);
+		clr_config_uts_name(key, lxc_conf, NULL);
 		return 0;
 	}
 
@@ -3050,7 +3056,7 @@ static int get_config_rootfs_backend(const char *key, char *retv, int inlen,
 	return lxc_get_conf_str(retv, inlen, c->rootfs.bdev_type);
 }
 
-static int get_config_utsname(const char *key, char *retv, int inlen,
+static int get_config_uts_name(const char *key, char *retv, int inlen,
 			      struct lxc_conf *c, void *data)
 {
 	return lxc_get_conf_str(
@@ -3472,7 +3478,7 @@ static inline int clr_config_rootfs_backend(const char *key, struct lxc_conf *c,
 	return 0;
 }
 
-static inline int clr_config_utsname(const char *key, struct lxc_conf *c,
+static inline int clr_config_uts_name(const char *key, struct lxc_conf *c,
 				     void *data)
 {
 	free(c->utsname);

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -226,18 +226,20 @@ static struct lxc_config_t config[] = {
 	{ "lxc.monitor.unshare",           set_config_monitor,                     get_config_monitor,                     clr_config_monitor,                   },
 	{ "lxc.group",                     set_config_group,                       get_config_group,                       clr_config_group,                     },
 	{ "lxc.environment",               set_config_environment,                 get_config_environment,                 clr_config_environment,               },
-	{ "lxc.init_cmd",                  set_config_init_cmd,                    get_config_init_cmd,                    clr_config_init_cmd,                  },
-	{ "lxc.init_uid",                  set_config_init_uid,                    get_config_init_uid,                    clr_config_init_uid,                  },
-	{ "lxc.init_gid",                  set_config_init_gid,                    get_config_init_gid,                    clr_config_init_gid,                  },
 	{ "lxc.ephemeral",                 set_config_ephemeral,                   get_config_ephemeral,                   clr_config_ephemeral,                 },
 	{ "lxc.syslog",                    set_config_syslog,                      get_config_syslog,                      clr_config_syslog,                    },
 	{ "lxc.no_new_privs",	           set_config_no_new_privs,                get_config_no_new_privs,                clr_config_no_new_privs,              },
 
-	/* REMOVE IN LXC 3.0
-	   legacy keys
-	 */
+	/* REMOVE IN LXC 3.0: legacy keys  [START]*/
+	{ "lxc.init_cmd",                  set_config_init_cmd,                    get_config_init_cmd,                    clr_config_init_cmd,                  },
+	{ "lxc.init_uid",                  set_config_init_uid,                    get_config_init_uid,                    clr_config_init_uid,                  },
+	{ "lxc.init_gid",                  set_config_init_gid,                    get_config_init_gid,                    clr_config_init_gid,                  },
 	{ "lxc.limit",                     set_config_limit,                       get_config_limit,                       clr_config_limit,                     },
+	/* REMOVE IN LXC 3.0: legacy keys  [END]*/
 
+	{ "lxc.init.cmd",                  set_config_init_cmd,                    get_config_init_cmd,                    clr_config_init_cmd,                  },
+	{ "lxc.init.uid",                  set_config_init_uid,                    get_config_init_uid,                    clr_config_init_uid,                  },
+	{ "lxc.init.gid",                  set_config_init_gid,                    get_config_init_gid,                    clr_config_init_gid,                  },
 	{ "lxc.prlimit",                   set_config_prlimit,                     get_config_prlimit,                     clr_config_prlimit,                   },
 };
 

--- a/src/lxc/confile_legacy.h
+++ b/src/lxc/confile_legacy.h
@@ -86,5 +86,6 @@ lxc_config_legacy_define(network_legacy);
 lxc_config_legacy_define(lsm_aa_profile);
 lxc_config_legacy_define(lsm_aa_incomplete);
 lxc_config_legacy_define(lsm_se_context);
+lxc_config_legacy_define(limit);
 
 #endif /* __LXC_CONFILE_LEGACY_H */

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -661,3 +661,23 @@ int lxc_get_conf_int(struct lxc_conf *c, char *retv, int inlen, int v)
 
 	return snprintf(retv, inlen, "%d", v);
 }
+
+bool parse_limit_value(const char **value, unsigned long *res)
+{
+	char *endptr = NULL;
+
+	if (strncmp(*value, "unlimited", sizeof("unlimited") - 1) == 0) {
+		*res = RLIM_INFINITY;
+		*value += sizeof("unlimited") - 1;
+		return true;
+	}
+
+	errno = 0;
+	*res = strtoul(*value, &endptr, 10);
+	if (errno || !endptr)
+		return false;
+	*value = endptr;
+
+	return true;
+}
+

--- a/src/lxc/confile_utils.h
+++ b/src/lxc/confile_utils.h
@@ -84,5 +84,5 @@ extern void update_hwaddr(const char *line);
 extern bool new_hwaddr(char *hwaddr);
 extern int lxc_get_conf_str(char *retv, int inlen, const char *value);
 extern int lxc_get_conf_int(struct lxc_conf *c, char *retv, int inlen, int v);
-
+extern bool parse_limit_value(const char **value, unsigned long *res);
 #endif /* __LXC_CONFILE_UTILS_H */

--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -463,10 +463,10 @@ extern void lxc_log_close(void)
 /*
  * This can be called:
  *   1. when a program calls lxc_log_init with no logfile parameter (in which
- *      case the default is used).  In this case lxc.logfile can override this.
+ *      case the default is used).  In this case lxc.loge can override this.
  *   2. when a program calls lxc_log_init with a logfile parameter.  In this
- *	case we don't want lxc.logfile to override this.
- *   3. When a lxc.logfile entry is found in config file.
+ *	case we don't want lxc.log to override this.
+ *   3. When a lxc.log entry is found in config file.
  */
 static int __lxc_log_set_file(const char *fname, int create_dirs)
 {
@@ -614,7 +614,7 @@ extern int lxc_log_init(struct lxc_log *log)
 }
 
 /*
- * This is called when we read a lxc.loglevel entry in a lxc.conf file.  This
+ * This is called when we read a lxc.log.level entry in a lxc.conf file.  This
  * happens after processing command line arguments, which override the .conf
  * settings.  So only set the level if previously unset.
  */

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3211,8 +3211,9 @@ static struct lxc_container *do_lxcapi_clone(struct lxc_container *c, const char
 	// update utsname
 	if (!(flags & LXC_CLONE_KEEPNAME)) {
 		clear_unexp_config_line(c2->lxc_conf, "lxc.utsname", false);
+		clear_unexp_config_line(c2->lxc_conf, "lxc.uts.name", false);
 
-		if (!set_config_item_locked(c2, "lxc.utsname", newname)) {
+		if (!set_config_item_locked(c2, "lxc.uts.name", newname)) {
 			ERROR("Error setting new hostname");
 			goto out;
 		}

--- a/src/python-lxc/examples/api_test.py
+++ b/src/python-lxc/examples/api_test.py
@@ -71,7 +71,7 @@ container.create("download", 0,
 
 assert(container.defined)
 assert(container.name == CONTAINER_NAME
-       == container.get_config_item("lxc.utsname"))
+       == container.get_config_item("lxc.uts.name"))
 assert(container.name in lxc.list_containers())
 
 ## Test the config
@@ -131,8 +131,8 @@ assert(len(ips) > 0)
 
 ## Test running config
 assert(container.name == CONTAINER_NAME
-       == container.get_config_item("lxc.utsname")
-       == container.get_running_config_item("lxc.utsname"))
+       == container.get_config_item("lxc.uts.name")
+       == container.get_running_config_item("lxc.uts.name"))
 
 ## Testing cgroups a bit
 print("Testing cgroup API")

--- a/src/python-lxc/lxc/__init__.py
+++ b/src/python-lxc/lxc/__init__.py
@@ -387,7 +387,7 @@ class Container(_lxc.Container):
         new_value = self.get_config_item(key)
 
         # loglevel is special and won't match the string we set
-        if key == "lxc.loglevel":
+        if key == "lxc.log.level":
             new_value = value
 
         if (isinstance(value, str) and isinstance(new_value, str) and

--- a/src/tests/concurrent.c
+++ b/src/tests/concurrent.c
@@ -85,8 +85,8 @@ static void do_function(void *arguments)
     }
 
     if (debug) {
-        c->set_config_item(c, "lxc.loglevel", "DEBUG");
-        c->set_config_item(c, "lxc.logfile", name);
+        c->set_config_item(c, "lxc.log.level", "DEBUG");
+        c->set_config_item(c, "lxc.log", name);
     }
 
     if (strcmp(args->mode, "create") == 0) {

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -531,10 +531,19 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
-	/* lxc.utsname */
+	/* REMOVE IN LXC 3.0
+	   legacy lxc.utsname key
+	 */
 	if (set_get_compare_clear_save_load(c, "lxc.utsname", "the-shire", tmpf,
 					    true) < 0) {
 		lxc_error("%s\n", "lxc.utsname");
+		goto non_test_error;
+	}
+
+	/* lxc.uts.name */
+	if (set_get_compare_clear_save_load(c, "lxc.uts.name", "the-shire", tmpf,
+					    true) < 0) {
+		lxc_error("%s\n", "lxc.uts.name");
 		goto non_test_error;
 	}
 

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -694,24 +694,51 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
-	/* lxc.init_cmd */
+	/* REMOVE IN LXC 3.0
+	   legacy lxc.init_cmd key
+	 */
 	if (set_get_compare_clear_save_load(c, "lxc.init_cmd", "/bin/bash",
 					    tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.init_cmd");
 		goto non_test_error;
 	}
 
-	/* lxc.init_uid */
+	/* lxc.init.cmd */
+	if (set_get_compare_clear_save_load(c, "lxc.init.cmd", "/bin/bash",
+					    tmpf, true) < 0) {
+		lxc_error("%s\n", "lxc.init.cmd");
+		goto non_test_error;
+	}
+
+	/* REMOVE IN LXC 3.0
+	   legacy lxc.init_uid key
+	 */
 	if (set_get_compare_clear_save_load(c, "lxc.init_uid", "1000", tmpf,
 					    true) < 0) {
 		lxc_error("%s\n", "lxc.init_uid");
 		goto non_test_error;
 	}
 
-	/* lxc.init_gid */
+	/* lxc.init.uid */
+	if (set_get_compare_clear_save_load(c, "lxc.init.uid", "1000", tmpf,
+					    true) < 0) {
+		lxc_error("%s\n", "lxc.init.uid");
+		goto non_test_error;
+	}
+
+	/* REMOVE IN LXC 3.0
+	   legacy lxc.init_gid key
+	 */
 	if (set_get_compare_clear_save_load(c, "lxc.init_gid", "1000", tmpf,
 					    true) < 0) {
 		lxc_error("%s\n", "lxc.init_gid");
+		goto non_test_error;
+	}
+
+	/* lxc.init.gid */
+	if (set_get_compare_clear_save_load(c, "lxc.init.gid", "1000", tmpf,
+					    true) < 0) {
+		lxc_error("%s\n", "lxc.init.gid");
 		goto non_test_error;
 	}
 

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -314,10 +314,19 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
-	/* lxc.devttydir */
+	/* REMOVE IN LXC 3.0
+	   legacy devttydir keys
+	 */
 	if (set_get_compare_clear_save_load(c, "lxc.devttydir", "not-dev", tmpf,
 					    true) < 0) {
 		lxc_error("%s\n", "lxc.devttydir");
+		goto non_test_error;
+	}
+
+	/* lxc.tty.dir */
+	if (set_get_compare_clear_save_load(c, "lxc.tty.dir", "not-dev", tmpf,
+					    true) < 0) {
+		lxc_error("%s\n", "lxc.tty.dir");
 		goto non_test_error;
 	}
 

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -729,10 +729,19 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
-	/* lxc.limit.nofile */
+	/* REMOVE IN LXC 3.0
+	   legacy lxc.limit.* key
+	 */
 	if (set_get_compare_clear_save_load(c, "lxc.limit.nofile", "65536",
 					    tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.limit.nofile");
+		goto non_test_error;
+	}
+
+	/* lxc.prlimit.nofile */
+	if (set_get_compare_clear_save_load(c, "lxc.prlimit.nofile", "65536",
+					    tmpf, true) < 0) {
+		lxc_error("%s\n", "lxc.prlimit.nofile");
 		goto non_test_error;
 	}
 

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -431,17 +431,36 @@ int main(int argc, char *argv[])
 	c->clear_config(c);
 	c->lxc_conf = NULL;
 
-	/* lxc.loglevel */
+	/* REMOVE IN LXC 3.0
+	   legacy lxc.loglevel key
+	 */
 	if (set_get_compare_clear_save_load(c, "lxc.loglevel", "DEBUG", tmpf,
 					    true) < 0) {
 		lxc_error("%s\n", "lxc.loglevel");
 		goto non_test_error;
 	}
 
-	/* lxc.logfile */
+	/* REMOVE IN LXC 3.0
+	   legacy lxc.logfile key
+	 */
 	if (set_get_compare_clear_save_load(c, "lxc.logfile", "/some/path",
 					    tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.logfile");
+		goto non_test_error;
+	}
+
+
+	/* lxc.log.level */
+	if (set_get_compare_clear_save_load(c, "lxc.log.level", "DEBUG", tmpf,
+					    true) < 0) {
+		lxc_error("%s\n", "lxc.log.level");
+		goto non_test_error;
+	}
+
+	/* lxc.log */
+	if (set_get_compare_clear_save_load(c, "lxc.log.file", "/some/path",
+					    tmpf, true) < 0) {
+		lxc_error("%s\n", "lxc.log.file");
 		goto non_test_error;
 	}
 
@@ -659,10 +678,10 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
-	/* lxc.syslog */
-	if (set_get_compare_clear_save_load(c, "lxc.syslog", "local0", tmpf,
+	/* lxc.log.syslog */
+	if (set_get_compare_clear_save_load(c, "lxc.log.syslog", "local0", tmpf,
 					    true) < 0) {
-		lxc_error("%s\n", "lxc.syslog");
+		lxc_error("%s\n", "lxc.log.syslog");
 		goto non_test_error;
 	}
 

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -636,24 +636,51 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
-	/* lxc.haltsignal */
+	/* REMOVE IN LXC 3.0
+	   legacy lxc.haltsignal key
+	 */
 	if (set_get_compare_clear_save_load(c, "lxc.haltsignal", "1", tmpf,
 					    true) < 0) {
 		lxc_error("%s\n", "lxc.haltsignal");
 		goto non_test_error;
 	}
 
-	/* lxc.rebootsignal */
+	/* lxc.signal.halt */
+	if (set_get_compare_clear_save_load(c, "lxc.signal.halt", "1", tmpf,
+					    true) < 0) {
+		lxc_error("%s\n", "lxc.signal.halt");
+		goto non_test_error;
+	}
+
+	/* REMOVE IN LXC 3.0
+	   legacy lxc.rebootsignal key
+	 */
 	if (set_get_compare_clear_save_load(c, "lxc.rebootsignal", "1", tmpf,
 					    true) < 0) {
 		lxc_error("%s\n", "lxc.rebootsignal");
 		goto non_test_error;
 	}
 
-	/* lxc.stopsignal */
+	/* lxc.signal.reboot */
+	if (set_get_compare_clear_save_load(c, "lxc.signal.reboot", "1", tmpf,
+					    true) < 0) {
+		lxc_error("%s\n", "lxc.signal.reboot");
+		goto non_test_error;
+	}
+
+	/* REMOVE IN LXC 3.0
+	   legacy lxc.stopsignal key
+	 */
 	if (set_get_compare_clear_save_load(c, "lxc.stopsignal", "1", tmpf,
 					    true) < 0) {
 		lxc_error("%s\n", "lxc.stopsignal");
+		goto non_test_error;
+	}
+
+	/* lxc.signal.stop */
+	if (set_get_compare_clear_save_load(c, "lxc.signal.stop", "1", tmpf,
+					    true) < 0) {
+		lxc_error("%s\n", "lxc.signal.stop");
 		goto non_test_error;
 	}
 

--- a/src/tests/startone.c
+++ b/src/tests/startone.c
@@ -154,8 +154,8 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	if (!c->set_config_item(c, "lxc.utsname", "bobo")) {
-		fprintf(stderr, "%d: failed setting lxc.utsname\n", __LINE__);
+	if (!c->set_config_item(c, "lxc.uts.name", "bobo")) {
+		fprintf(stderr, "%d: failed setting lxc.uts.name\n", __LINE__);
 		goto out;
 	}
 

--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -388,7 +388,7 @@ configure_container() {
 		lxc.arch = $arch
 
 		# Set hostname.
-		lxc.utsname = $hostname
+		lxc.uts.name = $hostname
 
 		# If something doesn't work, try to comment this out.
 		# Dropping sys_admin disables container root from doing a lot of things

--- a/templates/lxc-altlinux.in
+++ b/templates/lxc-altlinux.in
@@ -267,7 +267,7 @@ copy_configuration()
     mkdir -p $config_path
     grep -q "^lxc.rootfs" $config_path/config 2>/dev/null || echo "lxc.rootfs = $rootfs_path" >> $config_path/config
     cat <<EOF >> $config_path/config
-lxc.utsname = $name
+lxc.uts.name = $name
 lxc.tty = 4
 lxc.pts = 1024
 lxc.cap.drop = sys_module mac_admin mac_override sys_time

--- a/templates/lxc-archlinux.in
+++ b/templates/lxc-archlinux.in
@@ -122,9 +122,9 @@ ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 EOF
     # enable getty on active ttys
     local nttys=$(cat "${config_path}/config" ${shared_config} ${common_config} | grep "^lxc.tty" | head -n1 | cut -d= -f2 | tr -d "[:blank:]")
-    local devttydir=$(cat "${config_path}/config" ${shared_config} ${common_config} | grep "^lxc.devttydir" | head -n1 | cut -d= -f2 | tr -d "[:blank:]")
+    local devttydir=$(cat "${config_path}/config" ${shared_config} ${common_config} | grep "^lxc.tty.dir" | head -n1 | cut -d= -f2 | tr -d "[:blank:]")
     local devtty=""
-    # bind getty instances to /dev/<devttydir>/tty* if lxc.devttydir is set
+    # bind getty instances to /dev/<devttydir>/tty* if lxc.tty.dir is set
     [ -n "${devttydir}" ] && devtty="${devttydir}-"
     if [ ${nttys:-0} -gt 1 ]; then
       ( cd "${rootfs_path}/etc/systemd/system/getty.target.wants"

--- a/templates/lxc-archlinux.in
+++ b/templates/lxc-archlinux.in
@@ -148,7 +148,7 @@ EOF
 copy_configuration() {
     mkdir -p "${config_path}"
     local config="${config_path}/config"
-    echo "lxc.utsname = ${name}" >> "${config}"
+    echo "lxc.uts.name = ${name}" >> "${config}"
     grep -q "^lxc.arch" "${config}" 2>/dev/null \
         || echo "lxc.arch = ${arch}" >> "${config}"
     grep -q "^lxc.rootfs" "${config}" 2>/dev/null \

--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -343,7 +343,7 @@ grep -q "^lxc.rootfs" $path/config 2>/dev/null || echo "lxc.rootfs = $rootfs" >>
 cat <<EOF >> $path/config
 lxc.signal.halt = SIGUSR1
 lxc.rebootsignal = SIGTERM
-lxc.utsname = $name
+lxc.uts.name = $name
 lxc.tty = 1
 lxc.pts = 1
 lxc.cap.drop = sys_module mac_admin mac_override sys_time

--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -341,7 +341,7 @@ copy_configuration()
 
 grep -q "^lxc.rootfs" $path/config 2>/dev/null || echo "lxc.rootfs = $rootfs" >> $path/config
 cat <<EOF >> $path/config
-lxc.haltsignal = SIGUSR1
+lxc.signal.halt = SIGUSR1
 lxc.rebootsignal = SIGTERM
 lxc.utsname = $name
 lxc.tty = 1

--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -641,7 +641,7 @@ lxc.include = @LXCTEMPLATECONFIG@/centos.common.conf
     # Append things which require expansion here...
     cat <<EOF >> $config_path/config
 lxc.arch = $arch
-lxc.utsname = $utsname
+lxc.uts.name = $utsname
 
 # When using LXC with apparmor, uncomment the next line to run unconfined:
 #lxc.aa_profile = unconfined

--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -336,7 +336,7 @@ EOF
     # /dev/tty[1-4] will be symlinks to the ptys /dev/lxc/console and
     # /dev/lxc/tty[1-4] so that package updates can overwrite the symlinks.
     # lxc will maintain these links and bind mount ptys over /dev/lxc/*
-    # since lxc.devttydir is specified in the config.
+    # since lxc.tty.dir is specified in the config.
 
     # allow root login on console, tty[1-4], and pts/0 for libvirt
     echo "# LXC (Linux Containers)" >>${rootfs_path}/etc/securetty

--- a/templates/lxc-cirros.in
+++ b/templates/lxc-cirros.in
@@ -123,7 +123,7 @@ lxc.rootfs = $rootfs
 lxc.tty = 4
 lxc.pts = 1024
 
-lxc.utsname = $name
+lxc.uts.name = $name
 lxc.arch = $arch
 lxc.cap.drop = sys_module mac_admin mac_override sys_time
 

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -515,7 +515,7 @@ copy_configuration()
 
     cat <<EOF >> $path/config
 lxc.tty = $num_tty
-lxc.utsname = $hostname
+lxc.uts.name = $hostname
 lxc.arch = $arch
 lxc.pts=1023
 EOF

--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -547,7 +547,7 @@ fi
 if [ -e "$fstab" ]; then
     echo "lxc.mount = ${LXC_PATH}/fstab" >> ${LXC_PATH}/config
 fi
-echo "lxc.utsname = ${LXC_NAME}" >> ${LXC_PATH}/config
+echo "lxc.uts.name = ${LXC_NAME}" >> ${LXC_PATH}/config
 
 ## Re-add the previously removed network config
 if [ -e "${LXC_PATH}/config-network" ]; then

--- a/templates/lxc-fedora-legacy.in
+++ b/templates/lxc-fedora-legacy.in
@@ -276,7 +276,7 @@ EOF
     # /dev/tty[1-4] will be symlinks to the ptys /dev/lxc/console and
     # /dev/lxc/tty[1-4] so that package updates can overwrite the symlinks.
     # lxc will maintain these links and bind mount ptys over /dev/lxc/*
-    # since lxc.devttydir is specified in the config.
+    # since lxc.tty.dir is specified in the config.
 
     # allow root login on console, tty[1-4], and pts/0 for libvirt
     echo "# LXC (Linux Containers)" >>${rootfs_path}/etc/securetty

--- a/templates/lxc-fedora-legacy.in
+++ b/templates/lxc-fedora-legacy.in
@@ -1127,7 +1127,7 @@ lxc.include = @LXCTEMPLATECONFIG@/fedora.common.conf
     # Append things which require expansion here...
     cat <<EOF >> $config_path/config
 lxc.arch = $arch
-lxc.utsname = $utsname
+lxc.uts.name = $utsname
 
 # When using LXC with apparmor, uncomment the next line to run unconfined:
 #lxc.aa_profile = unconfined

--- a/templates/lxc-fedora.in
+++ b/templates/lxc-fedora.in
@@ -486,7 +486,7 @@ lxc.include = ${lxc_template_config}/fedora.common.conf
     cat <<EOF >> "${path}/config"
 # Container specific configuration
 lxc.arch = ${basearch}
-lxc.utsname = ${utsname}
+lxc.uts.name = ${utsname}
 
 # When using LXC with apparmor, uncomment the next line to run unconfined:
 #lxc.aa_profile = unconfined

--- a/templates/lxc-fedora.in
+++ b/templates/lxc-fedora.in
@@ -345,7 +345,7 @@ EOF
     # /dev/tty[1-4] will be symlinks to the ptys /dev/lxc/console and
     # /dev/lxc/tty[1-4] so that package updates can overwrite the symlinks.
     # lxc will maintain these links and bind mount ptys over /dev/lxc/*
-    # since lxc.devttydir is specified in the config.
+    # since lxc.tty.dir is specified in the config.
 
     # allow root login on console, tty[1-4], and pts/0 for libvirt
     cat <<EOF >> "${rootfs}/etc/securetty"

--- a/templates/lxc-gentoo.in
+++ b/templates/lxc-gentoo.in
@@ -705,7 +705,7 @@ container_conf()
 ${conf_arch_line}
 
 # set the hostname
-lxc.utsname = ${name}
+lxc.uts.name = ${name}
 lxc.tty = ${tty}
 
 ${conf_rootfs_line}

--- a/templates/lxc-openmandriva.in
+++ b/templates/lxc-openmandriva.in
@@ -228,7 +228,7 @@ copy_configuration()
     mkdir -p $config_path
     grep -q "^lxc.rootfs" $config_path/config 2>/dev/null || echo "lxc.rootfs = $rootfs_path" >> $config_path/config
     cat <<EOF >> $config_path/config
-lxc.utsname = $name
+lxc.uts.name = $name
 lxc.tty = 4
 lxc.pts = 1024
 lxc.cap.drop = sys_module mac_admin mac_override sys_time

--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -350,7 +350,7 @@ lxc.include = @LXCTEMPLATECONFIG@/opensuse.common.conf
     # Append things which require expansion here...
     cat <<EOF >> $path/config
 lxc.arch = $arch
-lxc.utsname = $name
+lxc.uts.name = $name
 
 lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed
 

--- a/templates/lxc-oracle.in
+++ b/templates/lxc-oracle.in
@@ -482,7 +482,7 @@ container_config_create()
     cat <<EOF >> $cfg_dir/config || die "unable to create $cfg_dir/config"
 # Container configuration for Oracle Linux $container_release_major.$container_release_minor
 lxc.arch = $arch
-lxc.utsname = $name
+lxc.uts.name = $name
 EOF
     grep -q "^lxc.rootfs" $cfg_dir/config 2>/dev/null || echo "lxc.rootfs = $container_rootfs" >> $cfg_dir/config
 

--- a/templates/lxc-oracle.in
+++ b/templates/lxc-oracle.in
@@ -359,7 +359,7 @@ EOF
     # /dev/tty[1-4] will be symlinks to the ptys /dev/lxc/console and
     # /dev/lxc/tty[1-4] so that package updates can overwrite the symlinks.
     # lxc will maintain these links and bind mount ptys over /dev/lxc/*
-    # since lxc.devttydir is specified in the config.
+    # since lxc.tty.dir is specified in the config.
 
     # allow root login on console, tty[1-4], and pts/0 for libvirt
     echo "# LXC (Linux Containers)" >>$container_rootfs/etc/securetty

--- a/templates/lxc-plamo.in
+++ b/templates/lxc-plamo.in
@@ -233,7 +233,7 @@ configure_plamo() {
 copy_configuration() {
   ret=0
   cat <<- EOF >> $path/config || let ret++
-	lxc.utsname = $name
+	lxc.uts.name = $name
 	lxc.arch = $arch
 	EOF
   if [ -f "@LXCTEMPLATECONFIG@/plamo.common.conf" ] ; then

--- a/templates/lxc-pld.in
+++ b/templates/lxc-pld.in
@@ -238,7 +238,7 @@ copy_configuration()
 	cat <<EOF >> $config_path/config
 # Most of below settings should be taken as defaults  from
 # lxc.include = /usr/share/lxc/config/common.conf
-lxc.utsname = $utsname
+lxc.uts.name = $utsname
 lxc.tty = 4
 lxc.pts = 1024
 # Consider if below line is right for systemd container

--- a/templates/lxc-sabayon.in
+++ b/templates/lxc-sabayon.in
@@ -324,7 +324,7 @@ lxc.cgroup.devices.allow = c 10:229 rwm
 lxc.arch = $arch
 
 # Set hostname.
-lxc.utsname = $hostname
+lxc.uts.name = $hostname
 
 # Include common configuration.
 lxc.include = $LXC_TEMPLATE_CONFIG/sabayon.common.conf

--- a/templates/lxc-slackware.in
+++ b/templates/lxc-slackware.in
@@ -638,7 +638,7 @@ name=$3
 
 cat <<EOF >> $path/config
 
-lxc.utsname = $name
+lxc.uts.name = $name
 lxc.arch = $arch
 
 lxc.mount = $rootfs/etc/fstab

--- a/templates/lxc-sparclinux.in
+++ b/templates/lxc-sparclinux.in
@@ -316,7 +316,7 @@ container_config_create()
     cat <<EOF >> $cfg_dir/config || die "unable to create $cfg_dir/config"
 # Container configuration for Linux for SPARC $container_release_major.$container_release_minor
 lxc.arch = $arch
-lxc.utsname = $name
+lxc.uts.name = $name
 EOF
     grep -q "^lxc.rootfs" $cfg_dir/config 2>/dev/null || echo "lxc.rootfs = $container_rootfs" >> $cfg_dir/config
 

--- a/templates/lxc-sparclinux.in
+++ b/templates/lxc-sparclinux.in
@@ -229,7 +229,7 @@ EOF
     # /dev/tty[1-4] will be symlinks to the ptys /dev/lxc/console and
     # /dev/lxc/tty[1-4] so that package updates can overwrite the symlinks.
     # lxc will maintain these links and bind mount ptys over /dev/lxc/*
-    # since lxc.devttydir is specified in the config.
+    # since lxc.tty.dir is specified in the config.
 
     # allow root login on console, tty[1-4], and pts/0 for libvirt
     echo "# LXC (Linux Containers)" >>$container_rootfs/etc/securetty

--- a/templates/lxc-sshd.in
+++ b/templates/lxc-sshd.in
@@ -129,7 +129,7 @@ copy_configuration()
 
     grep -q "^lxc.rootfs" $path/config 2>/dev/null || echo "lxc.rootfs = $rootfs" >> $path/config
 cat <<EOF >> $path/config
-lxc.utsname = $name
+lxc.uts.name = $name
 lxc.pts = 1024
 lxc.cap.drop = sys_module mac_admin mac_override sys_time
 

--- a/templates/lxc-ubuntu-cloud.in
+++ b/templates/lxc-ubuntu-cloud.in
@@ -91,7 +91,7 @@ copy_configuration()
     [ -e "$path/config-auto" ] && cat $path/config-auto >> $path/config && rm $path/config-auto
     grep -q "^lxc.rootfs" $path/config 2>/dev/null || echo "lxc.rootfs = $rootfs" >> $path/config
     cat <<EOF >> $path/config
-lxc.utsname = $name
+lxc.uts.name = $name
 lxc.arch = $arch
 EOF
 

--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -531,7 +531,7 @@ copy_configuration()
     [ -e "$path/config-auto" ] && cat $path/config-auto >> $path/config && rm $path/config-auto
     grep -q "^lxc.rootfs" $path/config 2>/dev/null || echo "lxc.rootfs = $rootfs" >> $path/config
     cat <<EOF >> $path/config
-lxc.utsname = $name
+lxc.uts.name = $name
 lxc.arch = $arch
 EOF
 

--- a/templates/lxc-voidlinux.in
+++ b/templates/lxc-voidlinux.in
@@ -68,7 +68,7 @@ declare -a additional_packages
 copy_configuration() {
     mkdir -p "${config_path}"
     local config="${config_path}/config"
-    echo "lxc.utsname = ${name}" >> "${config}"
+    echo "lxc.uts.name = ${name}" >> "${config}"
     grep -q "^lxc.rootfs" "${config}" 2>/dev/null \
         || echo "lxc.rootfs = ${rootfs_path}" >> "${config}"
 


### PR DESCRIPTION
Fix: https://github.com/lxc/lxc/issues/1642

This PR renames the following keys:
```
lxc.limit => lxc.prlimit
lxc.devttydir => lxc.tty.dir
lxc.utsname => lxc.uts.name
lxc.haltsignal => lxc.signal.halt
lxc.rebootsignal => lxc.signal.reboot
lxc.stopsignal => lxc.signal.stop
lxc.logfile => lxc.log.file
lxc.loglevel => lxc.log.level
lxc.syslog => lxc.log.syslog
lxc.init_cmd => lxc.init.cmd
lxc.init_uid => lxc.init.uid
lxc.init_gid => lxc.init.gid
```
the legacy keys will be kept around until **LXC 3.0** and then will be removed.
