### PR TITLE
commands: fix race when open()/close() cmd socket

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -753,12 +753,22 @@ void lxc_fini(const char *name, struct lxc_handler *handler)
 
 	cgroup_destroy(handler);
 
-	lxc_set_state(name, handler, STOPPED);
+	/* This function will try to connect to the legacy lxc-monitord state
+	 * server and only exists for backwards compatibility.
+	 */
+	lxc_monitor_send_state(name, STOPPED, handler->lxcpath);
 
 	if (handler->conf->reboot == 0) {
-		/* close command socket */
+		/* For all new state clients simply close the command socket.
+		 * This will inform all state clients that the container is
+		 * STOPPED and also prevents a race between a open()/close() on
+		 * the command socket causing a new process to get ECONNREFUSED
+		 * because we haven't yet closed the command socket.
+		 */
 		close(handler->conf->maincmd_fd);
 		handler->conf->maincmd_fd = -1;
+	} else {
+		lxc_set_state(name, handler, STOPPED);
 	}
 
 	if (run_lxc_hooks(name, "post-stop", handler->conf, handler->lxcpath, NULL)) {


### PR DESCRIPTION
When we report STOPPED to a caller and then close the command socket it is
technically possible - and I've seen this happen on the test builders - that a
container start() right after a wait() will receive ECONNREFUSED because it
called open() before we close(). So for all new state clients simply close the
command socket. This will inform all state clients that the container is
STOPPED and also prevents a race between a open()/close() on the command socket
causing a new process to get ECONNREFUSED because we haven't yet closed the
command socket.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>