### PR TITLE
Add return check for 'lxc_cmd_get_name'

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4913,6 +4913,8 @@ int list_active_containers(const char *lxcpath, char ***nret,
 			if (strncmp(lxcpath, recvpath, lxcpath_len) != 0)
 				continue;
 			p = lxc_cmd_get_name(p);
+			if (!p)
+				continue;
 		}
 
 		if (array_contains(&ct_name, p, ct_name_cnt))


### PR DESCRIPTION
If 'lxc_cmd_get_name' failed and return with NULL, this will cause a segment fault when calling ‘add_to_array’.

Signed-off-by: LiFeng <lifeng68@huawei.com>