### PR TITLE
Add support share pid namespace

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1126,7 +1126,7 @@ static int lxc_recv_ttys_from_child(struct lxc_handler *handler)
 
 void resolve_clone_flags(struct lxc_handler *handler)
 {
-	handler->clone_flags = CLONE_NEWPID | CLONE_NEWNS;
+	handler->clone_flags = CLONE_NEWNS;
 
 	if (!lxc_list_empty(&handler->conf->id_map))
 		handler->clone_flags |= CLONE_NEWUSER;
@@ -1147,6 +1147,11 @@ void resolve_clone_flags(struct lxc_handler *handler)
 		handler->clone_flags |= CLONE_NEWUTS;
 	else
 		INFO("Inheriting a UTS namespace.");
+
+	if (handler->conf->inherit_ns_fd[LXC_NS_PID] == -1)
+		handler->clone_flags |= CLONE_NEWPID;
+	else
+		INFO("Inheriting a PID namespace.");
 }
 
 /* lxc_spawn() performs crucial setup tasks and clone()s the new process which

--- a/src/lxc/tools/lxc_start.c
+++ b/src/lxc/tools/lxc_start.c
@@ -53,6 +53,7 @@
 #define OPT_SHARE_NET OPT_USAGE + 1
 #define OPT_SHARE_IPC OPT_USAGE + 2
 #define OPT_SHARE_UTS OPT_USAGE + 3
+#define OPT_SHARE_PID OPT_USAGE + 4
 
 lxc_log_define(lxc_start_ui, lxc);
 
@@ -149,6 +150,7 @@ static int my_parser(struct lxc_arguments* args, int c, char* arg)
 	case OPT_SHARE_NET: args->share_ns[LXC_NS_NET] = arg; break;
 	case OPT_SHARE_IPC: args->share_ns[LXC_NS_IPC] = arg; break;
 	case OPT_SHARE_UTS: args->share_ns[LXC_NS_UTS] = arg; break;
+	case OPT_SHARE_PID: args->share_ns[LXC_NS_PID] = arg; break;
 	}
 	return 0;
 }
@@ -165,6 +167,7 @@ static const struct option my_longopts[] = {
 	{"share-net", required_argument, 0, OPT_SHARE_NET},
 	{"share-ipc", required_argument, 0, OPT_SHARE_IPC},
 	{"share-uts", required_argument, 0, OPT_SHARE_UTS},
+	{"share-pid", required_argument, 0, OPT_SHARE_PID},
 	LXC_COMMON_OPTIONS
 };
 
@@ -187,7 +190,7 @@ Options :\n\
                          If not specified, exit with failure instead\n\
                          Note: --daemon implies --close-all-fds\n\
   -s, --define KEY=VAL   Assign VAL to configuration variable KEY\n\
-      --share-[net|ipc|uts]=NAME Share a namespace with another container or pid\n\
+      --share-[net|ipc|uts|pid]=NAME Share a namespace with another container or pid\n\
 ",
 	.options   = my_longopts,
 	.parser    = my_parser,


### PR DESCRIPTION
use-case for share pid namespace:
If we share the PID namespace, then we can start a container to debug another running container with debug tools (gdb).

Signed-off-by: LiFeng <lifeng68@huawei.com>