### PR TITLE
Change alpine template file check to also check file size (`-f` => `-s`)

### DIFF
--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -185,7 +185,7 @@ fetch_apk_keys() {
 
 	echo "$APK_KEYS_SHA256" | while read -r line; do
 		keyname="${line##* }"
-		if [ ! -f "$keyname" ]; then
+		if [ ! -s "$keyname" ]; then
 			fetch "$APK_KEYS_URI/$keyname" > "$keyname"
 		fi
 		echo "$line" | sha256sum -c -
@@ -210,7 +210,7 @@ fetch_apk_static() {
 	fetch "$MIRROR_URL/latest-stable/main/$arch/${pkg_name}-${pkg_ver}.apk" \
 		| tar -xz -C "$dest" sbin/  # --extract --gzip --directory
 
-	[ -f "$dest/sbin/apk.static" ] || die 2 'apk.static not found'
+	[ -s "$dest/sbin/apk.static" ] || die 2 'apk.static not found'
 
 	local keyname=$(echo "$dest"/sbin/apk.static.*.pub | sed 's/.*\.SIGN\.RSA\.//')
 	openssl dgst -sha1 \


### PR DESCRIPTION
Because the `fetch` wget wrapper outputs files to stdout we may end up in a
situation where wget fails but the files are still created. This can happen
e.g. when the host date is out of sync leading to a failed certificate
check, resulting in the creation of empty key files.

Once the empty files have been created the template will try to use them which
causes the certificate check to fail.

By using `-s` instead of `-f` the template will re-fetch the files unless they
exist AND have a size greater than zero.