### PR TITLE
lxc_init: don't mount filesystems

### DIFF
--- a/src/lxc/cmd/lxc_init.c
+++ b/src/lxc/cmd/lxc_init.c
@@ -318,8 +318,6 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	lxc_setup_fs();
-
 	remove_self();
 
 	pid = fork();


### PR DESCRIPTION
We have an extensive set of container config options to do this
for us, and doing this unconditionally breaks several use cases.
For instance, if we want to bind mount a /dev/shm using the
container configuration, then lxc-execute, then lxc-init will
rudely unmount the /dev/shm and remount it as a private tmpfs.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>