### PR TITLE
[RFC] commands: add LXC_CMD_OPENPTY

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -140,6 +140,7 @@ static int lxc_cmd_rsp_recv(int sock, struct lxc_cmd_rr *cmd)
 		if (!rspdata) {
 			ERROR("Command %s couldn't allocate response buffer.",
 			      lxc_cmd_str(cmd->req.cmd));
+			close(rspfd);
 			return -1;
 		}
 		rspdata->masterfd = rspfd;

--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -21,33 +21,35 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <stdio.h>
+#include "config.h"
+
 #include <errno.h>
-#include <unistd.h>
-#include <signal.h>
 #include <fcntl.h>
+#include <malloc.h>
 #include <poll.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <sys/param.h>
-#include <malloc.h>
-#include <stdlib.h>
 
-#include "log.h"
-#include "lxc.h"
-#include "conf.h"
-#include "start.h"	/* for struct lxc_handler */
-#include "utils.h"
+#include "af_unix.h"
 #include "cgroup.h"
 #include "commands.h"
 #include "commands_utils.h"
-#include "console.h"
+#include "conf.h"
+#include "config.h"
 #include "confile.h"
+#include "console.h"
+#include "log.h"
+#include "lxc.h"
 #include "lxclock.h"
 #include "mainloop.h"
 #include "monitor.h"
