### PR TITLE
cgfsng: do not use uninitialized variable

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1904,10 +1904,12 @@ static int cgfsng_set(const char *filename, const char *value, const char *name,
  */
 static int convert_devpath(const char *invalue, char *dest)
 {
-	char *p, *path, *mode, type;
+	int n_parts;
+	char *p, *path, type;
 	struct stat sb;
 	unsigned long minor, major;
-	int n_parts, ret = -EINVAL;
+	int ret = -EINVAL;
+	char *mode = NULL;
 
 	path = must_copy_string(invalue);
 
@@ -1956,8 +1958,8 @@ static int convert_devpath(const char *invalue, char *dest)
 	minor = MINOR(sb.st_rdev);
 	ret = snprintf(dest, 50, "%c %lu:%lu %s", type, major, minor, mode);
 	if (ret < 0 || ret >= 50) {
-		ERROR("Error on configuration value \"%c %lu:%lu %s\" (max 50 chars)",
-				type, major, minor, mode);
+		ERROR("Error on configuration value \"%c %lu:%lu %s\" (max 50 "
+		      "chars)", type, major, minor, mode);
 		ret = -ENAMETOOLONG;
 		goto out;
 	}

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -705,18 +705,6 @@ static int lxc_rcv_status(int state_socket)
 {
         int ret;
         int state = -1;
-        struct timeval timeout = {0};
-
-        /* Set 5 second timeout to prevent hanging forever in case something
-         * goes wrong. 5 seconds is a long time to get into RUNNING state.
-         */
-        timeout.tv_sec = 5;
-        ret = setsockopt(state_socket, SOL_SOCKET, SO_RCVTIMEO,
-                         (const void *)&timeout, sizeof(timeout));
-        if (ret < 0) {
-                SYSERROR("Failed to set 5s timeout on containter state socket");
-                return -1;
-        }
 
 again:
         /* Receive container state. */


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>