### PR TITLE
lxclock: bugfix and update some comment

### DIFF
--- a/src/lxc/lxclock.c
+++ b/src/lxc/lxclock.c
@@ -224,6 +224,7 @@ int lxclock(struct lxc_lock *l, int timeout)
 					S_IWUSR | S_IRUSR);
 			if (l->u.f.fd == -1) {
 				ERROR("Error opening %s", l->u.f.fname);
+				saved_errno = errno;
 				goto out;
 			}
 		}

--- a/src/lxc/lxclock.c
+++ b/src/lxc/lxclock.c
@@ -19,7 +19,6 @@
  */
 
 #define _GNU_SOURCE
-#include "lxclock.h"
 #include <malloc.h>
 #include <stdio.h>
 #include <errno.h>
@@ -30,6 +29,7 @@
 
 #include <lxc/lxccontainer.h>
 
+#include "lxclock.h"
 #include "utils.h"
 #include "log.h"
 
@@ -75,7 +75,7 @@ static void lock_mutex(pthread_mutex_t *l)
 	if ((ret = pthread_mutex_lock(l)) != 0) {
 		fprintf(stderr, "pthread_mutex_lock returned:%d %s\n", ret, strerror(ret));
 		dump_stacktrace();
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 }
 
@@ -86,7 +86,7 @@ static void unlock_mutex(pthread_mutex_t *l)
 	if ((ret = pthread_mutex_unlock(l)) != 0) {
 		fprintf(stderr, "pthread_mutex_unlock returned:%d %s\n", ret, strerror(ret));
 		dump_stacktrace();
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 }
 
@@ -211,12 +211,10 @@ int lxclock(struct lxc_lock *l, int timeout)
 		ret = -2;
 		if (timeout) {
 			ERROR("Error: timeout not supported with flock");
-			ret = -2;
 			goto out;
 		}
 		if (!l->u.f.fname) {
 			ERROR("Error: filename not set for flock");
-			ret = -2;
 			goto out;
 		}
 		if (l->u.f.fd == -1) {

--- a/src/lxc/lxclock.h
+++ b/src/lxc/lxclock.h
@@ -68,7 +68,8 @@ struct lxc_lock {
  * will be placed in \c l->u.sem.
  *
  * If \ref lxcpath and \ref name are given (both must be given if either is
- * given) then a lockfile is created as \c $lxcpath/$lxcname/locks/$name.
+ * given) then a lockfile is created as \c /run/lxc/lock/$lxcpath/.$name if root,
+ * or \c $XDG_RUNTIME_DIR/lxc/lock/$lxcpath/.$name if non-root.
  * The lock is used to protect the containers on-disk representation.
  *
  * \internal This function allocates the pathname for the given lock in memory
@@ -87,7 +88,8 @@ extern struct lxc_lock *lxc_newlock(const char *lxcpath, const char *name);
  * indefinite wait).
  *
  * \return \c 0 if lock obtained, \c -2 on failure to set timeout,
- *  or \c -1 on any other error (\c errno will be set by \c sem_wait(3)).
+ *  or \c -1 on any other error (\c errno will be set by \c sem_wait(3)
+ * or \c fcntl(2)).
  *
  * \note \p timeout is (currently?) only supported for privlock, not
  * for slock.  Since currently there is not a single use of the timeout
@@ -102,7 +104,7 @@ extern int lxclock(struct lxc_lock *lock, int timeout);
  * \param lock \ref lxc_lock.
  *
  * \return \c 0 on success, \c -2 if provided lock was not already held,
- * otherwise \c -1 with \c errno saved from \c flock(2) or sem_post function.
+ * otherwise \c -1 with \c errno saved from \c fcntl(2) or sem_post function.
  */
 extern int lxcunlock(struct lxc_lock *lock);
 
@@ -153,6 +155,9 @@ extern int container_disk_lock(struct lxc_container *c);
 
 /*!
  * \brief Unlock the containers disk data.
+ *
+ * \param c Container.
+ *
  */
 extern void container_disk_unlock(struct lxc_container *c);
 


### PR DESCRIPTION
This pr mainly updates comments based on the current code and also fix a small bug(the errno is the wrong value when open lock file failed).