### PR TITLE
Fix lxc-console hang

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -540,6 +540,8 @@ int lxc_poll(const char *name, struct lxc_handler *handler)
 			ERROR("Failed to add console handlers to console mainloop");
 			goto out_mainloop_console;
 		}
+
+		handler->conf->console.descr = &descr;
 	}
 
 	ret = lxc_cmd_mainloop_add(name, &descr, handler);


### PR DESCRIPTION
The variable 'descr' is mistakenly covered with 'descr_console'.

Steps to reproduce the problem：

1. Create and start an container test1
2. use lxc-console to attach the container, it hang

Signed-off-by: LiFeng <lifeng68@huawei.com>