### PR TITLE
console: exit mainloop on SIGTERM

### DIFF
--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -371,7 +371,7 @@ err3:
 	lxc_mainloop_close(&descr);
 err2:
 	if (ts && ts->sigfd != -1)
-		lxc_console_sigwinch_fini(ts);
+		lxc_console_signal_fini(ts);
 err1:
 	lxc_console_delete(&conf->console);
 


### PR DESCRIPTION
This allows cleanly exiting a console session without control sequences.

Relates to lxc/lxd#4001 .

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>