### PR TITLE
Add OCI container creation template

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -898,6 +898,7 @@ AC_CONFIG_FILES([
 	templates/lxc-fedora
 	templates/lxc-fedora-legacy
 	templates/lxc-gentoo
+	templates/lxc-oci
 	templates/lxc-openmandriva
 	templates/lxc-opensuse
 	templates/lxc-oracle

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -263,6 +263,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <variablelist>
         <varlistentry>
           <term>
+            <option>lxc.execute.cmd</option>
+          </term>
+          <listitem>
+            <para>
+              Absolute path from container rootfs to the binary to run by default.  This
+	      mostly makes sense for lxc-execute.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+      <variablelist>
+        <varlistentry>
+          <term>
             <option>lxc.init.cmd</option>
           </term>
           <listitem>

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3525,6 +3525,7 @@ void lxc_conf_free(struct lxc_conf *conf)
 	free(conf->ttydir);
 	free(conf->fstab);
 	free(conf->rcfile);
+	free(conf->execute_cmd);
 	free(conf->init_cmd);
 	free(conf->unexpanded_config);
 	free(conf->pty_names);

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -309,6 +309,9 @@ struct lxc_conf {
 	char *unexpanded_config;
 	size_t unexpanded_len, unexpanded_alloced;
 
+	/* default command for lxc-execute */
+	char *execute_cmd;
+
 	/* init command */
 	char *init_cmd;
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -127,6 +127,7 @@ lxc_config_define(start);
 lxc_config_define(monitor);
 lxc_config_define(group);
 lxc_config_define(environment);
+lxc_config_define(execute_cmd);
 lxc_config_define(init_cmd);
 lxc_config_define(init_uid);
 lxc_config_define(init_gid);
@@ -149,6 +150,7 @@ static struct lxc_config_t config[] = {
 	{ "lxc.console.path",              false,                  set_config_console_path,                get_config_console_path,                clr_config_console_path,              },
 	{ "lxc.environment",               false,                  set_config_environment,                 get_config_environment,                 clr_config_environment,               },
 	{ "lxc.ephemeral",                 false,                  set_config_ephemeral,                   get_config_ephemeral,                   clr_config_ephemeral,                 },
+	{ "lxc.execute.cmd",               false,                  set_config_execute_cmd,                 get_config_execute_cmd,                 clr_config_execute_cmd,                  },
 	{ "lxc.group",                     false,                  set_config_group,                       get_config_group,                       clr_config_group,                     },
 	{ "lxc.hook.autodev",              false,                  set_config_hooks,                       get_config_hooks,                       clr_config_hooks,                     },
 	{ "lxc.hook.clone",                false,                  set_config_hooks,                       get_config_hooks,                       clr_config_hooks,                     },
@@ -918,6 +920,12 @@ static int set_config_seccomp_profile(const char *key, const char *value,
 				      struct lxc_conf *lxc_conf, void *data)
 {
 	return set_config_path_item(&lxc_conf->seccomp, value);
+}
+
+static int set_config_execute_cmd(const char *key, const char *value,
+			       struct lxc_conf *lxc_conf, void *data)
+{
+	return set_config_path_item(&lxc_conf->execute_cmd, value);
 }
 
 static int set_config_init_cmd(const char *key, const char *value,
@@ -3095,6 +3103,12 @@ static int get_config_environment(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
+static int get_config_execute_cmd(const char *key, char *retv, int inlen,
+			       struct lxc_conf *c, void *data)
+{
+	return lxc_get_conf_str(retv, inlen, c->execute_cmd);
+}
+
 static int get_config_init_cmd(const char *key, char *retv, int inlen,
 			       struct lxc_conf *c, void *data)
 {
@@ -3448,6 +3462,14 @@ static inline int clr_config_environment(const char *key, struct lxc_conf *c,
 					 void *data)
 {
 	return lxc_clear_environment(c);
+}
+
+static inline int clr_config_execute_cmd(const char *key, struct lxc_conf *c,
+				      void *data)
+{
+	free(c->execute_cmd);
+	c->execute_cmd = NULL;
+	return 0;
 }
 
 static inline int clr_config_init_cmd(const char *key, struct lxc_conf *c,

--- a/templates/Makefile.am
+++ b/templates/Makefile.am
@@ -12,6 +12,7 @@ templates_SCRIPTS = \
 	lxc-fedora \
 	lxc-fedora-legacy \
 	lxc-gentoo \
+	lxc-oci \
 	lxc-openmandriva \
 	lxc-opensuse \
 	lxc-oracle \

--- a/templates/lxc-oci.in
+++ b/templates/lxc-oci.in
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+# Create application containers from OCI images
+
+# Copyright © 2014 Stéphane Graber <stgraber@ubuntu.com>
+# Copyright © 2017 Serge Hallyn <serge@hallyn.com>
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+#  USA
+
+set -eu
+# set -x  # debug
+
+# Make sure the usual locations are in PATH
+export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Check for required binaries
+for bin in skopeo umoci jq; do
+    if ! type $bin >/dev/null 2>&1; then
+        echo "ERROR: Missing required tool: $bin" 1>&2
+        exit 1
+    fi
+done
+
+# Some useful functions
+cleanup() {
+    if [ -d "$DOWNLOAD_TEMP" ]; then
+        rm -Rf $DOWNLOAD_TEMP
+    fi
+}
+
+in_userns() {
+    [ -e /proc/self/uid_map ] || { echo no; return; }
+    while read line; do
+        fields=$(echo $line | awk '{ print $1 " " $2 " " $3 }')
+        [ "$fields" = "0 0 4294967295" ] && { echo no; return; } || true
+        echo $fields | grep -q " 0 1$" && { echo userns-root; return; } || true
+    done < /proc/self/uid_map
+
+    [ "$(cat /proc/self/uid_map)" = "$(cat /proc/1/uid_map)" ] && \
+        { echo userns-root; return; }
+    echo yes
+}
+
+# get entrypoint from oci image.  Use sh if unspecified
+# TODO - we can get other things like resource limits here
+getep() {
+	basedir="$1"
+	q="$2"
+
+
+	digest=`cat "${basedir}/index.json" | jq --arg q "$q" '.manifests[] | if .annotations."org.opencontainers.image.ref.name" == $q then .digest else null end' | sed -e 's/"//g'`
+	if [ -z "${digest}" ]; then
+		echo "$q not found in index.json" >&2
+		echo "/bin/sh"
+		return
+	fi
+
+	# Ok we have the image config digest, now get the config from that,
+	d=${digest:7}
+	cdigest=`cat "${basedir}/blobs/sha256/${d}" | jq '.config.digest' | sed -e 's/"//g'`
+	if [ -z "${cdigest}" ]; then
+		echo "container config not found" >&2
+		echo "/bin/sh"
+		return
+	fi
+
+	d2=${cdigest:7}
+	ep=`cat "${basedir}/blobs/sha256/${d2}" | jq -c '.config.Entrypoint' | sed -e 's/^\[//; s/\]$//; s/","/" "/'`
+	cmd=`cat "${basedir}/blobs/sha256/${d2}" | jq -c '.config.Cmd' | sed -e 's/^\[//; s/\]$//; s/","/" "/'`
+	if [ "${ep}" = "null" ]; then
+		ep="${cmd}"
+		if [ "${ep}" = "null" ]; then
+			ep="/bin/sh"
+		fi
+	elif [ "${cmd}" != "null" ]; then
+		ep="${ep} ${cmd}"
+	fi
+
+	if [ -z "${ep}" ]; then
+		echo "/bin/sh"
+		return
+	fi
+	echo "${ep}"
+	return
+}
+
+usage() {
+    cat <<EOF
+LXC container template for OCI images
+
+Special arguments:
+[ -h | --help ]: Print this help message and exit.
+
+Required arguments:
+[ -u | --url <url> ]: The OCI image URL
+
+LXC internal arguments (do not pass manually!):
+[ --name <name> ]: The container name
+[ --path <path> ]: The path to the container
+[ --rootfs <rootfs> ]: The path to the container's rootfs
+[ --mapped-uid <map> ]: A uid map (user namespaces)
+[ --mapped-gid <map> ]: A gid map (user namespaces)
+
+EOF
+    return 0
+}
+
+options=$(getopt -o u:h -l help,name:,path:,\
+rootfs:,mapped-uid:,mapped-gid: -- "$@")
+
+if [ $? -ne 0 ]; then
+    usage
+    exit 1
+fi
+eval set -- "$options"
+
+OCI_URL=""
+LXC_MAPPED_GID=
+LXC_MAPPED_UID=
+LXC_NAME=
+LXC_PATH=
+LXC_ROOTFS=
+
+while :; do
+    case "$1" in
+        -h|--help)          usage && exit 1;;
+        -u|--url)           OCI_URL=$2; shift 2;;
+        --name)             LXC_NAME=$2; shift 2;;
+        --path)             LXC_PATH=$2; shift 2;;
+        --rootfs)           LXC_ROOTFS=$2; shift 2;;
+        --mapped-uid)       LXC_MAPPED_UID=$2; shift 2;;
+        --mapped-gid)       LXC_MAPPED_GID=$2; shift 2;;
+        *)                  break;;
+    esac
+done
+
+# Check that we have all variables we need
+if [ -z "$LXC_NAME" ] || [ -z "$LXC_PATH" ] || [ -z "$LXC_ROOTFS" ]; then
+    echo "ERROR: Not running through LXC." 1>&2
+    exit 1
+fi
+
+if [ -z "$OCI_URL" ]; then
+    echo "ERROR: no OCI URL given"
+    exit 1
+fi
+
+USERNS=$(in_userns)
+
+if [ "$USERNS" != "no" ]; then
+    if [ "$USERNS" = "yes" ]; then
+        if [ -z "$LXC_MAPPED_UID" ] || [ "$LXC_MAPPED_UID" = "-1" ]; then
+            echo "ERROR: In a user namespace without a map." 1>&2
+            exit 1
+        fi
+        DOWNLOAD_MODE="user"
+        DOWNLOAD_TARGET="user"
+    else
+        DOWNLOAD_MODE="user"
+        DOWNLOAD_TARGET="system"
+    fi
+fi
+
+# Trap all exit signals
+trap cleanup EXIT HUP INT TERM
+
+if ! type mktemp >/dev/null 2>&1; then
+    DOWNLOAD_TEMP=/tmp/lxc-oci.$$
+    mkdir -p $DOWNLOAD_TEMP
+else
+    DOWNLOAD_TEMP=$(mktemp -d)
+fi
+
+# Download the image - TODO - cache
+skopeo copy "${OCI_URL}" "oci:${DOWNLOAD_TEMP}:latest"
+
+# Unpack the rootfs
+echo "Unpacking the rootfs"
+
+umoci unpack --image "${DOWNLOAD_TEMP}:latest" "${LXC_ROOTFS}.tmp"
+rmdir "${LXC_ROOTFS}"
+mv "${LXC_ROOTFS}.tmp/rootfs" "${LXC_ROOTFS}"
+entrypoint=$(getep ${DOWNLOAD_TEMP} latest)
+rm -rf "${LXC_ROOTFS}.tmp"
+
+LXC_CONF_FILE="${LXC_PATH}/config"
+echo "lxc.execute.cmd = ${entrypoint}" >> "${LXC_CONF_FILE}"
+echo "lxc.mount.auto = proc:mixed sys:mixed cgroup:mixed" >> "${LXC_CONF_FILE}"
+
+echo "lxc.uts.name = ${LXC_NAME}" >> ${LXC_PATH}/config
+
+if [ -n "$LXC_MAPPED_UID" ] && [ "$LXC_MAPPED_UID" != "-1" ]; then
+    chown $LXC_MAPPED_UID $LXC_PATH/config $LXC_PATH/fstab >/dev/null 2>&1 || true
+fi
+if [ -n "$LXC_MAPPED_GID" ] && [ "$LXC_MAPPED_GID" != "-1" ]; then
+    chgrp $LXC_MAPPED_GID $LXC_PATH/config $LXC_PATH/fstab >/dev/null 2>&1 || true
+fi
+
+exit 0


### PR DESCRIPTION
This adds preliminary (but working) support for creating application
containers from OCI formats.  Examples:

sudo lxc-create -t oci -n a1 -- -u oci:../oci:alpine -t alpine

create a container from a local OCI layout in ../oci.

sudo lxc-create -t oci -n u1 -- -u docker://ubuntu -t ubuntu

create a container pulling from the docker hub.

I'm pretty sure we'll wan to fine-tune the way "urls' are
specified.  The separate specifying of a 'tag' is unfortunate.
Maybe we can be smart enough to know to pull the name for
dockerhub and the tag for oci:.  But for now it simplified things
to the point of making it easy enough to implement and use.

Comments appreciated.

TODO:
 - implement lxc.execute.cmd configuration key
 - pull more of the OCI runtime information like memory/cpu limits

Signed-off-by: Serge Hallyn <shallyn@cisco.com>