### PR TITLE
usernsexec: init log fd

### DIFF
--- a/src/lxc/cmd/lxc_usernsexec.c
+++ b/src/lxc/cmd/lxc_usernsexec.c
@@ -53,6 +53,8 @@
 #define MS_SLAVE (1 << 19)
 #endif
 
+extern int lxc_log_fd;
+
 int unshare(int flags);
 
 static void usage(const char *name)
@@ -273,6 +275,8 @@ int main(int argc, char *argv[])
 	char buf[1];
 	int pipe1[2],  /* child tells parent it has unshared */
 	    pipe2[2];  /* parent tells child it is mapped and may proceed */
+
+	lxc_log_fd = STDERR_FILENO;
 
 	memset(ttyname0, '\0', sizeof(ttyname0));
 	memset(ttyname1, '\0', sizeof(ttyname1));


### PR DESCRIPTION
lxc-usernsexec uses some functions (e.g. lxc_map_ids()), which are part of
the lxc library and thus use the WARN etc. macros to emit log messages.
However, it doesn't initialize the log in any way, so these messages go
into the ether.

lxc-usernsexec currently has no log parameters, so let's just log these to
stderr. Someone can do something fancier later if they want.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>