### PR TITLE
utils: use lxc_raw_clone() in run_command()

### DIFF
--- a/src/lxc/namespace.h
+++ b/src/lxc/namespace.h
@@ -28,6 +28,38 @@
 
 #include "config.h"
 
+#ifndef CLONE_PARENT_SETTID
+#define CLONE_PARENT_SETTID 0x00100000
+#endif
+
+#ifndef CLONE_CHILD_CLEARTID
+#define CLONE_CHILD_CLEARTID 0x00200000
+#endif
+
+#ifndef CLONE_CHILD_SETTID
+#define CLONE_CHILD_SETTID 0x01000000
+#endif
+
+#ifndef CLONE_VFORK
+#define CLONE_VFORK 0x00004000
+#endif
+
+#ifndef CLONE_THREAD
+#define CLONE_THREAD 0x00010000
+#endif
+
+#ifndef CLONE_SETTLS
+#define CLONE_SETTLS 0x00080000
+#endif
+
+#ifndef CLONE_VM
+#define CLONE_VM 0x00000100
+#endif
+
+#ifndef CLONE_FILES
+#define CLONE_FILES 0x00000400
+#endif
+
 #ifndef CLONE_FS
 #  define CLONE_FS                0x00000200
 #endif
@@ -81,6 +113,7 @@ int clone(int (*fn)(void *), void *child_stack,
 #endif
 
 extern pid_t lxc_clone(int (*fn)(void *), void *arg, int flags);
+extern pid_t lxc_raw_clone(unsigned long flags);
 
 extern int lxc_namespace_2_cloneflag(const char *namespace);
 extern int lxc_namespace_2_ns_idx(const char *namespace);

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -2230,7 +2230,7 @@ int run_command(char *buf, size_t buf_size, int (*child_fn)(void *), void *args)
 		return -1;
 	}
 
