### PR TITLE
criu: add feature check capability

### DIFF
--- a/src/lxc/criu.h
+++ b/src/lxc/criu.h
@@ -30,5 +30,6 @@
 bool __criu_pre_dump(struct lxc_container *c, struct migrate_opts *opts);
 bool __criu_dump(struct lxc_container *c, struct migrate_opts *opts);
 bool __criu_restore(struct lxc_container *c, struct migrate_opts *opts);
+bool __criu_check_feature(uint64_t *features_to_check);
 
 #endif

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4474,6 +4474,7 @@ static int do_lxcapi_migrate(struct lxc_container *c, unsigned int cmd,
 {
 	int ret = -1;
 	struct migrate_opts *valid_opts = opts;
+	uint64_t features_to_check = 0;
 
 	/* If the caller has a bigger (newer) struct migrate_opts, let's make
 	 * sure that the stuff on the end is zero, i.e. that they didn't ask us
@@ -4526,6 +4527,15 @@ static int do_lxcapi_migrate(struct lxc_container *c, unsigned int cmd,
 			goto on_error;
 		}
 		ret = !__criu_restore(c, valid_opts);
+		break;
+	case MIGRATE_FEATURE_CHECK:
+		features_to_check = valid_opts->features_to_check;
+		ret = !__criu_check_feature(&features_to_check);
+		if (ret) {
+			/* Something went wrong. Let's let the caller
+			 * know which feature checks failed. */
+			valid_opts->features_to_check = features_to_check;
+		}
 		break;
 	default:
 		ERROR("invalid migrate command %u", cmd);

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -904,7 +904,14 @@ enum {
 	MIGRATE_PRE_DUMP,
 	MIGRATE_DUMP,
 	MIGRATE_RESTORE,
+	MIGRATE_FEATURE_CHECK,
 };
+
+/*!
+ * \brief Available feature checks.
+ */
+#define FEATURE_MEM_TRACK    (1ULL << 0)
+#define FEATURE_LAZY_PAGES   (1ULL << 1)
 
 /*!
  * \brief Options for the migrate API call.
@@ -942,6 +949,13 @@ struct migrate_opts {
 	 * which at this time is 1MB.
 	 */
 	uint64_t ghost_limit;
+
+	/* Some features cannot be checked by comparing the CRIU version.
+	 * Features like dirty page tracking or userfaultfd depend on
+	 * the architecture/kernel/criu combination. This is a bitmask
+	 * in which the desired feature checks can be encoded.
+	 */
+	uint64_t features_to_check;
 };
 
 struct lxc_console_log {

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -32,6 +32,7 @@ lxc_test_shortlived_SOURCES = shortlived.c
 lxc_test_livepatch_SOURCES = livepatch.c lxctest.h
 lxc_test_state_server_SOURCES = state_server.c lxctest.h
 lxc_test_share_ns_SOURCES = share_ns.c lxctest.h
+lxc_test_criu_check_feature_SOURCES = criu_check_feature.c lxctest.h
 
 AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	-DLXCPATH=\"$(LXCPATH)\" \
@@ -61,7 +62,8 @@ bin_PROGRAMS = lxc-test-containertests lxc-test-locktests lxc-test-startone \
 	lxc-test-reboot lxc-test-list lxc-test-attach lxc-test-device-add-remove \
 	lxc-test-apparmor lxc-test-utils lxc-test-parse-config-file \
 	lxc-test-config-jump-table lxc-test-shortlived lxc-test-livepatch \
-	lxc-test-api-reboot lxc-test-state-server lxc-test-share-ns
+	lxc-test-api-reboot lxc-test-state-server lxc-test-share-ns \
+	lxc-test-criu-check-feature
 
 bin_SCRIPTS = lxc-test-automount \
 	      lxc-test-autostart \
@@ -93,6 +95,7 @@ EXTRA_DIST = \
 	console_log.c \
 	containertests.c \
 	createtest.c \
+	criu_check_feature.c \
 	destroytest.c \
 	device_add_remove.c \
 	get_item.c \

--- a/src/tests/criu_check_feature.c
+++ b/src/tests/criu_check_feature.c
@@ -1,0 +1,90 @@
+/* liblxcapi
+ *
+ * Copyright © 2017 Adrian Reber <areber@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string.h>
+#include <limits.h>
+
+#include "lxc/lxccontainer.h"
+#include "lxctest.h"
+
+int main(int argc, char *argv[])
+{
+	struct lxc_container *c;
+	struct migrate_opts m_opts;
+	int ret = EXIT_FAILURE;
+
+	/* Test the feature check interface,
+	 * we actually do not need a container. */
+	c = lxc_container_new("check_feature", NULL);
+	if (!c) {
+		lxc_error("%s", "Failed to create container \"check_feature\"");
+		exit(ret);
+	}
+
+	if (c->is_defined(c)) {
+		lxc_error("%s\n", "Container \"check_feature\" is defined");
+		goto on_error_put;
+	}
+
+	/* check the migrate API call with wrong 'cmd' */
+	if (!c->migrate(c, UINT_MAX, &m_opts, sizeof(struct migrate_opts))) {
+		/* This should failed */
+		lxc_error("%s\n", "Migrate API calls with command UINT_MAX did not fail");
+		goto on_error_put;
+	}
+
+	/* do the actual fature check for memory tracking */
+	m_opts.features_to_check = FEATURE_MEM_TRACK;
+	if (c->migrate(c, MIGRATE_FEATURE_CHECK, &m_opts, sizeof(struct migrate_opts))) {
+		lxc_debug("%s\n", "System does not support \"FEATURE_MEM_TRACK\".");
+	}
+
+	/* check for lazy pages */
+	m_opts.features_to_check = FEATURE_LAZY_PAGES;
+	if (c->migrate(c, MIGRATE_FEATURE_CHECK, &m_opts, sizeof(struct migrate_opts))) {
+		lxc_debug("%s\n", "System does not support \"FEATURE_LAZY_PAGES\".");
+	}
+
+	/* check for lazy pages and memory tracking */
+	m_opts.features_to_check = FEATURE_LAZY_PAGES | FEATURE_MEM_TRACK;
+	if (c->migrate(c, MIGRATE_FEATURE_CHECK, &m_opts, sizeof(struct migrate_opts))) {
+		if (m_opts.features_to_check == FEATURE_LAZY_PAGES)
+			lxc_debug("%s\n", "System does not support \"FEATURE_MEM_TRACK\"");
+		else if (m_opts.features_to_check == FEATURE_MEM_TRACK)
+			lxc_debug("%s\n", "System does not support \"FEATURE_LAZY_PAGES\"");
+		else
+			lxc_debug("%s\n", "System does not support \"FEATURE_MEM_TRACK\" "
+					"and \"FEATURE_LAZY_PAGES\"");
+	}
+
+	/* test for unknown feature; once there are 64 features to test
+	 * this will be valid... */
+	m_opts.features_to_check = -1ULL;
+	if (!c->migrate(c, MIGRATE_FEATURE_CHECK, &m_opts, sizeof(struct migrate_opts))) {
+		lxc_error("%s\n", "Unsupported feature supported, which is strange.");
+		goto on_error_put;
+	}
+
+	ret = EXIT_SUCCESS;
+
+on_error_put:
+	lxc_container_put(c);
+	if (ret == EXIT_SUCCESS)
+		lxc_debug("%s\n", "All criu feature check tests passed");
+	exit(ret);
+}


### PR DESCRIPTION
For migration optimization features like pre-copy or post-copy migration the support cannot be determined by simply looking at the CRIU version. Features like that depend on the architecture/kernel/criu combination and CRIU offers a feature checking interface to query if it is supported.

This adds a LXC interface to query CRIU for those feature via the migrate() API call. For the recent pre-copy migration support in LXD this can be used to automatically detect if pre-copy migration should be used.

In addition to the existing migrate() API commands this adds a new command: MIGRATE_FEATURE_CHECK'.

The migrate_opts{} structure is extended by the member features_to_check which is a bitmask defining which CRIU features should be queried.

Currently only the querying of the features FEATURE_MEM_TRACK and FEATURE_LAZY_PAGES is supported.
