### PR TITLE
legacy confile: fix legacy network parser

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3293,13 +3293,12 @@ int lxc_clear_limits(struct lxc_conf *c, const char *key)
 	bool all = false;
 	const char *k = NULL;
 
-	if (strcmp(key, "lxc.limit") == 0
-	    || strcmp(key, "lxc.prlimit"))
+	if (strcmp(key, "lxc.limit") == 0 || strcmp(key, "lxc.prlimit") == 0)
 		all = true;
-	else if (strncmp(key, "lxc.limit.", sizeof("lxc.limit.")-1) == 0)
-		k = key + sizeof("lxc.limit.")-1;
-	else if (strncmp(key, "lxc.prlimit.", sizeof("lxc.prlimit.")-1) == 0)
-		k = key + sizeof("lxc.prlimit.")-1;
+	else if (strncmp(key, "lxc.limit.", sizeof("lxc.limit.") - 1) == 0)
+		k = key + sizeof("lxc.limit.") - 1;
+	else if (strncmp(key, "lxc.prlimit.", sizeof("lxc.prlimit.") - 1) == 0)
+		k = key + sizeof("lxc.prlimit.") - 1;
 	else
 		return -1;
 
@@ -3312,6 +3311,7 @@ int lxc_clear_limits(struct lxc_conf *c, const char *key)
 		free(lim);
 		free(it);
 	}
+
 	return 0;
 }
 


### PR DESCRIPTION
This fixes a bug introduced by:

commit 94f0035bf636ba853451d59c129e26d94850c04d
Author: Christian Brauner <christian.brauner@ubuntu.com>
Date:   Thu Dec 7 15:07:26 2017 +0100

    coverity: #1425924

    remove logically dead condition

    Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>

Coverity's bug analysis is correct but my fix wasn't.

This commit fixes a bunch of other bugs I just spotted as well.

This unblocks #2009.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>