### PR TITLE
 network: clear ifindeces

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -2510,20 +2510,21 @@ bool lxc_delete_network_priv(struct lxc_handler *handler)
 		ret = lxc_netdev_delete_by_index(netdev->ifindex);
 		if (-ret == ENODEV) {
 			INFO("Interface \"%s\" with index %d already "
-					"deleted or existing in different network "
-					"namespace",
-					netdev->name[0] != '\0' ? netdev->name : "(null)",
-					netdev->ifindex);
+			     "deleted or existing in different network "
+			     "namespace",
+			     netdev->name[0] != '\0' ? netdev->name : "(null)",
+			     netdev->ifindex);
 		} else if (ret < 0) {
 			WARN("Failed to remove interface \"%s\" with "
-					"index %d: %s",
-					netdev->name[0] != '\0' ? netdev->name : "(null)",
-					netdev->ifindex, strerror(-ret));
 			continue;
+			     "index %d: %s",
+			     netdev->name[0] != '\0' ? netdev->name : "(null)",
+			     netdev->ifindex, strerror(-ret));
+			     continue;
 		}
 		INFO("Removed interface \"%s\" with index %d",
-				netdev->name[0] != '\0' ? netdev->name : "(null)",
-				netdev->ifindex);
+		     netdev->name[0] != '\0' ? netdev->name : "(null)",
+		     netdev->ifindex);
 
 		if (netdev->type != LXC_NET_VETH)
 			continue;

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -266,8 +266,7 @@ extern int lxc_network_move_created_netdev_priv(const char *lxcpath,
 						char *lxcname,
 						struct lxc_list *network,
 						pid_t pid);
-extern bool lxc_delete_network_priv(struct lxc_handler *handler);
-extern bool lxc_delete_network_unpriv(struct lxc_handler *handler);
+extern void lxc_delete_network(struct lxc_handler *handler);
 extern int lxc_find_gateway_addresses(struct lxc_handler *handler);
 extern int lxc_create_network_unpriv(const char *lxcpath, char *lxcname,
 				     struct lxc_list *network, pid_t pid);

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1400,14 +1400,8 @@ out_delete_net:
 	if (cgroups_connected)
 		cgroup_disconnect();
 
-	if (handler->clone_flags & CLONE_NEWNET) {
-		DEBUG("Tearing down network devices");
-		if (!lxc_delete_network_priv(handler))
-			DEBUG("Failed tearing down network devices");
-
-		if (!lxc_delete_network_unpriv(handler))
-			DEBUG("Failed tearing down network devices");
-	}
+	if (handler->clone_flags & CLONE_NEWNET)
+		lxc_delete_network(handler);
 
 out_abort:
 	lxc_abort(name, handler);
@@ -1518,17 +1512,7 @@ int __lxc_start(const char *name, struct lxc_handler *handler,
 	err =  lxc_error_set_and_log(handler->pid, status);
 
 out_fini:
-	DEBUG("Tearing down network devices");
-	if (!lxc_delete_network_priv(handler))
-		DEBUG("Failed tearing down network devices");
-
-	if (!lxc_delete_network_unpriv(handler))
-		DEBUG("Failed tearing down network devices");
-
-	if (handler->netnsfd >= 0) {
-		close(handler->netnsfd);
-		handler->netnsfd = -1;
-	}
+	lxc_delete_network(handler);
 
 out_detach_blockdev:
 	detach_block_device(handler->conf);


### PR DESCRIPTION
We need to clear any ifindeces we recorded so liblxc won't have cached stale
data which would cause it to fail on reboot we're we don't re-read the on-disk
config file.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>