### PR TITLE
Started to remove dependencies from /tools subfolder

### DIFF
--- a/src/lxc/tools/arguments.c
+++ b/src/lxc/tools/arguments.c
@@ -1,0 +1,295 @@
+/*
+ * lxc: linux Container library
+ *
+ * (C) Copyright IBM Corp. 2007, 2008
+ *
+ * Authors:
+ * Daniel Lezcano <daniel.lezcano at free.fr>
+ * Michel Normand <normand at fr.ibm.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <lxc/lxccontainer.h>
+
+#include "tools/arguments.h"
+#include "tools/utils.h"
+#include "version.h"
+
+
+static int build_shortopts(const struct option *a_options, char *a_shortopts,
+			   size_t a_size)
+{
+	size_t i = 0;
+	const struct option *opt;
+
+	if (!a_options || !a_shortopts || !a_size)
+		return -1;
+
+	for (opt = a_options; opt->name; opt++) {
+
+		if (!isascii(opt->val))
+			continue;
+
+		if (i < a_size)
+			a_shortopts[i++] = opt->val;
+		else
+			goto is2big;
+
+		if (opt->has_arg == no_argument)
+			continue;
+
+		if (i < a_size)
+			a_shortopts[i++] = ':';
+		else
+			goto is2big;
+
+		if (opt->has_arg == required_argument)
+			continue;
+
+		if (i < a_size)
+			a_shortopts[i++] = ':';
+		else
+			goto is2big;
+	}
+
+	if (i < a_size)
+		a_shortopts[i] = '\0';
+	else
+		goto is2big;
+
+	return 0;
+
+is2big:
+	errno = E2BIG;
+	return -1;
+}
+
+static void print_usage(const struct option longopts[],
+			const struct lxc_arguments *a_args)
+
+{
+	int i;
+	const struct option *opt;
+
+	fprintf(stderr, "Usage: %s ", a_args->progname);
+
+	for (opt = longopts, i = 1; opt->name; opt++, i++) {
+		int j;
+		char *uppername;
+
+		uppername = strdup(opt->name);
+		if (!uppername)
+			exit(-ENOMEM);
+
+		for (j = 0; uppername[j]; j++)
+			uppername[j] = toupper(uppername[j]);
+
+		fprintf(stderr, "[");
+
+		if (isprint(opt->val))
+			fprintf(stderr, "-%c|", opt->val);
+
+		fprintf(stderr, "--%s", opt->name);
+
+		if (opt->has_arg == required_argument)
+			fprintf(stderr, "=%s", uppername);
+
+		if (opt->has_arg == optional_argument)
+			fprintf(stderr, "[=%s]", uppername);
+
+		fprintf(stderr, "] ");
+
+		if (!(i % 4))
+			fprintf(stderr, "\n\t");
+
+		free(uppername);
+	}
+
+	fprintf(stderr, "\n");
+	exit(0);
+}
+
+static void print_version()
+{
+	printf("%s%s\n", LXC_VERSION, LXC_DEVEL ? "-devel" : "");
+	exit(0);
+}
+
+static void print_help(const struct lxc_arguments *args, int code)
+{
+	fprintf(stderr, "\
+Usage: %s %s\
+\n\
+Common options :\n\
+  -o, --logfile=FILE               Output log to FILE instead of stderr\n\
+  -l, --logpriority=LEVEL          Set log priority to LEVEL\n\
+  -q, --quiet                      Don't produce any output\n\
+  -P, --lxcpath=PATH               Use specified container path\n\
+  -?, --help                       Give this help list\n\
+      --usage                      Give a short usage message\n\
+      --version                    Print the version number\n\
+\n\
+Mandatory or optional arguments to long options are also mandatory or optional\n\
+for any corresponding short options.\n\
+\n\
+See the %s man page for further information.\n\n",
+	args->progname, args->help, args->progname);
+
+	if (args->helpfn)
+		args->helpfn(args);
+	exit(code);
+}
+
+static int lxc_arguments_lxcpath_add(struct lxc_arguments *args,
+				     const char *lxcpath)
+{
+	if (args->lxcpath_additional != -1 &&
+	    args->lxcpath_cnt > args->lxcpath_additional) {
+		fprintf(stderr,
+			"This command only accepts %d -P,--lxcpath arguments\n",
+			args->lxcpath_additional + 1);
+		exit(EXIT_FAILURE);
+	}
+
+	args->lxcpath = realloc(
+	    args->lxcpath, (args->lxcpath_cnt + 1) * sizeof(args->lxcpath[0]));
+	if (args->lxcpath == NULL) {
+		lxc_error(args, "no memory");
+		return -ENOMEM;
+	}
+	args->lxcpath[args->lxcpath_cnt++] = lxcpath;
+	return 0;
+}
+
+extern int lxc_arguments_parse(struct lxc_arguments *args, int argc,
+			       char *const argv[])
+{
+	int ret = 0;
+	char shortopts[256];
+
+	ret = build_shortopts(args->options, shortopts, sizeof(shortopts));
+	if (ret < 0) {
+		lxc_error(args, "build_shortopts() failed : %s",
+			  strerror(errno));
+		return ret;
+	}
+
+	while (true) {
+		int c;
+		int index = 0;
+
+		c = getopt_long(argc, argv, shortopts, args->options, &index);
+		if (c == -1)
+			break;
+		switch (c) {
+		case 'n':
+			args->name = optarg;
+			break;
+		case 'o':
+			args->log_file = optarg;
+			break;
+		case 'l':
+			args->log_priority = optarg;
+			break;
+		case 'q':
+			args->quiet = 1;
+			break;
+		case OPT_RCFILE:
+			args->rcfile = optarg;
+			break;
+		case 'P':
+			remove_trailing_slashes(optarg);
+			ret = lxc_arguments_lxcpath_add(args, optarg);
+			if (ret < 0)
+				return ret;
+			break;
+		case OPT_USAGE:
+			print_usage(args->options, args);
+		case OPT_VERSION:
+			print_version();
+		case '?':
+			print_help(args, 1);
+		case 'h':
+			print_help(args, 0);
+		default:
+			if (args->parser) {
+				ret = args->parser(args, c, optarg);
+				if (ret)
+					goto error;
+			}
+		}
+	}
+
+	/*
+	 * Reclaim the remaining command arguments
+	 */
+	args->argv = &argv[optind];
+	args->argc = argc - optind;
+
+	/* If no lxcpaths were given, use default */
+	if (!args->lxcpath_cnt) {
+		ret = lxc_arguments_lxcpath_add(
+		    args, lxc_get_global_config_item("lxc.lxcpath"));
+		if (ret < 0)
+			return ret;
+	}
+
+	/* Check the command options */
+
+	if (!args->name && strcmp(args->progname, "lxc-autostart") != 0) {
+		lxc_error(args, "missing container name, use --name option");
+		return -1;
+	}
+
+	if (args->checker)
+		ret = args->checker(args);
+error:
+	if (ret)
+		lxc_error(args, "could not parse command line");
+	return ret;
+}
+
+int lxc_arguments_str_to_int(struct lxc_arguments *args, const char *str)
+{
+	long val;
+	char *endptr;
+
+	errno = 0;
+	val = strtol(str, &endptr, 10);
+	if (errno) {
+		lxc_error(args, "invalid statefd '%s' : %s", str,
+			  strerror(errno));
+		return -1;
+	}
+
+	if (*endptr) {
+		lxc_error(args, "invalid digit for statefd '%s'", str);
+		return -1;
+	}
+
+	return (int)val;
+}
+

