### PR TITLE
confile: ignore lxc.kmsg and lxc.pivotdir 

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -75,66 +75,67 @@ lxc_log_define(lxc_confile, lxc);
 				     struct lxc_conf *, void *);               \
 	static int clr_config_##name(const char *, struct lxc_conf *, void *);
 
-lxc_config_define(personality);
-lxc_config_define(pty_max);
-lxc_config_define(tty_max);
-lxc_config_define(tty_dir);
-lxc_config_define(apparmor_profile);
+lxc_config_define(autodev);
 lxc_config_define(apparmor_allow_incomplete);
-lxc_config_define(selinux_context);
+lxc_config_define(apparmor_profile);
+lxc_config_define(cap_drop);
+lxc_config_define(cap_keep);
 lxc_config_define(cgroup_controller);
 lxc_config_define(cgroup_dir);
+lxc_config_define(console_logfile);
+lxc_config_define(console_path);
+lxc_config_define(environment);
+lxc_config_define(ephemeral);
+lxc_config_define(execute_cmd);
+lxc_config_define(group);
+lxc_config_define(hooks);
 lxc_config_define(idmaps);
-lxc_config_define(log_level);
+lxc_config_define(includefiles);
+lxc_config_define(init_cmd);
+lxc_config_define(init_gid);
+lxc_config_define(init_uid);
 lxc_config_define(log_file);
+lxc_config_define(log_level);
+lxc_config_define(log_syslog);
+lxc_config_define(monitor);
 lxc_config_define(mount);
 lxc_config_define(mount_auto);
 lxc_config_define(mount_fstab);
-lxc_config_define(rootfs_mount);
-lxc_config_define(rootfs_options);
-lxc_config_define(rootfs_backend);
-lxc_config_define(rootfs_path);
-lxc_config_define(uts_name);
-lxc_config_define(hooks);
-lxc_config_define(net_type);
+lxc_config_define(net);
 lxc_config_define(net_flags);
-lxc_config_define(net_link);
-lxc_config_define(net_name);
-lxc_config_define(net_veth_pair);
-lxc_config_define(net_macvlan_mode);
 lxc_config_define(net_hwaddr);
-lxc_config_define(net_vlan_id);
-lxc_config_define(net_mtu);
 lxc_config_define(net_ipv4_address);
 lxc_config_define(net_ipv4_gateway);
-lxc_config_define(net_script_up);
-lxc_config_define(net_script_down);
 lxc_config_define(net_ipv6_address);
 lxc_config_define(net_ipv6_gateway);
+lxc_config_define(net_link);
+lxc_config_define(net_macvlan_mode);
+lxc_config_define(net_mtu);
+lxc_config_define(net_name);
 lxc_config_define(net_nic);
-lxc_config_define(net);
-lxc_config_define(cap_drop);
-lxc_config_define(cap_keep);
-lxc_config_define(console_logfile);
-lxc_config_define(console_path);
+lxc_config_define(net_script_down);
+lxc_config_define(net_script_up);
+lxc_config_define(net_type);
+lxc_config_define(net_veth_pair);
+lxc_config_define(net_vlan_id);
+lxc_config_define(no_new_privs);
+lxc_config_define(noop);
+lxc_config_define(personality);
+lxc_config_define(prlimit);
+lxc_config_define(pty_max);
+lxc_config_define(rootfs_backend);
+lxc_config_define(rootfs_mount);
+lxc_config_define(rootfs_options);
+lxc_config_define(rootfs_path);
 lxc_config_define(seccomp_profile);
-lxc_config_define(includefiles);
-lxc_config_define(autodev);
+lxc_config_define(selinux_context);
 lxc_config_define(signal_halt);
 lxc_config_define(signal_reboot);
 lxc_config_define(signal_stop);
 lxc_config_define(start);
