### PR TITLE
fix userns helper error handling

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4003,13 +4003,13 @@ int userns_exec_1(struct lxc_conf *conf, int (*fn)(void *), void *data,
 	}
 
 on_error:
-	/* Wait for child to finish. */
-	if (pid > 0)
-		status = wait_for_pid(pid);
-
 	if (p[0] != -1)
 		close(p[0]);
 	close(p[1]);
+
+	/* Wait for child to finish. */
+	if (pid > 0)
+		status = wait_for_pid(pid);
 
 	if (status < 0)
 		ret = -1;
@@ -4178,6 +4178,10 @@ int userns_exec_full(struct lxc_conf *conf, int (*fn)(void *), void *data,
 	}
 
 on_error:
+	if (p[0] != -1)
+		close(p[0]);
+	close(p[1]);
+
 	/* Wait for child to finish. */
 	if (pid > 0)
 		ret = wait_for_pid(pid);
@@ -4188,10 +4192,6 @@ on_error:
 		free(host_uid_map);
 	if (host_gid_map && (host_gid_map != container_root_gid))
 		free(host_gid_map);
-
-	if (p[0] != -1)
-		close(p[0]);
-	close(p[1]);
 
 	return ret;
 }


### PR DESCRIPTION
In both of these cases if there is actually an error, we won't close the
pipe and the api call will hang. Instead, let's be sure to close the pipe
before waiting, so that it doesn't hang.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>