-	child = fork();
+	child = lxc_raw_clone(0);
 	if (child < 0) {
 		close(pipefd[0]);
 		close(pipefd[1]);

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -33,6 +33,7 @@ lxc_test_livepatch_SOURCES = livepatch.c lxctest.h
 lxc_test_state_server_SOURCES = state_server.c lxctest.h
 lxc_test_share_ns_SOURCES = share_ns.c lxctest.h
 lxc_test_criu_check_feature_SOURCES = criu_check_feature.c lxctest.h
+lxc_test_raw_clone_SOURCES = lxc_raw_clone.c lxctest.h
 
 AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	-DLXCPATH=\"$(LXCPATH)\" \
@@ -63,7 +64,7 @@ bin_PROGRAMS = lxc-test-containertests lxc-test-locktests lxc-test-startone \
 	lxc-test-apparmor lxc-test-utils lxc-test-parse-config-file \
 	lxc-test-config-jump-table lxc-test-shortlived lxc-test-livepatch \
 	lxc-test-api-reboot lxc-test-state-server lxc-test-share-ns \
-	lxc-test-criu-check-feature
+	lxc-test-criu-check-feature lxc-test-raw-clone
 
 bin_SCRIPTS = lxc-test-automount \
 	      lxc-test-autostart \
@@ -104,6 +105,7 @@ EXTRA_DIST = \
 	livepatch.c \
 	locktests.c \
 	lxcpath.c \
+	lxc_raw_clone.c \
 	lxc-test-lxc-attach \
 	lxc-test-automount \
 	lxc-test-rootfs \

--- a/src/tests/lxc_raw_clone.c
+++ b/src/tests/lxc_raw_clone.c
@@ -1,0 +1,173 @@
+/*
+ * lxc: linux Container library
+ *
+ * Copyright © 2017 Canonical Ltd.
+ *
+ * Authors:
+ * Christian Brauner <christian.brauner@ubuntu.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#define _GNU_SOURCE
+#define __STDC_FORMAT_MACROS
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "lxctest.h"
+#include "namespace.h"
+#include "utils.h"
+
+int main(int argc, char *argv[])
+{
+	int status;
+	pid_t pid;
+	int flags = 0;
+
+	pid = lxc_raw_clone(CLONE_PARENT_SETTID);
+	if (pid >= 0 || pid != -EINVAL) {
+		lxc_error("%s\n", "Calling lxc_raw_clone(CLONE_PARENT_SETTID) "
+				  "should not be possible");
+		exit(EXIT_FAILURE);
+	}
+
+	pid = lxc_raw_clone(CLONE_CHILD_SETTID);
+	if (pid >= 0 || pid != -EINVAL) {
+		lxc_error("%s\n", "Calling lxc_raw_clone(CLONE_CHILD_SETTID) "
+				  "should not be possible");
+		exit(EXIT_FAILURE);
+	}
+
+	pid = lxc_raw_clone(CLONE_CHILD_CLEARTID);
+	if (pid >= 0 || pid != -EINVAL) {
+		lxc_error("%s\n", "Calling lxc_raw_clone(CLONE_CHILD_CLEARTID) "
+				  "should not be possible");
+		exit(EXIT_FAILURE);
+	}
+
+	pid = lxc_raw_clone(CLONE_SETTLS);
+	if (pid >= 0 || pid != -EINVAL) {
+		lxc_error("%s\n", "Calling lxc_raw_clone(CLONE_SETTLS) should "
+				  "not be possible");
+		exit(EXIT_FAILURE);
+	}
+
+	pid = lxc_raw_clone(CLONE_VM);
+	if (pid >= 0 || pid != -EINVAL) {
+		lxc_error("%s\n", "Calling lxc_raw_clone(CLONE_VM) should "
+			  "not be possible");
+		exit(EXIT_FAILURE);
+	}
+
+	pid = lxc_raw_clone(0);
+	if (pid < 0) {
+		lxc_error("%s\n", "Failed to call lxc_raw_clone(0)");
+		exit(EXIT_FAILURE);
+	}
+
+	if (pid == 0) {
+		lxc_error("%s\n", "Child will exit(EXIT_SUCCESS)");
+		exit(EXIT_SUCCESS);
+	}
+
+	status = wait_for_pid(pid);
+	if (status != 0) {
+		lxc_error("%s\n", "Failed to retrieve correct exit status");
+		exit(EXIT_FAILURE);
+	}
+
+	pid = lxc_raw_clone(0);
+	if (pid < 0) {
+		lxc_error("%s\n", "Failed to call lxc_raw_clone(0)");
+		exit(EXIT_FAILURE);
+	}
+
+	if (pid == 0) {
+		lxc_error("%s\n", "Child will exit(EXIT_FAILURE)");
+		exit(EXIT_FAILURE);
+	}
+
+	status = wait_for_pid(pid);
+	if (status == 0) {
+		lxc_error("%s\n", "Failed to retrieve correct exit status");
+		exit(EXIT_FAILURE);
+	}
+
+	pid = lxc_raw_clone(CLONE_NEWUSER | CLONE_NEWCGROUP | CLONE_NEWNS |
+			    CLONE_NEWIPC | CLONE_NEWNET | CLONE_NEWIPC |
+			    CLONE_NEWPID | CLONE_NEWUTS);
+	if (pid < 0) {
+		lxc_error("%s\n", "Failed to call lxc_raw_clone(CLONE_NEWUSER "
+				  "| CLONE_NEWCGROUP | CLONE_NEWNS | "
+				  "CLONE_NEWIPC | CLONE_NEWNET | CLONE_NEWIPC "
+				  "| CLONE_NEWPID | CLONE_NEWUTS);");
+		exit(EXIT_FAILURE);
+	}
+
+	if (pid == 0) {
+		lxc_error("%s\n", "Child will exit(EXIT_SUCCESS)");
+		exit(EXIT_SUCCESS);
+	}
+
+	status = wait_for_pid(pid);
+	if (status != 0) {
+		lxc_error("%s\n", "Failed to retrieve correct exit status");
+		exit(EXIT_FAILURE);
+	}
+
+	flags |= CLONE_NEWUSER;
+	if (cgns_supported())
+		flags |= CLONE_NEWCGROUP;
+	flags |= CLONE_NEWNS;
+	flags |= CLONE_NEWIPC;
+	flags |= CLONE_NEWNET;
+	flags |= CLONE_NEWIPC;
+	flags |= CLONE_NEWPID;
+	flags |= CLONE_NEWUTS;
+	pid = lxc_raw_clone(flags);
+	if (pid < 0) {
+		lxc_error("%s\n", "Failed to call lxc_raw_clone(CLONE_NEWUSER "
+				  "| CLONE_NEWCGROUP | CLONE_NEWNS | "
+				  "CLONE_NEWIPC | CLONE_NEWNET | CLONE_NEWIPC "
+				  "| CLONE_NEWPID | CLONE_NEWUTS);");
+		exit(EXIT_FAILURE);
+	}
+
+
+	if (pid == 0) {
+		lxc_error("%s\n", "Child will exit(EXIT_FAILURE)");
+		exit(EXIT_FAILURE);
+	}
+
+	status = wait_for_pid(pid);
+	if (status == 0) {
+		lxc_error("%s\n", "Failed to retrieve correct exit status");
+		exit(EXIT_SUCCESS);
+	}
+
+	lxc_debug("%s\n", "All lxc_raw_clone() tests successful");
+	exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
run_command() is called in contexts where threads explicitly hold a lock while
fork()ing. Currently, this just affects the legacy cgmanager cgroup driver.
Here's what's happening when we use fork():

1. cgm_chown() calls cgm_dbus_connect()
2. cgm_dbus_connect() calls cgm_lock():
   Now the thread holds an explicit lock on the mutex
3. cgm_chown() calls chown_cgroup()
4. chown_cgroup() calls userns_exec_1()
5. userns_exec_1() forks with an explicit lock on the mutex being held
6. pthread_atfork() handlers get run including the prepare() handler:

        #ifdef HAVE_PTHREAD_ATFORK __attribute__((constructor))
        static void process_lock_setup_atfork(void)
        {
                pthread_atfork(cgm_lock, cgm_unlock, cgm_unlock);
        }
        #endif

   thus trying to acquire the mutex that is being explicitly held in the
   parent. If we were using recursive locks then the parent would now
   hold two locks but since I don't see us using them I guess we're
   simply getting undefined behavior.

There are multiple ways to solve this problem. They are all not very nice. One
solution is to use interposition wrapper for pthread_atfork() but that is
rather tricky since we need to have wrappers for the pthread_atfork() callbacks
and need to identify our caller so that we can make a decision whether we
should execute the callback or not. If this were a generic problem I'd say we
go for this solution but as this only affects the legacy cgmanager driver we
don't really care and I'd much rather enforce that any future code does not
take an explicit lock during a fork(). That sounds like a bad idea in the first
place. So simply switch from using fork() to clone() which does not run
pthread_atfork() handlers. If push comes to shove we might just go for doing
the clone() syscall directly via syscall(SYS_clone, ...).

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>