--- a/src/lxc/tools/arguments.h
+++ b/src/lxc/tools/arguments.h
@@ -1,0 +1,174 @@
+/*
+ * lxc: linux Container library
+ *
+ * (C) Copyright IBM Corp. 2007, 2008
+ *
+ * Authors:
+ * Daniel Lezcano <daniel.lezcano at free.fr>
+ * Michel Normand <normand at fr.ibm.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __TOOLS_ARGUMENTS_H
+#define __TOOLS_ARGUMENTS_H
+
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+struct lxc_arguments;
+
+typedef int (*lxc_arguments_parser_t)(struct lxc_arguments *, int, char *);
+typedef int (*lxc_arguments_checker_t)(const struct lxc_arguments *);
+
+struct lxc_arguments {
+	const char *help;
+	void (*helpfn)(const struct lxc_arguments *);
+	const char *progname;
+	const struct option *options;
+	lxc_arguments_parser_t parser;
+	lxc_arguments_checker_t checker;
+
+	const char *name;
+	char *log_file;
+	char *log_priority;
+	int quiet;
+	int daemonize;
+	const char *rcfile;
+	const char *console;
+	const char *console_log;
+	const char *pidfile;
+	const char **lxcpath;
+	int lxcpath_cnt;
+	/* set to 0 to accept only 1 lxcpath, -1 for unlimited */
+	int lxcpath_additional;
+
+	/* for lxc-start */
+	const char *share_ns[32]; /* size must be greater than LXC_NS_MAX */
+
+	/* for lxc-console */
+	unsigned int ttynum;
+	char escape;
+
+	/* for lxc-wait */
+	char *states;
+	long timeout;
+
+	/* for lxc-autostart */
+	int shutdown;
+
+	/* for lxc-stop */
+	int hardstop;
+	int nokill;
+	int nolock;
+	int nowait;
+	int reboot;
+
+	/* for lxc-destroy */
+	int force;
+
+	/* close fds from parent? */
+	int close_all_fds;
+
+	/* lxc-create */
+	char *bdevtype, *configfile, *template;
+	char *fstype;
+	uint64_t fssize;
+	char *lvname, *vgname, *thinpool;
+	char *rbdname, *rbdpool;
+	char *zfsroot, *lowerdir, *dir;
+
+	/* lxc-execute */
+	uid_t uid;
+	gid_t gid;
+
+	/* auto-start */
+	int all;
+	int ignore_auto;
+	int list;
+	char *groups; /* also used by lxc-ls */
+
+	/* lxc-snapshot and lxc-copy */
+	enum task {
+		CLONE,
+		DESTROY,
+		LIST,
+		RESTORE,
+		SNAP,
+		RENAME,
+	} task;
+	int print_comments;
+	char *commentfile;
+	char *newname;
+	char *newpath;
+	char *snapname;
+	int keepdata;
+	int keepname;
+	int keepmac;
+
+	/* lxc-ls */
+	char *ls_fancy_format;
+	char *ls_filter;
+	unsigned int ls_nesting; /* maximum allowed nesting level */
+	bool ls_active;
+	bool ls_fancy;
+	bool ls_frozen;
+	bool ls_line;
+	bool ls_running;
+	bool ls_stopped;
+	bool ls_defined;
+
+	/* lxc-copy */
+	bool tmpfs;
+
+	/* remaining arguments */
+	char *const *argv;
+	int argc;
+
+	/* private arguments */
+	void *data;
+};
+
+#define LXC_COMMON_OPTIONS                                                     \
+	    { "name",        required_argument, 0, 'n'         },              \
+            { "help",        no_argument,       0, 'h'         },              \
+	    { "usage",       no_argument,       0, OPT_USAGE   },              \
+	    { "version",     no_argument,       0, OPT_VERSION },              \
+	    { "quiet",       no_argument,       0, 'q'         },              \
+	    { "logfile",     required_argument, 0, 'o'         },              \
+	    { "logpriority", required_argument, 0, 'l'         },              \
+	    { "lxcpath",     required_argument, 0, 'P'         },              \
+	    { "rcfile",      required_argument, 0, OPT_RCFILE  },              \
+	    { 0,             0,                 0, 0           }
+
+/* option keys for long only options */
+#define OPT_USAGE 0x1000
+#define OPT_VERSION OPT_USAGE - 1
+#define OPT_RCFILE OPT_USAGE - 2
+
+extern int lxc_arguments_parse(struct lxc_arguments *args, int argc,
+			       char *const argv[]);
+
+extern int lxc_arguments_str_to_int(struct lxc_arguments *args,
+				    const char *str);
+
+#define lxc_error(arg, fmt, args...)                                           \
+	if (!(arg)->quiet)                                                     \
+	fprintf(stderr, "%s: " fmt "\n", (arg)->progname, ##args)
+
+#endif /* __TOOLS_ARGUMENTS_H */
+

--- a/src/lxc/tools/lxc_cgroup.c
+++ b/src/lxc/tools/lxc_cgroup.c
@@ -26,12 +26,12 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <string.h>
+#include <sys/param.h>
 
 #include <lxc/lxccontainer.h>
 
-#include "arguments.h"
-#include "log.h"
-#include "lxc.h"
+#include "tools/arguments.h"
 
 static int my_checker(const struct lxc_arguments* args)
 {
@@ -83,7 +83,6 @@ int main(int argc, char *argv[])
 
 	if (lxc_log_init(&log))
 		exit(EXIT_FAILURE);
-	lxc_log_options_no_override();
 
 	/* REMOVE IN LXC 3.0 */
 	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);

--- a/src/lxc/tools/utils.c
+++ b/src/lxc/tools/utils.c
@@ -1,0 +1,9 @@
+
+#include "tools/utils.h"
+
+extern void remove_trailing_slashes(char *p)
+{
+	int l = strlen(p);
+	while (--l >= 0 && (p[l] == '/' || p[l] == '\n'))
+		p[l] = '\0';
+}

--- a/src/lxc/tools/utils.h
+++ b/src/lxc/tools/utils.h
@@ -1,0 +1,7 @@
+
+#ifndef __TOOLS_UTILS_H
+#define __TOOLS_UTILS_H
+
+extern void remove_trailing_slashes(char *p);
+
+#endif /* __TOOLS_UTILS_H */


### PR DESCRIPTION
Added arguments.{c,h} and utils.{c,h} to /tools and removed dependencies from "lxc_cgroup.c".

Note: we're not sure if we should've removed all logging stuff from lxc_group.c. Currently we just removed the call to lxc_log_options_no_override() since that's defined in the internal "log.h"