### PR TITLE
[confile] wrong condition

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4675,7 +4675,7 @@ struct lxc_container *lxc_container_new(const char *name, const char *configpath
 		goto err;
 	}
 
-	if (file_exists(c->configfile) && !lxcapi_load_config(c, NULL)) {
+	if (!file_exists(c->configfile) && !lxcapi_load_config(c, NULL)) {
 		fprintf(stderr, "Failed to load config for %s\n", name);
 		goto err;
 	}


### PR DESCRIPTION
if (file_exists(c->configfile) && !lxcapi_load_config(c, NULL))
        goto err;

if c->configfile is not exist, will donot call lxcapi_load_config.
And not goto err, c->lxc_conf will not init.
if user call size_t len = c->get_config_item(c, key, NULL, 0);
will get a large length.

```
$ ./a.out
befor len: 18446744073709551615
len: 18446744073709551615
```
source code
```
int test_container(const char *name)
{
        int ret = -1;
        struct lxc_container *c;
        char key[256] = "lxc.console.logfile";
        /* Setup container struct */
        c = lxc_container_new(name, NULL);
        if (!c) {
                fprintf(stderr, "Failed to setup lxc_container struct\n");
                goto out;
        }

        size_t len = c->get_config_item(c, key, NULL, 0);
        printf("befor len: %lu\n", len);
        if (c->is_defined(c)) {
                fprintf(stderr, "Container already exists\n");
                goto out;
        }
        len = c->get_config_item(c, key, NULL, 0);
        printf("len: %lu\n", len);

        out:
                lxc_container_put(c);
                return ret;
}
```

Signed-off-by: duguhaotian <duguhaotian@gmail.com>