### PR TITLE
lxc_execute: properly figure out number of needed arguments

### DIFF
--- a/src/lxc/execute.c
+++ b/src/lxc/execute.c
@@ -49,14 +49,14 @@ static int execute_start(struct lxc_handler *handler, void* data)
 
 	while (my_args->argv[argc++]);
 
-	argc_add = 4;
+	/* lxc-init -n name -- [argc] NULL -> 5 */
+	argc_add = 5;
 	if (my_args->quiet)
 		argc_add++;
-	if (!handler->conf->rootfs.path) {
-		argc_add += 4;
-		if (lxc_log_has_valid_level())
-			argc_add += 2;
-	}
+	if (!handler->conf->rootfs.path)
+		argc_add += 2;
+	if (lxc_log_has_valid_level())
+		argc_add += 2;
 
 	argv = malloc((argc + argc_add) * sizeof(*argv));
 	if (!argv)


### PR DESCRIPTION
The lxc_log args have noghing to do with lxc.rootfs.path, and
we need room for a NULL at end of arguments.

How this bug was hidden for so long I don't know - I can only
trigger it on certain systems under certain conditions, but it's
definately wrong as is.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>