### PR TITLE
If the console client exited, clean the tty_state and return 0

### DIFF
--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -174,6 +174,15 @@ static int lxc_console_cb_con(int fd, uint32_t events, void *data,
 	if (r <= 0) {
 		INFO("console client on fd %d has exited", fd);
 		lxc_mainloop_del_handler(descr, fd);
+		if (fd == console->peer) {
+			if (console->tty_state) {
+				lxc_console_sigwinch_fini(console->tty_state);
+				console->tty_state = NULL;
+			}
+			console->peer = -1;
+			close(fd);
+			return 0;
+		}
 		close(fd);
 		return 1;
 	}


### PR DESCRIPTION
In the past, if the console client exited , `lxc_console_cb_con` return 1. And the `lxc_poll ` will exit,  the process will wait at  `waitpid`.  At this moment, the process could not handle any command( for example get the container  state  `LXC_CMD_GET_STATE ` or stop the container  `LXC_CMD_STOP`).

I think we should clean the tty_state and return 0 in this case. So, we can use the lxc-console to connect the console of the container. And we will not exit the function `lxc_poll `and  we can handle the commands by `lxc_cmd_process`

```
	err = lxc_poll(name, handler);
	if (err) {
		ERROR("LXC mainloop exited with error: %d.", err);
		if (handler->netnsfd >= 0) {
			close(handler->netnsfd);
			handler->netnsfd = -1;
		}
		goto out_abort;
	}

	while (waitpid(handler->pid, &status, 0) < 0 && errno == EINTR)
		continue;
```
Signed-off-by: LiFeng <lifeng68@huawei.com>