### PR TITLE
start: send state to legacy lxc-monitord state server even if no state clients registered

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -359,6 +359,7 @@ int lxc_set_state(const char *name, struct lxc_handler *handler,
 	if (lxc_list_empty(&handler->state_clients)) {
 		TRACE("no state clients registered");
 		process_unlock();
+		lxc_monitor_send_state(name, state, handler->lxcpath);
 		return 0;
 	}
 


### PR DESCRIPTION
This pr https://github.com/lxc/lxc/pull/1618 kill lxc-monitord, for backwards compatibility,
we also send state to legacy lxc-monitord state server in function `lxc_set_state`.

we should also send state if there is no state clients registered, otherwise `lxc-monitor` client will
not get state change event if container changed state to `STARTING` or `RUNNING`.


Signed-off-by: 0x0916 <w@laoqinren.net>