### PR TITLE
Add two auto mount options:

### DIFF
--- a/src/lxc/cgroups/cgfsng.c.rej
+++ b/src/lxc/cgroups/cgfsng.c.rej
@@ -1,0 +1,53 @@
+diff a/src/lxc/cgroups/cgfsng.c b/src/lxc/cgroups/cgfsng.c	(rejected hunks)
+@@ -1960,7 +1960,7 @@ static int do_secondstage_mounts_if_needed(int type, struct hierarchy *h,
+ 
+ 	if (flags & MS_RDONLY) {
+ 		ret = mount(sourcepath, cgpath, "cgroup",
+-			    MS_REMOUNT | flags | MS_RDONLY, NULL);
++			    MS_REMOUNT | flags, NULL);
+ 		if (ret < 0) {
+ 			SYSERROR("Failed to remount \"%s\" ro", cgpath);
+ 			free(sourcepath);
+@@ -1975,24 +1975,27 @@ static int do_secondstage_mounts_if_needed(int type, struct hierarchy *h,
+ 
+ static int mount_cgroup_cgns_supported(int type, struct hierarchy *h, const char *controllerpath)
+ {
+-	 int ret;
+-	 char *controllers = NULL;
+-	 char *fstype = "cgroup2";
+-	 unsigned long flags = 0;
++	int ret;
++	char *controllers = NULL;
++	char *fstype = "cgroup2";
++	unsigned long flags = 0;
+ 
+-	 flags |= MS_NOSUID;
+-	 flags |= MS_NOEXEC;
+-	 flags |= MS_NODEV;
+-	 flags |= MS_RELATIME;
++	flags |= MS_NOSUID;
++	flags |= MS_NOEXEC;
++	flags |= MS_NODEV;
++	flags |= MS_RELATIME;
+ 
+-	 if (type == LXC_AUTO_CGROUP_RO || type == LXC_AUTO_CGROUP_FULL_RO)
+-		 flags |= MS_RDONLY;
++	if (type & LXC_AUTO_CGROUP_FORCE){
++		type &= ~LXC_AUTO_CGROUP_FORCE;
++	}
++	if (type == LXC_AUTO_CGROUP_RO || type == LXC_AUTO_CGROUP_FULL_RO)
++		flags |= MS_RDONLY;
+ 
+-	 if (h->version != CGROUP2_SUPER_MAGIC) {
+-		 controllers = lxc_string_join(",", (const char **)h->controllers, false);
+-		 if (!controllers)
+-			 return -ENOMEM;
+-		 fstype = "cgroup";
++	if (h->version != CGROUP2_SUPER_MAGIC) {
++		controllers = lxc_string_join(",", (const char **)h->controllers, false);
++		if (!controllers)
++			return -ENOMEM;
++		fstype = "cgroup";
+ 	}
+ 
+ 	ret = mount("cgroup", controllerpath, fstype, flags, controllers);

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -715,7 +715,7 @@ static int lxc_mount_auto_mounts(struct lxc_conf *conf, int flags, struct lxc_ha
 	if (flags & LXC_AUTO_CGROUP_MASK) {
 		int cg_flags;
 
-		cg_flags = flags & LXC_AUTO_CGROUP_MASK;
+		cg_flags = flags & (LXC_AUTO_CGROUP_MASK & ~LXC_AUTO_CGROUP_FORCE);
 		/* If the type of cgroup mount was not specified, it depends on the
 		 * container's capabilities as to what makes sense: if we have
 		 * CAP_SYS_ADMIN, the read-only part can be remounted read-write
@@ -737,7 +737,8 @@ static int lxc_mount_auto_mounts(struct lxc_conf *conf, int flags, struct lxc_ha
 			else
 				cg_flags = has_sys_admin ? LXC_AUTO_CGROUP_FULL_RW : LXC_AUTO_CGROUP_FULL_MIXED;
 		}
-
+		if (flags & LXC_AUTO_CGROUP_FORCE)
+				cg_flags |= LXC_AUTO_CGROUP_FORCE;
 		if (!cgroup_mount(conf->rootfs.path ? conf->rootfs.mount : "", handler, cg_flags)) {
 			SYSERROR("error mounting /sys/fs/cgroup");
 			return -1;
@@ -3343,7 +3344,8 @@ int lxc_setup(struct lxc_handler *handler)
 	 * before, /sys could not have been mounted
 	 * (is either mounted automatically or via fstab entries)
 	 */
-	if (lxc_mount_auto_mounts(lxc_conf, lxc_conf->auto_mounts & LXC_AUTO_CGROUP_MASK, handler) < 0) {
+	if (lxc_mount_auto_mounts(lxc_conf,
+		lxc_conf->auto_mounts & (LXC_AUTO_CGROUP_MASK), handler) < 0) {
 		ERROR("failed to setup the automatic mounts for '%s'", name);
 		return -1;
 	}

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -233,9 +233,9 @@ enum {
 	 * variants, which is safe. */
 	LXC_AUTO_CGROUP_NOSPEC        = 0x0B0,   /* /sys/fs/cgroup (partial mount, r/w or mixed, depending on caps) */
 	LXC_AUTO_CGROUP_FULL_NOSPEC   = 0x0E0,   /* /sys/fs/cgroup (full mount, r/w or mixed, depending on caps) */
-	LXC_AUTO_CGROUP_MASK          = 0x0F0,
-
-	LXC_AUTO_ALL_MASK             = 0x0FF,   /* all known settings */
+	LXC_AUTO_CGROUP_FORCE         = 0x100,   /* force mount cgroup */
+	LXC_AUTO_CGROUP_MASK          = 0x1F0,   /* all known cgroup options,not contain LXC_AUTO_CGROUP_FORCE */
+	LXC_AUTO_ALL_MASK             = 0x1FF,   /* all known settings */
 };
 
 /*

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1706,26 +1706,30 @@ static int set_config_mount_auto(const char *key, const char *value,
 		int mask;
 		int flag;
 	} allowed_auto_mounts[] = {
-	    { "proc",              LXC_AUTO_PROC_MASK,   LXC_AUTO_PROC_MIXED         },
-	    { "proc:mixed",        LXC_AUTO_PROC_MASK,   LXC_AUTO_PROC_MIXED         },
-	    { "proc:rw",           LXC_AUTO_PROC_MASK,   LXC_AUTO_PROC_RW            },
-	    { "sys",               LXC_AUTO_SYS_MASK,    LXC_AUTO_SYS_MIXED          },
-	    { "sys:ro",            LXC_AUTO_SYS_MASK,    LXC_AUTO_SYS_RO             },
-	    { "sys:mixed",         LXC_AUTO_SYS_MASK,    LXC_AUTO_SYS_MIXED          },
-	    { "sys:rw",            LXC_AUTO_SYS_MASK,    LXC_AUTO_SYS_RW             },
-	    { "cgroup",            LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_NOSPEC      },
-	    { "cgroup:mixed",      LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_MIXED       },
-	    { "cgroup:ro",         LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_RO          },
-	    { "cgroup:rw",         LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_RW          },
-	    { "cgroup-full",       LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_FULL_NOSPEC },
-	    { "cgroup-full:mixed", LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_FULL_MIXED  },
-	    { "cgroup-full:ro",    LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_FULL_RO     },
-	    { "cgroup-full:rw",    LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_FULL_RW     },
+	    { "proc",                    LXC_AUTO_PROC_MASK,   LXC_AUTO_PROC_MIXED                               },
+	    { "proc:mixed",              LXC_AUTO_PROC_MASK,   LXC_AUTO_PROC_MIXED                               },
+	    { "proc:rw",                 LXC_AUTO_PROC_MASK,   LXC_AUTO_PROC_RW                                  },
+	    { "sys",                     LXC_AUTO_SYS_MASK,    LXC_AUTO_SYS_MIXED                                },
+	    { "sys:ro",                  LXC_AUTO_SYS_MASK,    LXC_AUTO_SYS_RO                                   },
+	    { "sys:mixed",               LXC_AUTO_SYS_MASK,    LXC_AUTO_SYS_MIXED                                },
+	    { "sys:rw",                  LXC_AUTO_SYS_MASK,    LXC_AUTO_SYS_RW                                   },
+	    { "cgroup",                  LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_NOSPEC                            },
+	    { "cgroup:mixed",            LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_MIXED                             },
+	    { "cgroup:ro",               LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_RO                                },
+	    { "cgroup:rw",               LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_RW                                },
+	    { "cgroup:force",            LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_NOSPEC|LXC_AUTO_CGROUP_FORCE      },
+	    { "cgroup:mixed:force",      LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_MIXED|LXC_AUTO_CGROUP_FORCE       },
+	    { "cgroup:ro:force",         LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_RO|LXC_AUTO_CGROUP_FORCE          },
+	    { "cgroup:rw:force",         LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_RW|LXC_AUTO_CGROUP_FORCE          },
+	    { "cgroup-full",             LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_FULL_NOSPEC                       },
+	    { "cgroup-full:mixed",       LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_FULL_MIXED                        },
+	    { "cgroup-full:ro",          LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_FULL_RO                           },
+	    { "cgroup-full:rw",          LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_FULL_RW                           },
 	    /* For adding anything that is just a single on/off, but has no
 	     * options: keep mask and flag identical and just define the enum
 	     * value as an unused bit so far
 	     */
-	    { NULL,                0,                    0                           }
+	    { NULL,                      0,                    0                                                 }
 	};
 
 	if (lxc_config_value_empty(value)) {


### PR DESCRIPTION
With cgroup:ro(rw/mixed) option, we have some restrictions:
   * general containers(non system containers with cgroup namespace and sys_admin) have no cgroup (/sys/fs/cgroup is empty)
   * container's /sys/fs/cgroup has lxc/containersid, sometimes it's not a issue, but it is strange and the  os also make cgroup subsystem directly in /sys/fs/cgroup.

What I do?
Add two auto mount options:
   *  cgroup-self:ro   partial mount by lxc itself, no lxc/containerid exist in /sys/fs/cgroup r/o
   *  cgroup-self:rw   partial mount by lxc itself, no lxc/containerid exist in /sys/fs/cgroup r/w

Signed-off-by: Shukui Yang <yangshukui@huawei.com>