### PR TITLE
Fix lxc-ubuntu template usage without qemu-debootstrap

### DIFF
--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -375,7 +375,7 @@ download_ubuntu()
     choose_container_proxy $cache/partial-$arch/ $arch
     # download a mini ubuntu into a cache
     echo "Downloading ubuntu $release minimal ..."
-    if [ -n "$(which qemu-debootstrap)" ]; then
+    if [ -n "$(which qemu-debootstrap 2>/dev/null || :)" ]; then
         qemu-debootstrap --verbose $debootstrap_parameters --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch $MIRROR
     else
         debootstrap --verbose $debootstrap_parameters --components=main,universe --arch=$arch --include=${packages_template} $release $cache/partial-$arch $MIRROR


### PR DESCRIPTION
In case if 'qemu-debootstrap' binary is not available then container
creation with 'lxc-ubuntu' template fail.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>