### PR TITLE
Create console when the rootfs is NULL

### DIFF
--- a/src/lxc/console.c
+++ b/src/lxc/console.c
@@ -747,12 +747,6 @@ int lxc_console_create(struct lxc_conf *conf)
 	int ret;
 	struct lxc_console *console = &conf->console;
 
-	if (!conf->rootfs.path) {
-		INFO("Container does not have a rootfs. The console will be "
-		     "shared with the host");
-		return 0;
-	}
-
 	if (console->path && !strcmp(console->path, "none")) {
 		INFO("No console was requested");
 		return 0;


### PR DESCRIPTION
Steps to reproduce the problem：

1. Create a container with -t none
`lxc-create -n test1 -t none `
2. Modify the config of container test1 as follow
```
$ cat /var/lib/lcrd/lcr/test1/config
lxc.init_cmd = echo test
lxc.console.logfile = /home/out.log
```

3.Start the container test1,and check the output file `/home/out.log`, It is empty.

We should set the config` lxc.autodev = 0`, if we want to create console when the rootfs is NULL. Because so that we could see the allocated /dev/pts/x device and use it to bind mount the /dev/console.

Signed-off-by: LiFeng <lifeng68@huawei.com>