### PR TITLE
Add new dependency to Slackware template

### DIFF
--- a/templates/lxc-slackware.in
+++ b/templates/lxc-slackware.in
@@ -564,6 +564,7 @@ glibc-solibs
 gnupg
 grep
 gzip
+hostname
 iputils
 libunistring
 logrotate


### PR DESCRIPTION
I followed the [changelog of Slackware-current](http://www.slackware.com/changelog/),
and found that Slackware-current split hostname utility from util-linux package in Nov 17 2017.
So I add the new package to the template.

Signed-off-by: Chia-Chun Hsu <a12321aabb@gmail.com>