### PR TITLE
ringbuffer: implement efficient and performant ringbuffer

### DIFF
--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -116,6 +116,7 @@ liblxc_la_SOURCES = \
 	log.c log.h \
 	attach.c attach.h \
 	criu.c criu.h \
+	ringbuf.c ringbuf.h \
 	\
 	network.c network.h \
 	nl.c nl.h \

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -68,10 +68,6 @@
 #include <../include/openpty.h>
 #endif
 
-#ifdef HAVE_LINUX_MEMFD_H
-#include <linux/memfd.h>
-#endif
-
 #include "af_unix.h"
 #include "caps.h"       /* for lxc_caps_last_cap() */
 #include "cgroup.h"
@@ -179,59 +175,6 @@ static int sethostname(const char * name, size_t len)
 
 #ifndef MS_LAZYTIME
 #define MS_LAZYTIME (1<<25)
-#endif
-
-/* memfd_create() */
-#ifndef MFD_CLOEXEC
-#define MFD_CLOEXEC 0x0001U
-#endif
-
-#ifndef MFD_ALLOW_SEALING
-#define MFD_ALLOW_SEALING 0x0002U
-#endif
-
-#ifndef HAVE_MEMFD_CREATE
-static int memfd_create(const char *name, unsigned int flags) {
-	#ifndef __NR_memfd_create
-		#if defined __i386__
-			#define __NR_memfd_create 356
-		#elif defined __x86_64__
-			#define __NR_memfd_create 319
-		#elif defined __arm__
-			#define __NR_memfd_create 385
-		#elif defined __aarch64__
-			#define __NR_memfd_create 279
-		#elif defined __s390__
-			#define __NR_memfd_create 350
-		#elif defined __powerpc__
-			#define __NR_memfd_create 360
-		#elif defined __sparc__
-			#define __NR_memfd_create 348
-		#elif defined __blackfin__
-			#define __NR_memfd_create 390
-		#elif defined __ia64__
-			#define __NR_memfd_create 1340
-		#elif defined _MIPS_SIM
-			#if _MIPS_SIM == _MIPS_SIM_ABI32
-				#define __NR_memfd_create 4354
-			#endif
-			#if _MIPS_SIM == _MIPS_SIM_NABI32
-				#define __NR_memfd_create 6318
-			#endif
-			#if _MIPS_SIM == _MIPS_SIM_ABI64
-				#define __NR_memfd_create 5314
-			#endif
-		#endif
-	#endif
-	#ifdef __NR_memfd_create
-	return syscall(__NR_memfd_create, name, flags);
-	#else
-	errno = ENOSYS;
-	return -1;
-	#endif
-}
-#else
-extern int memfd_create(const char *name, unsigned int flags);
 #endif
 
 char *lxchook_names[NUM_LXC_HOOKS] = {"pre-start", "pre-mount", "mount",

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3079,7 +3079,7 @@ static bool verify_start_hooks(struct lxc_conf *conf)
 	return true;
 }
 
