### PR TITLE
tools: block using lxc-execute without config file

### DIFF
--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -191,7 +191,10 @@ int main(int argc, char *argv[])
 
 	c->daemonize = my_args.daemonize == 1;
 	bret = c->start(c, 1, my_args.argv);
-	ret = c->error_num;
+	if (c->daemonize)
+		ret = EXIT_SUCCESS;
+	else
+		ret = c->error_num;
 	lxc_container_put(c);
 	if (!bret) {
 		fprintf(stderr, "Failed run an application inside container\n");

--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -163,6 +163,12 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	if (!c->lxc_conf) {
+		fprintf(stderr, "Executing a container with no configuration file may crash the host\n");
+		lxc_container_put(c);
+		exit(EXIT_FAILURE);
+	}
+
 	if (my_args.argc == 0) {
 		if (!set_argv(c->lxc_conf, &my_args)) {
 			fprintf(stderr, "missing command to execute!\n");


### PR DESCRIPTION
Moving away from internal symbols we can't do hacks like we currently do in
lxc-start and call internal functions like lxc_conf_init(). This is unsafe
anyway. Instead, we should simply error out if the user didn't give us a
configuration file to use. lxc-start refuses to start in that case already.

Relates to discussion in lxc/go-lxc#96 (comment) .
Closes #2023.

Reported-by: Felix Abecassis <fabecassis@nvidia.com>
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>