### PR TITLE
arguments: print "-devel" when LXC_DEVEL is true

### DIFF
--- a/src/lxc/arguments.c
+++ b/src/lxc/arguments.c
@@ -131,7 +131,7 @@ static void print_usage(const struct option longopts[],
 
 static void print_version()
 {
-	printf("%s\n", LXC_VERSION);
+	printf("%s%s\n", LXC_VERSION, LXC_DEVEL ? "-devel" : "");
 	exit(0);
 }
 


### PR DESCRIPTION
liblxc should inform users that they are using a devel version. This will have
liblxc print

    MAJOR.MINOR.PATCH-devel

if LXC_DEVEL is true and

    MAJOR.MINOR.PATCH

otherwise.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>