### PR TITLE
tools: make "-n" optional

### DIFF
--- a/src/lxc/tools/arguments.c
+++ b/src/lxc/tools/arguments.c
@@ -256,10 +256,18 @@ extern int lxc_arguments_parse(struct lxc_arguments *args, int argc,
 	}
 
 	/* Check the command options */
-
 	if (!args->name && strcmp(args->progname, "lxc-autostart") != 0) {
-		lxc_error(args, "missing container name, use --name option");
-		return -1;
+		if (args->argv) {
+			args->name = argv[optind];
+			optind++;
+			args->argv = &argv[optind];
+			args->argc = argc - optind;
+		}
+
+		if (!args->name) {
+			lxc_error(args, "No container name specified");
+			return -1;
+		}
 	}
 
 	if (args->checker)


### PR DESCRIPTION
This lets users use the tools with "lxc-* -n <container-name>" or
"lxc-* <container-name>".

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
