### PR TITLE
console: report detach message on demand

### DIFF
--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -832,11 +832,14 @@ int lxc_console(struct lxc_container *c, int ttynum,
 		goto close_mainloop;
 	}
 
-	fprintf(stderr, "\n"
+	if (ts->escape >= 1) {
+		fprintf(stderr,
+			"\n"
 			"Connected to tty %1$d\n"
 			"Type <Ctrl+%2$c q> to exit the console, "
 			"<Ctrl+%2$c Ctrl+%2$c> to enter Ctrl+%2$c itself\n",
 			ttynum, 'a' + escape - 1);
+	}
 
 	if (istty) {
 		ret = lxc_setup_tios(stdinfd, &oldtios);


### PR DESCRIPTION
When users pass -1 there's there won't be an escape sequence to exit the
console so no need to print a misleading info message about how to detach.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>