### PR TITLE
Use "rsync -SHaAX" to copy the cached rootfs into place

### DIFF
--- a/templates/lxc-altlinux.in
+++ b/templates/lxc-altlinux.in
@@ -221,7 +221,7 @@ copy_altlinux()
     #cp -a $cache/rootfs-$arch $rootfs_path || return 1
     # i prefer rsync (no reason really)
     mkdir -p $rootfs_path
-    rsync -Ha $cache/rootfs/ $rootfs_path/
+    rsync -SHaAX $cache/rootfs/ $rootfs_path/
     return 0
 }
 

--- a/templates/lxc-centos.in
+++ b/templates/lxc-centos.in
@@ -533,7 +533,7 @@ copy_centos()
     #cp -a $cache/rootfs-$arch $rootfs_path || return 1
     # i prefer rsync (no reason really)
     mkdir -p $rootfs_path
-    rsync -a $cache/rootfs/ $rootfs_path/
+    rsync -SHaAX $cache/rootfs/ $rootfs_path/
     echo
     return 0
 }

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -433,7 +433,7 @@ copy_debian()
       btrfs subvolume snapshot "$cache/rootfs-$release-$arch" "$realrootfs" || return 1
       [ "$rootfs" = "$realrootfs" ] || mount --bind "$realrootfs" "$rootfs" || return 1
     else
-        rsync -Ha "$cache/rootfs-$release-$arch"/ "$rootfs"/ || return 1
+        rsync -SHaAX "$cache/rootfs-$release-$arch"/ $rootfs/ || return 1
     fi
     return 0
 }

--- a/templates/lxc-fedora-legacy.in
+++ b/templates/lxc-fedora-legacy.in
@@ -1015,7 +1015,7 @@ copy_fedora()
     #cp -a $cache/rootfs-$basearch $rootfs_path || return 1
     # i prefer rsync (no reason really)
     mkdir -p $rootfs_path
-    rsync -Ha $cache/rootfs/ $rootfs_path/
+    rsync -SHaAX $cache/rootfs/ $rootfs_path/
     echo
     return 0
 }

--- a/templates/lxc-fedora.in
+++ b/templates/lxc-fedora.in
@@ -520,7 +520,7 @@ copy_fedora()
     echo -n "Copying ${cache} to ${rootfs} ... "
 
     mkdir -p "${rootfs}" &&
-    rsync --archive --hard-links --sparse "${cache}/" "${rootfs}/" &&
+    rsync --archive --hard-links --sparse --acls --xattrs "${cache}/" "${rootfs}/" &&
     echo || return 1
 
     return 0

--- a/templates/lxc-openmandriva.in
+++ b/templates/lxc-openmandriva.in
@@ -155,7 +155,7 @@ copy_openmandriva()
 
     echo -n "Copying rootfs to $rootfs_path ..."
     mkdir -p $rootfs_path
-    rsync -Ha $cache/rootfs/ $rootfs_path/
+    rsync -SHaAX $cache/rootfs/ $rootfs_path/
     return 0
 }
 

--- a/templates/lxc-opensuse.in
+++ b/templates/lxc-opensuse.in
@@ -251,7 +251,7 @@ copy_opensuse()
     # make a local copy of the mini opensuse
     echo "Copying rootfs to $rootfs ..."
     mkdir -p $rootfs
-    rsync -Ha $cache/rootfs-$arch/ $rootfs/ || return 1
+    rsync -SHaAX $cache/rootfs-$arch/ $rootfs/ || return 1
     return 0
 }
 

--- a/templates/lxc-ubuntu.in
+++ b/templates/lxc-ubuntu.in
@@ -439,7 +439,7 @@ copy_ubuntu()
       btrfs subvolume snapshot $cache/rootfs-$arch $realrootfs || return 1
       [ "$rootfs" = "$realrootfs" ] || mount --bind $realrootfs $rootfs || return 1
     else
-      rsync -Ha $cache/rootfs-$arch/ $rootfs/ || return 1
+      rsync -SHaAX $cache/rootfs-$arch/ $rootfs/ || return 1
     fi
     return 0
 }


### PR DESCRIPTION
(updated by Serge to also handle hte new lxc-fedora{-legacy{.in
templates)

Signed-off-by: Harald Dunkel <harri@afaics.de>
Signed-off-by: Serge Hallyn <serge@hallyn.com>
Acked-by: Serge Hallyn <serge@hallyn.com>