### PR TITLE
confile: make update warning opt-in

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -2009,13 +2009,15 @@ static int parse_line(char *buffer, void *data)
 	/* [START]: REMOVE IN LXC 3.0 */
 	if (config->is_legacy_key && !plc->conf->contains_legacy_key) {
 		plc->conf->contains_legacy_key = true;
-		/* Warn the user once loud and clear that there is at least one
-		 * legacy configuration item in the configuration file and then
-		 * an update is required.
-		 */
-		fprintf(stderr, "The configuration file contains legacy "
-				"configuration keys.\nPlease update your "
-				"configuration file!\n");
+		if (getenv("LXC_UPDATE_CONFIG_FORMAT")) {
+			/* Warn the user once loud and clear that there is at
+			 * least one legacy configuration item in the
+			 * configuration file and then an update is required.
+			 */
+			fprintf(stderr, "The configuration file contains "
+					"legacy configuration keys.\nPlease "
+					"update your configuration file!\n");
+		}
 	}
 	/* [END]: REMOVE IN LXC 3.0 */
 

--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -406,6 +406,9 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	struct lxc_container *c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c)
 		exit(EXIT_FAILURE);

--- a/src/lxc/tools/lxc_autostart.c
+++ b/src/lxc/tools/lxc_autostart.c
@@ -368,6 +368,9 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	count = list_defined_containers(my_args.lxcpath[0], NULL, &containers);
 
 	if (count < 0)

--- a/src/lxc/tools/lxc_cgroup.c
+++ b/src/lxc/tools/lxc_cgroup.c
@@ -21,16 +21,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <stdio.h>
-#include <unistd.h>
 #include <libgen.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 #include <sys/types.h>
 
 #include <lxc/lxccontainer.h>
 
-#include "lxc.h"
-#include "log.h"
 #include "arguments.h"
+#include "log.h"
+#include "lxc.h"
 
 lxc_log_define(lxc_cgroup_ui, lxc);
 
@@ -85,6 +86,9 @@ int main(int argc, char *argv[])
 	if (lxc_log_init(&log))
 		exit(EXIT_FAILURE);
 	lxc_log_options_no_override();
+
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
 
 	state_object = my_args.argv[0];
 

--- a/src/lxc/tools/lxc_checkpoint.c
+++ b/src/lxc/tools/lxc_checkpoint.c
@@ -255,6 +255,9 @@ int main(int argc, char *argv[])
 
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c) {
 		fprintf(stderr, "System error loading %s\n", my_args.name);

--- a/src/lxc/tools/lxc_clone.c
+++ b/src/lxc/tools/lxc_clone.c
@@ -176,6 +176,8 @@ int main(int argc, char *argv[])
 		usage(argv[0]);
 	}
 
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	c1 = lxc_container_new(orig, lxcpath);
 	if (!c1)
 		exit(EXIT_FAILURE);

--- a/src/lxc/tools/lxc_config.c
+++ b/src/lxc/tools/lxc_config.c
@@ -62,6 +62,8 @@ int main(int argc, char *argv[])
 	struct lxc_config_items *i;
 	const char *value;
 
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	if (argc < 2)
 		usage(argv[0]);
 	if (strcmp(argv[1], "-l") == 0)

