### PR TITLE
lxc-test-unpriv: check user existence before removing it

### DIFF
--- a/src/tests/lxc-test-unpriv
+++ b/src/tests/lxc-test-unpriv
@@ -105,7 +105,7 @@ fi
 trap cleanup EXIT SIGHUP SIGINT SIGTERM
 set -eu
 
-deluser $TUSER && rm -Rf $HDIR || true
+id $TUSER &> /dev/null && deluser -q --remove-home $TUSER
 useradd $TUSER
 
 mkdir -p $HDIR


### PR DESCRIPTION
Check the test user (lxcunpriv) before calling deluser command,
otherwise it will print unnecessary error message:
/usr/sbin/deluser: The user 'lxcunpriv' does not exist.

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>