### PR TITLE
start.c: always handing uid and gid

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -776,6 +776,9 @@ static int do_start(void *data)
 	char path[PATH_MAX];
 	int devnull_fd = -1;
 	struct lxc_handler *handler = data;
+	bool have_cap_setgid;
+	uid_t new_uid;
+	gid_t new_gid;
 
 	if (sigprocmask(SIG_SETMASK, &handler->oldmask, NULL)) {
 		SYSERROR("Failed to set signal mask.");
@@ -1009,29 +1012,26 @@ static int do_start(void *data)
 	/* The container has been setup. We can now switch to an unprivileged
 	 * uid/gid.
 	 */
-	if (handler->conf->is_execute) {
-		bool have_cap_setgid;
-		uid_t new_uid = handler->conf->init_uid;
-		gid_t new_gid = handler->conf->init_gid;
+	new_uid = handler->conf->init_uid;
+	new_gid = handler->conf->init_gid;
 
-		/* If we are in a new user namespace we already dropped all
-		 * groups when we switched to root in the new user namespace
-		 * further above. Only drop groups if we can, so ensure that we
-		 * have necessary privilege.
-		 */
-		#if HAVE_LIBCAP
-		have_cap_setgid = lxc_proc_cap_is_set(CAP_SETGID, CAP_EFFECTIVE);
-		#else
-		have_cap_setgid = false;
-		#endif
-		if (lxc_list_empty(&handler->conf->id_map) && have_cap_setgid) {
-			if (lxc_setgroups(0, NULL) < 0)
-				goto out_warn_father;
-		}
-
-		if (lxc_switch_uid_gid(new_uid, new_gid) < 0)
+	/* If we are in a new user namespace we already dropped all
+	 * groups when we switched to root in the new user namespace
+	 * further above. Only drop groups if we can, so ensure that we
+	 * have necessary privilege.
+	 */
+	#if HAVE_LIBCAP
+	have_cap_setgid = lxc_proc_cap_is_set(CAP_SETGID, CAP_EFFECTIVE);
+	#else
+	have_cap_setgid = false;
+	#endif
+	if (lxc_list_empty(&handler->conf->id_map) && have_cap_setgid) {
+		if (lxc_setgroups(0, NULL) < 0)
 			goto out_warn_father;
 	}
+
+	if (lxc_switch_uid_gid(new_uid, new_gid) < 0)
+		goto out_warn_father;
 
 	/* After this call, we are in error because this ops should not return
 	 * as it execs.


### PR DESCRIPTION
Currently, when we configured `lxc.init_cmd=/bin/bash` and uid, gid which is not 0, running `lxc-start` will not execute `/bin/bash` with specified uid, gid, because we  ignore handing uid, gid in [do_start](https://github.com/lxc/lxc/blob/dc3de872519390f5c359586b9f07defb262bcf64/src/lxc/start.c#L1012).

Maybe lxc do not allow us to start a container without root permission since its default cmd is `/sbin/init`, I think remove this constraint is better for user to configure container.

Signed-off-by: Yifeng Tan <tanyifeng1@huawei.com>