### PR TITLE
attach: handle namespace inheritance

### DIFF
--- a/src/lxc/attach.h
+++ b/src/lxc/attach.h
@@ -24,8 +24,11 @@
 #ifndef __LXC_ATTACH_H
 #define __LXC_ATTACH_H
 
+#include <stdbool.h>
 #include <lxc/attach_options.h>
 #include <sys/types.h>
+
+#include "namespace.h"
 
 struct lxc_conf;
 
@@ -34,6 +37,8 @@ struct lxc_proc_context_info {
 	struct lxc_container *container;
 	signed long personality;
 	unsigned long long capability_mask;
+	int ns_inherited;
+	int ns_fd[LXC_NS_MAX];
 };
 
 extern int lxc_attach(const char *name, const char *lxcpath,


### PR DESCRIPTION
We need to have lxc_attach() distinguish between a caller specifying specific
namespaces to attach to and a caller not requesting specific namespaces. The
latter is taken by lxc_attach() to mean that all namespaces will be attached.
This also needs to include all inherited namespaces.

Closes #1890.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>