### PR TITLE
start: set loglevel correctly

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -572,6 +572,7 @@ on_error:
 
 int lxc_init(const char *name, struct lxc_handler *handler)
 {
+	const char *loglevel;
 	struct lxc_conf *conf = handler->conf;
 
 	lsm_init();
@@ -612,8 +613,9 @@ int lxc_init(const char *name, struct lxc_handler *handler)
 	if (setenv("LXC_CGNS_AWARE", "1", 1))
 		SYSERROR("Failed to set environment variable LXC_CGNS_AWARE=1.");
 
-	if (setenv("LXC_LOG_LEVEL", lxc_log_priority_to_string(handler->conf->loglevel), 1))
-		SYSERROR("Failed to set environment variable LXC_CGNS_AWARE=1.");
+	loglevel = lxc_log_priority_to_string(lxc_log_get_level());
+	if (setenv("LXC_LOG_LEVEL", loglevel, 1))
+		SYSERROR("Failed to set environment variable LXC_LOG_LEVEL=%s", loglevel);
 	/* End of environment variable setup for hooks. */
 
 	TRACE("set environment variables");


### PR DESCRIPTION
We want the loglevel that the user specified when starting the container
because it overrides the default one set in the config.

Closes #2003.

Reported-by: Felix Abecassis <fabecassis@nvidia.com>
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>