### PR TITLE
Allow containers to start in AppArmor namespaces

### DIFF
--- a/config/apparmor/abstractions/start-container
+++ b/config/apparmor/abstractions/start-container
@@ -41,3 +41,4 @@
 
   change_profile -> lxc-*,
   change_profile -> unconfined,
+  change_profile -> :lxc-*:unconfined,


### PR DESCRIPTION
This patch allows users to start containers in AppArmor namespaces.
Users can define their own profiles for their containers, but
lxc-start must be allowed to change to a namespace.

A container configuration file can wrap a container in an AppArmor
profile using lxc.aa_profile.

A process in an AppArmor namespace is restricted to view
or manage only the profiles belonging to this namespace, as if no
other profiles existed. A namespace can be created as follow:
sudo mkdir /sys/kernel/security/apparmor/policy/namespaces/$NAMESPACE

AppArmor can stack profiles so that the contained process is bound
by the intersection of all profiles of the stack. This is achieved
using the '//&' operator as follow:

lxc.aa_profile = $PROFILE//&:$NAMESPACE://unconfined

In this case, even the guest process appears unconfined in the
namespace, it is still confined by $PROFILE.

A guest allowed to access "/sys/kernel/security/apparmor/** rwklix,"
will be able to manage its own profile set, while still being
enclosed in the topmost profile $PROFILE:

Different guests can be assigned the same namespace or different
namespaces. In the first case, they will share their profiles.
In the second case, they will have distinct sets of profiles.

This is validated on privileged containers.

Signed-off-by: Frédéric Dalleau <frederic.dalleau@collabora.com>