### PR TITLE
Change locale "en-US.UTF-8" to "en_US.UTF-8"

### DIFF
--- a/templates/lxc-archlinux.in
+++ b/templates/lxc-archlinux.in
@@ -41,7 +41,7 @@ export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
 # defaults
 arch=$(uname -m)
 default_path="@LXCPATH@"
-default_locale="en-US.UTF-8"
+default_locale="en_US.UTF-8"
 pacman_config="/etc/pacman.conf"
 common_config="@LXCTEMPLATECONFIG@/common.conf"
 shared_config="@LXCTEMPLATECONFIG@/archlinux.common.conf"


### PR DESCRIPTION
This template would always add "en-US.UTF-8" to the end of the container's locale.gen, which in turn confused locale-gen.