--- a/src/lxc/tools/lxc_console.c
+++ b/src/lxc/tools/lxc_console.c
@@ -119,6 +119,9 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c) {
 		fprintf(stderr, "System error loading container\n");

--- a/src/lxc/tools/lxc_copy.c
+++ b/src/lxc/tools/lxc_copy.c
@@ -190,6 +190,9 @@ int main(int argc, char *argv[])
 		exit(ret);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	if (geteuid()) {
 		if (access(my_args.lxcpath[0], O_RDONLY) < 0) {
 			if (!my_args.quiet)

--- a/src/lxc/tools/lxc_create.c
+++ b/src/lxc/tools/lxc_create.c
@@ -229,6 +229,9 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	if (!my_args.template) {
 		fprintf(stderr, "A template must be specified.\n");
 		fprintf(stderr, "Use \"none\" if you really want a container without a rootfs.\n");

--- a/src/lxc/tools/lxc_destroy.c
+++ b/src/lxc/tools/lxc_destroy.c
@@ -89,6 +89,9 @@ int main(int argc, char *argv[])
 	if (my_args.quiet)
 		quiet = true;
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c) {
 		if (!quiet)
@@ -278,4 +281,3 @@ static bool do_destroy_with_snapshots(struct lxc_container *c)
 
 	return bret;
 }
-

--- a/src/lxc/tools/lxc_device.c
+++ b/src/lxc/tools/lxc_device.c
@@ -127,6 +127,9 @@ int main(int argc, char *argv[])
 		goto err;
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c) {
 		ERROR("%s doesn't exist", my_args.name);

--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -136,6 +136,9 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c) {
 		ERROR("Failed to create lxc_container");

--- a/src/lxc/tools/lxc_freeze.c
+++ b/src/lxc/tools/lxc_freeze.c
@@ -76,6 +76,9 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c) {
 		ERROR("No such container: %s:%s", my_args.lxcpath[0], my_args.name);

--- a/src/lxc/tools/lxc_info.c
+++ b/src/lxc/tools/lxc_info.c
@@ -413,6 +413,9 @@ int main(int argc, char *argv[])
 		exit(ret);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	if (print_info(my_args.name, my_args.lxcpath[0]) == 0)
 		ret = EXIT_SUCCESS;
 

--- a/src/lxc/tools/lxc_ls.c
+++ b/src/lxc/tools/lxc_ls.c
@@ -233,6 +233,9 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	struct lengths max_len = {
 		/* default header length */
 		.name_length = 4,      /* NAME */

--- a/src/lxc/tools/lxc_monitor.c
+++ b/src/lxc/tools/lxc_monitor.c
@@ -113,6 +113,9 @@ int main(int argc, char *argv[])
 		exit(rc_main);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	if (quit_monitord) {
 		int ret = EXIT_SUCCESS;
 		for (i = 0; i < my_args.lxcpath_cnt; i++) {

--- a/src/lxc/tools/lxc_snapshot.c
+++ b/src/lxc/tools/lxc_snapshot.c
@@ -101,6 +101,9 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	if (geteuid()) {
 		if (access(my_args.lxcpath[0], O_RDONLY) < 0) {
 			fprintf(stderr, "You lack access to %s\n",
@@ -304,4 +307,3 @@ static void print_file(char *path)
 	free(line);
 	fclose(f);
 }
-

--- a/src/lxc/tools/lxc_start.c
+++ b/src/lxc/tools/lxc_start.c
@@ -244,6 +244,9 @@ int main(int argc, char *argv[])
 
 	const char *lxcpath = my_args.lxcpath[0];
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	/*
 	 * rcfile possibilities:
 	 * 1. rcfile from random path specified in cli option

--- a/src/lxc/tools/lxc_stop.c
+++ b/src/lxc/tools/lxc_stop.c
@@ -173,6 +173,9 @@ int main(int argc, char *argv[])
 		exit(ret);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	/* Set default timeout */
 	if (my_args.timeout == -2) {
 		if (my_args.hardstop)

--- a/src/lxc/tools/lxc_unfreeze.c
+++ b/src/lxc/tools/lxc_unfreeze.c
@@ -75,6 +75,9 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c) {
 		ERROR("No such container: %s:%s", my_args.lxcpath[0], my_args.name);

--- a/src/lxc/tools/lxc_wait.c
+++ b/src/lxc/tools/lxc_wait.c
@@ -102,6 +102,9 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	lxc_log_options_no_override();
 
+	/* REMOVE IN LXC 3.0 */
+	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
+
 	c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c)
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
With the release LXC 2.1 we started warning users who use LXC through the API
and users who use LXC through the tools equally about updating their config.
This quickly got confusing and annoying to API users who e.g. generate configs
on the fly (e.g. LXD). So instead of unconditionally warning users we make this
opt-in. If LXC detects that the env variable LXC_UPDATE_CONFIG_FORMAT is set
then it will warn the user if any legacy configuration keys are present. If it
is not set however, it will not warn the user. This is ok, since the log will
still log WARN()s for all legacy configuration keys.
The tools will all set LXC_UPDATE_CONFIG_FORMAT since it is very much required
that users update to the new configuration format pre-LXC 3.0.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>