### PR TITLE
Added allowrunning command line option for snapshotting running containers

### DIFF
--- a/doc/lxc-copy.sgml.in
+++ b/doc/lxc-copy.sgml.in
@@ -55,6 +55,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <arg choice="opt">-p, --newpath <replaceable>newpath</replaceable></arg>
       <arg choice="opt">-B, --backingstorage <replaceable>backingstorage</replaceable></arg>
       <arg choice="opt">-s, --snapshot</arg>
+      <arg choice="opt">-a, --allowrunning</arg>
       <arg choice="opt">-K, --keepname</arg>
       <arg choice="opt">-D, --keepdata</arg>
       <arg choice="opt">-M, --keepmac</arg>
@@ -70,6 +71,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <arg choice="req">-e, --ephemeral</arg>
       <arg choice="opt">-B, --backingstorage <replaceable>backingstorage</replaceable></arg>
       <arg choice="opt">-s, --snapshot</arg>
+      <arg choice="opt">-a, --allowrunning</arg>
       <arg choice="opt">-K, --keepname</arg>
       <arg choice="opt">-D, --keepdata</arg>
       <arg choice="opt">-M, --keepmac</arg>
@@ -205,6 +207,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             <para> Create a snapshot of the original container. The backing
             storage for the copy must support snapshots. This currently includes
             btrfs, lvm, overlay, and zfs. </para>
+	   </listitem>
+	  </varlistentry>
+
+	  <varlistentry>
+	    <term> <option>-a,--allowrunning </option> </term>
+	   <listitem>
+	    <para> Allow the creation of a Snapshot of an already running container.
+	    This may cause data corruption or data loss depending on the used
+	    filesystem and applications. Use with care. </para>
 	   </listitem>
 	  </varlistentry>
 

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3799,9 +3799,8 @@ static struct lxc_container *do_lxcapi_clone(struct lxc_container *c, const char
 
 	if (container_mem_lock(c))
 		return NULL;
-
-	if (!is_stopped(c)) {
-		ERROR("error: Original container (%s) is running", c->name);
+	if (!is_stopped(c) && !(flags & LXC_CLONE_ALLOW_RUNNING)) {
+		ERROR("error: Original container (%s) is running. Use --allowrunning if you want to force a snapshot of the running container.", c->name);
 		goto out;
 	}
 

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -41,6 +41,7 @@ extern "C" {
 #define LXC_CLONE_KEEPBDEVTYPE    (1 << 3) /*!< Use the same bdev type */
 #define LXC_CLONE_MAYBE_SNAPSHOT  (1 << 4) /*!< Snapshot only if bdev supports it, else copy */
 #define LXC_CLONE_MAXFLAGS        (1 << 5) /*!< Number of \c LXC_CLONE_* flags */
+#define LXC_CLONE_ALLOW_RUNNING   (1 << 6) /*!< allow snapshot creation even if source container is running */
 #define LXC_CREATE_QUIET          (1 << 0) /*!< Redirect \c stdin to \c /dev/zero and \c stdout and \c stderr to \c /dev/null */
 #define LXC_CREATE_MAXFLAGS       (1 << 1) /*!< Number of \c LXC_CREATE* flags */
 #define LXC_MOUNT_API_V1		   1

--- a/src/lxc/tools/arguments.h
+++ b/src/lxc/tools/arguments.h
@@ -122,6 +122,7 @@ struct lxc_arguments {
 	int keepdata;
 	int keepname;
 	int keepmac;
+	int allowrunning;
 
 	/* lxc-ls */
 	char *ls_fancy_format;

--- a/src/lxc/tools/lxc_copy.c
+++ b/src/lxc/tools/lxc_copy.c
@@ -73,6 +73,7 @@ static const struct option my_longopts[] = {
 	{ "newpath", required_argument, 0, 'p'},
 	{ "rename", no_argument, 0, 'R'},
 	{ "snapshot", no_argument, 0, 's'},
+	{ "allowrunning", no_argument, 0, 'a'},
 	{ "foreground", no_argument, 0, 'F'},
 	{ "daemon", no_argument, 0, 'd'},
 	{ "ephemeral", no_argument, 0, 'e'},
@@ -108,6 +109,7 @@ Options :\n\
   -p, --newpath=NEWPATH     NEWPATH for the container to be stored\n\
   -R, --rename              rename container\n\
   -s, --snapshot            create snapshot instead of clone\n\
+  -a, --allowrunning        allow snapshot creation even if source container is running\n\
   -F, --foreground          start with current tty attached to /dev/console\n\
   -d, --daemon              daemonize the container (default)\n\
   -e, --ephemeral           start ephemeral container\n\
@@ -195,7 +197,8 @@ int main(int argc, char *argv[])
 
 	if (my_args.task == SNAP || my_args.task == DESTROY)
 		flags |= LXC_CLONE_SNAPSHOT;
-
+	if (my_args.allowrunning)
+		flags |= LXC_CLONE_ALLOW_RUNNING;
 	if (my_args.keepname)
 		flags |= LXC_CLONE_KEEPNAME;
 
@@ -556,6 +559,9 @@ static int my_parser(struct lxc_arguments *args, int c, char *arg)
 		break;
 	case 's':
 		args->task = SNAP;
+		break;
+	case 'a':
+		args->allowrunning = 1;
 		break;
 	case 'F':
 		args->daemonize = 0;


### PR DESCRIPTION
Currently, LXC only allows to create new containers using a snapshot if the source container is shutdown.
While it is safer to do so, it is not required to shutdown the source container to get an working clone.

This is because creating a snapshot is much like an unexpected power outage; most Filesystems and databases are built from ground up to handle this case with minimum impact.

I have deployed LXC in a way that i have "live" containers that receive traffic and some sandbox/dev containers that are for testing with live data and environment. Using the --allowrunning option, i can reset and retest the sandboxes multiple times without downtime of the live containers.

i tested this against lxc-2.0 branch and have had no problems so far.