### PR TITLE
start: reap intermediate process

### DIFF
--- a/src/lxc/error.h
+++ b/src/lxc/error.h
@@ -23,6 +23,8 @@
 #ifndef __LXC_ERROR_H
 #define __LXC_ERROR_H
 
+#define LXC_CLONE_ERROR "Failed to clone a new set of namespaces"
+
 extern int  lxc_error_set_and_log(int pid, int status);
 
 #endif


### PR DESCRIPTION
When we inherit namespaces we need to reap the attaching process.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>