### PR TITLE
lxc-init: use SIGKILL after alarm timeout

### DIFF
--- a/src/lxc/lxc_init.c
+++ b/src/lxc/lxc_init.c
@@ -408,7 +408,7 @@ int main(int argc, char *argv[])
 			if (mypid != 1) {
 				kill_children(mypid);
 			} else {
-				ret = kill(-1, SIGTERM);
+				ret = kill(-1, SIGKILL);
 				if (ret < 0)
 					DEBUG("%s - Failed to send SIGTERM to "
 					      "all children", strerror(errno));


### PR DESCRIPTION
d76e3e1 inadvertently switched the alarm timeout from sigterm to sigkill.
We really want sigkill here, so let's bring it back.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>