### PR TITLE
lxc-debian: allow creating `testing` and `unstable`

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -770,7 +770,7 @@ fi
 
 current_release=$(wget "${MIRROR}/dists/stable/Release" -O - 2> /dev/null | head |awk '/^Codename: (.*)$/ { print $2; }')
 release=${release:-${current_release}}
-valid_releases=('wheezy' 'jessie' 'stretch' 'buster' 'sid')
+valid_releases=('wheezy' 'jessie' 'stretch' 'buster' 'testing' 'sid' 'unstable')
 if [[ ! "${valid_releases[*]}" =~ (^|[^[:alpha:]])$release([^[:alpha:]]|$) ]]; then
     echo "Invalid release ${release}, valid ones are: ${valid_releases[*]}"
     exit 1


### PR DESCRIPTION
Being able to create `testing` containers, regardless of what's the name
of the next stable, is useful in several contexts, included but not
limited to testing purposes. i.e. one won't need to explicitly switch to
`bullseye` once `buster` is released to be able to continue tracking
`testing`. While we are at it, let's also enable `unstable`, which is
exactly the same as `sid`, but there is no reason for not being able to.

Signed-off-by: Antonio Terceiro <terceiro@debian.org>