### PR TITLE
Add missing dependency libunistring in Slackware template

### DIFF
--- a/templates/lxc-slackware.in
+++ b/templates/lxc-slackware.in
@@ -565,6 +565,7 @@ gnupg
 grep
 gzip
 iputils
+libunistring
 logrotate
 mpfr
 net-tools


### PR DESCRIPTION
Hi,

I try to create a Slackware container in a Slackware64 14.2 current and find that wget depends on libunistring.

So I add libunistring to the package list.

Signed-off-by: Chia-Chun Hsu <a12321aabb@gmail.com>