### PR TITLE
[TRIVIAL] fix regex-typo in documentation example

### DIFF
--- a/doc/lxc-monitor.sgml.in
+++ b/doc/lxc-monitor.sgml.in
@@ -121,7 +121,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       </varlistentry>
 
       <varlistentry>
-	<term>lxc-monitor -n '[f|b].*'</term>
+	<term>lxc-monitor -n '[fb].*'</term>
 	<listitem>
 	<para>
 	  will monitor the different states for container with the


### PR DESCRIPTION
To match names beginning with the letters `f` or `b` one can use `[fb].*` or `(f|b).*`, but not `[f|b].*`, which would match strings beginning with `f`, `|`, or `b`.