### PR TITLE
Fix issue #1702, do remount with the MS_REMOUNT flag when mounts with MS_RDONLY

### DIFF
--- a/src/lxc/bdev/lxcdir.c
+++ b/src/lxc/bdev/lxcdir.c
@@ -136,6 +136,7 @@ int dir_mount(struct bdev *bdev)
 	unsigned long mntflags;
 	char *src, *mntdata;
 	int ret;
+	unsigned long mflags;
 
 	if (strcmp(bdev->type, "dir"))
 		return -22;
@@ -154,7 +155,8 @@ int dir_mount(struct bdev *bdev)
 	if ((0 == ret) && (mntflags & MS_RDONLY)) {
 		DEBUG("remounting %s on %s with readonly options",
 			src ? src : "(none)", bdev->dest ? bdev->dest : "(none)");
-		ret = mount(src, bdev->dest, "bind", MS_BIND | MS_REC | mntflags | MS_REMOUNT, mntdata);
+		mflags = add_required_remount_flags(src, bdev->dest, MS_BIND | MS_REC | mntflags | MS_REMOUNT);
+		ret = mount(src, bdev->dest, "bind", mflags, mntdata);
 	}
 
 	free(mntdata);

--- a/src/lxc/bdev/lxcdir.c
+++ b/src/lxc/bdev/lxcdir.c
@@ -151,6 +151,12 @@ int dir_mount(struct bdev *bdev)
 	src = lxc_storage_get_path(bdev->src, bdev->type);
 
 	ret = mount(src, bdev->dest, "bind", MS_BIND | MS_REC | mntflags, mntdata);
+	if ((0 == ret) && (mntflags & MS_RDONLY)) {
+		DEBUG("remounting %s on %s with readonly options",
+			src ? src : "(none)", bdev->dest ? bdev->dest : "(none)");
+		ret = mount(src, bdev->dest, "bind", MS_BIND | MS_REC | mntflags | MS_REMOUNT, mntdata);
+	}
+
 	free(mntdata);
 	return ret;
 }

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -628,7 +628,7 @@ int pin_rootfs(const char *rootfs)
  * If we are asking to remount something, make sure that any
  * NOEXEC etc are honored.
  */
-static unsigned long add_required_remount_flags(const char *s, const char *d,
+unsigned long add_required_remount_flags(const char *s, const char *d,
 		unsigned long flags)
 {
 #ifdef HAVE_STATVFS

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -481,4 +481,7 @@ void remount_all_slave(void);
 extern void suggest_default_idmap(void);
 FILE *make_anonymous_mount_file(struct lxc_list *mount);
 struct lxc_list *sort_cgroup_settings(struct lxc_list* cgroup_settings);
+unsigned long add_required_remount_flags(const char *s, const char *d,
+		unsigned long flags);
+
 #endif

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -61,7 +61,8 @@ bin_SCRIPTS = lxc-test-automount \
 	      lxc-test-autostart \
 	      lxc-test-cloneconfig \
 	      lxc-test-createconfig \
-	      lxc-test-no-new-privs
+	      lxc-test-no-new-privs \
+	      lxc-test-rootfs
 
 if DISTRO_UBUNTU
 bin_SCRIPTS += \
@@ -94,6 +95,7 @@ EXTRA_DIST = \
 	lxcpath.c \
 	lxc-test-lxc-attach \
 	lxc-test-automount \
+	lxc-test-rootfs \
 	lxc-test-autostart \
 	lxc-test-apparmor-mount \
 	lxc-test-checkpoint-restore \

--- a/src/tests/lxc-test-rootfs
+++ b/src/tests/lxc-test-rootfs
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# lxc: linux Container library
+
+# Authors:
+# Feng Li <lifeng68@huawei.com>
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+set -ex
+
+cleanup() {
+	set +e
+	lxc-destroy -n lxc-test-rootfs -f
+	if [ $PHASE != "done" ]; then
+		echo "rootfs test failed at $PHASE"
+		exit 1
+	fi
+	echo "rootfs test passed"
+	exit 0
+}
+
+PHASE=setup
+trap cleanup EXIT
+
+lxc-destroy -n lxc-test-rootfs -f || true
+lxc-create -t busybox -n lxc-test-rootfs
+
+PHASE=ro_rootfs
+echo "Starting phase $PHASE"
+config=/var/lib/lxc/lxc-test-rootfs/config
+sed -i '/lxc.rootfs.options/d' $config
+echo "lxc.rootfs.options = ro" >> $config
+
+lxc-start -n lxc-test-rootfs
+pid=`lxc-info -n lxc-test-rootfs -p -H`
+ro=0
+mkdir /proc/$pid/root/rotest || ro=1
+[ $ro -ne 0 ]
+
+lxc-stop -n lxc-test-rootfs -k
+PHASE=rw_rootfs
+echo "Starting phase $PHASE"
+sed -i '/lxc.rootfs.options/d' $config
+echo "lxc.rootfs.options = rw" >> $config
+lxc-start -n lxc-test-rootfs
+pid=`lxc-info -n lxc-test-rootfs -p -H`
+ro=0
+mkdir /proc/$pid/root/rwtest || ro=1
+[ $ro -ne 1 ]
+rmdir /proc/$pid/root/rwtest
+ro=0
+
+PHASE=done


### PR DESCRIPTION
If we want to mount a readonly rootfs. LXC calls mount() only once in the function `dir_mount `, to do the bind mount with the ro mount flag. But because of the behavior of the Linux kernel regarding bind mounts it ignores the MS_RDONLY flag and the bind mount stays writable. ["kernel bug #24912" ](https://bugzilla.kernel.org/show_bug.cgi?id=24912)

Changing mount options requires a second mount() with the MS_REMOUNT flag. LXC should therefore handle this case be doing the rootfs mount in two steps:

1. bind mounting the rootfs
2. re-mount with MS_REMOUNT | MS_BIND | MS_RDONLY

This patch will resolve issue #1702 and #570.

Signed-off-by: Li Feng <lifeng68@huawei.com>