### PR TITLE
debian: Use iproute2 instead of iproute

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -329,7 +329,7 @@ dialog,\
 isc-dhcp-client,\
 netbase,\
 net-tools,\
-iproute,\
+iproute2,\
 openssh-server
 
     cache=$1


### PR DESCRIPTION
The package has pretty much always been iproute2 with iproute being an
alias for it, the alias is now gone so we need to use iproute2.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>