### PR TITLE
Fix lxc_inherit_namespace function error

### DIFF
--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -759,8 +759,8 @@ int lxc_inherit_namespace(const char *lxcname_or_pid, const char *lxcpath,
 		if (!dup)
 			return -ENOMEM;
 
-		*lastslash = '\0';
-		pid = lxc_container_name_to_pid(lastslash, dup);
+		dup[lastslash - lxcname_or_pid] = '\0';
+		pid = lxc_container_name_to_pid(lastslash + 1, dup);
 		free(dup);
 	} else {
 		pid = lxc_container_name_to_pid(lxcname_or_pid, lxcpath);


### PR DESCRIPTION
Steps to reproduce the problem：
1. Modify the config of container `test1 `as follow

```
$ cat /var/lib/lcrd/lcr/test1/config
......
lxc.namespace.pid = /var/lib/lcrd/lcr/test
.....
```
2. Start the container `test1`, it will be failed to inherit pid namespace  of `test`

Signed-off-by: LiFeng <lifeng68@huawei.com>