### PR TITLE
lxccontainer: enable daemonized execute

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -842,18 +842,6 @@ static bool do_lxcapi_start(struct lxc_container *c, int useinit, char * const a
 	if (!handler)
 		return false;
 
-	if (useinit) {
-		TRACE("calling \"lxc_execute\"");
-		ret = lxc_execute(c->name, argv, 1, handler, c->config_path,
-				  daemonize);
-		c->error_num = ret;
-
-		if (ret != 0)
-			return false;
-
-		return true;
-	}
-
 	/* If no argv was passed in, use lxc.init_cmd if provided in the
 	 * configuration
 	 */
@@ -1033,7 +1021,10 @@ reboot:
 		goto on_error;
 	}
 
-	ret = lxc_start(c->name, argv, handler, c->config_path, daemonize);
+	if (useinit)
+		ret = lxc_execute(c->name, argv, 1, handler, c->config_path, daemonize);
+	else
+		ret = lxc_start(c->name, argv, handler, c->config_path, daemonize);
 	c->error_num = ret;
 
 	if (conf->reboot == 1) {

--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -49,6 +49,9 @@ static struct lxc_list defines;
 static int my_parser(struct lxc_arguments* args, int c, char* arg)
 {
 	switch (c) {
+	case 'd':
+		args->daemonize = 1;
+		break;
 	case 'f':
 		args->rcfile = arg;
 		break;
@@ -67,6 +70,7 @@ static int my_parser(struct lxc_arguments* args, int c, char* arg)
 }
 
 static const struct option my_longopts[] = {
+	{"daemon", no_argument, 0, 'd'},
 	{"rcfile", required_argument, 0, 'f'},
 	{"define", required_argument, 0, 's'},
 	{"uid", required_argument, 0, 'u'},
@@ -90,6 +94,7 @@ Options :\n\
   -g, --gid=GID        Execute COMMAND with GID inside the container\n",
 	.options  = my_longopts,
 	.parser   = my_parser,
+	.daemonize = 0,
 };
 
 static bool set_argv(struct lxc_conf *conf, struct lxc_arguments *args)
@@ -180,7 +185,7 @@ int main(int argc, char *argv[])
 	if (my_args.gid)
 		c->lxc_conf->init_gid = my_args.gid;
 
-	c->daemonize = false;
+	c->daemonize = my_args.daemonize == 1;
 	bret = c->start(c, 1, my_args.argv);
 	ret = c->error_num;
 	lxc_container_put(c);


### PR DESCRIPTION
This enables daemonized execute containers with our minimal init running as
pid one and the requested program running as second pid.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>