### PR TITLE
fix some cppcheck warnings

### DIFF
--- a/src/lxc/cgroups/cgfs.c
+++ b/src/lxc/cgroups/cgfs.c
@@ -791,7 +791,7 @@ static char *cgroup_rename_nsgroup(const char *mountpath, const char *oldname, p
 
 	len = strlen(oldname) + strlen(mountpath) + 22;
 	fulloldpath = alloca(len);
-	ret = snprintf(fulloldpath, len, "%s/%s/%ld", mountpath, oldname, (unsigned long)pid);
+	ret = snprintf(fulloldpath, len, "%s/%s/%lu", mountpath, oldname, (unsigned long)pid);
 	if (ret < 0 || ret >= len)
 		return NULL;
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -4437,7 +4437,7 @@ static int get_config_net_ipv4(const char *key, char *retv, int inlen,
 	lxc_list_for_each(it, &netdev->ipv4) {
 		struct lxc_inetdev *i = it->elem;
 		inet_ntop(AF_INET, &i->addr, buf, sizeof(buf));
-		strprint(retv, inlen, "%s/%d%s", buf, i->prefix,
+		strprint(retv, inlen, "%s/%u%s", buf, i->prefix,
 			 (listlen-- > 1) ? "\n" : "");
 	}
 
@@ -4498,7 +4498,7 @@ static int get_config_net_ipv6(const char *key, char *retv, int inlen,
 	lxc_list_for_each(it, &netdev->ipv6) {
 		struct lxc_inet6dev *i = it->elem;
 		inet_ntop(AF_INET6, &i->addr, buf, sizeof(buf));
-		strprint(retv, inlen, "%s/%d%s", buf, i->prefix,
+		strprint(retv, inlen, "%s/%u%s", buf, i->prefix,
 			 (listlen-- > 1) ? "\n" : "");
 	}
 

--- a/src/lxc/confile_legacy.c
+++ b/src/lxc/confile_legacy.c
@@ -918,7 +918,7 @@ int get_config_network_legacy_item(const char *key, char *retv, int inlen,
 			struct lxc_inetdev *i = it2->elem;
 			char buf[INET_ADDRSTRLEN];
 			inet_ntop(AF_INET, &i->addr, buf, sizeof(buf));
-			strprint(retv, inlen, "%s/%d\n", buf, i->prefix);
+			strprint(retv, inlen, "%s/%u\n", buf, i->prefix);
 		}
 	} else if (strcmp(p1, "ipv6.gateway") == 0) {
 		if (netdev->ipv6_gateway_auto) {
@@ -935,7 +935,7 @@ int get_config_network_legacy_item(const char *key, char *retv, int inlen,
 			struct lxc_inet6dev *i = it2->elem;
 			char buf[INET6_ADDRSTRLEN];
 			inet_ntop(AF_INET6, &i->addr, buf, sizeof(buf));
-			strprint(retv, inlen, "%s/%d\n", buf, i->prefix);
+			strprint(retv, inlen, "%s/%u\n", buf, i->prefix);
 		}
 	}
 	return fulllen;

--- a/src/lxc/lxclock.c
+++ b/src/lxc/lxclock.c
@@ -60,7 +60,7 @@ static inline void dump_stacktrace(void)
 	strings = backtrace_symbols(array, size);
 
 	// Using fprintf here as our logging module is not thread safe
-	fprintf(stderr, "\tObtained %zd stack frames.\n", size);
+	fprintf(stderr, "\tObtained %zu stack frames.\n", size);
 
 	for (i = 0; i < size; i++)
 		fprintf(stderr, "\t\t%s\n", strings[i]);

--- a/src/lxc/tools/lxc_info.c
+++ b/src/lxc/tools/lxc_info.c
@@ -116,18 +116,18 @@ static void size_humanize(unsigned long long val, char *buf, size_t bufsz)
 {
 	if (val > 1 << 30) {
 		snprintf(buf, bufsz, "%u.%2.2u GiB",
-			    (int)(val >> 30),
-			    (int)(val & ((1 << 30) - 1)) / 10737419);
+			    (unsigned int)(val >> 30),
+			    (unsigned int)(val & ((1 << 30) - 1)) / 10737419);
 	} else if (val > 1 << 20) {
-		int x = val + 5243;  /* for rounding */
+		unsigned int x = val + 5243;  /* for rounding */
 		snprintf(buf, bufsz, "%u.%2.2u MiB",
 			    x >> 20, ((x & ((1 << 20) - 1)) * 100) >> 20);
 	} else if (val > 1 << 10) {
-		int x = val + 5;  /* for rounding */
+		unsigned int x = val + 5;  /* for rounding */
 		snprintf(buf, bufsz, "%u.%2.2u KiB",
 			    x >> 10, ((x & ((1 << 10) - 1)) * 100) >> 10);
 	} else {
-		snprintf(buf, bufsz, "%u bytes", (int)val);
+		snprintf(buf, bufsz, "%u bytes", (unsigned int)val);
 	}
 }
 

--- a/src/lxc/tools/lxc_top.c
+++ b/src/lxc/tools/lxc_top.c
@@ -209,19 +209,19 @@ static void sig_handler(int sig)
 static void size_humanize(unsigned long long val, char *buf, size_t bufsz)
 {
 	if (val > 1 << 30) {
-		snprintf(buf, bufsz, "%u.%2.2u GB",
-			    (int)(val >> 30),
-			    (int)(val & ((1 << 30) - 1)) / 10737419);
+		snprintf(buf, bufsz, "%u.%2.2u GiB",
+			    (unsigned int)(val >> 30),
+			    (unsigned int)(val & ((1 << 30) - 1)) / 10737419);
 	} else if (val > 1 << 20) {
-		int x = val + 5243;  /* for rounding */
-		snprintf(buf, bufsz, "%u.%2.2u MB",
+		unsigned int x = val + 5243;  /* for rounding */
+		snprintf(buf, bufsz, "%u.%2.2u MiB",
 			    x >> 20, ((x & ((1 << 20) - 1)) * 100) >> 20);
 	} else if (val > 1 << 10) {
-		int x = val + 5;  /* for rounding */
-		snprintf(buf, bufsz, "%u.%2.2u KB",
+		unsigned int x = val + 5;  /* for rounding */
+		snprintf(buf, bufsz, "%u.%2.2u KiB",
 			    x >> 10, ((x & ((1 << 10) - 1)) * 100) >> 10);
 	} else {
-		snprintf(buf, bufsz, "%3u.00   ", (int)val);
+		snprintf(buf, bufsz, "%3u.00   ", (unsigned int)val);
 	}
 }
 


### PR DESCRIPTION
use cppcheck tools `cppcheck --enable=warning  .` on lxc source directory.

This patch fix the following warnings

```
[src/lxc/cgroups/cgfs.c:794]: (warning) %ld in format string (no. 3) requires 'long' but the argument type is 'unsigned long'.
[src/lxc/confile.c:4441]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned int'.
[src/lxc/confile.c:4502]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned int'.
[src/lxc/confile_legacy.c:921]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned int'.
[src/lxc/confile_legacy.c:938]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned int'.
[src/lxc/lxclock.c:63]: (warning) %zd in format string (no. 1) requires 'ssize_t' but the argument type is 'size_t {aka unsigned long}'.
[src/lxc/tools/lxc_info.c:118]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'.
[src/lxc/tools/lxc_info.c:118]: (warning) %u in format string (no. 2) requires 'unsigned int' but the argument type is 'signed int'.
[src/lxc/tools/lxc_info.c:123]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'.
[src/lxc/tools/lxc_info.c:127]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'.
[src/lxc/tools/lxc_info.c:130]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'.
[src/lxc/tools/lxc_top.c:212]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'.
[src/lxc/tools/lxc_top.c:212]: (warning) %u in format string (no. 2) requires 'unsigned int' but the argument type is 'signed int'.
[src/lxc/tools/lxc_top.c:217]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'.
[src/lxc/tools/lxc_top.c:221]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'.
[src/lxc/tools/lxc_top.c:224]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'.
```

Signed-off-by: Long Wang <w@laoqinren.net>