### PR TITLE
implement lxc_string_split_quoted

### DIFF
--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -99,10 +99,7 @@ static bool set_argv(struct lxc_conf *conf, struct lxc_arguments *args)
 	if (!conf->execute_cmd)
 		return false;
 
-	/* TODO -
-	   we should honor '"' etc; This seems worth a new helper in utils.c.
-	 */
-	components = lxc_string_split(conf->execute_cmd, ' ');
+	components = lxc_string_split_quoted(conf->execute_cmd);
 	if (!components)
 		return false;
 

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -292,6 +292,7 @@ extern bool lxc_string_in_list(const char *needle, const char *haystack,
 			       char sep);
 extern char **lxc_string_split(const char *string, char sep);
 extern char **lxc_string_split_and_trim(const char *string, char sep);
+extern char **lxc_string_split_quoted(char *string);
 /* Append string to NULL-terminated string array. */
 extern int lxc_append_string(char ***list, char *entry);
 

--- a/templates/lxc-oci.in
+++ b/templates/lxc-oci.in
@@ -197,7 +197,7 @@ entrypoint=$(getep ${DOWNLOAD_TEMP} latest)
 rm -rf "${LXC_ROOTFS}.tmp"
 
 LXC_CONF_FILE="${LXC_PATH}/config"
-echo "lxc.execute.cmd = ${entrypoint}" >> "${LXC_CONF_FILE}"
+echo "lxc.execute.cmd = '${entrypoint}'" >> "${LXC_CONF_FILE}"
 echo "lxc.mount.auto = proc:mixed sys:mixed cgroup:mixed" >> "${LXC_CONF_FILE}"
 
 echo "lxc.uts.name = ${LXC_NAME}" >> ${LXC_PATH}/config


### PR DESCRIPTION
lxc_string_split_quoted() splits a string on spaces, but keeps
groups in single or double qoutes together.  In other words,
generally what we'd want for argv behavior.

Switch lxc-execute to use this for lxc.execute.cmd.

Switch lxc-oci template to put the lxc.execute.cmd inside single
quotes, because parse_line() will eat those.  If we don't do that,
then if we have lxc.execute.cmd = /bin/echo "hello, world", then the
last double quote will disappear.