### PR TITLE
Don't force getty@ configuration

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -238,14 +238,6 @@ configure_debian_systemd()
     config=$3
     num_tty=$4
 
-    # this only works if we have getty@.service to manipulate
-    if [ -f "${rootfs}/lib/systemd/system/getty@.service" ]; then
-       sed -e 's/^ConditionPathExists=/# ConditionPathExists=/' \
-           -e 's/After=dev-%i.device/After=/' \
-           < "${rootfs}/lib/systemd/system/getty@.service" \
-           > "${rootfs}/etc/systemd/system/getty@.service"
-    fi
-
     # just in case systemd is not installed
     mkdir -p "${rootfs}/lib/systemd/system"
     mkdir -p "${rootfs}/etc/systemd/system/getty.target.wants"


### PR DESCRIPTION
```
    # this only works if we have getty@.service to manipulate
    if [ -f "${rootfs}/lib/systemd/system/getty@.service" ]; then
       sed -e 's/^ConditionPathExists=/# ConditionPathExists=/' \
           -e 's/After=dev-%i.device/After=/' \
           < "${rootfs}/lib/systemd/system/getty@.service" \
           > "${rootfs}/etc/systemd/system/getty@.service"
    fi
```
we have only /dev/tty in a container - so this little cutie will spam the log all 10s with the following:

```
Jul 28 22:33:00 mariadb systemd[1]: getty@tty4.service: Service has no hold-off time, scheduling restart.
Jul 28 22:33:00 mariadb systemd[1]: getty@tty3.service: Service has no hold-off time, scheduling restart.
Jul 28 22:33:00 mariadb systemd[1]: getty@tty1.service: Service has no hold-off time, scheduling restart.
Jul 28 22:33:00 mariadb systemd[1]: getty@tty2.service: Service has no hold-off time, scheduling restart.
Jul 28 22:33:00 mariadb systemd[1]: Stopped Getty on tty2.
Jul 28 22:33:00 mariadb systemd[1]: getty@tty2.service: Failed to set invocation ID on control group /system.slice/system-getty.slice/getty@tty2.service, ignoring: Operation not permitted
Jul 28 22:33:00 mariadb systemd[1]: Started Getty on tty2.
Jul 28 22:33:00 mariadb systemd[1]: Stopped Getty on tty1.
Jul 28 22:33:00 mariadb systemd[1]: getty@tty1.service: Failed to set invocation ID on control group /system.slice/system-getty.slice/getty@tty1.service, ignoring: Operation not permitted
Jul 28 22:33:00 mariadb systemd[1]: Started Getty on tty1.
Jul 28 22:33:00 mariadb systemd[1]: Stopped Getty on tty3.
Jul 28 22:33:00 mariadb systemd[1]: getty@tty3.service: Failed to set invocation ID on control group /system.slice/system-getty.slice/getty@tty3.service, ignoring: Operation not permitted
Jul 28 22:33:00 mariadb systemd[1]: Started Getty on tty3.
Jul 28 22:33:00 mariadb systemd[1]: Stopped Getty on tty4.
Jul 28 22:33:00 mariadb systemd[1]: getty@tty4.service: Failed to set invocation ID on control group /system.slice/system-getty.slice/getty@tty4.service, ignoring: Operation not permitted
Jul 28 22:33:00 mariadb systemd[1]: Started Getty on tty4.
Jul 28 22:33:00 mariadb agetty[242]: /dev/tty1: cannot open as standard input: No such file or directory
Jul 28 22:33:00 mariadb agetty[241]: /dev/tty2: cannot open as standard input: No such file or directory
Jul 28 22:33:00 mariadb agetty[244]: /dev/tty4: cannot open as standard input: No such file or directory
Jul 28 22:33:00 mariadb agetty[243]: /dev/tty3: cannot open as standard input: No such file or directory
Jul 28 22:33:10 mariadb systemd[1]: getty@tty4.service: Service has no hold-off time, scheduling restart.
Jul 28 22:33:10 mariadb systemd[1]: getty@tty2.service: Service has no hold-off time, scheduling restart.
Jul 28 22:33:10 mariadb systemd[1]: getty@tty1.service: Service has no hold-off time, scheduling restart.
Jul 28 22:33:10 mariadb systemd[1]: getty@tty3.service: Service has no hold-off time, scheduling restart.
Jul 28 22:33:10 mariadb systemd[1]: Stopped Getty on tty3.
Jul 28 22:33:10 mariadb systemd[1]: getty@tty3.service: Failed to set invocation ID on control group /system.slice/system-getty.slice/getty@tty3.service, ignoring: Operation not permitted
Jul 28 22:33:10 mariadb systemd[1]: Started Getty on tty3.
Jul 28 22:33:10 mariadb systemd[1]: Stopped Getty on tty1.
Jul 28 22:33:10 mariadb systemd[1]: getty@tty1.service: Failed to set invocation ID on control group /system.slice/system-getty.slice/getty@tty1.service, ignoring: Operation not permitted
Jul 28 22:33:10 mariadb systemd[1]: Started Getty on tty1.
Jul 28 22:33:10 mariadb systemd[1]: Stopped Getty on tty2.
Jul 28 22:33:10 mariadb systemd[1]: getty@tty2.service: Failed to set invocation ID on control group /system.slice/system-getty.slice/getty@tty2.service, ignoring: Operation not permitted
Jul 28 22:33:10 mariadb systemd[1]: Started Getty on tty2.
Jul 28 22:33:10 mariadb systemd[1]: Stopped Getty on tty4.
Jul 28 22:33:10 mariadb systemd[1]: getty@tty4.service: Failed to set invocation ID on control group /system.slice/system-getty.slice/getty@tty4.service, ignoring: Operation not permitted
Jul 28 22:33:10 mariadb systemd[1]: Started Getty on tty4.
Jul 28 22:33:10 mariadb agetty[245]: /dev/tty3: cannot open as standard input: No such file or directory
Jul 28 22:33:10 mariadb agetty[247]: /dev/tty2: cannot open as standard input: No such file or directory
Jul 28 22:33:10 mariadb agetty[246]: /dev/tty1: cannot open as standard input: No such file or directory
Jul 28 22:33:10 mariadb agetty[248]: /dev/tty4: cannot open as standard input: No such file or directory
```
if more reasons are whished i could attach the logs from 10 containers after one month runtime. (approx 30G)