### PR TITLE
cgfsng: only output debug info when we set cgroup data

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1979,9 +1979,8 @@ static bool cgfsng_setup_limits(void *hdata, struct lxc_list *cgroup_settings,
 				      cg->subsystem, cg->value, d->name);
 				goto out;
 			}
+			DEBUG("cgroup '%s' set to '%s'", cg->subsystem, cg->value);
 		}
-
-		DEBUG("cgroup '%s' set to '%s'", cg->subsystem, cg->value);
 	}
 
 	ret = true;


### PR DESCRIPTION
Only output debug info `cgroup 'xxxx' set to 'yyyy'` when we set
cgroup data.

Signed-off-by: Long Wang <w@laoqinren.net>