### PR TITLE
Use deb.debian.org as the default Debian mirror

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -34,7 +34,7 @@ done
 export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
 export GREP_OPTIONS=""
 
-MIRROR=${MIRROR:-http://httpredir.debian.org/debian}
+MIRROR=${MIRROR:-http://deb.debian.org/debian}
 SECURITY_MIRROR=${SECURITY_MIRROR:-http://security.debian.org/}
 LOCALSTATEDIR="@LOCALSTATEDIR@"
 LXC_TEMPLATE_CONFIG="@LXCTEMPLATECONFIG@"


### PR DESCRIPTION
The httpredir.debian.org service has been discontinued in favour of
deb.debian.org and httpredir.debian.org now redirects to deb.debian.org.

https://lists.debian.org/debian-mirrors/2017/02/msg00000.html
https://wiki.debian.org/DebianGeoMirror#httpredir.debian.org_.2F_http.debian.net

Cf. https://bugs.debian.org/872719