-int lxc_setup(struct lxc_handler *handler)
+int lxc_setup_child(struct lxc_handler *handler)
 {
 	int ret;
 	const char *name = handler->name;

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -36,6 +36,7 @@
 #include <stdbool.h>
 
 #include "list.h"
+#include "ringbuf.h"
 #include "start.h" /* for lxc_handler */
 
 #if HAVE_SCMP_FILTER_CTX
@@ -153,6 +154,7 @@ struct lxc_console {
 	struct termios *tios;
 	struct lxc_tty_state *tty_state;
 	uint64_t log_size;
+	struct lxc_ringbuf ringbuf;
 };
 
 /*
@@ -378,6 +380,7 @@ extern void lxc_clear_includes(struct lxc_conf *conf);
 extern int do_rootfs_setup(struct lxc_conf *conf, const char *name,
 			   const char *lxcpath);
 extern int lxc_setup_child(struct lxc_handler *handler);
+extern int lxc_setup_parent(struct lxc_handler *handler);
 extern int setup_resource_limits(struct lxc_list *limits, pid_t pid);
 extern int find_unmapped_nsid(struct lxc_conf *conf, enum idtype idtype);
 extern int mapped_hostid(unsigned id, struct lxc_conf *conf,

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -152,6 +152,7 @@ struct lxc_console {
 	char name[MAXPATHLEN];
 	struct termios *tios;
 	struct lxc_tty_state *tty_state;
+	uint64_t log_size;
 };
 
 /*

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -377,7 +377,7 @@ extern int lxc_delete_autodev(struct lxc_handler *handler);
 extern void lxc_clear_includes(struct lxc_conf *conf);
 extern int do_rootfs_setup(struct lxc_conf *conf, const char *name,
 			   const char *lxcpath);
-extern int lxc_setup(struct lxc_handler *handler);
+extern int lxc_setup_child(struct lxc_handler *handler);
 extern int setup_resource_limits(struct lxc_list *limits, pid_t pid);
 extern int find_unmapped_nsid(struct lxc_conf *conf, enum idtype idtype);
 extern int mapped_hostid(unsigned id, struct lxc_conf *conf,

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -672,6 +672,16 @@ int lxc_get_conf_int(struct lxc_conf *c, char *retv, int inlen, int v)
 	return snprintf(retv, inlen, "%d", v);
 }
 
+int lxc_get_conf_uint64(struct lxc_conf *c, char *retv, int inlen, uint64_t v)
+{
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	return snprintf(retv, inlen, "%"PRIu64, v);
+}
+
 bool parse_limit_value(const char **value, rlim_t *res)
 {
 	char *endptr = NULL;

--- a/src/lxc/confile_utils.h
+++ b/src/lxc/confile_utils.h
@@ -84,5 +84,7 @@ extern void update_hwaddr(const char *line);
 extern bool new_hwaddr(char *hwaddr);
 extern int lxc_get_conf_str(char *retv, int inlen, const char *value);
 extern int lxc_get_conf_int(struct lxc_conf *c, char *retv, int inlen, int v);
+extern int lxc_get_conf_uint64(struct lxc_conf *c, char *retv, int inlen, uint64_t v);
 extern bool parse_limit_value(const char **value, rlim_t *res);
+
 #endif /* __LXC_CONFILE_UTILS_H */

--- a/src/lxc/namespace.c
+++ b/src/lxc/namespace.c
@@ -21,17 +21,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <unistd.h>
 #include <alloca.h>
 #include <errno.h>
-#include <signal.h>
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <signal.h>
+#include <unistd.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
-#include "namespace.h"
 #include "log.h"
+#include "namespace.h"
+#include "utils.h"
 
 lxc_log_define(lxc_namespace, lxc);
 
@@ -53,7 +54,7 @@ pid_t lxc_clone(int (*fn)(void *), void *arg, int flags)
 		.arg = arg,
 	};
 
-	size_t stack_size = sysconf(_SC_PAGESIZE);
+	size_t stack_size = lxc_getpagesize();
 	void *stack = alloca(stack_size);
 	pid_t ret;
 

