### PR TITLE
lvm: check whether lxc.bdev.lvm.vg is empty

### DIFF
--- a/src/lxc/bdev/lxclvm.c
+++ b/src/lxc/bdev/lxclvm.c
@@ -307,6 +307,11 @@ int lvm_clonepaths(struct bdev *orig, struct bdev *new, const char *oldname,
 			return -1;
 		}
 		vg = lxc_global_config_value("lxc.bdev.lvm.vg");
+		if (!vg) {
+			ERROR("The \"lxc.bdev.lvm.vg\" key is not set");
+			return -1;
+		}
+
 		len = strlen("/dev/") + strlen(vg) + strlen(cname) + 4 + 2;
 		new->src = malloc(len);
 		if (new->src)

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1315,7 +1315,7 @@ static inline bool cgfsng_create(void *hdata)
 {
 	struct cgfsng_handler_data *d = hdata;
 	char *tmp, *cgname, *offset;
-	int i, ret;
+	int i;
 	int idx = 0;
 	size_t len;
 
@@ -1343,6 +1343,8 @@ again:
 		goto out_free;
 	}
 	if (idx) {
+		int ret;
+
 		ret = snprintf(offset, 5, "-%d", idx);
 		if (ret < 0 || (size_t)ret >= 5) {
 			FILE *f = fopen("/dev/null", "w");


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>