### PR TITLE
lxc-alpine: allow retaining sys_ptrace per container

### DIFF
--- a/config/templates/alpine.common.conf.in
+++ b/config/templates/alpine.common.conf.in
@@ -11,7 +11,6 @@ lxc.cap.drop = mknod
 lxc.cap.drop = setpcap
 lxc.cap.drop = sys_nice
 lxc.cap.drop = sys_pacct
-lxc.cap.drop = sys_ptrace
 lxc.cap.drop = sys_rawio
 lxc.cap.drop = sys_resource
 lxc.cap.drop = sys_tty_config

--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -398,6 +398,9 @@ configure_container() {
 		# hostname(1).
 		lxc.cap.drop = sys_admin
 
+		# Comment this out if you have to debug processes by tracing.
+		lxc.cap.drop = sys_ptrace
+
 		# Include common configuration.
 		lxc.include = $LXC_TEMPLATE_CONFIG/alpine.common.conf
 	EOF


### PR DESCRIPTION
It would be convenient to be able to toggle sys_ptrace on a per container basis. Removing the option from the common configuration file would have an effect on deployed containers, though.

Any better ideas to achieve this? Most of the templates do not drop this capability, so there is no good precedent.