### PR TITLE
dir_detect: warn on eperm

### DIFF
--- a/src/lxc/storage/dir.c
+++ b/src/lxc/storage/dir.c
@@ -136,10 +136,19 @@ int dir_destroy(struct lxc_storage *orig)
 
 bool dir_detect(const char *path)
 {
+	struct stat statbuf;
+	int ret;
+
 	if (!strncmp(path, "dir:", 4))
 		return true;
 
-	if (is_dir(path))
+	ret = stat(path, &statbuf);
+	if (ret == -1 && errno == EPERM) {
+		SYSERROR("dir_detect: failed to look at \"%s\"", path);
+		return false;
+	}
+
+	if (ret == 0 && S_ISDIR(statbuf.st_mode))
 		return true;
 
 	return false;


### PR DESCRIPTION
if user has lxc.rootfs.path = /some/path/foo, but can't access
some piece of that path, then we'll get an unhelpful "failed to
mount" without any indication of the problem.

At least show that there is a permission problem.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>