### PR TITLE
network.c: Remove ip_forward_set and callers

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -1368,32 +1368,6 @@ static int proc_sys_net_write(const char *path, const char *value)
 	return err;
 }
 
-static int ip_forward_set(const char *ifname, int family, int flag)
-{
-	int rc;
-	char path[MAXPATHLEN];
-
-	if (family != AF_INET && family != AF_INET6)
-		return -EINVAL;
-
-	rc = snprintf(path, MAXPATHLEN, "/proc/sys/net/%s/conf/%s/forwarding",
-		      family == AF_INET ? "ipv4" : "ipv6", ifname);
-	if (rc < 0 || (size_t)rc >= MAXPATHLEN)
-		return -E2BIG;
-
-	return proc_sys_net_write(path, flag ? "1" : "0");
-}
-
-int lxc_ip_forward_on(const char *ifname, int family)
-{
-	return ip_forward_set(ifname, family, 1);
-}
-
-int lxc_ip_forward_off(const char *ifname, int family)
-{
-	return ip_forward_set(ifname, family, 0);
-}
-
 static int neigh_proxy_set(const char *ifname, int family, int flag)
 {
 	int ret;

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -207,12 +207,6 @@ extern int lxc_macvlan_create(const char *master, const char *name, int mode);
 extern int lxc_vlan_create(const char *master, const char *name,
 			   unsigned short vid);
 
-/* Activate forwarding.*/
-extern int lxc_ip_forward_on(const char *name, int family);
-
-/* Disable forwarding. */
-extern int lxc_ip_forward_off(const char *name, int family);
-
 /* Set ip address. */
 extern int lxc_ipv6_addr_add(int ifindex, struct in6_addr *addr,
 			     struct in6_addr *mcast,


### PR DESCRIPTION
The last user of ip_forward_set, lxc_ip_forward_on and
lxc_ip_forward_off was in 2009:

commit 92d385229be040cf034ac6efd9405b7bdfe06a3e
Author: Daniel Lezcano <dlezcano@fr.ibm.com>
Date:   Thu Oct 22 15:33:40 2009 +0200

    remove test directory

These functions are not called anymore.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>