### PR TITLE
storage: treat return value from ops->destroy as int

### DIFF
--- a/src/lxc/storage/storage.c
+++ b/src/lxc/storage/storage.c
@@ -603,13 +603,14 @@ bool storage_destroy(struct lxc_conf *conf)
 {
 	struct lxc_storage *r;
 	bool ret = false;
+	int destroy_rv = 0;
 
 	r = storage_init(conf);
 	if (!r)
 		return ret;
 
-	ret = r->ops->destroy(r);
-	if (ret == 0)
+	destroy_rv = r->ops->destroy(r);
+	if (destroy_rv == 0)
 		ret = true;
 
 	storage_put(r);


### PR DESCRIPTION
r->ops->destroy() returns an int, -1 on error.
When assigned to a bool, this becomes true and hides errors.

ret will always be true - on error, it's -1 - a true bool - or it is zero and thus set to true.

Signed-off-by: Michael McCracken <mikmccra@cisco.com>