### PR TITLE
cgroups: enable container without CAP_SYS_ADMIN

### DIFF
--- a/src/lxc/cgroups/cgfs.c
+++ b/src/lxc/cgroups/cgfs.c
@@ -1418,11 +1418,12 @@ static bool cgroupfs_mount_cgroup(void *hdata, const char *root, int type)
 	struct cgfs_data *cgfs_d;
 	struct cgroup_process_info *info, *base_info;
 	int r, saved_errno = 0;
+	struct lxc_handler *handler = hdata;
 
 	if (cgns_supported())
 		return true;
 
-	cgfs_d = hdata;
+	cgfs_d = handler->cgroup_data;
 	if (!cgfs_d)
 		return false;
 	base_info = cgfs_d->info;

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -815,7 +815,7 @@ static void add_controller(char **clist, char *mountpoint, char *base_cgroup)
 	new->fullcgpath = NULL;
 
 	/* record if this is the cgroup v2 hierarchy */
-	if (!strcmp(base_cgroup, "cgroup2"))
+	if (clist && !strcmp(*clist, "cgroup2"))
 		new->is_cgroup_v2 = true;
 	else
 		new->is_cgroup_v2 = false;

--- a/src/lxc/cgroups/cgroup.c
+++ b/src/lxc/cgroups/cgroup.c
@@ -166,7 +166,7 @@ bool cgroup_chown(struct lxc_handler *handler)
 bool cgroup_mount(const char *root, struct lxc_handler *handler, int type)
 {
 	if (ops)
-		return ops->mount_cgroup(handler->cgroup_data, root, type);
+		return ops->mount_cgroup(handler, root, type);
 
 	return false;
 }

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -210,9 +210,6 @@ __thread struct lxc_conf *current_config;
 struct lxc_conf *current_config;
 #endif
 
-/* Declare this here, since we don't want to reshuffle the whole file. */
-static int in_caplist(int cap, struct lxc_list *caps);
-
 static struct mount_opt mount_opt[] = {
 	{ "async",         1, MS_SYNCHRONOUS },
 	{ "atime",         1, MS_NOATIME     },

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -402,5 +402,6 @@ extern unsigned long add_required_remount_flags(const char *s, const char *d,
 						unsigned long flags);
 extern int run_script(const char *name, const char *section, const char *script,
 		      ...);
+extern int in_caplist(int cap, struct lxc_list *caps);
 
 #endif /* __LXC_CONF_H */


### PR DESCRIPTION
In case cgroup namespaces are supported but we do not have CAP_SYS_ADMIN we
need to mount cgroups for the container. This patch enables both privileged and
unprivileged containers without CAP_SYS_ADMIN.

Closes #1737.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>