### PR TITLE
POC: container live patching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ src/tests/lxc-test-destroytest
 src/tests/lxc-test-get_item
 src/tests/lxc-test-getkeys
 src/tests/lxc-test-list
+src/tests/lxc-test-livepatch
 src/tests/lxc-test-locktests
 src/tests/lxc-test-lxcpath
 src/tests/lxc-test-may-control

--- a/src/lxc/commands.h
+++ b/src/lxc/commands.h
@@ -48,6 +48,7 @@ typedef enum {
 	LXC_CMD_GET_NAME,
 	LXC_CMD_GET_LXCPATH,
 	LXC_CMD_ADD_STATE_CLIENT,
+	LXC_CMD_SET_CONFIG_ITEM,
 	LXC_CMD_MAX,
 } lxc_cmd_t;
 
@@ -71,6 +72,11 @@ struct lxc_cmd_rr {
 struct lxc_cmd_console_rsp_data {
 	int masterfd;
 	int ttynum;
+};
+
+struct lxc_cmd_set_config_item_req_data {
+	const char *item;
+	void *value;
 };
 
 extern int lxc_cmd_console_winch(const char *name, const char *lxcpath);
@@ -115,5 +121,8 @@ extern int lxc_cmd_init(const char *name, struct lxc_handler *handler,
 extern int lxc_cmd_mainloop_add(const char *name, struct lxc_epoll_descr *descr,
 				    struct lxc_handler *handler);
 extern int lxc_try_cmd(const char *name, const char *lxcpath);
+
+extern int lxc_cmd_set_config_item(const char *name, const char *item,
+				   const char *value, const char *lxcpath);
 
 #endif /* __commands_h */

--- a/src/lxc/lxc.h
+++ b/src/lxc/lxc.h
@@ -149,6 +149,13 @@ extern int lxc_get_wait_states(const char **states);
  */
 extern int add_rdepend(struct lxc_conf *lxc_conf, char *rdepend);
 
+/*
+ * Set a key/value configuration option. Requires that to take a lock on the
+ * in-memory config of the container.
+ */
+extern int lxc_set_config_item_locked(struct lxc_conf *conf, const char *key,
+				      const char *v);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2838,7 +2838,7 @@ static bool do_lxcapi_set_running_config_item(struct lxc_container *c, const cha
 
 	ret = lxc_cmd_set_config_item(c->name, key, v, do_lxcapi_get_config_path(c));
 	if (ret < 0)
-		ERROR("Failed to live patch container");
+		SYSERROR("%s - Failed to live patch container", strerror(-ret));
 
 	container_mem_unlock(c);
 	return ret == 0;

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2765,9 +2765,35 @@ static bool do_lxcapi_destroy_with_snapshots(struct lxc_container *c)
 
 WRAP_API(bool, lxcapi_destroy_with_snapshots)
 
-static bool set_config_item_locked(struct lxc_container *c, const char *key, const char *v)
+int lxc_set_config_item_locked(struct lxc_conf *conf, const char *key,
+			       const char *v)
 {
+	int ret;
 	struct lxc_config_t *config;
+	bool bret = true;
+
+	config = lxc_get_config(key);
+	if (!config)
+		return -EINVAL;
+
+	ret = config->set(key, v, conf, NULL);
+	if (ret < 0)
+		return -EINVAL;
+
+	if (lxc_config_value_empty(v))
+		do_clear_unexp_config_line(conf, key);
+	else
+		bret = do_append_unexp_config_line(conf, key, v);
+	if (!bret)
+		return -ENOMEM;
+
+	return 0;
+}
+
+static bool do_set_config_item_locked(struct lxc_container *c, const char *key,
+				      const char *v)
+{
+	int ret;
 
 	if (!c->lxc_conf)
 		c->lxc_conf = lxc_conf_init();
@@ -2775,19 +2801,11 @@ static bool set_config_item_locked(struct lxc_container *c, const char *key, con
 	if (!c->lxc_conf)
 		return false;
 
-	config = lxc_get_config(key);
-	if (!config)
+	ret = lxc_set_config_item_locked(c->lxc_conf, key, v);
+	if (ret < 0)
 		return false;
 
-	if (config->set(key, v, c->lxc_conf, NULL) != 0)
-		return false;
-
-	if (lxc_config_value_empty(v)) {
-		do_clear_unexp_config_line(c->lxc_conf, key);
-		return true;
-	}
-
-	return do_append_unexp_config_line(c->lxc_conf, key, v);
+	return true;
 }
 
 static bool do_lxcapi_set_config_item(struct lxc_container *c, const char *key, const char *v)
@@ -2800,13 +2818,33 @@ static bool do_lxcapi_set_config_item(struct lxc_container *c, const char *key, 
 	if (container_mem_lock(c))
 		return false;
 
-	b = set_config_item_locked(c, key, v);
+	b = do_set_config_item_locked(c, key, v);
 
 	container_mem_unlock(c);
 	return b;
 }
 
 WRAP_API_2(bool, lxcapi_set_config_item, const char *, const char *)
+
+static bool do_lxcapi_set_running_config_item(struct lxc_container *c, const char *key, const char *v)
+{
+	int ret;
+
+	if (!c)
+		return false;
+
+	if (container_mem_lock(c))
+		return false;
+
+	ret = lxc_cmd_set_config_item(c->name, key, v, do_lxcapi_get_config_path(c));
+	if (ret < 0)
+		ERROR("Failed to live patch container");
+
+	container_mem_unlock(c);
+	return ret == 0;
+}
+
+WRAP_API_2(bool, lxcapi_set_running_config_item, const char *, const char *)
 
 static char *lxcapi_config_file_name(struct lxc_container *c)
 {
@@ -3502,7 +3540,7 @@ static struct lxc_container *do_lxcapi_clone(struct lxc_container *c, const char
 		clear_unexp_config_line(c2->lxc_conf, "lxc.utsname", false);
 		clear_unexp_config_line(c2->lxc_conf, "lxc.uts.name", false);
 
-		if (!set_config_item_locked(c2, "lxc.uts.name", newname)) {
+		if (!do_set_config_item_locked(c2, "lxc.uts.name", newname)) {
 			ERROR("Error setting new hostname");
 			goto out;
 		}
@@ -4544,6 +4582,7 @@ struct lxc_container *lxc_container_new(const char *name, const char *configpath
 	c->clear_config_item = lxcapi_clear_config_item;
 	c->get_config_item = lxcapi_get_config_item;
 	c->get_running_config_item = lxcapi_get_running_config_item;
+	c->set_running_config_item = lxcapi_set_running_config_item;
 	c->get_cgroup_item = lxcapi_get_cgroup_item;
 	c->set_cgroup_item = lxcapi_set_cgroup_item;
 	c->get_config_path = lxcapi_get_config_path;

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -280,6 +280,17 @@ struct lxc_container {
 	bool (*set_config_item)(struct lxc_container *c, const char *key, const char *value);
 
 	/*!
+	 * \brief Set a key/value configuration option on a running container.
+	 *
+	 * \param c Container.
+	 * \param key Name of option to set.
+	 * \param value Value of \p name to set.
+	 *
+	 * \return \c true on success, else \c false.
+	 */
+	bool (*set_running_config_item)(struct lxc_container *c, const char *key, const char *value);
+
+	/*!
 	 * \brief Delete the container.
 	 *
 	 * \param c Container.

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -27,6 +27,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c lxctest.h
 lxc_test_parse_config_file_SOURCES = parse_config_file.c lxctest.h
 lxc_test_config_jump_table_SOURCES = config_jump_table.c lxctest.h
 lxc_test_shortlived_SOURCES = shortlived.c
+lxc_test_livepatch_SOURCES = livepatch.c lxctest.h
 
 AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	-DLXCPATH=\"$(LXCPATH)\" \
@@ -55,7 +56,7 @@ bin_PROGRAMS = lxc-test-containertests lxc-test-locktests lxc-test-startone \
 	lxc-test-snapshot lxc-test-concurrent lxc-test-may-control \
 	lxc-test-reboot lxc-test-list lxc-test-attach lxc-test-device-add-remove \
 	lxc-test-apparmor lxc-test-utils lxc-test-parse-config-file \
-	lxc-test-config-jump-table lxc-test-shortlived
+	lxc-test-config-jump-table lxc-test-shortlived lxc-test-livepatch
 
 bin_SCRIPTS = lxc-test-automount \
 	      lxc-test-autostart \
@@ -91,6 +92,7 @@ EXTRA_DIST = \
 	get_item.c \
 	getkeys.c \
 	list.c \
+	livepatch.c \
 	locktests.c \
 	lxcpath.c \
 	lxc-test-lxc-attach \

--- a/src/tests/livepatch.c
+++ b/src/tests/livepatch.c
@@ -1,0 +1,256 @@
+/* liblxcapi
+ *
+ * Copyright © 2017 Christian Brauner <christian.brauner@ubuntu.com>.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <lxc/lxccontainer.h>
+
+#include "lxctest.h"
+
+int main(int argc, char *argv[])
+{
+	char *value;
+	struct lxc_container *c;
+	int ret = EXIT_FAILURE;
+
+	c = lxc_container_new("livepatch", NULL);
+	if (!c) {
+		lxc_error("%s", "Failed to create container \"livepatch\"");
+		exit(ret);
+	}
+
+	if (c->is_defined(c)) {
+		lxc_error("%s\n", "Container \"livepatch\" is defined");
+		goto on_error_put;
+	}
+
+	if (!c->set_config_item(c, "lxc.net.0.type", "veth")) {
+		lxc_error("%s\n", "Failed to set network item \"lxc.net.0.type\"");
+		goto on_error_put;
+	}
+
+	if (!c->set_config_item(c, "lxc.net.0.link", "lxcbr0")) {
+		lxc_error("%s\n", "Failed to set network item \"lxc.net.0.link\"");
+		goto on_error_put;
+	}
+
+	if (!c->set_config_item(c, "lxc.net.0.flags", "up")) {
+		lxc_error("%s\n", "Failed to set network item \"lxc.net.0.flags\"");
+		goto on_error_put;
+	}
+
+	if (!c->set_config_item(c, "lxc.net.0.name", "eth0")) {
+		lxc_error("%s\n", "Failed to set network item \"lxc.net.0.name\"");
+		goto on_error_put;
+	}
+
+	if (!c->createl(c, "busybox", NULL, NULL, 0, NULL)) {
+		lxc_error("%s\n", "Failed to create busybox container \"livepatch\"");
+		goto on_error_put;
+	}
+
+	if (!c->is_defined(c)) {
+		lxc_error("%s\n", "Container \"livepatch\" is not defined");
+		goto on_error_put;
+	}
+
+	c->clear_config(c);
+
+	if (!c->load_config(c, NULL)) {
+		lxc_error("%s\n", "Failed to load config for container \"livepatch\"");
+		goto on_error_stop;
+	}
+
+	if (!c->want_daemonize(c, true)) {
+		lxc_error("%s\n", "Failed to mark container \"livepatch\" daemonized");
+		goto on_error_stop;
+	}
+
+	if (!c->startl(c, 0, NULL)) {
+		lxc_error("%s\n", "Failed to start container \"livepatch\" daemonized");
+		goto on_error_stop;
+	}
+
+	/* Test whether the current value is ok. */
+	value = c->get_running_config_item(c, "lxc.net.0.name");
+	if (!value) {
+		lxc_error("%s\n", "Failed to retrieve running config item \"lxc.net.0.name\"");
+		goto on_error_stop;
+	}
+
+	if (strcmp(value, "eth0")) {
+		lxc_error("Retrieved unexpected value for config item "
+			  "\"lxc.net.0.name\": eth0 != %s", value);
+		free(value);
+		goto on_error_stop;
+	}
+	free(value);
+
+	/* Change current in-memory value. */
+	if (!c->set_running_config_item(c, "lxc.net.0.name", "blabla")) {
+		lxc_error("%s\n", "Failed to set running config item "
+				  "\"lxc.net.0.name\" to \"blabla\"");
+		goto on_error_stop;
+	}
+
+	/* Verify change. */
+	value = c->get_running_config_item(c, "lxc.net.0.name");
+	if (!value) {
+		lxc_error("%s\n", "Failed to retrieve running config item \"lxc.net.0.name\"");
+		goto on_error_stop;
+	}
+
+	if (strcmp(value, "blabla")) {
+		lxc_error("Retrieved unexpected value for config item "
+			  "\"lxc.net.0.name\": blabla != %s", value);
+		free(value);
+		goto on_error_stop;
+	}
+	free(value);
+
+	/* Change current in-memory value. */
+	if (!c->set_running_config_item(c, "lxc.net.0.name", "eth0")) {
+		lxc_error("%s\n", "Failed to set running config item "
+				  "\"lxc.net.0.name\" to \"eth0\"");
+		goto on_error_stop;
+	}
+
+	/* Add new in-memory value. */
+	if (!c->set_running_config_item(c, "lxc.net.1.type", "veth")) {
+		lxc_error("%s\n", "Failed to set running config item "
+				  "\"lxc.net.1.type\" to \"veth\"");
+		goto on_error_stop;
+	}
+
+	/* Verify change. */
+	value = c->get_running_config_item(c, "lxc.net.1.type");
+	if (!value) {
+		lxc_error("%s\n", "Failed to retrieve running config item \"lxc.net.1.type\"");
+		goto on_error_stop;
+	}
+
+	if (strcmp(value, "veth")) {
+		lxc_error("Retrieved unexpected value for config item "
+			  "\"lxc.net.1.type\": veth != %s", value);
+		free(value);
+		goto on_error_stop;
+	}
+	free(value);
+
+	/* Add new in-memory value. */
+	if (!c->set_running_config_item(c, "lxc.net.1.flags", "up")) {
+		lxc_error("%s\n", "Failed to set running config item "
+				  "\"lxc.net.1.flags\" to \"up\"");
+		goto on_error_stop;
+	}
+
+	/* Verify change. */
+	value = c->get_running_config_item(c, "lxc.net.1.flags");
+	if (!value) {
+		lxc_error("%s\n", "Failed to retrieve running config item \"lxc.net.1.flags\"");
+		goto on_error_stop;
+	}
+
+	if (strcmp(value, "up")) {
+		lxc_error("Retrieved unexpected value for config item "
+			  "\"lxc.net.1.flags\": up != %s", value);
+		free(value);
+		goto on_error_stop;
+	}
+	free(value);
+
+	/* Add new in-memory value. */
+	if (!c->set_running_config_item(c, "lxc.net.1.link", "lxcbr0")) {
+		lxc_error("%s\n", "Failed to set running config item "
+				  "\"lxc.net.1.link\" to \"lxcbr0\"");
+		goto on_error_stop;
+	}
+
+	/* Verify change. */
+	value = c->get_running_config_item(c, "lxc.net.1.link");
+	if (!value) {
+		lxc_error("%s\n", "Failed to retrieve running config item \"lxc.net.1.link\"");
+		goto on_error_stop;
+	}
+
+	if (strcmp(value, "lxcbr0")) {
+		lxc_error("Retrieved unexpected value for config item "
+			  "\"lxc.net.1.link\": lxcbr0 != %s", value);
+		free(value);
+		goto on_error_stop;
+	}
+	free(value);
+
+	if (!c->reboot(c)) {
+		lxc_error("%s", "Failed to create container \"livepatch\"");
+		goto on_error_stop;
+	}
+
+	/* Busybox shouldn't take long to reboot. Sleep for 5s. */
+	sleep(5);
+
+	if (!c->is_running(c)) {
+		lxc_error("%s\n", "Failed to reboot container \"livepatch\"");
+		goto on_error_destroy;
+	}
+
+	/* Remove in-memory value. */
+	if (!c->set_running_config_item(c, "lxc.net.1.name", "eth1")) {
+		lxc_error("%s\n", "Failed to clear running config item "
+				  "\"lxc.net.1.name\"");
+		goto on_error_stop;
+	}
+
+	if (!c->stop(c)) {
+		lxc_error("%s\n", "Failed to stop container \"livepatch\"");
+		goto on_error_stop;
+	}
+
+	if (!c->startl(c, 0, NULL)) {
+		lxc_error("%s\n", "Failed to start container \"livepatch\" daemonized");
+		goto on_error_destroy;
+	}
+
+	/* Remove in-memory value. */
+	if (!c->set_running_config_item(c, "lxc.net.1.mtu", "3000")) {
+		lxc_error("%s\n", "Failed to set running config item "
+				  "\"lxc.net.1.mtu\"");
+		goto on_error_stop;
+	}
+
+	ret = 0;
+
+on_error_stop:
+	if (c->is_running(c) && !c->stop(c))
+		lxc_error("%s\n", "Failed to stop container \"livepatch\"");
+
+on_error_destroy:
+	if (!c->destroy(c))
+		lxc_error("%s\n", "Failed to destroy container \"livepatch\"");
+
+on_error_put:
+	lxc_container_put(c);
+	exit(ret);
+}


### PR DESCRIPTION
This adds set_running_config_item() which is the analogue of
get_running_config_item(). In essence it allows a caller to livepatch the
container's in-memory configuration. This POC is severly limited. Here are the
most obvious ones:
- Only the container's in-memory config can be updated but no further actions
  (e.g. on-disk actions) are made.
- Only keys in the "lxc.net." namespace can be changed. This POC also allows
  updating an existing network. For example it allows to change the network
  type of an existing network. This is obviously nonsense and in a non-POC
  implementation this should be blocked.

Use Case:
Callers can hotplug a new network for the container. For example, LXD can
create a pair of veth devices in the host and in the container and add it to
the container's in-memory config. This means, the container can later be
queried for the name of the device later on etc. Note that liblxc will
currently not delete hotplugged network devices on container shutdown since it
won't have the ifindex of the container.

Relates to lxc/lxd#3920 .

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>