### PR TITLE
conf: write "deny" to /proc/[pid]/setgroups

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1284,7 +1284,7 @@ static int rmdir_wrapper(void *data)
 		SYSERROR("Failed to setgid to 0");
 	if (setresuid(nsuid, nsuid, nsuid) < 0)
 		SYSERROR("Failed to setuid to 0");
-	if (setgroups(0, NULL) < 0)
+	if (setgroups(0, NULL) < 0 && errno != EPERM)
 		SYSERROR("Failed to clear groups");
 
 	return cgroup_rmdir(arg->path);
@@ -1481,7 +1481,7 @@ static int chown_cgroup_wrapper(void *data)
 		SYSERROR("Failed to setgid to 0");
 	if (setresuid(nsuid, nsuid, nsuid) < 0)
 		SYSERROR("Failed to setuid to 0");
-	if (setgroups(0, NULL) < 0)
+	if (setgroups(0, NULL) < 0 && errno != EPERM)
 		SYSERROR("Failed to clear groups");
 
 	destuid = get_ns_uid(arg->origuid);

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1206,7 +1206,7 @@ out_free:
 	return NULL;
 }
 
-static int cgroup_rmdir(char *dirname)
+static int recursive_destroy(char *dirname)
 {
 	int ret;
 	struct dirent *direntp;
@@ -1241,30 +1241,55 @@ static int cgroup_rmdir(char *dirname)
 		if (!S_ISDIR(mystat.st_mode))
 			goto next;
 
-		ret = cgroup_rmdir(pathname);
+		ret = recursive_destroy(pathname);
 		if (ret < 0)
 			r = -1;
-next:
+	next:
 		free(pathname);
 	}
 
 	ret = rmdir(dirname);
 	if (ret < 0) {
 		if (!r)
-			WARN("Failed to delete \"%s\": %s", dirname,
-			     strerror(errno));
+			WARN("%s - Failed to delete \"%s\"", strerror(errno),
+			     dirname);
 		r = -1;
 	}
 
 	ret = closedir(dir);
 	if (ret < 0) {
 		if (!r)
-			WARN("Failed to delete \"%s\": %s", dirname,
-			     strerror(errno));
+			WARN("%s - Failed to delete \"%s\"", strerror(errno),
+			     dirname);
 		r = -1;
 	}
 
 	return r;
