### PR TITLE
unlink lxc-init

### DIFF
--- a/src/lxc/lxc_init.c
+++ b/src/lxc/lxc_init.c
@@ -195,6 +195,30 @@ static void kill_children(pid_t pid)
 	fclose(f);
 }
 
+static void remove_self(void)
+{
+	char path[PATH_MAX];
+	ssize_t n;
+
+	n = readlink("/proc/self/exe", path, sizeof(path));
+	if (n < 0) {
+		SYSERROR("Failed to readlink \"/proc/self/exe\"");
+		return;
+	}
+
+	path[n] = 0;
+
+	if (umount2(path, MNT_DETACH) < 0) {
+		SYSERROR("Failed to unmount \"%s\"", path);
+		return;
+	}
+
+	if (unlink(path) < 0) {
+		SYSERROR("Failed to unlink \"%s\"", path);
+		return;
+	}
+}
+
 int main(int argc, char *argv[])
 {
 	int i, ret;
@@ -295,6 +319,8 @@ int main(int argc, char *argv[])
 	}
 
 	lxc_setup_fs();
+
+	remove_self();
 
 	pid = fork();
 	if (pid < 0)


### PR DESCRIPTION
It's sort of an implementation detail that this exists at all, and we
should probably not pollute the container's mount tables or FS with this.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>