-#include "af_unix.h"
-#include "config.h"
+#include "start.h" /* for struct lxc_handler */
+#include "utils.h"
 
 /*
  * This file provides the different functions for clients to

--- a/src/lxc/commands.h
+++ b/src/lxc/commands.h
@@ -48,6 +48,7 @@ typedef enum {
 	LXC_CMD_GET_NAME,
 	LXC_CMD_GET_LXCPATH,
 	LXC_CMD_ADD_STATE_CLIENT,
+	LXC_CMD_OPENPTY,
 	LXC_CMD_MAX,
 } lxc_cmd_t;
 
@@ -71,6 +72,11 @@ struct lxc_cmd_rr {
 struct lxc_cmd_console_rsp_data {
 	int masterfd;
 	int ttynum;
+};
+
+struct lxc_cmd_openpty_rsp_data {
+	int master;
+	int slave;
 };
 
 extern int lxc_cmd_console_winch(const char *name, const char *lxcpath);
@@ -115,5 +121,19 @@ extern int lxc_cmd_init(const char *name, struct lxc_handler *handler,
 extern int lxc_cmd_mainloop_add(const char *name, struct lxc_epoll_descr *descr,
 				    struct lxc_handler *handler);
 extern int lxc_try_cmd(const char *name, const char *lxcpath);
+
+/* lxc_cmd_openpty     Allocate a {master,slave} pseudoterminal file descriptor
+ *                     pair from the container's devpts instance.
+ *
+ * @param[in] name     Name of container to connect to.
+ * @param[in] lxcpath  The lxcpath in which the container is running.
+ * @param[out] amaster The master pseudoterminal file descriptor.
+ * @param[out] aslave  The slave pseudoterminal file descriptor.
+ *
+ * @return             Return   0 on success
+ *                            < 0 on error
+ */
+extern int lxc_cmd_openpty(const char *name, const char *lxcpath, int *amaster,
+			   int *aslave);
 
 #endif /* __commands_h */

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1431,7 +1431,7 @@ static int lxc_allocate_dev_ptmx_opath_fd(struct lxc_conf *conf)
 {
 	int fd;
 
-	fd = open("/dev/pts/ptmx", O_PATH);
+	fd = open("/dev/ptmx", O_PATH | O_CLOEXEC);
 	if (fd < 0)
 		return -1;
 
@@ -4325,15 +4325,17 @@ int lxc_setup(struct lxc_handler *handler)
 	/* Allocate "/dev/pts/ptmx" O_PATH file descriptor. */
 	ret = lxc_allocate_dev_ptmx_opath_fd(lxc_conf);
 	if (ret < 0) {
-		ERROR("Failed to allocate \"/dev/pts/ptmx\" file descriptor");
+		SYSERROR("Failed to allocate \"/dev/ptmx\" file descriptor");
 		return -1;
 	}
 
 	/* Send "/dev/pts/ptmx" O_PATH file descriptor to parent. */
 	ret = lxc_abstract_unix_send_fds(handler->ttysock[0],
 					 &lxc_conf->dev_ptmx.opath_fd, 1, NULL, 0);
+	close(lxc_conf->dev_ptmx.opath_fd);
+	lxc_conf->dev_ptmx.opath_fd = -1;
 	if (ret < 0) {
-		ERROR("Failed to send \"/dev/pts/ptmx\" file descriptor");
+		ERROR("Failed to send \"/dev/ptmx\" file descriptor");
 		return -1;
 	}
 

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -329,8 +329,10 @@ struct lxc_conf {
 	struct lxc_list caps;
 	struct lxc_list keepcaps;
 	struct lxc_tty_info tty_info;
-	/* Comma-separated list of lxc.tty.max pty names. */
+
+	/* comma-separated list of lxc.tty.max pty names */
 	char *pty_names;
+
 	struct lxc_console console;
 	struct lxc_rootfs rootfs;
 	char *ttydir;
@@ -341,24 +343,35 @@ struct lxc_conf {
 	unsigned int lsm_aa_allow_incomplete;
 	char *lsm_se_context;
 	int tmp_umount_proc;
-	char *seccomp;  // filename with the seccomp rules
+	char *seccomp;
 #if HAVE_SCMP_FILTER_CTX
 	scmp_filter_ctx seccomp_ctx;
 #endif
 	int maincmd_fd;
-	unsigned int autodev;  // if 1, mount and fill a /dev at start
-	int haltsignal; // signal used to halt container
-	int rebootsignal; // signal used to reboot container
-	int stopsignal; // signal used to hard stop container
-	char *rcfile;	// Copy of the top level rcfile we read
 
-	// Logfile and logleve can be set in a container config file.
-	// Those function as defaults.  The defaults can be overriden
-	// by command line.  However we don't want the command line
-	// specified values to be saved on c->save_config().  So we
-	// store the config file specified values here.
-	char *logfile;  // the logfile as specifed in config
-	int loglevel;   // loglevel as specifed in config (if any)
+	/* if 1, mount and fill a /dev at start */
+	unsigned int autodev;
+
+	/* signal used to halt container */
+	int haltsignal;
+
+	/* signal used to reboot container */
+	int rebootsignal;
+
+	/* signal used to hard stop container */
+	int stopsignal;
+
+	/* Copy of the top level rcfile we read */
+	char *rcfile;
+
+	/* Logfile and loglevel can be set in a container config file. Those
+	 * function as defaults. The defaults can be overriden by command line.
+	 * However we don't want the command line specified values to be saved
+	 * on c->save_config(). So we store the config file specified values
+	 * here.
+	 */
+	char *logfile;
+	int loglevel;
 	int logfd;
 
 	int inherit_ns_fd[LXC_NS_MAX];
@@ -377,11 +390,13 @@ struct lxc_conf {
 
 	/* list of included files */
 	struct lxc_list includes;
+
 	/* config entries which are not "lxc.*" are aliens */
 	struct lxc_list aliens;
 
-	/* list of environment variables we'll add to the container when
-	 * started */
+	/* List of environment variables we'll add to the container when
+	 * started.
+	 */
 	struct lxc_list environment;
 
 	/* text representation of the config file */
@@ -391,8 +406,9 @@ struct lxc_conf {
 	/* init command */
 	char *init_cmd;
 
-	/* if running in a new user namespace, the UID/GID that init and COMMAND
-	 * should run under when using lxc-execute */
+	/* If running in a new user namespace, the UID/GID that init and COMMAND
+	 * should run under when using lxc-execute.
+	 */
 	uid_t init_uid;
 	gid_t init_gid;
 
@@ -400,7 +416,8 @@ struct lxc_conf {
 	unsigned int ephemeral;
 
 	/* The facility to pass to syslog. Let's users establish as what type of
-	 * program liblxc is supposed to write to the syslog. */
+	 * program liblxc is supposed to write to the syslog.
+	 */
 	char *syslog;
 
 	/* Whether PR_SET_NO_NEW_PRIVS will be set for the container. */

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -311,6 +311,11 @@ struct saved_nic {
 	char *orig_name;
 };
 
+/* O_PATH File descriptor */
+struct lxc_dev_ptmx {
+	int opath_fd;
+};
+
 struct lxc_conf {
 	int is_execute;
 	char *fstab;
@@ -425,6 +430,8 @@ struct lxc_conf {
 
 	/* RLIMIT_* limits */
 	struct lxc_list limits;
+
+	struct lxc_dev_ptmx dev_ptmx;
 };
 
 #ifdef HAVE_TLS

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1417,14 +1417,14 @@ static int lxc_spawn(struct lxc_handler *handler)
 	 * value, causing us to error out).
 	 */
 	if (lxc_sync_barrier_child(handler, LXC_SYNC_POST_CGROUP))
-		return -1;
+		goto out_delete_net;
 
 	/* Receive "/dev/pts/ptmx" O_PATH file descriptor from child. */
 	if (lxc_abstract_unix_recv_fds(handler->ttysock[1],
-				       &handler->conf->dev_ptmx.opath_fd, 1, NULL,
-				       0) < 0) {
-		ERROR("Failed to send \"/dev/pts/ptmx\" file descriptor");
-		return -1;
+				       &handler->conf->dev_ptmx.opath_fd, 1,
+				       NULL, 0) < 0) {
+		ERROR("Failed to send \"/dev/ptmx\" file descriptor");
+		goto out_delete_net;
 	}
 
 	/* Read tty fds allocated by child. */

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1419,6 +1419,14 @@ static int lxc_spawn(struct lxc_handler *handler)
 	if (lxc_sync_barrier_child(handler, LXC_SYNC_POST_CGROUP))
 		return -1;
 
+	/* Receive "/dev/pts/ptmx" O_PATH file descriptor from child. */
+	if (lxc_abstract_unix_recv_fds(handler->ttysock[1],
+				       &handler->conf->dev_ptmx.opath_fd, 1, NULL,
+				       0) < 0) {
+		ERROR("Failed to send \"/dev/pts/ptmx\" file descriptor");
+		return -1;
+	}
+
 	/* Read tty fds allocated by child. */
 	if (lxc_recv_ttys_from_child(handler) < 0) {
 		ERROR("Failed to receive tty info from child process.");

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -51,6 +51,15 @@
 #define LXC_NUMSTRLEN64 21
 #define LXC_LINELEN 4096
 #define LXC_IDMAPLEN 4096
+/* strlen("/proc/self/") = 11
+ * +
+ * uint64_t_as_string = 21
+ * +
+ * strlen("fd/") = 3;
+ * +
+ * \0
+ */
+#define LXC_PROC_SELF_LEN 36
 
 /* returns 1 on success, 0 if there were any failures */
 extern int lxc_rmdir_onedev(char *path, const char *exclude);


### PR DESCRIPTION
Closes #1620.

#### Introduction
For security reasons, LXC allocates fresh pty devices before attaching to container namespaces. Current LXC will perform this allocation on the host. A downside with host-allocated pty devices was that the corresponding slave pty file descriptor is either not present under the devpts mount in the container's mount namespace or is accidently present. This would cause functions like ttyname{_r}() to report NULL while isatty() would report 1 (true) when asked whether the current process is attached to a pty. This non-standard behavior has caused a number of programs (e.g. sudo, tmux, screen, etc.) to not correctly
work in a container. A better solution would thus be to allocate the pty file descriptors from the container's devpts mount in the container's mount namespace. So far, this was not possible since there was no safe way to allocate the corresponding slave file descriptor of a pty master file descriptor inside
the container since the allocation was path based. A container could easily trick the caller by e.g. mounting a malicious fuse filesystem as its devpts mount. This way the container could have tricked the caller into opening a /dev/pts/<n> path that would not allocate from the original devpts mount instantiated during container setup but rather from the fuse filesystem. Furthermore, slave pty allocation was inherently racy. After a pty file descriptor for the master side of a pty device was opened there was no direct way to allocate a slave side pty file descriptor based solely on the master file descriptor without resorting to - as mentioned before - path based resolution based on an index provided by the kernel.
Based on an outline and discussion of this problem Aleksa Sarai and I came up with a viable in-kernel solution. Essentially, a new ioctl() flag was added which allows to allocate a slave side file descriptor solely based on the provided master file descriptor without having to resort to path resolution. This means pty file descriptors can now be safely allocated from inside the container's mount namespace.
 
#### Outline
For safety reasons it is still not possible to simply rely on the callback system to get a new master pty file descriptor from the container's devpts mount. When the init binary of the container has started LXC will not be able to guarantee that the devpts mount in the container's mount namespace is pristine.
The init binary or any other suitably privileged process inside the container could still mount a custom fuse filesystem instead of the pristine devpts mount. The only safe way is to pre-allocate a file descriptor for the /dev/pts/ptmx mount inside the container's mount namespaces on container setup before the init
binary is spawned, i.e. before control is handed over to the container itself. The problem is that opening the /dev/pts/ptmx device will not return a file descriptor referring to the /dev/pts/ptmx device but rather to a new master pty file descriptor. Thus, we need to resort to a trick. The /dev/pts/ptmx device will be opened with the O_PATH flag. We then cache the O_PATH /dev/pts/ptmx device file descriptor and cache it in the LXC handler. Furthermore, a new command lxc_cmd_pty_allocate() will be added. The callback for this command will open the corresponding /proc/self/<ptmx-fd-nr> file and allocate a new master file descriptor. After it has succeeded in doing so it will also allocate the corresponding slave pty file descriptor. Both file descriptors will then be sent back to the caller via the container's command socket. The caller is will be responsible for closing the corresponding file descriptor.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>

Marked `BLOCKED` because of the following bug:
Recently the kernel has implemented the TIOCGPTPEER ioctl() call which allows
users to retrieve an fd for the slave side of a pty solely based on the
corresponding fd for the master side. The ioctl()-based fd retrieval however
causes the "/proc/<pid>/fd/<pty-slave-fd>" symlink to point to the wrong dentry.
Currently, it will always point to "/". This needs to be fixed before this can be merged.