### PR TITLE
Fixes for analysed code

### DIFF
--- a/src/lxc/cgroups/cgfs.c
+++ b/src/lxc/cgroups/cgfs.c
@@ -656,7 +656,7 @@ static struct cgroup_hierarchy *lxc_cgroup_find_hierarchy(struct cgroup_meta_dat
 		struct cgroup_hierarchy *h = meta_data->hierarchies[i];
 		if (!h)
 			continue;
-		if (h && lxc_string_in_array(subsystem, (const char **)h->subsystems))
+		if (lxc_string_in_array(subsystem, (const char **)h->subsystems))
 			return h;
 	}
 	return NULL;
@@ -1769,8 +1769,7 @@ lxc_cgroup_process_info_getx(const char *proc_pid_cgroup_str,
 
 out_error:
 	saved_errno = errno;
-	if (proc_pid_cgroup)
-		fclose(proc_pid_cgroup);
+	fclose(proc_pid_cgroup);
 	lxc_cgroup_process_info_free(result);
 	lxc_cgroup_process_info_free(entry);
 	free(line);

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4404,21 +4404,24 @@ static int do_lxcapi_migrate(struct lxc_container *c, unsigned int cmd,
 	case MIGRATE_PRE_DUMP:
 		if (!do_lxcapi_is_running(c)) {
 			ERROR("container is not running");
-			return false;
+			ret = false;
+			break;
 		}
 		ret = !__criu_pre_dump(c, valid_opts);
 		break;
 	case MIGRATE_DUMP:
 		if (!do_lxcapi_is_running(c)) {
 			ERROR("container is not running");
-			return false;
+			ret = false;
+			break;
 		}
 		ret = !__criu_dump(c, valid_opts);
 		break;
 	case MIGRATE_RESTORE:
 		if (do_lxcapi_is_running(c)) {
 			ERROR("container is already running");
-			return false;
+			ret = false;
+			break;
 		}
 		ret = !__criu_restore(c, valid_opts);
 		break;

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1001,10 +1001,8 @@ static int do_start(void *data)
 			goto out_warn_father;
 		}
 
-	if (devnull_fd >= 0) {
-		close(devnull_fd);
-		devnull_fd = -1;
-	}
+	close(devnull_fd);
+	devnull_fd = -1;
 
 	setsid();
 

--- a/src/lxc/storage/rsync.c
+++ b/src/lxc/storage/rsync.c
@@ -73,8 +73,10 @@ int lxc_rsync_exec(const char *src, const char *dest)
 		return -1;
 
 	ret = snprintf(s, l, "%s", src);
-	if (ret < 0 || (size_t)ret >= l)
+	if (ret < 0 || (size_t)ret >= l) {
+		free(s);
 		return -1;
+	}
 
 	s[l - 2] = '/';
 	s[l - 1] = '\0';


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warning, found using PVS-Studio:
**Fixed conditions**
lxc/src/lxc/cgroups/cgfs.c  659     warn    V560 A part of conditional expression is always true: h.
lxc/src/lxc/cgroups/cgfs.c  1772    warn    V547 Expression 'proc_pid_cgroup' is always true.
lxc/src/lxc/start.c 1004    warn    V547 Expression 'devnull_fd >= 0' is always true.
**Fixed possible memory leak**
lxc/src/lxc/storage/rsync.c	77	err	V773 The function was exited without releasing the 's' pointer. A memory leak is possible.
lxc/src/lxc/lxccontainer.c	4407	err	V773 The function was exited without releasing the 'valid_opts' pointer. A memory leak is possible.