### PR TITLE
[cgfsng] show wrong errno

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -2143,6 +2143,7 @@ static int lxc_cgroup_set_data(const char *filename, const char *value, struct c
 		      "The controller seems to be unused by \"cgfsng\" cgroup "
 		      "driver or not enabled on the cgroup hierarchy",
 		      controller);
+		errno = ENOENT;
 		return -1;
 	}
 


### PR DESCRIPTION
lxc_cgroup_set_data: h = get_hierarchy(controller);
if h is NULL, now errno is old, it donot set new one.
And then,
cgfsng_setup_limits:

    if (lxc_cgroup_set_data(cg->subsystem, cg->value, d)) {
		if (do_devices && (errno == EACCES ||
			errno == EPERM)) {
			WARN("Error setting %s to %s for %s",
				cg->subsystem, cg->value,
				d->name);
			continue;
		}
		SYSERROR("Error setting %s to %s for
			 %s",
			 cg->subsystem, cg->value,
			 d->name);
		goto out;
	}

SYSERROR will show old errno, make me confused.

Signed-off-by: duguhaotian <duguhaotian@gmail.com>