### PR TITLE
start: dup std{in,out,err} to pty slave

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1063,8 +1063,13 @@ static int do_start(void *data)
 	 * setup on its console ie. the pty allocated in lxc_console_create() so
 	 * make sure that that pty is stdin,stdout,stderr.
 	 */
-	if (lxc_console_set_stdfds(handler->conf->console.slave) < 0)
-		goto out_warn_father;
+	 if (handler->conf->console.slave >= 0)
+		 if (set_stdfds(handler->conf->console.slave) < 0) {
+			ERROR("Failed to redirect std{in,out,err} to pty file "
+			      "descriptor %d",
+			      handler->conf->console.slave);
+			goto out_warn_father;
+		 }
 
 	/* If we mounted a temporary proc, then unmount it now. */
 	tmp_proc_unmount(handler->conf);
@@ -1142,8 +1147,12 @@ static int do_start(void *data)
 			goto out_warn_father;
 	}
 
-	if (handler->backgrounded && set_stdfds(devnull_fd))
-		goto out_warn_father;
+	if (handler->conf->console.slave < 0 && handler->backgrounded)
+		if (set_stdfds(devnull_fd) < 0) {
+			ERROR("Failed to redirect std{in,out,err} to "
+			      "\"/dev/null\"");
+			goto out_warn_father;
+		}
 
 	if (devnull_fd >= 0) {
 		close(devnull_fd);

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1822,14 +1822,21 @@ int open_devnull(void)
 
 int set_stdfds(int fd)
 {
+	int ret;
+
 	if (fd < 0)
 		return -1;
 
-	if (dup2(fd, 0) < 0)
+	ret = dup2(fd, STDIN_FILENO);
+	if (ret < 0)
 		return -1;
-	if (dup2(fd, 1) < 0)
+
+	ret = dup2(fd, STDOUT_FILENO);
+	if (ret < 0)
 		return -1;
-	if (dup2(fd, 2) < 0)
+
+	ret = dup2(fd, STDERR_FILENO);
+	if (ret < 0)
 		return -1;
 
 	return 0;


### PR DESCRIPTION
In the case the container has a console with a valid slave pty file descriptor
we duplicate std{in,out,err} to the slave file descriptor so console logging
works correctly. When the container does not have a valid slave pty file
descriptor for its console and is started daemonized we should dup to
/dev/null.

Closes #1646.

Signed-off-by: Li Feng <lifeng68@huawei.com>
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>