### PR TITLE
cgroups/cgfsng: adapt to new cgroup2 delegation

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1503,6 +1503,25 @@ static int chown_cgroup_wrapper(void *data)
 		if (chmod(fullpath, 0664) < 0)
 			WARN("Error chmoding %s: %s", path, strerror(errno));
 		free(fullpath);
+
+		if (!hierarchies[i]->is_cgroup_v2)
+			continue;
+
+		fullpath = must_make_path(path, "cgroup.subtree_control", NULL);
+		if (chown(fullpath, destuid, 0) < 0 && errno != ENOENT)
+			WARN("Failed chowning %s to %d: %s", fullpath, (int) destuid,
+			     strerror(errno));
+		if (chmod(fullpath, 0664) < 0)
+			WARN("Error chmoding %s: %s", path, strerror(errno));
+		free(fullpath);
+
+		fullpath = must_make_path(path, "cgroup.threads", NULL);
+		if (chown(fullpath, destuid, 0) < 0 && errno != ENOENT)
+			WARN("Failed chowning %s to %d: %s", fullpath, (int) destuid,
+			     strerror(errno));
+		if (chmod(fullpath, 0664) < 0)
+			WARN("Error chmoding %s: %s", path, strerror(errno));
+		free(fullpath);
 	}
 
 	return 0;


### PR DESCRIPTION
In order to enable proper unprivileged cgroup delegation on newer kernels we not
just need to delegate the "cgroup.procs" file but also "cgroup.threads". But
don't report an error in case it doesn't exist. Also delegate
"cgroup.subtree_control" to enable delegation of controllers to descendant
cgroups.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>