### PR TITLE
tools: fix lxc-upate-config

### DIFF
--- a/src/lxc/tools/lxc-update-config.in
+++ b/src/lxc/tools/lxc-update-config.in
@@ -63,8 +63,10 @@ sed -i \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.init_uid\)\([[:blank:]*]\|=\)/\1lxc\.init\.uid\3/g' \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.init_gid\)\([[:blank:]*]\|=\)/\1lxc\.init\.gid\3/g' \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.limit\)\([[:blank:]*]\|=\)/\1lxc\.prlimit\3/g' \
+-e 's/\([[:blank:]*]\|#*\)\(lxc\.network\)\(\.[[:digit:]*]\)\(\.ipv4\)/\1lxc\.net\3\4\.address/g' \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.network\)\(\.[[:digit:]*]\)/\1lxc\.net\3/g' \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.network\)\([[:blank:]*]\|=\)/\1lxc\.net\3/g' \
+-e '/\([[:blank:]*]\|#*\)\(lxc\.rootfs\.backend\)\([[:blank:]*]\|=\)/d' \
 	"${CONFIGPATH}"
 
 # Finally, deal with network definitions of the following form:


### PR DESCRIPTION
- replace lxc.network.[i].ipv4 with lxc.net.[i].ipv4.address
- remove lxc.rootfs.backend lines

Closes #1790.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>