### PR TITLE
lxc/start.c: Fix legacy PR_{G,S}ET_NO_NEW_PRIVS handling

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -52,15 +52,15 @@
 #include <sys/capability.h>
 #endif
 
-#ifndef HAVE_DECL_PR_CAPBSET_DROP
+#if !HAVE_DECL_PR_CAPBSET_DROP
 #define PR_CAPBSET_DROP 24
 #endif
 
-#ifndef HAVE_DECL_PR_SET_NO_NEW_PRIVS
+#if !HAVE_DECL_PR_SET_NO_NEW_PRIVS
 #define PR_SET_NO_NEW_PRIVS 38
 #endif
 
-#ifndef HAVE_DECL_PR_GET_NO_NEW_PRIVS
+#if !HAVE_DECL_PR_GET_NO_NEW_PRIVS
 #define PR_GET_NO_NEW_PRIVS 39
 #endif
 


### PR DESCRIPTION
The configure checks for these use AC_CHECK_DECLS, which define the symbol
to 0 if not available - So adjust the code to match.  From the autoconf
manual:

https://www.gnu.org/software/autoconf/manual/autoconf-2.65/html_node/Generic-Declarations.html)

For each of the symbols (comma-separated list), define HAVE_DECL_symbol (in
all capitals) to ‘1’ if symbol is declared, otherwise to ‘0’.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>