### PR TITLE
btrfs: fix unprivileged snapshot creation

### DIFF
--- a/src/lxc/storage/btrfs.c
+++ b/src/lxc/storage/btrfs.c
@@ -469,11 +469,11 @@ bool btrfs_create_snapshot(struct lxc_conf *conf, struct lxc_storage *orig,
 	if (am_unpriv()) {
 		struct rsync_data_char args;
 
-		args.src = orig->dest;
+		args.src = orig->src;
 		args.dest = new->dest;
 
 		ret = userns_exec_1(conf, btrfs_snapshot_wrapper, &args,
-				"btrfs_snapshot_wrapper");
+				    "btrfs_snapshot_wrapper");
 		if (ret < 0) {
 			ERROR("Failed to run \"btrfs_snapshot_wrapper\"");
 			return false;


### PR DESCRIPTION
We already fixed privileged btrfs snapshot creation in:

commit 1c7222c084769a1d9406ca7dab943d8a5f016a56
Author: Christian Brauner <christian.brauner@ubuntu.com>
Date:   Tue Nov 28 13:51:03 2017 +0100

    btrfs: fix btrfs_snapshot()

    Closes #1956.

    Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
    Signed-off-by: Adrian Reber <areber@redhat.com>

but missed unprivileged btrfs snapshot creation. Fix it too.

Follow-up to #1956.
Closes #2051.

Reported-by: Oleg Freedhom overlayfs@gmail.com
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>