### PR TITLE
templates: remove legacy key from busybox

### DIFF
--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -342,7 +342,7 @@ copy_configuration()
 grep -q "^lxc.rootfs.path" $path/config 2>/dev/null || echo "lxc.rootfs.path = $rootfs" >> $path/config
 cat <<EOF >> $path/config
 lxc.signal.halt = SIGUSR1
-lxc.rebootsignal = SIGTERM
+lxc.signal.reboot = SIGTERM
 lxc.uts.name = $name
 lxc.tty.max = 1
 lxc.pty.max = 1


### PR DESCRIPTION
lxc.rebootsignal -> lxc.signal.reboot

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>