### PR TITLE
commands: remove mutex from state client list

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -1149,7 +1149,6 @@ static void lxc_cmd_fd_cleanup(int fd, struct lxc_handler *handler,
 		return;
 	}
 
-	process_lock();
 	lxc_list_for_each_safe(cur, &handler->conf->state_clients, next) {
 		client = cur->elem;
 		if (client->clientfd != fd)
@@ -1165,7 +1164,6 @@ static void lxc_cmd_fd_cleanup(int fd, struct lxc_handler *handler,
 		 */
 		break;
 	}
-	process_unlock();
 }
 
 static int lxc_cmd_handler(int fd, uint32_t events, void *data,

--- a/src/lxc/commands_utils.c
+++ b/src/lxc/commands_utils.c
@@ -211,14 +211,11 @@ int lxc_add_state_client(int state_client_fd, struct lxc_handler *handler,
 		return -ENOMEM;
 	}
 
-	process_lock();
 	state = handler->state;
 	if (states[state] != 1) {
 		lxc_list_add_elem(tmplist, newclient);
 		lxc_list_add_tail(&handler->conf->state_clients, tmplist);
-		process_unlock();
 	} else {
-		process_unlock();
 		free(newclient);
 		free(tmplist);
 		return state;

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -390,7 +390,6 @@ int lxc_serve_state_clients(const char *name, struct lxc_handler *handler,
 	struct lxc_state_client *client;
 	struct lxc_msg msg = {.type = lxc_msg_state, .value = state};
 
-	process_lock();
 	if (state == THAWED)
 		handler->state = RUNNING;
 	else
@@ -400,7 +399,6 @@ int lxc_serve_state_clients(const char *name, struct lxc_handler *handler,
 
 	if (lxc_list_empty(&handler->conf->state_clients)) {
 		TRACE("No state clients registered");
-		process_unlock();
 		return 0;
 	}
 
@@ -437,7 +435,6 @@ int lxc_serve_state_clients(const char *name, struct lxc_handler *handler,
 		free(cur->elem);
 		free(cur);
 	}
-	process_unlock();
 
 	return 0;
 }


### PR DESCRIPTION
I was thinking about the locking here yesterday and it dawned on me that we
actually don't need this at all:
- possible contention between traversing list to send states to state clients
  and adding new state clients to the list:
  It is the command handler that adds new state clients to the state client
  list. The command handler and the code that actually sends out the container
  states run in the same process so there's not contention and thus no locking
  needed.
- adding state clients to the list from multiple threads:
  The command handler itself is single-threaded so only one thread's request can
  be served at the same time so no locking is needed.
- sending out the state to state clients via the command handler itself:
  The state client also adds and removes state clients from the state client
  list so there's no locking needed.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>