### PR TITLE
Fix compilation on toolchain without prlimit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -671,6 +671,10 @@ AC_CHECK_FUNCS([prlimit],
 	AM_CONDITIONAL(HAVE_PRLIMIT, true)
 	AC_DEFINE(HAVE_PRLIMIT,1,[Have prlimit]),
 	AM_CONDITIONAL(HAVE_PRLIMIT, false))
+AC_CHECK_FUNCS([prlimit64],
+	AM_CONDITIONAL(HAVE_PRLIMIT64, true)
+	AC_DEFINE(HAVE_PRLIMIT64,1,[Have prlimit64]),
+	AM_CONDITIONAL(HAVE_PRLIMIT64, false))
 
 # Check for some libraries
 AC_SEARCH_LIBS(sem_open, [rt pthread])

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -45,7 +45,10 @@ noinst_HEADERS += \
 	../include/ifaddrs.h \
 	../include/openpty.h \
 	../include/lxcmntent.h
+endif
+
 if !HAVE_PRLIMIT
+if HAVE_PRLIMIT64
 noinst_HEADERS += ../include/prlimit.h
 endif
 endif
@@ -143,7 +146,10 @@ liblxc_la_SOURCES += \
 	../include/ifaddrs.c ../include/ifaddrs.h \
 	../include/openpty.c ../include/openpty.h \
 	../include/lxcmntent.c ../include/lxcmntent.h
+endif
+
 if !HAVE_PRLIMIT
+if HAVE_PRLIMIT64
 liblxc_la_SOURCES += ../include/prlimit.c ../include/prlimit.h
 endif
 endif

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -97,11 +97,12 @@
 
 #if IS_BIONIC
 #include <../include/lxcmntent.h>
-#ifndef HAVE_PRLIMIT
-#include <../include/prlimit.h>
-#endif
 #else
 #include <mntent.h>
+#endif
+
+#if !defined(HAVE_PRLIMIT) && defined(HAVE_PRLIMIT64)
+#include <../include/prlimit.h>
 #endif
 
 lxc_log_define(lxc_conf, lxc);
@@ -2399,10 +2400,15 @@ int setup_resource_limits(struct lxc_list *limits, pid_t pid) {
 			return -1;
 		}
 
+#if HAVE_PRLIMIT || HAVE_PRLIMIT64
 		if (prlimit(pid, resid, &lim->limit, NULL) != 0) {
 			ERROR("failed to set limit %s: %s", lim->resource, strerror(errno));
 			return -1;
 		}
+#else
+		ERROR("Cannot set limit %s as prlimit is missing", lim->resource);
+		return -1;
+#endif
 	}
 	return 0;
 }


### PR DESCRIPTION
Some toolchains which are not bionic like uclibc does not support
prlimit or prlimit64. In this case, return an error.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>