### PR TITLE
lxc: Distinguish pthread_mutex_unlock error messages

### DIFF
--- a/src/lxc/cgroups/cgmanager.c
+++ b/src/lxc/cgroups/cgmanager.c
@@ -88,7 +88,8 @@ static void unlock_mutex(pthread_mutex_t *l)
 	int ret;
 
 	if ((ret = pthread_mutex_unlock(l)) != 0) {
-		fprintf(stderr, "pthread_mutex_unlock returned:%d %s\n", ret, strerror(ret));
+		fprintf(stderr, "%s: pthread_mutex_unlock returned:%d %s\n",
+				__FILE__, ret, strerror(ret));
 		exit(1);
 	}
 }

--- a/src/lxc/lxclock.c
+++ b/src/lxc/lxclock.c
@@ -84,7 +84,8 @@ static void unlock_mutex(pthread_mutex_t *l)
 	int ret;
 
 	if ((ret = pthread_mutex_unlock(l)) != 0) {
-		fprintf(stderr, "pthread_mutex_unlock returned:%d %s\n", ret, strerror(ret));
+		fprintf(stderr, "%s: pthread_mutex_unlock returned:%d %s\n",
+				__FILE__, ret, strerror(ret));
 		dump_stacktrace();
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
The same message exists in lxclock.c and cgmanager.c, so print the
filename along with the message.

Before this patch:
lxc-destroy -n u1
pthread_mutex_unlock returned:1 Operation not permitted

After this patch:
xc-destroy -n u1
lxclock.c: pthread_mutex_unlock returned:1 Operation not permitted

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>