--- a/src/lxc/ringbuf.c
+++ b/src/lxc/ringbuf.c
@@ -1,0 +1,145 @@
+/* liblxcapi
+ *
+ * Copyright © 2017 Christian Brauner <christian.brauner@ubuntu.com>.
+ * Copyright © 2017 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#define _GNU_SOURCE
+#define __STDC_FORMAT_MACROS
+#include <errno.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#include "ringbuf.h"
+#include "utils.h"
+
+int lxc_ringbuf_create(struct lxc_ringbuf *buf, size_t size)
+{
+	char *tmp;
+	int ret;
+	int memfd = -1;
+
+	buf->size = size;
+	buf->r_off = 0;
+	buf->w_off = 0;
+
+	/* verify that we are at least given the multiple of a page size */
+	if (buf->size % lxc_getpagesize())
+		return -EINVAL;
+
+	buf->addr = mmap(NULL, buf->size * 2, PROT_NONE,
+			 MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	if (buf->addr == MAP_FAILED)
+		return -EINVAL;
+
+	memfd = memfd_create(".lxc_ringbuf", MFD_CLOEXEC);
+	if (memfd < 0) {
+		if (errno != ENOSYS)
+			goto on_error;
+
+		memfd = lxc_make_tmpfile((char *){P_tmpdir"/.lxc_ringbuf_XXXXXX"}, true);
+	}
+	if (memfd < 0)
+		goto on_error;
+
+	ret = ftruncate(memfd, buf->size);
+	if (ret < 0)
+		goto on_error;
+
+	tmp = mmap(buf->addr, buf->size, PROT_READ | PROT_WRITE,
+		   MAP_FIXED | MAP_SHARED, memfd, 0);
+	if (tmp == MAP_FAILED || tmp != buf->addr)
+		goto on_error;
+
+	tmp = mmap(buf->addr + buf->size, buf->size, PROT_READ | PROT_WRITE,
+		   MAP_FIXED | MAP_SHARED, memfd, 0);
+	if (tmp == MAP_FAILED || tmp != (buf->addr + buf->size))
+		goto on_error;
+
+	close(memfd);
+
+	return 0;
+
+on_error:
+	lxc_ringbuf_release(buf);
+	if (memfd >= 0)
+		close(memfd);
+	return -1;
+}
+
+void lxc_ringbuf_move_read_addr(struct lxc_ringbuf *buf, size_t len)
+{
+	buf->r_off += len;
+
+	if (buf->r_off < buf->size)
+		return;
+
+	/* wrap around */
+	buf->r_off -= buf->size;
+	buf->w_off -= buf->size;
+}
+
+/**
+ * lxc_ringbuf_write - write a message to the ringbuffer
+ * - The size of the message should never be greater than the size of the whole
+ *   ringbuffer.
+ * - The write method will always succeed i.e. it will always advance the r_off
+ *   if it detects that there's not enough space available to write the
+ *   message.
+ */
+int lxc_ringbuf_write(struct lxc_ringbuf *buf, const char *msg, size_t len)
+{
+	char *w_addr;
+	uint64_t free;
+
+	/* sanity check: a write should never exceed the ringbuffer's total size */
+	if (len > buf->size)
+		return -EFBIG;
+
+	free = lxc_ringbuf_free(buf);
+
+	/* not enough space left so advance read address */
+	if (len > free)
+		lxc_ringbuf_move_read_addr(buf, len);
+	w_addr = lxc_ringbuf_get_write_addr(buf);
+	memcpy(w_addr, msg, len);
+	lxc_ringbuf_move_write_addr(buf, len);
+	return 0;
+}
+
+int lxc_ringbuf_read(struct lxc_ringbuf *buf, char *out, size_t *len)
+{
+	uint64_t used;
+
+	/* there's nothing to read */
+	if (buf->r_off == buf->w_off)
+		return -ENODATA;
+
+	/* read maximum amount available */
+	used = lxc_ringbuf_used(buf);
+	if (used < *len)
+		*len = used;
+
+	/* copy data to reader but don't advance addr */
+	memcpy(out, lxc_ringbuf_get_read_addr(buf), *len);
+	out[*len - 1] = '\0';
+	return 0;
+}

--- a/src/lxc/ringbuf.h
+++ b/src/lxc/ringbuf.h
@@ -1,0 +1,90 @@
+/* liblxcapi
+ *
+ * Copyright © 2017 Christian Brauner <christian.brauner@ubuntu.com>.
+ * Copyright © 2017 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __LXC_RINGBUF_H
+#define __LXC_RINGBUF_H
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <sys/mman.h>
+
+/**
+ * lxc_ringbuf - Implements a simple and efficient memory mapped ringbuffer.
+ * - The "addr" field of struct lxc_ringbuf is considered immutable. Instead the
+ *   read and write offsets r_off and w_off are used to calculate the current
+ *   read and write addresses. There should never be a need to use any of those
+ *   fields directly. Instead use the appropriate helpers below.
+ * - Callers are expected to synchronize read and write accesses to the
+ *   ringbuffer.
+ */
+struct lxc_ringbuf {
+	char *addr; /* start address of the ringbuffer */
+	uint64_t size; /* total size of the ringbuffer in bytes */
+	uint64_t r_off; /* read offset */
+	uint64_t w_off; /* write offset */
+};
+
+/**
+ * lxc_ringbuf_create - Initialize a new ringbuffer.
+ *
+ * @param[in] size	Size of the new ringbuffer as a power of 2.
+ */
+extern int lxc_ringbuf_create(struct lxc_ringbuf *buf, size_t size);
+extern void lxc_ringbuf_move_read_addr(struct lxc_ringbuf *buf, size_t len);
+extern int lxc_ringbuf_write(struct lxc_ringbuf *buf, const char *msg, size_t len);
+extern int lxc_ringbuf_read(struct lxc_ringbuf *buf, char *out, size_t *len);
+
+static inline void lxc_ringbuf_release(struct lxc_ringbuf *buf)
+{
+	munmap(buf->addr, buf->size * 2);
+}
+
+static inline void lxc_ringbuf_clear(struct lxc_ringbuf *buf)
+{
+	buf->r_off = 0;
+	buf->w_off = 0;
+}
+
+static inline uint64_t lxc_ringbuf_used(struct lxc_ringbuf *buf)
+{
+	return buf->w_off - buf->r_off;
+}
+
+static inline uint64_t lxc_ringbuf_free(struct lxc_ringbuf *buf)
+{
+	return buf->size - lxc_ringbuf_used(buf);
+}
+
+static inline char *lxc_ringbuf_get_read_addr(struct lxc_ringbuf *buf)
+{
+	return buf->addr + buf->r_off;
+}
+
+static inline char *lxc_ringbuf_get_write_addr(struct lxc_ringbuf *buf)
+{
+	return buf->addr + buf->w_off;
+}
+
+static inline void lxc_ringbuf_move_write_addr(struct lxc_ringbuf *buf, size_t len)
+{
+	buf->w_off += len;
+}
+
+#endif /* __LXC_RINGBUF_H */

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1254,6 +1254,11 @@ static int lxc_spawn(struct lxc_handler *handler)
 		 */
 		flags &= ~CLONE_NEWNET;
 	}
