### PR TITLE
Call lxc_config_define_load from lxc_execute again

### DIFF
--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -168,8 +168,11 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (lxc_config_define_load(&defines, c->lxc_conf))
+	ret = lxc_config_define_load(&defines, c->lxc_conf);
+	if (ret) {
+		lxc_container_put(c);
 		exit(EXIT_FAILURE);
+	}
 
 	if (my_args.uid)
 		c->lxc_conf->init_uid = my_args.uid;

--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -168,6 +168,9 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	if (lxc_config_define_load(&defines, c->lxc_conf))
+		exit(EXIT_FAILURE);
+
 	if (my_args.uid)
 		c->lxc_conf->init_uid = my_args.uid;
 


### PR DESCRIPTION
At some point, `lxc-execute` lost its call to `lxc_config_define_load` - this means it accepted configuration parameters on the command-line via `-s` but didn't actually do anything with them. This puts the call back more-or-less where it was before.

Fixes https://github.com/lxc/lxc/issues/1878