### PR TITLE
Change _have => have into bash/lxc.in

### DIFF
--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -1,4 +1,4 @@
-_have lxc-start && {
+have lxc-start && {
     _lxc_names() {
         COMPREPLY=( $( compgen -W "$( lxc-ls )" "$cur" ) )
     }


### PR DESCRIPTION
`/etc/bash_completion` contains only `have`