+}
+
+static int cgroup_rmdir(char *container_cgroup)
+{
+	int i;
+
+	if (!container_cgroup || !hierarchies)
+		return 0;
+
+	for (i = 0; hierarchies[i]; i++) {
+		int ret;
+		struct hierarchy *h = hierarchies[i];
+
+		if (!h->fullcgpath)
+			continue;
+
+		ret = recursive_destroy(h->fullcgpath);
+		if (ret < 0)
+			WARN("Failed to destroy \"%s\"", h->fullcgpath);
+
+		free(h->fullcgpath);
+		h->fullcgpath = NULL;
+	}
+
+	return 0;
 }
 
 struct generic_userns_exec_data {
@@ -1274,7 +1299,7 @@ struct generic_userns_exec_data {
 	char *path;
 };
 
-static int rmdir_wrapper(void *data)
+static int cgroup_rmdir_wrapper(void *data)
 {
 	struct generic_userns_exec_data *arg = data;
 	uid_t nsuid = (arg->conf->root_nsuid_map != NULL) ? 0 : arg->conf->init_uid;
@@ -1287,45 +1312,30 @@ static int rmdir_wrapper(void *data)
 	if (setgroups(0, NULL) < 0 && errno != EPERM)
 		SYSERROR("Failed to clear groups");
 
-	return cgroup_rmdir(arg->path);
-}
-
-void recursive_destroy(char *path, struct lxc_conf *conf)
-{
-	int r;
-	struct generic_userns_exec_data wrap;
-
-	wrap.origuid = 0;
-	wrap.d = NULL;
-	wrap.path = path;
-	wrap.conf = conf;
-
-	if (conf && !lxc_list_empty(&conf->id_map))
-		r = userns_exec_1(conf, rmdir_wrapper, &wrap, "rmdir_wrapper");
-	else
-		r = cgroup_rmdir(path);
-
-	if (r < 0)
-		ERROR("Error destroying %s", path);
+	return cgroup_rmdir(arg->d->container_cgroup);
 }
 
 static void cgfsng_destroy(void *hdata, struct lxc_conf *conf)
 {
+	int ret;
 	struct cgfsng_handler_data *d = hdata;
+	struct generic_userns_exec_data wrap;
 
 	if (!d)
 		return;
 
-	if (d->container_cgroup && hierarchies) {
-		int i;
-		for (i = 0; hierarchies[i]; i++) {
-			struct hierarchy *h = hierarchies[i];
-			if (h->fullcgpath) {
-				recursive_destroy(h->fullcgpath, conf);
-				free(h->fullcgpath);
-				h->fullcgpath = NULL;
-			}
-		}
+	wrap.origuid = 0;
+	wrap.d = hdata;
+	wrap.conf = conf;
+
+	if (conf && !lxc_list_empty(&conf->id_map))
+		ret = userns_exec_1(conf, cgroup_rmdir_wrapper, &wrap,
+				    "cgroup_rmdir_wrapper");
+	else
+		ret = cgroup_rmdir(d->container_cgroup);
+	if (ret < 0) {
+		WARN("Failed to destroy cgroups");
+		return;
 	}
 
 	free_handler_data(d);

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1423,6 +1423,15 @@ static struct id_map *find_mapped_nsid_entry(struct lxc_conf *conf, unsigned id,
 	struct id_map *map;
 	struct id_map *retmap = NULL;
 
+	/* Shortcut for container's root mappings. */
+	if (id == 0) {
+		if (idtype == ID_TYPE_UID)
+			return conf->root_nsuid_map;
+
+		if (idtype == ID_TYPE_GID)
+			return conf->root_nsgid_map;
+	}
+
 	lxc_list_for_each(it, &conf->id_map) {
 		map = it->elem;
 		if (map->idtype != idtype)
@@ -3857,86 +3866,46 @@ static struct id_map *mapped_hostid_add(struct lxc_conf *conf, uid_t id, enum id
 	return entry;
 }
 
-/* Run a function in a new user namespace.
- * The caller's euid/egid will be mapped if it is not already.
- * Afaict, userns_exec_1() is only used to operate based on privileges for the
- * user's own {g,u}id on the host and for the container root's unmapped {g,u}id.
- * This means we require only to establish a mapping from:
- * - the container root {g,u}id as seen from the host > user's host {g,u}id
- * - the container root -> some sub{g,u}id
- * The former we add, if the user did not specifiy a mapping. The latter we
- * retrieve from the ontainer's configured {g,u}id mappings as it must have been
- * there to start the container in the first place.
- */
-int userns_exec_1(struct lxc_conf *conf, int (*fn)(void *), void *data,
-		  const char *fn_name)
+struct lxc_list *get_minimal_idmap(struct lxc_conf *conf)
 {
-	pid_t pid;
 	uid_t euid, egid;
-	struct userns_fn_data d;
-	int p[2];
-	struct lxc_list *it;
-	struct id_map *map;
-	char c = '1';
-	int ret = -1, status = -1;
 	uid_t nsuid = (conf->root_nsuid_map != NULL) ? 0 : conf->init_uid;
 	gid_t nsgid = (conf->root_nsgid_map != NULL) ? 0 : conf->init_gid;
 	struct lxc_list *idmap = NULL, *tmplist = NULL;
 	struct id_map *container_root_uid = NULL, *container_root_gid = NULL,
 		      *host_uid_map = NULL, *host_gid_map = NULL;
 
-	ret = pipe(p);
-	if (ret < 0) {
-		SYSERROR("opening pipe");
-		return -1;
-	}
-	d.fn = fn;
-	d.fn_name = fn_name;
-	d.arg = data;
-	d.p[0] = p[0];
-	d.p[1] = p[1];
-
-	/* Clone child in new user namespace. */
-	pid = lxc_clone(run_userns_fn, &d, CLONE_NEWUSER);
-	if (pid < 0) {
-		ERROR("failed to clone child process in new user namespace");
-		goto on_error;
-	}
-
-	close(p[0]);
-	p[0] = -1;
-
 	/* Find container root mappings. */
-	euid = geteuid();
 	container_root_uid = mapped_nsid_add(conf, nsuid, ID_TYPE_UID);
 	if (!container_root_uid) {
-		DEBUG("Failed to find mapping for container root uid %d", 0);
+		DEBUG("Failed to find mapping for namespace uid %d", 0);
 		goto on_error;
 	}
-	if (euid >= container_root_uid->hostid && euid < container_root_uid->hostid + container_root_uid->range)
+	euid = geteuid();
+	if (euid >= container_root_uid->hostid &&
+	    euid < (container_root_uid->hostid + container_root_uid->range))
 		host_uid_map = container_root_uid;
 
-	egid = getegid();
 	container_root_gid = mapped_nsid_add(conf, nsgid, ID_TYPE_GID);
 	if (!container_root_gid) {
-		DEBUG("Failed to find mapping for container root gid %d", 0);
+		DEBUG("Failed to find mapping for namespace gid %d", 0);
 		goto on_error;
 	}
-	if (egid >= container_root_gid->hostid && egid < container_root_gid->hostid + container_root_gid->range)
+	egid = getegid();
+	if (egid >= container_root_gid->hostid &&
+	    egid < (container_root_gid->hostid + container_root_gid->range))
 		host_gid_map = container_root_gid;
 
 	/* Check whether the {g,u}id of the user has a mapping. */
 	if (!host_uid_map)
 		host_uid_map = mapped_hostid_add(conf, euid, ID_TYPE_UID);
-
-	if (!host_gid_map)
-		host_gid_map = mapped_hostid_add(conf, egid, ID_TYPE_GID);
-
 	if (!host_uid_map) {
 		DEBUG("Failed to find mapping for uid %d", euid);
 		goto on_error;
 	}
 
+	if (!host_gid_map)
+		host_gid_map = mapped_hostid_add(conf, egid, ID_TYPE_GID);
 	if (!host_gid_map) {
 		DEBUG("Failed to find mapping for gid %d", egid);
 		goto on_error;
@@ -3992,37 +3961,10 @@ int userns_exec_1(struct lxc_conf *conf, int (*fn)(void *), void *data,
 	/* idmap will now keep track of that memory. */
 	host_gid_map = NULL;
 
-	if (lxc_log_get_level() == LXC_LOG_LEVEL_TRACE ||
-	    conf->loglevel == LXC_LOG_LEVEL_TRACE) {
-		lxc_list_for_each(it, idmap) {
-			map = it->elem;
-			TRACE("establishing %cid mapping for \"%d\" in new "
-			      "user namespace: nsuid %lu - hostid %lu - range "
-			      "%lu",
-			      (map->idtype == ID_TYPE_UID) ? 'u' : 'g', pid,
-			      map->nsid, map->hostid, map->range);
-		}
-	}
-
-	/* Set up {g,u}id mapping for user namespace of child process. */
-	ret = lxc_map_ids(idmap, pid);
-	if (ret < 0) {
-		ERROR("error setting up {g,u}id mappings for child process "
-		      "\"%d\"", pid);
-		goto on_error;
-	}
-
-	/* Tell child to proceed. */
-	if (write(p[1], &c, 1) != 1) {
-		SYSERROR("failed telling child process \"%d\" to proceed", pid);
-		goto on_error;
-	}
+	TRACE("Allocated minimal idmapping");
+	return idmap;
 
 on_error:
-	/* Wait for child to finish. */
-	if (pid > 0)
-		status = wait_for_pid(pid);
-
 	if (idmap)
 		lxc_free_idmap(idmap);
 	if (container_root_uid)
@@ -4033,6 +3975,88 @@ on_error:
 		free(host_uid_map);
 	if (host_gid_map && (host_gid_map != container_root_gid))
 		free(host_gid_map);
+
+	return NULL;
+}
+
+/* Run a function in a new user namespace.
+ * The caller's euid/egid will be mapped if it is not already.
+ * Afaict, userns_exec_1() is only used to operate based on privileges for the
+ * user's own {g,u}id on the host and for the container root's unmapped {g,u}id.
+ * This means we require only to establish a mapping from:
+ * - the container root {g,u}id as seen from the host > user's host {g,u}id
+ * - the container root -> some sub{g,u}id
+ * The former we add, if the user did not specifiy a mapping. The latter we
+ * retrieve from the ontainer's configured {g,u}id mappings as it must have been
+ * there to start the container in the first place.
+ */
+int userns_exec_1(struct lxc_conf *conf, int (*fn)(void *), void *data,
+		  const char *fn_name)
+{
+	pid_t pid;
+	struct userns_fn_data d;
+	int p[2];
+	char c = '1';
+	int ret = -1, status = -1;
+	struct lxc_list *idmap;
+
+	idmap = get_minimal_idmap(conf);
+	if (!idmap)
+		return -1;
+
+	ret = pipe(p);
+	if (ret < 0) {
+		SYSERROR("Failed to create pipe");
+		return -1;
+	}
+	d.fn = fn;
+	d.fn_name = fn_name;
+	d.arg = data;
+	d.p[0] = p[0];
+	d.p[1] = p[1];
+
+	/* Clone child in new user namespace. */
+	pid = lxc_raw_clone_cb(run_userns_fn, &d, CLONE_NEWUSER);
+	if (pid < 0) {
+		ERROR("failed to clone child process in new user namespace");
+		goto on_error;
+	}
+
+	close(p[0]);
+	p[0] = -1;
+
+	if (lxc_log_get_level() == LXC_LOG_LEVEL_TRACE ||
+	    conf->loglevel == LXC_LOG_LEVEL_TRACE) {
+		struct lxc_list *it;
+		struct id_map *map;
+
+		lxc_list_for_each(it, idmap) {
+			map = it->elem;
+			TRACE("Establishing %cid mapping for \"%d\" in new "
+			      "user namespace: nsuid %lu - hostid %lu - range "
+			      "%lu", (map->idtype == ID_TYPE_UID) ? 'u' : 'g',
+			      pid, map->nsid, map->hostid, map->range);
+		}
+	}
+
+	/* Set up {g,u}id mapping for user namespace of child process. */
+	ret = lxc_map_ids(idmap, pid);
+	if (ret < 0) {
+		ERROR("Error setting up {g,u}id mappings for child process "
+		      "\"%d\"", pid);
+		goto on_error;
+	}
+
+	/* Tell child to proceed. */
+	if (write(p[1], &c, 1) != 1) {
+		SYSERROR("Failed telling child process \"%d\" to proceed", pid);
+		goto on_error;
+	}
+
+on_error:
+	/* Wait for child to finish. */
+	if (pid > 0)
+		status = wait_for_pid(pid);
 
 	if (p[0] != -1)
 		close(p[0]);

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3471,7 +3471,8 @@ int lxc_clear_config_caps(struct lxc_conf *c)
 	return 0;
 }
 
-static int lxc_free_idmap(struct lxc_list *id_map) {
+static int lxc_free_idmap(struct lxc_list *id_map)
+{
 	struct lxc_list *it, *next;
 
 	lxc_list_for_each_safe(it, id_map, next) {
@@ -3479,6 +3480,7 @@ static int lxc_free_idmap(struct lxc_list *id_map) {
 		free(it->elem);
 		free(it);
 	}
+
 	return 0;
 }
 

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -410,7 +410,7 @@ struct lxc_conf {
 	struct lxc_list procs;
 };
 
-int write_id_mapping(enum idtype idtype, pid_t pid, const char *buf,
+extern int write_id_mapping(enum idtype idtype, pid_t pid, const char *buf,
 			    size_t buf_size);
 
 #ifdef HAVE_TLS

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -284,9 +284,11 @@ struct lxc_conf {
 	struct lxc_list cgroup;
 	struct {
 		struct lxc_list id_map;
+
 		/* Pointer to the idmap entry for the container's root uid in
 		 * the id_map list. Do not free! */
 		struct id_map *root_nsuid_map;
+
 		/* Pointer to the idmap entry for the container's root gid in
 		 * the id_map list. Do not free! */
 		struct id_map *root_nsgid_map;

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1014,7 +1014,7 @@ static int do_start(void *data)
 		 * user namespace.
 		 */
 		ret = lxc_setgroups(0, NULL);
-		if (ret < 0)
+		if (ret < 0 && (handler->am_root || errno != EPERM))
 			goto out_warn_father;
 
 		if (!handler->am_root) {


### PR DESCRIPTION
When fully unprivileged users run a container that only maps their own {g,u}id
and they do not have access to setuid new{g,u}idmap binaries we will write the
idmapping directly. This however requires us to write "deny" to
/proc/[pid]/setgroups otherwise any write to /proc/[pid]/gid_map will be
denied.

On a sidenote, this patch enables fully unprivileged containers. If you now set
lxc.net.[i].type = empty no privilege whatsoever is required to run a container.

Enhances #2033.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
Cc: Felix Abecassis <fabecassis@nvidia.com>
Cc: Jonathan Calmels <jcalmels@nvidia.com>