+
+	ret = lxc_setup_parent(handler);
+	if (ret < 0)
+		goto out_delete_net;
+
 	handler->pid = lxc_clone(do_start, handler, flags);
 	if (handler->pid < 0) {
 		SYSERROR("Failed to clone a new set of namespaces.");

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -937,7 +937,7 @@ static int do_start(void *data)
 	}
 
 	/* Setup the container, ip, names, utsname, ... */
-	ret = lxc_setup(handler);
+	ret = lxc_setup_child(handler);
 	close(handler->data_sock[0]);
 	close(handler->data_sock[1]);
 	if (ret < 0) {

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -2359,3 +2359,14 @@ int lxc_make_tmpfile(char *template, bool rm)
 
 	return fd;
 }
+
+uint64_t lxc_getpagesize(void)
+{
+	int64_t pgsz;
+
+	pgsz = sysconf(_SC_PAGESIZE);
+	if (pgsz <= 0)
+		pgsz = 1 << 12;
+
+	return pgsz;
+}

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -2339,3 +2339,23 @@ bool lxc_nic_exists(char *nic)
 
 	return true;
 }
+
+int lxc_make_tmpfile(char *template, bool rm)
+{
+	int fd, ret;
+
+	fd = mkstemp(template);
+	if (fd < 0)
+		return -1;
+
+	if (!rm)
+		return fd;
+
+	ret = unlink(template);
+	if (ret < 0) {
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -2457,3 +2457,21 @@ int parse_byte_size_string(const char *s, int64_t *converted)
 	*converted = overflow;
 	return 0;
 }
+
+uint64_t lxc_find_next_power2(uint64_t n)
+{
+	/* 0 is not valid input. We return 0 to the caller since 0 is not a
+	 * valid power of two.
+	 */
+	if (n == 0)
+		return 0;
+
+	if (!(n & (n - 1)))
+		return n;
+
+	while (n & (n - 1))
+		n = n & (n - 1);
+
+	n = n << 1;
+	return n;
+}

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -47,6 +47,7 @@
 #include "log.h"
 #include "lxclock.h"
 #include "namespace.h"
+#include "parse.h"
 #include "utils.h"
 
 #ifndef O_PATH
@@ -2389,4 +2390,70 @@ uint64_t lxc_getpagesize(void)
 		pgsz = 1 << 12;
 
 	return pgsz;
+}
+
+int parse_byte_size_string(const char *s, int64_t *converted)
+{
+	int ret, suffix_len;
+	long long int conv;
+	int64_t mltpl, overflow;
+	char *end;
+	char dup[LXC_NUMSTRLEN64 + 2];
+	char suffix[3];
+
+	if (!s || !strcmp(s, ""))
+		return -EINVAL;
+
+	end = stpncpy(dup, s, sizeof(dup));
+	if (*end != '\0')
+		return -EINVAL;
+
+	if (isdigit(*(end - 1)))
+		suffix_len = 0;
+	else if (isalpha(*(end - 1)))
+		suffix_len = 1;
+	else
+		return -EINVAL;
+
+	if ((end - 2) == dup && !isdigit(*(end - 2)))
+		return -EINVAL;
+
+	if (isalpha(*(end - 2))) {
+		if (suffix_len == 1)
+			suffix_len++;
+		else
+			return -EINVAL;
+	}
+
+	if (suffix_len > 0) {
+		memcpy(suffix, end - suffix_len, suffix_len);
+		*(suffix + suffix_len) = '\0';
+		*(end - suffix_len) = '\0';
+	}
+	dup[lxc_char_right_gc(dup, strlen(dup))] = '\0';
+
+	ret = lxc_safe_long_long(dup, &conv);
+	if (ret < 0)
+		return -ret;
+
+	if (suffix_len != 2) {
+		*converted = conv;
+		return 0;
+	}
+
+	if (!strcmp(suffix, "kB"))
+		mltpl = 1024;
+	else if (!strcmp(suffix, "MB"))
+		mltpl = 1024 * 1024;
+	else if (!strcmp(suffix, "GB"))
+		mltpl = 1024 * 1024 * 1024;
+	else
+		return -EINVAL;
+
+	overflow = conv * mltpl;
+	if (conv != 0 && (overflow / conv) != mltpl)
+		return -ERANGE;
+
+	*converted = overflow;
+	return 0;
 }

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -2003,6 +2003,26 @@ int lxc_safe_long(const char *numstr, long int *converted)
 	return 0;
 }
 