-lxc_config_define(monitor);
-lxc_config_define(group);
-lxc_config_define(environment);
-lxc_config_define(execute_cmd);
-lxc_config_define(init_cmd);
-lxc_config_define(init_uid);
-lxc_config_define(init_gid);
-lxc_config_define(ephemeral);
-lxc_config_define(log_syslog);
-lxc_config_define(no_new_privs);
-lxc_config_define(prlimit);
+lxc_config_define(tty_max);
+lxc_config_define(tty_dir);
+lxc_config_define(uts_name);
 
 static struct lxc_config_t config[] = {
                                            /* REMOVE in LXC 3.0 */
@@ -249,12 +250,14 @@ static struct lxc_config_t config[] = {
 	{ "lxc.rebootsignal",              true,                   set_config_signal_reboot,               get_config_signal_reboot,               clr_config_signal_reboot,             },
 	{ "lxc.stopsignal",                true,                   set_config_signal_stop,                 get_config_signal_stop,                 clr_config_signal_stop,               },
 	{ "lxc.syslog",                    true,                   set_config_log_syslog,                  get_config_log_syslog,                  clr_config_log_syslog,                },
+	{ "lxc.kmsg",                      true,                   set_config_noop,                        get_config_noop,                        clr_config_noop,                      },
 	{ "lxc.loglevel",                  true,                   set_config_log_level,                   get_config_log_level,                   clr_config_log_level,                 },
 	{ "lxc.logfile",                   true,                   set_config_log_file,                    get_config_log_file,                    clr_config_log_file,                  },
 	{ "lxc.init_cmd",                  true,                   set_config_init_cmd,                    get_config_init_cmd,                    clr_config_init_cmd,                  },
 	{ "lxc.init_uid",                  true,                   set_config_init_uid,                    get_config_init_uid,                    clr_config_init_uid,                  },
 	{ "lxc.init_gid",                  true,                   set_config_init_gid,                    get_config_init_gid,                    clr_config_init_gid,                  },
 	{ "lxc.limit",                     true,                   set_config_limit,                       get_config_limit,                       clr_config_limit,                     },
+	{ "lxc.pivotdir",                  true,                   set_config_noop,                        get_config_noop,                        clr_config_noop,                      },
 	/* [END]: REMOVE IN LXC 3.0 */
 };
 
@@ -2580,6 +2583,12 @@ static int set_config_no_new_privs(const char *key, const char *value,
 	return 0;
 }
 
+static int set_config_noop(const char *key, const char *value,
+			   struct lxc_conf *lxc_conf, void *data)
+{
+	return 0;
+}
+
 /* Callbacks to get configuration items. */
 static int get_config_personality(const char *key, char *retv, int inlen,
 				  struct lxc_conf *c, void *data)
@@ -3196,6 +3205,12 @@ static int get_config_prlimit(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
+static int get_config_noop(const char *key, char *retv, int inlen,
+			   struct lxc_conf *c, void *data)
+{
+	return 0;
+}
+
 /* Callbacks to clear config items. */
 static inline int clr_config_personality(const char *key, struct lxc_conf *c,
 					 void *data)
@@ -3518,6 +3533,12 @@ static inline int clr_config_includefiles(const char *key, struct lxc_conf *c,
 					  void *data)
 {
 	lxc_clear_includes(c);
+	return 0;
+}
+
+static inline int clr_config_noop(const char *key, struct lxc_conf *c,
+				  void *data)
+{
 	return 0;
 }
 

--- a/src/lxc/tools/lxc-update-config.in
+++ b/src/lxc/tools/lxc-update-config.in
@@ -67,6 +67,8 @@ sed -i \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.network\)\(\.[[:digit:]*]\)/\1lxc\.net\3/g' \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.network\)\([[:blank:]*]\|=\)/\1lxc\.net\3/g' \
 -e '/\([[:blank:]*]\|#*\)\(lxc\.rootfs\.backend\)\([[:blank:]*]\|=\)/d' \
+-e '/\([[:blank:]*]\|#*\)\(lxc\.pivotdir\)\([[:blank:]*]\|=\)/d' \
+-e '/\([[:blank:]*]\|#*\)\(lxc\.kmsg\)\([[:blank:]*]\|=\)/d' \
 	"${CONFIGPATH}"
 
 # Finally, deal with network definitions of the following form:


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>