### PR TITLE
cgfsng: Add new macro to print errors

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -118,6 +118,11 @@ char *cgroup_use;
  */
 static bool lxc_cgfsng_debug;
 
+#define CGFSNG_DEBUG(format, ...) do {		\
+	if (lxc_cgfsng_debug)			\
+		printf("cgfsng: " format, ##__VA_ARGS__);	\
+} while(0)
+
 static void free_string_list(char **clist)
 {
 	if (clist) {
@@ -727,7 +732,7 @@ static bool all_controllers_found(void)
 	struct hierarchy ** hlist = hierarchies;
 
 	if (!controller_found(hlist, "freezer")) {
-		ERROR("No freezer controller mountpoint found");
+		CGFSNG_DEBUG("No freezer controller mountpoint found\n");
 		return false;
 	}
 
@@ -737,7 +742,7 @@ static bool all_controllers_found(void)
 	for (p = strtok_r(cgroup_use, ",", &saveptr); p;
 			p = strtok_r(NULL, ",", &saveptr)) {
 		if (!controller_found(hlist, p)) {
-			ERROR("No %s controller mountpoint found", p);
+			CGFSNG_DEBUG("No %s controller mountpoint found\n", p);
 			return false;
 		}
 	}
@@ -770,13 +775,13 @@ static char **get_controllers(char **klist, char **nlist, char *line, int type)
 	/* note - if we change how mountinfo works, then our caller
 	 * will need to verify /sys/fs/cgroup/ in this field */
 	if (strncmp(p, "/sys/fs/cgroup/", 15)) {
-		INFO("Found hierarchy not under /sys/fs/cgroup: \"%s\"", p);
+		CGFSNG_DEBUG("Found hierarchy not under /sys/fs/cgroup: \"%s\"\n", p);
 		return NULL;
 	}
 	p += 15;
 	p2 = strchr(p, ' ');
 	if (!p2) {
-		ERROR("Corrupt mountinfo");
+		CGFSNG_DEBUG("Corrupt mountinfo\n");
 		return NULL;
 	}
 	*p2 = '\0';
@@ -1068,7 +1073,7 @@ static bool parse_hierarchies(void)
 		return false;
 
 	if ((f = fopen("/proc/self/mountinfo", "r")) == NULL) {
-		SYSERROR("Failed to open \"/proc/self/mountinfo\"");
+		CGFSNG_DEBUG("Failed to open \"/proc/self/mountinfo\"\n");
 		return false;
 	}
 
@@ -1099,14 +1104,14 @@ static bool parse_hierarchies(void)
 
 		mountpoint = get_mountpoint(line);
 		if (!mountpoint) {
-			ERROR("Failed parsing mountpoint from \"%s\"", line);
+			CGFSNG_DEBUG("Failed parsing mountpoint from \"%s\"\n", line);
 			free_string_list(controller_list);
 			continue;
 		}
 
 		base_cgroup = get_current_cgroup(basecginfo, controller_list[0]);
 		if (!base_cgroup) {
-			ERROR("Failed to find current cgroup for controller \"%s\"", controller_list[0]);
+			CGFSNG_DEBUG("Failed to find current cgroup for controller \"%s\"\n", controller_list[0]);
 			free_string_list(controller_list);
 			free(mountpoint);
 			continue;
@@ -1155,7 +1160,7 @@ static bool collect_hierarchy_info(void)
 	errno = 0;
 	tmp = lxc_global_config_value("lxc.cgroup.use");
 	if (!cgroup_use && errno != 0) { /* lxc.cgroup.use can be NULL */
-		ERROR("Failed to retrieve list of cgroups to use");
+		CGFSNG_DEBUG("Failed to retrieve list of cgroups to use\n");
 		return false;
 	}
 	cgroup_use = must_copy_string(tmp);


### PR DESCRIPTION
At this point, macros such DEBUG or ERROR does not take effect because
this code is called from cgroup_ops_init(cgroup.c), which runs with
__attribute__((constructor)), before any log level is set form any tool
like lxc-start, so these messages are lost.

For now on, use the same LXC_DEBUG_CGFSNG environment variable to
control these messages.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>