### PR TITLE
doc: fix regex-typo in Japanese and Korean lxc-monitor(1)

### DIFF
--- a/doc/ja/lxc-monitor.sgml.in
+++ b/doc/ja/lxc-monitor.sgml.in
@@ -148,7 +148,7 @@ by KATOH Yasufumi <karma at jazz.email.ne.jp>
       </varlistentry>
 
       <varlistentry>
-	<term>lxc-monitor -n '[f|b].*'</term>
+	<term>lxc-monitor -n '[fb].*'</term>
 	<listitem>
 	<para>
           <!--

--- a/doc/ko/lxc-monitor.sgml.in
+++ b/doc/ko/lxc-monitor.sgml.in
@@ -148,7 +148,7 @@ by Sungbae Yoo <sungbae.yoo at samsung.com>
       </varlistentry>
 
       <varlistentry>
-	<term>lxc-monitor -n '[f|b].*'</term>
+	<term>lxc-monitor -n '[fb].*'</term>
 	<listitem>
 	<para>
           <!--


### PR DESCRIPTION
Update for commit e3dd06ef41b63d0ee362fea74a3f2d798dbfe929

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>