### PR TITLE
configure.ac: fix the check for static libcap

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -347,16 +347,32 @@ else
 	AC_MSG_RESULT([no])
 fi
 
+AC_MSG_CHECKING(for static libcap)
 # Check for static libcap, make sure the function checked for differs from the
 # the one checked below so the cache doesn't give a wrong answer
 OLD_CFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS -static"
-AC_CHECK_LIB([cap],[cap_init],[have_static_libcap=yes],[have_static_libcap=no])
+OLD_CPPFLAGS="$CPPFLAGS"
+OLD_LDFLAGS="$LDFLAGS"
+OLD_LIBS="$LIBS"
+CFLAGS=""
+CPPFLAGS=""
+LDFLAGS="-static"
+LIBS="-lcap"
+AC_LINK_IFELSE([
+  AC_LANG_SOURCE(
+    [[int main() { return 0; }]]
+  )],[have_static_libcap=yes],[have_static_libcap=no])
 AM_CONDITIONAL([HAVE_STATIC_LIBCAP], [test "x$have_static_libcap" = "xyes"])
 if test "x$have_static_libcap" = "xyes"; then
 	AC_DEFINE([HAVE_STATIC_LIBCAP], 1, [Have static libcap])
+	AC_MSG_RESULT([yes])
+else
+	AC_MSG_RESULT([no])
 fi
+CPPFLAGS="$OLD_CPPFLAGS"
 CFLAGS="$OLD_CFLAGS"
+LDFLAGS="$OLD_LDFLAGS"
+LIBS="$OLD_LIBS"
 
 
 # Linux capabilities


### PR DESCRIPTION
The existing check doesn't work, because when you statically
link a program against libc, any functions not called are not
included.  So cap_init() which we check for is not there in
the built binary.

So instead just check whether a "gcc -lcap -static" works.
If libcap.a is not available it will fail, if it is it will
succeed.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>