### PR TITLE
lxc-monitord: exit when got a quit command

### DIFF
--- a/src/lxc/lxc_monitord.c
+++ b/src/lxc/lxc_monitord.c
@@ -430,8 +430,16 @@ int main(int argc, char *argv[])
 	       getpid(), mon.lxcpath);
 	for (;;) {
 		ret = lxc_mainloop(&mon.descr, 1000 * 30);
+		if (ret) {
+			ERROR("mainloop returned an error");
+			break;
+		}
 		if (mon.clientfds_cnt <= 0) {
 			NOTICE("No remaining clients. lxc-monitord is exiting.");
+			break;
+		}
+		if (quit == 1) {
+			NOTICE("got quit command. lxc-monitord is exitting.");
 			break;
 		}
 	}


### PR DESCRIPTION
lxc-monitor has an option to tell lxc-monitord to quit.

```
~/lxc (master) # lxc-monitor --help
lxc-monitor monitors the state of the NAME container

Options :
  -n, --name=NAME   NAME of the container
                    NAME may be a regular expression
  -Q, --quit        tell lxc-monitord to quit
```
But it does not work. This patch fix that.

Signed-off-by: 0x0916 <w@laoqinren.net>