### PR TITLE
drop useless apparmor denies

### DIFF
--- a/config/apparmor/abstractions/container-base
+++ b/config/apparmor/abstractions/container-base
@@ -72,8 +72,6 @@
 
   # block some other dangerous paths
   deny @{PROC}/kcore rwklx,
-  deny @{PROC}/kmem rwklx,
-  deny @{PROC}/mem rwklx,
   deny @{PROC}/sysrq-trigger rwklx,
 
   # deny writes in /sys except for /sys/fs/cgroup, also allow

--- a/config/apparmor/abstractions/container-base.in
+++ b/config/apparmor/abstractions/container-base.in
@@ -72,8 +72,6 @@
 
   # block some other dangerous paths
   deny @{PROC}/kcore rwklx,
-  deny @{PROC}/kmem rwklx,
-  deny @{PROC}/mem rwklx,
   deny @{PROC}/sysrq-trigger rwklx,
 
   # deny writes in /sys except for /sys/fs/cgroup, also allow

--- a/src/tests/aa.c
+++ b/src/tests/aa.c
@@ -105,7 +105,7 @@ char *files_to_allow[] = { "/sys/class/net/lo/ifalias",
 		"/proc/sys/kernel/shmmax",
 		NULL };
 
-char *files_to_deny[] = { "/proc/mem", "/proc/kmem",
+char *files_to_deny[] = {
 		"/sys/kernel/uevent_helper",
 		"/proc/sys/fs/file-nr",
 		"/sys/kernel/mm/ksm/pages_to_scan",


### PR DESCRIPTION
mem and kmem are really in /dev, so this does us no good.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>