### PR TITLE
lxc-test-unpriv: fix the overlayfs mount error

### DIFF
--- a/src/tests/lxc-test-unpriv
+++ b/src/tests/lxc-test-unpriv
@@ -39,8 +39,8 @@ if modprobe -q overlayfs; then
 
         mount -t tmpfs none ${MOUNTDIR}
 
-        mkdir "${MOUNTDIR}/lowerdir" "${MOUNTDIR}/upperdir" "${MOUNTDIR}/overlayfs"
-        mount -t overlayfs -o lowerdir="${MOUNTDIR}/lowerdir",upperdir="${MOUNTDIR}/upperdir" none "${MOUNTDIR}/overlayfs"
+        mkdir ${MOUNTDIR}/{lowerdir,upperdir,workdir,overlayfs}
+        mount -t overlayfs -o lowerdir="${MOUNTDIR}/lowerdir",upperdir="${MOUNTDIR}/upperdir",workdir="${MOUNTDIR}/workdir" none "${MOUNTDIR}/overlayfs"
 
         CORRECT_LINK_TARGET="${MOUNTDIR}/overlayfs/dummy_file"
         exec 9> "${CORRECT_LINK_TARGET}"


### PR DESCRIPTION
This patch fixes the missing workdir issue for the overlayfs mount command in
the lxc-test-unpriv test.

Bug link: https://bugs.launchpad.net/bugs/1730915

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>