### PR TITLE
cgroups: use correct mask for chmod()

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1833,7 +1833,7 @@ static int chown_cgroup_wrapper(void *data)
 		char *fullpath;
 		char *path = hierarchies[i]->fullcgpath;
 
-		ret = chowmod(path, destuid, nsgid, 0755);
+		ret = chowmod(path, destuid, nsgid, 0775);
 		if (ret < 0)
 			return -1;
 


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>