### PR TITLE
lsm.c: Remove constructor attribute

### DIFF
--- a/src/lxc/lsm/lsm.c
+++ b/src/lxc/lsm/lsm.c
@@ -39,7 +39,6 @@ extern struct lsm_drv *lsm_apparmor_drv_init(void);
 extern struct lsm_drv *lsm_selinux_drv_init(void);
 extern struct lsm_drv *lsm_nop_drv_init(void);
 
-__attribute__((constructor))
 void lsm_init(void)
 {
 	if (drv) {


### PR DESCRIPTION
Only start.c uses makes use of lsm_init, and calls it exlpicity, so we
can safety remove __attribute__((constructor)) of it.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>