### PR TITLE
add --share-$NS= support to lxc-execute

### DIFF
--- a/src/lxc/lxc_init.c
+++ b/src/lxc/lxc_init.c
@@ -46,6 +46,9 @@
 #define OPT_USAGE 0x1000
 #define OPT_VERSION OPT_USAGE - 1   
 
+#define QUOTE(macro) #macro
+#define QUOTEVAL(macro) QUOTE(macro)
+
 lxc_log_define(lxc_init, lxc);
 
 static sig_atomic_t was_interrupted = 0;
@@ -95,40 +98,49 @@ static struct arguments my_args = {
 static void prevent_forking(void)
 {
 	FILE *f;
-	char name[PATH_MAX], path[PATH_MAX];
+	char name[MAXPATHLEN], path[MAXPATHLEN];
 	int ret;
 
 	f = fopen("/proc/self/cgroup", "r");
 	if (!f) {
-		SYSERROR("opening /proc/self/cgroup");
+		SYSERROR("Failed to open \"/proc/self/cgroup\"");
 		return;
 	}
 
 	while (!feof(f)) {
-		int fd;
+		int fd, i;
 
-		if (2 != fscanf(f, "%*d:%[^:]:%s", name, path)) {
-			ERROR("didn't scan the right number of things");
+		if (1 != fscanf(f, "%*d:%" QUOTEVAL(MAXPATHLEN) "s", name)) {
+			ERROR("Failed to parse \"/proc/self/cgroup\"");
 			goto out;
+		}
+		path[0] = 0;
+
+		for (i = 0; i < sizeof(name); i++) {
+			if (name[i] == ':') {
+				name[i] = 0;
+				strncpy(path, name + i + 1, sizeof(path));
+				break;
+			}
 		}
 
 		if (strcmp(name, "pids"))
 			continue;
 
 		ret = snprintf(name, sizeof(name), "/sys/fs/cgroup/pids/%s/pids.max", path);
-		if (ret < 0 || ret >= sizeof(path)) {
-			ERROR("failed snprintf");
+		if (ret < 0 || (size_t)ret >= sizeof(path)) {
+			ERROR("Failed to create string");
 			goto out;
 		}
 
 		fd = open(name, O_WRONLY);
 		if (fd < 0) {
-			SYSERROR("open");
+			SYSERROR("Failed to open \"%s\"", name);
 			goto out;
 		}
 
 		if (write(fd, "1", 1) != 1)
-			SYSERROR("write");
+			SYSERROR("Failed to write to \"%s\"", name);
 
 		close(fd);
 		break;
@@ -145,14 +157,14 @@ static void kill_children(pid_t pid)
 	int ret;
 
 	ret = snprintf(path, sizeof(path), "/proc/%d/task/%d/children", pid, pid);
-	if (ret < 0 || ret >= sizeof(path)) {
-		ERROR("failed snprintf");
+	if (ret < 0 || (size_t)ret >= sizeof(path)) {
+		ERROR("Failed to create string");
 		return;
 	}
 
 	f = fopen(path, "r");
 	if (!f) {
-		SYSERROR("couldn't open %s", path);
+		SYSERROR("Failed to open %s", path);
 		return;
 	}
 
@@ -160,7 +172,7 @@ static void kill_children(pid_t pid)
 		pid_t pid;
 
 		if (fscanf(f, "%d ", &pid) != 1) {
-			ERROR("couldn't scan pid");
+			ERROR("Failed to retrieve pid");
 			fclose(f);
 			return;
 		}
@@ -337,10 +349,12 @@ int main(int argc, char *argv[])
 		case SIGPWR:
 		case SIGTERM:
 			if (!shutdown) {
+				pid_t mypid = getpid();
+
 				shutdown = 1;
 				prevent_forking();
-				if (getpid() != 1) {
-					kill_children(getpid());
+				if (mypid != 1) {
+					kill_children(mypid);
 				} else {
 					ret = kill(-1, SIGTERM);
 					if (ret < 0)
@@ -350,10 +364,12 @@ int main(int argc, char *argv[])
 				alarm(1);
 			}
 			break;
-		case SIGALRM:
+		case SIGALRM: {
+			pid_t mypid = getpid();
+
 			prevent_forking();
-			if (getpid() != 1) {
-				kill_children(getpid());
+			if (mypid != 1) {
+				kill_children(mypid);
 			} else {
 				ret = kill(-1, SIGTERM);
 				if (ret < 0)
@@ -361,6 +377,7 @@ int main(int argc, char *argv[])
 					      "all children", strerror(errno));
 			}
 			break;
+		}
 		default:
 			ret = kill(pid, was_interrupted);
 			if (ret < 0)

--- a/src/lxc/tools/arguments.c
+++ b/src/lxc/tools/arguments.c
@@ -35,6 +35,7 @@
 #include "arguments.h"
 #include "utils.h"
 #include "version.h"
+#include "namespace.h"
 
 static int build_shortopts(const struct option *a_options, char *a_shortopts,
 			   size_t a_size)
@@ -288,4 +289,35 @@ int lxc_arguments_str_to_int(struct lxc_arguments *args, const char *str)
 	}
 
 	return (int)val;
+}
+
+bool lxc_setup_shared_ns(struct lxc_arguments *args, struct lxc_container *c)
+{
+	int i;
+
+	for (i = 0; i < LXC_NS_MAX; i++) {
+		const char *key, *value;
+
+		value = args->share_ns[i];
+		if (!value)
+			continue;
+
+		if (i == LXC_NS_NET)
+			key = "lxc.namespace.net";
+		else if (i == LXC_NS_IPC)
+			key = "lxc.namespace.ipc";
+		else if (i == LXC_NS_UTS)
+			key = "lxc.namespace.uts";
+		else if (i == LXC_NS_PID)
+			key = "lxc.namespace.pid";
+		else
+			continue;
+
+		if (!c->set_config_item(c, key, value)) {
+			fprintf(stderr, "failed to set %s\n", key);
+			return false;
+		}
+	}
+
+	return true;
 }

--- a/src/lxc/tools/arguments.c
+++ b/src/lxc/tools/arguments.c
@@ -314,7 +314,7 @@ bool lxc_setup_shared_ns(struct lxc_arguments *args, struct lxc_container *c)
 			continue;
 
 		if (!c->set_config_item(c, key, value)) {
-			fprintf(stderr, "failed to set %s\n", key);
+			lxc_error(args, "Failed to set \"%s = %s\"", key, value);
 			return false;
 		}
 	}

--- a/src/lxc/tools/arguments.h
+++ b/src/lxc/tools/arguments.h
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
+#include <lxc/lxccontainer.h>
 
 struct lxc_arguments;
 
@@ -160,6 +161,11 @@ struct lxc_arguments {
 #define OPT_VERSION OPT_USAGE - 1
 #define OPT_RCFILE OPT_USAGE - 2
 
+#define OPT_SHARE_NET OPT_USAGE + 1
+#define OPT_SHARE_IPC OPT_USAGE + 2
+#define OPT_SHARE_UTS OPT_USAGE + 3
+#define OPT_SHARE_PID OPT_USAGE + 4
+
 extern int lxc_arguments_parse(struct lxc_arguments *args, int argc,
 			       char *const argv[]);
 
@@ -169,5 +175,7 @@ extern int lxc_arguments_str_to_int(struct lxc_arguments *args,
 #define lxc_error(arg, fmt, args...)                                           \
 	if (!(arg)->quiet)                                                     \
 	fprintf(stderr, "%s: " fmt "\n", (arg)->progname, ##args)
+
+extern bool lxc_setup_shared_ns(struct lxc_arguments *args, struct lxc_container *c);
 
 #endif /* __LXC_ARGUMENTS_H */

--- a/src/lxc/tools/arguments.h
+++ b/src/lxc/tools/arguments.h
@@ -160,11 +160,10 @@ struct lxc_arguments {
 #define OPT_USAGE 0x1000
 #define OPT_VERSION OPT_USAGE - 1
 #define OPT_RCFILE OPT_USAGE - 2
-
-#define OPT_SHARE_NET OPT_USAGE + 1
-#define OPT_SHARE_IPC OPT_USAGE + 2
-#define OPT_SHARE_UTS OPT_USAGE + 3
-#define OPT_SHARE_PID OPT_USAGE + 4
+#define OPT_SHARE_NET OPT_USAGE - 3
+#define OPT_SHARE_IPC OPT_USAGE - 4
+#define OPT_SHARE_UTS OPT_USAGE - 5
+#define OPT_SHARE_PID OPT_USAGE - 6
 
 extern int lxc_arguments_parse(struct lxc_arguments *args, int argc,
 			       char *const argv[]);

--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -63,6 +63,10 @@ static int my_parser(struct lxc_arguments* args, int c, char* arg)
 	case 'g':
 		if (lxc_safe_uint(arg, &args->gid) < 0)
 			return -1;
+	case OPT_SHARE_NET: args->share_ns[LXC_NS_NET] = arg; break;
+	case OPT_SHARE_IPC: args->share_ns[LXC_NS_IPC] = arg; break;
+	case OPT_SHARE_UTS: args->share_ns[LXC_NS_UTS] = arg; break;
+	case OPT_SHARE_PID: args->share_ns[LXC_NS_PID] = arg; break;
 	}
 	return 0;
 }
@@ -73,6 +77,10 @@ static const struct option my_longopts[] = {
 	{"define", required_argument, 0, 's'},
 	{"uid", required_argument, 0, 'u'},
 	{"gid", required_argument, 0, 'g'},
+	{"share-net", required_argument, 0, OPT_SHARE_NET},
+	{"share-ipc", required_argument, 0, OPT_SHARE_IPC},
+	{"share-uts", required_argument, 0, OPT_SHARE_UTS},
+	{"share-pid", required_argument, 0, OPT_SHARE_PID},
 	LXC_COMMON_OPTIONS
 };
 
@@ -182,6 +190,11 @@ int main(int argc, char *argv[])
 
 	if (my_args.gid)
 		c->lxc_conf->init_gid = my_args.gid;
+
+	if (!lxc_setup_shared_ns(&my_args, c)) {
+		lxc_container_put(c);
+		exit(EXIT_FAILURE);
+	}
 
 	c->daemonize = my_args.daemonize == 1;
 	bret = c->start(c, 1, my_args.argv);

--- a/src/lxc/tools/lxc_start.c
+++ b/src/lxc/tools/lxc_start.c
@@ -50,11 +50,6 @@
 #include "confile.h"
 #include "arguments.h"
 
-#define OPT_SHARE_NET OPT_USAGE + 1
-#define OPT_SHARE_IPC OPT_USAGE + 2
-#define OPT_SHARE_UTS OPT_USAGE + 3
-#define OPT_SHARE_PID OPT_USAGE + 4
-
 static struct lxc_list defines;
 
 static int ensure_path(char **confpath, const char *path)
@@ -152,7 +147,6 @@ Options :\n\
 
 int main(int argc, char *argv[])
 {
-	int i;
 	struct lxc_conf *conf;
 	struct lxc_log log;
 	const char *lxcpath;
@@ -284,27 +278,8 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	for (i = 0; i < LXC_NS_MAX; i++) {
-		const char *key, *value;
-
-		value = my_args.share_ns[i];
-		if (!value)
-			continue;
-
-		if (i == LXC_NS_NET)
-			key = "lxc.namespace.net";
-		else if (i == LXC_NS_IPC)
-			key = "lxc.namespace.ipc";
-		else if (i == LXC_NS_UTS)
-			key = "lxc.namespace.uts";
-		else if (i == LXC_NS_PID)
-			key = "lxc.namespace.pid";
-		else
-			continue;
-
-		if (!c->set_config_item(c, key, value))
-			goto out;
-	}
+	if (!lxc_setup_shared_ns(&my_args, c))
+		goto out;
 
 	if (!my_args.daemonize) {
 		c->want_daemonize(c, false);


### PR DESCRIPTION
This is basically just hoisting the functionality out of lxc-start, so lxc-execute can use it too.