### PR TITLE
lxc_abstract_unix_connect: remove the workaround-code

### DIFF
--- a/src/lxc/af_unix.c
+++ b/src/lxc/af_unix.c
@@ -123,12 +123,7 @@ int lxc_abstract_unix_connect(const char *path)
 	strncpy(&addr.sun_path[1], &path[1], strlen(&path[1]));
 
 	if (connect(fd, (struct sockaddr *)&addr, offsetof(struct sockaddr_un, sun_path) + len + 1)) {
-		int tmp = errno;
-		/* special case to connect to older containers */
-		if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0)
-			return fd;
 		close(fd);
-		errno = tmp;
 		return -1;
 	}
 


### PR DESCRIPTION
commit bdb3f44147bc1a55a97131b4b39d42844ae4fb9e says that we may undo
the change in august 2014.

I think that it is time to do that.

Signed-off-by: Long Wang <w@laoqinren.net>