### PR TITLE
confile_utils: fix overlapping strncpy

### DIFF
--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -567,7 +567,8 @@ bool lxc_config_net_hwaddr(const char *line)
 			return false;
 		}
 		/* strlen("hwaddr") = 6 */
-		strncpy(copy + 8, p + 1, 6);
+		if (strlen(p + 1) >= 6)
+			 memmove(copy + 8, p + 1, 6);
 		copy[8 + 6] = '\0';
 	}
 	if (strncmp(copy, "lxc.net.hwaddr", 14) == 0) {
@@ -591,7 +592,8 @@ bool lxc_config_net_hwaddr(const char *line)
 			return false;
 		}
 		/* strlen("hwaddr") = 6 */
-		strncpy(copy + 12, p + 1, 6);
+		if (strlen(p + 1) >= 6)
+			memmove(copy + 12, p + 1, 6);
 		copy[12 + 6] = '\0';
 	}
 	if (strncmp(copy, "lxc.network.hwaddr", 18) == 0) {


### PR DESCRIPTION
In the case of "lxc.net.0.type", the pointers passed to strncpy were
only 2 elements apart, resulting in undefined behavior.

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>