### PR TITLE
Revert "cgroups: don't escape if we're not real root"

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1368,7 +1368,7 @@ static char *cg_unified_get_current_cgroup(void)
 	bool will_escape;
 	char *copy = NULL;
 
-	will_escape = !am_host_unpriv();
+	will_escape = (geteuid() == 0);
 	if (will_escape)
 		basecginfo = read_file("/proc/1/cgroup");
 	else


### PR DESCRIPTION
This reverts commit 8d961e28f1d759669b477a659cbb694aaa2af915.

Unfortunately I don't believe the check is correct in the general case.

(not in the actual commit msg) - in particular, root-started containers in an unprivileged container will end up starting under the cgroup which systemd assigned (for instance) or, worse, which the user calling 'sudo lxc-start mailcontainer -d' logged in as.