### PR TITLE
manpage: correct lxc.log.file conf option

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -2136,7 +2136,7 @@ dev/null proc/kcore none bind,relative 0 0
         </varlistentry>
         <varlistentry>
           <term>
-            <option>lxc.log</option>
+            <option>lxc.log.file</option>
           </term>
           <listitem>
             <para>


### PR DESCRIPTION
lxc.log.file instead of just lxc.log