### PR TITLE
cmd/lxc-update-config: check for empty arguments

### DIFF
--- a/src/lxc/cmd/lxc-update-config.in
+++ b/src/lxc/cmd/lxc-update-config.in
@@ -14,6 +14,12 @@ EOF
     return 0
 }
 
+# Check whether any arguments are provided.
+if [ $# -eq 0 ]; then
+    usage "${0}"
+    exit 0
+fi
+
 OPTIONS=$(getopt -o c:h --long config:,help -- "${@}")
 eval set -- "${OPTIONS}"
 


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>