### PR TITLE
selinux.c: Simplify label_set

### DIFF
--- a/src/lxc/lsm/apparmor.c
+++ b/src/lxc/lsm/apparmor.c
@@ -162,8 +162,8 @@ static bool aa_needs_transition(char *curlabel)
  * apparmor_process_label_set: Set AppArmor process profile
  *
  * @label   : the profile to set
- * @conf    : the container configuration to use @label is NULL
- * @default : use the default profile if label is NULL
+ * @conf    : the container configuration to use if @label is NULL
+ * @default : use the default profile if @label is NULL
  * @on_exec : this is ignored.  Apparmor profile will be changed immediately
  *
  * Returns 0 on success, < 0 on failure
@@ -230,7 +230,6 @@ static int apparmor_process_label_set(const char *inlabel, struct lxc_conf *conf
 		INFO("apparmor profile unchanged");
 		return 0;
 	}
-
 	tid = lxc_raw_gettid();
 	label_fd = lsm_process_label_fd_get(tid, on_exec);
 	if (label_fd < 0) {

--- a/src/lxc/lsm/selinux.c
+++ b/src/lxc/lsm/selinux.c
@@ -76,12 +76,12 @@ static int selinux_process_label_set(const char *inlabel, struct lxc_conf *conf,
 {
 	const char *label = inlabel ? inlabel : conf->lsm_se_context;
 	if (!label) {
-		if (use_default)
-			label = DEFAULT_LABEL;
-		else
+		if (!use_default)
 			return -1;
+		label = DEFAULT_LABEL;
 	}
-	if (!strcmp(label, "unconfined_t"))
+
+	if (!strcmp(label, DEFAULT_LABEL))
 		return 0;
 
 	if (on_exec) {

--- a/src/lxc/lsm/selinux.c
+++ b/src/lxc/lsm/selinux.c
@@ -63,8 +63,8 @@ static char *selinux_process_label_get(pid_t pid)
  * selinux_process_label_set: Set SELinux context of a process
  *
  * @label   : label string
- * @conf    : the container configuration to use @label is NULL
- * @default : use the default context if label is NULL
+ * @conf    : the container configuration to use if @label is NULL
+ * @default : use the default context if @label is NULL
  * @on_exec : the new context will take effect on exec(2) not immediately
  *
  * Returns 0 on success, < 0 on failure


### PR DESCRIPTION
If there is no label in the argument or in the config, and we can't use
the default, return error.

If we can use the default, later on we compare the label with
"unconfined_t", which is the same as DEFAUL_LABEL.

We can simplify it by checking if there is not label (in argument and in
conf), and return error if we can't use the default, or return 0 if we
the default applies. After this change, DEFAULT_LABEL can also be
removed, as it is not used anymore.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>