### PR TITLE
fix build failures on x32

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1453,7 +1453,7 @@ static int set_config_prlimit(const char *key, const char *value,
 {
 	struct lxc_list *iter;
 	struct rlimit limit;
-	unsigned long limit_value;
+	rlim_t limit_value;
 	struct lxc_list *limlist = NULL;
 	struct lxc_limit *limelem = NULL;
 

--- a/src/lxc/confile_legacy.c
+++ b/src/lxc/confile_legacy.c
@@ -1081,7 +1081,7 @@ extern int set_config_limit(const char *key, const char *value,
 {
 	struct lxc_list *iter;
 	struct rlimit limit;
-	unsigned long limit_value;
+	rlim_t limit_value;
 	struct lxc_list *limlist = NULL;
 	struct lxc_limit *limelem = NULL;
 

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -672,7 +672,7 @@ int lxc_get_conf_int(struct lxc_conf *c, char *retv, int inlen, int v)
 	return snprintf(retv, inlen, "%d", v);
 }
 
-bool parse_limit_value(const char **value, unsigned long *res)
+bool parse_limit_value(const char **value, rlim_t *res)
 {
 	char *endptr = NULL;
 
@@ -683,7 +683,7 @@ bool parse_limit_value(const char **value, unsigned long *res)
 	}
 
 	errno = 0;
-	*res = strtoul(*value, &endptr, 10);
+	*res = strtoull(*value, &endptr, 10);
 	if (errno || !endptr)
 		return false;
 	*value = endptr;

--- a/src/lxc/confile_utils.h
+++ b/src/lxc/confile_utils.h
@@ -84,5 +84,5 @@ extern void update_hwaddr(const char *line);
 extern bool new_hwaddr(char *hwaddr);
 extern int lxc_get_conf_str(char *retv, int inlen, const char *value);
 extern int lxc_get_conf_int(struct lxc_conf *c, char *retv, int inlen, int v);
-extern bool parse_limit_value(const char **value, unsigned long *res);
+extern bool parse_limit_value(const char **value, rlim_t *res);
 #endif /* __LXC_CONFILE_UTILS_H */

--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -222,7 +222,7 @@ int lxc_unix_epoch_to_utc(char *buf, size_t bufsize, const struct timespec *time
 	seconds = (time->tv_sec - d_in_s - h_in_s - (minutes * 60));
 
 	/* Make string from nanoseconds. */
-	ret = snprintf(nanosec, LXC_NUMSTRLEN64, "%ld", time->tv_nsec);
+	ret = snprintf(nanosec, LXC_NUMSTRLEN64, "%"PRId64, (int64_t)time->tv_nsec);
 	if (ret < 0 || ret >= LXC_NUMSTRLEN64)
 		return -1;
 


### PR DESCRIPTION
There's two new build failures on x32, both due to assumption that some type is identical to ｢long｣.