### PR TITLE
debian: We must use iproute on wheezy

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -316,9 +316,11 @@ download_debian()
     case "$release" in
       wheezy)
         init=sysvinit
+        iproute=iproute
         ;;
       *)
         init=init
+        iproute=iproute2
         ;;
     esac
     packages=\
@@ -329,7 +331,7 @@ dialog,\
 isc-dhcp-client,\
 netbase,\
 net-tools,\
-iproute2,\
+$iproute,\
 openssh-server
 
     cache=$1


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>