+int lxc_safe_long_long(const char *numstr, long long int *converted)
+{
+	char *err = NULL;
+	signed long long int sli;
+
+	errno = 0;
+	sli = strtoll(numstr, &err, 0);
+	if (errno == ERANGE && (sli == LLONG_MAX || sli == LLONG_MIN))
+		return -ERANGE;
+
+	if (errno != 0 && sli == 0)
+		return -EINVAL;
+
+	if (err == numstr || *err != '\0')
+		return -EINVAL;
+
+	*converted = sli;
+	return 0;
+}
+
 int lxc_switch_uid_gid(uid_t uid, gid_t gid)
 {
 	if (setgid(gid) < 0) {

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -467,5 +467,6 @@ extern bool has_fs_type(const char *path, fs_type_magic magic_val);
 extern bool is_fs_type(const struct statfs *fs, fs_type_magic magic_val);
 extern bool lxc_nic_exists(char *nic);
 extern int lxc_make_tmpfile(char *template, bool rm);
+extern uint64_t lxc_getpagesize(void);
 
 #endif /* __LXC_UTILS_H */

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -241,6 +241,11 @@ static inline int memfd_create(const char *name, unsigned int flags) {
 extern int memfd_create(const char *name, unsigned int flags);
 #endif
 
+static inline int lxc_set_cloexec(int fd)
+{
+	return fcntl(fd, F_SETFD, FD_CLOEXEC);
+}
+
 /* Struct to carry child pid from lxc_popen() to lxc_pclose().
  * Not an opaque struct to allow direct access to the underlying FILE *
  * (i.e., struct lxc_popen_FILE *file; fgets(buf, sizeof(buf), file->f))

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -472,4 +472,14 @@ extern bool lxc_nic_exists(char *nic);
 extern int lxc_make_tmpfile(char *template, bool rm);
 extern uint64_t lxc_getpagesize(void);
 
+/* If n is not a power of 2 this function will return the next power of 2
+ * greater than that number. Note that this function always returns the *next*
+ * power of 2 *greater* that number not the *nearest*. For example, passing 1025
+ * as argument this function will return 2048 although the closest power of 2
+ * would be 1024.
+ * If the caller passes in 0 they will receive 0 in return since this is invalid
+ * input and 0 is not a power of 2.
+ */
+extern uint64_t lxc_find_next_power2(uint64_t n);
+
 #endif /* __LXC_UTILS_H */

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -466,5 +466,6 @@ typedef __typeof__(((struct statfs *)NULL)->f_type) fs_type_magic;
 extern bool has_fs_type(const char *path, fs_type_magic magic_val);
 extern bool is_fs_type(const struct statfs *fs, fs_type_magic magic_val);
 extern bool lxc_nic_exists(char *nic);
+extern int lxc_make_tmpfile(char *template, bool rm);
 
 #endif /* __LXC_UTILS_H */

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -419,6 +419,7 @@ extern bool task_blocking_signal(pid_t pid, int signal);
 extern int lxc_safe_uint(const char *numstr, unsigned int *converted);
 extern int lxc_safe_int(const char *numstr, int *converted);
 extern int lxc_safe_long(const char *numstr, long int *converted);
+extern int lxc_safe_long_long(const char *numstr, long long int *converted);
 extern int lxc_safe_ulong(const char *numstr, unsigned long *converted);
 
 /* Switch to a new uid and gid. */

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -421,6 +421,8 @@ extern int lxc_safe_int(const char *numstr, int *converted);
 extern int lxc_safe_long(const char *numstr, long int *converted);
 extern int lxc_safe_long_long(const char *numstr, long long int *converted);
 extern int lxc_safe_ulong(const char *numstr, unsigned long *converted);
+/* Handles B, kb, MB, GB. Detects overflows and reports -ERANGE. */
+extern int parse_byte_size_string(const char *s, int64_t *converted);
 
 /* Switch to a new uid and gid. */
 extern int lxc_switch_uid_gid(uid_t uid, gid_t gid);

--- a/src/tests/lxc-test-utils.c
+++ b/src/tests/lxc-test-utils.c
@@ -380,6 +380,88 @@ void test_lxc_string_in_array(void)
 	lxc_test_assert_abort(lxc_string_in_array("XYZ", (const char *[]){"BERTA", "ARQWE(9", "C8Zhkd", "7U", "XYZ", "UOIZ9", "=)()", NULL}));
 }
 
+void test_parse_byte_size_string(void)
+{
+	int ret;
+	int64_t n;
+
+	ret = parse_byte_size_string("0", &n);
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+	if (n != 0)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1", &n);
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+	if (n != 1)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1 ", &n);
+	if (ret == 0)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1B", &n);
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+	if (n != 1)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1kB", &n);
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+	if (n != 1024)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1MB", &n);
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+	if (n != 1048576)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1GB", &n);
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+	if (n != 1073741824)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1TB", &n);
+	if (ret == 0)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1 B", &n);
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+	if (n != 1)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1 kB", &n);
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+	if (n != 1024)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1 MB", &n);
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+	if (n != 1048576)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1 GB", &n);
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+	if (n != 1073741824)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("1 TB", &n);
+	if (ret == 0)
+		exit(EXIT_FAILURE);
+
+	ret = parse_byte_size_string("asdf", &n);
+	if (ret == 0)
+		exit(EXIT_FAILURE);
+}
+
 int main(int argc, char *argv[])
 {
 	test_lxc_string_replace();
@@ -389,6 +471,7 @@ int main(int argc, char *argv[])
 	test_lxc_safe_uint();
 	test_lxc_safe_int();
 	test_lxc_safe_long();
+	test_parse_byte_size_string();
 
 	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
liblxc will use a ringbuffer implementation that employs mmap()ed memory.
Specifically, the ringbuffer will create an anonymous memory mapping twice the
requested size for the ringbuffer. Afterwards, an in-memory file the requested
size for the ringbuffer will be created. This in-memory file will then be
memory mapped twice into the previously established anonymous memory mapping
thereby effectively splitting the anoymous memory mapping in two halves of
equal size.  This will allow the ringbuffer to get rid of any complex boundary
and wrap-around calculation logic. Since the underlying physical memory is the
same in both halves of the memory mapping only a single memcpy() call for both
reads and writes from and to the ringbuffer is needed.

Design Notes:
- Since we're using MAP_FIXED memory mappings to map the same in-memory file
  twice into the anonymous memory mapping the kernel requires us to always
  operate on properly aligned pages. To guarantee proper page aligment the size
  of the ringbuffer must always be a muliple of the kernel's page size. This
  also implies that the minimum size of the ringbuffer must be at least equal to
  one page size. This additional requirement is reasonably unproblematic.
  First, any ringbuffer smaller than the size of a single page is very likely
  useless since the standard page size on linux is 4096 bytes.
- Because liblxc is not able to predict the output a user is going to produce
  (e.g. users could cat binary files onto the console) and because the
  ringbuffer is located in a hotpath and needs to be as performant as possible
  liblxc will not parse the buffer.

Use Case:
The ringbuffer is needed by liblxc in order to safely log the output of write
intensive callers that produce unpredictable output or unpredictable amounts of
output. The console output created by a booting system and the user is one of
those cases. Allowing a container to log the console's output to a file it
would be possible for a malicious user to fill up the host filesystem by
producing random ouput on the container's console if quota support is either
not enabled or not available for the underlying filesystem. Using a ringbuffer
is a reliable and secure way to ensure a fixed-size log.

Closes #1857.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>