### PR TITLE
lxc_get_version() should show the "-devel" suffix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,9 @@ m4_define([lxc_abi], [lxc_abi_major.lxc_abi_minor.lxc_abi_micro])
 
 m4_define([lxc_version_base], [lxc_version_major.lxc_version_minor.lxc_version_micro])
 m4_define([lxc_version],
-	  [ifelse(lxc_version_beta, [], [lxc_version_base], [lxc_version_base.lxc_version_beta])])
+	  [ifelse(lxc_devel, 1,
+        ifelse(lxc_version_beta, [], [lxc_version_base], [lxc_version_base.lxc_version_beta])-devel,
+        ifelse(lxc_version_beta, [], [lxc_version_base], [lxc_version_base.lxc_version_beta]))])
 
 AC_INIT([lxc], [lxc_version])
 

--- a/src/lxc/lxc_init.c
+++ b/src/lxc/lxc_init.c
@@ -440,7 +440,7 @@ static void print_usage(const struct option longopts[])
 
 static void print_version()
 {
-	printf("%s%s\n", LXC_VERSION, LXC_DEVEL ? "-devel" : "");
+	printf("%s\n", LXC_VERSION);
 	exit(0);
 }
 

--- a/src/lxc/lxc_init.c
+++ b/src/lxc/lxc_init.c
@@ -63,7 +63,7 @@ static void interrupt_handler(int sig)
 
 static struct option long_options[] = {
 	    { "name",        required_argument, 0, 'n'         },
-     	    { "help",        no_argument,       0, 'h'         },
+	    { "help",        no_argument,       0, 'h'         },
 	    { "usage",       no_argument,       0, OPT_USAGE   },
 	    { "version",     no_argument,       0, OPT_VERSION },
 	    { "quiet",       no_argument,       0, 'q'         },

--- a/src/lxc/tools/arguments.c
+++ b/src/lxc/tools/arguments.c
@@ -132,7 +132,7 @@ static void print_usage(const struct option longopts[],
 
 static void print_version()
 {
-	printf("%s%s\n", LXC_VERSION, LXC_DEVEL ? "-devel" : "");
+	printf("%s\n", lxc_get_version());
 	exit(0);
 }
 


### PR DESCRIPTION
As this is actively looked for by go-lxc and LXD.