### PR TITLE
lsm: do not #ifdefine

### DIFF
--- a/src/lxc/lsm/lsm.c
+++ b/src/lxc/lsm/lsm.c
@@ -21,8 +21,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#if HAVE_APPARMOR || HAVE_SELINUX
-
 #include <errno.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -31,7 +29,7 @@
 
 #include "conf.h"
 #include "log.h"
-#include "lsm/lsm.h"
+#include "lsm.h"
 
 lxc_log_define(lxc_lsm, lxc);
 
@@ -183,5 +181,3 @@ int lsm_process_label_set(const char *label, struct lxc_conf *conf,
 	}
 	return drv->process_label_set(label, conf, use_default, on_exec);
 }
-
-#endif

--- a/src/lxc/lsm/lsm.h
+++ b/src/lxc/lsm/lsm.h
@@ -28,7 +28,7 @@ struct lxc_conf;
 
 #include <sys/types.h>
 
-#include "../utils.h"
+#include "utils.h"
 
 #define LXC_LSMATTRLEN (5 + (LXC_NUMSTRLEN64) + 7 + 1)
 
@@ -41,7 +41,6 @@ struct lsm_drv {
 				 bool use_default, bool on_exec);
 };
 
-#if HAVE_APPARMOR || HAVE_SELINUX
 extern void lsm_init(void);
 extern int lsm_enabled(void);
 extern const char *lsm_name(void);
@@ -51,43 +50,5 @@ extern int lsm_process_label_set(const char *label, struct lxc_conf *conf,
 extern int lsm_process_label_fd_get(pid_t pid, bool on_exec);
 extern int lsm_process_label_set_at(int label_fd, const char *label,
 				    bool on_exec);
-#else
-static inline void lsm_init(void)
-{
-	return;
-}
 
-static inline int lsm_enabled(void) {
-	return 0;
-}
-
-static inline const char *lsm_name(void)
-{
-	return "none";
-}
-
-static inline char *lsm_process_label_get(pid_t pid)
-{
-	return NULL;
-}
-
-static inline int lsm_process_label_set(const char *label,
-					struct lxc_conf *conf, bool use_default,
-					bool on_exec)
-{
-	return 0;
-}
-
-static inline int lsm_process_label_fd_get(pid_t pid, bool on_exec)
-{
-	return 0;
-}
-
-extern int lsm_process_label_set_at(int label_fd, const char *label,
-				    bool on_exec)
-{
-	return 0;
-}
-#endif
-
-#endif
+#endif /* __LXC_LSM_H */

--- a/src/lxc/lsm/selinux.c
+++ b/src/lxc/lsm/selinux.c
@@ -28,7 +28,7 @@
 #include <selinux/selinux.h>
 
 #include "log.h"
-#include "lsm/lsm.h"
+#include "lsm.h"
 #include "conf.h"
 
 #define DEFAULT_LABEL "unconfined_t"


### PR DESCRIPTION
Since we stopped linking against AppArmor we can now remove the conditional
compilation.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>