### PR TITLE
cgroups: don't escape if we're not real root

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1368,7 +1368,7 @@ static char *cg_unified_get_current_cgroup(void)
 	bool will_escape;
 	char *copy = NULL;
 
-	will_escape = (geteuid() == 0);
+	will_escape = !am_host_unpriv();
 	if (will_escape)
 		basecginfo = read_file("/proc/1/cgroup");
 	else


### PR DESCRIPTION
If we're host unpriv but root in our userns, we can't really escape
cgroups. Let's switch the cgroup escape test to reflect this.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>