### PR TITLE
lxc_helper.h: Avoid duplicated sethostname

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -122,19 +122,6 @@ static int pivot_root(const char * new_root, const char * put_old)
 extern int pivot_root(const char * new_root, const char * put_old);
 #endif
 
-/* Define sethostname() if missing from the C library */
-#ifndef HAVE_SETHOSTNAME
-static int sethostname(const char * name, size_t len)
-{
-#ifdef __NR_sethostname
-	return syscall(__NR_sethostname, name, len);
-#else
-	errno = ENOSYS;
-	return -1;
-#endif
-}
-#endif
-
 #ifndef MS_PRIVATE
 #define MS_PRIVATE (1<<18)
 #endif

--- a/src/lxc/tools/lxc_unshare.c
+++ b/src/lxc/tools/lxc_unshare.c
@@ -32,7 +32,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
-#include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -44,19 +43,6 @@
 #include "namespace.h"
 #include "network.h"
 #include "utils.h"
-
-/* Define sethostname() if missing from the C library */
-#ifndef HAVE_SETHOSTNAME
-static int sethostname(const char * name, size_t len)
-{
-#ifdef __NR_sethostname
-return syscall(__NR_sethostname, name, len);
-#else
-errno = ENOSYS;
-return -1;
-#endif
-}
-#endif
 
 lxc_log_define(lxc_unshare_ui, lxc);
 

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -120,6 +120,19 @@ static inline int setns(int fd, int nstype)
 }
 #endif
 
+/* Define sethostname() if missing from the C library */
+#ifndef HAVE_SETHOSTNAME
+static int sethostname(const char * name, size_t len)
+{
+#ifdef __NR_sethostname
+return syscall(__NR_sethostname, name, len);
+#else
+errno = ENOSYS;
+return -1;
+#endif
+}
+#endif
+
 /* Define unshare() if missing from the C library */
 #ifndef HAVE_UNSHARE
 static inline int unshare(int flags)


### PR DESCRIPTION
Create new lxc_helper.h header to hold the implementation of
sethostname, instead of duplicating code in conf.c and lxc_unshare.c

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>