### PR TITLE
tools: Include config.h in tool_utils.c

### DIFF
--- a/src/lxc/tools/tool_utils.c
+++ b/src/lxc/tools/tool_utils.c
@@ -37,6 +37,8 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include "config.h"
+
 #if HAVE_SYS_PERSONALITY_H
 #include <sys/personality.h>
 #endif


### PR DESCRIPTION
Since we do not include config.h, personality is not set. This is fix
it. See issue #2208.

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>