### PR TITLE
lxc_config: Add -h and --help flags handler

### DIFF
--- a/src/lxc/tools/lxc_config.c
+++ b/src/lxc/tools/lxc_config.c
@@ -64,7 +64,8 @@ int main(int argc, char *argv[])
 
 	setenv("LXC_UPDATE_CONFIG_FORMAT", "1", 0);
 
-	if (argc < 2)
+	if (argc < 2 || strcmp(argv[1], "-h") == 0 ||
+			strcmp(argv[1], "--help") == 0)
 		usage(argv[0]);
 	if (strcmp(argv[1], "-l") == 0)
 		list_config_items();


### PR DESCRIPTION
As the other tools already handle, show usage message when -h or --help
are used.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>