### PR TITLE
lxc_init: set the control terminal in the child session

### DIFF
--- a/src/lxc/tools/lxc_init.c
+++ b/src/lxc/tools/lxc_init.c
@@ -201,6 +201,9 @@ int main(int argc, char *argv[])
 		if (sid < 0)
 			DEBUG("Failed to make child session leader");
 
+                if (ioctl(STDIN_FILENO, TIOCSCTTY, 0) < 0)
+                        DEBUG("Failed to set controlling terminal");
+
 		NOTICE("Exec'ing \"%s\"", my_args.argv[0]);
 
 		ret = execvp(my_args.argv[0], my_args.argv);


### PR DESCRIPTION
Additionally, the console seems to be [execute only (0111)](https://github.com/lxc/lxc/blob/master/src/lxc/conf.c#L1536) not sure if it's intended or not.