### PR TITLE
network parser fixes

### DIFF
--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -942,6 +942,12 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
+	if (!set_get_compare_clear_save_load(c, "lxc.net.0.asdf", "veth",
+					    tmpf, true)) {
+		lxc_error("%s\n", "lxc.net.0.asdf");
+		goto non_test_error;
+	}
+
 	if (set_get_compare_clear_save_load_network(
 		c, "lxc.net.0.macvlan.mode", "private", tmpf, true,
 		"macvlan")) {


### PR DESCRIPTION
When we are passed a network key like "lxc.net.[i].ipv4.address" we need to
make sure that we pass the deindexed key "lxc.net.ipv4.address" to the
{get,clr,set} methods otherwise we'll end up in an endless loop.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>