### PR TITLE
tools: fix usage of boolean function set_config_item

### DIFF
--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -194,8 +194,8 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	ret = lxc_config_define_load(&defines, c);
-	if (ret) {
+	bret = lxc_config_define_load(&defines, c);
+	if (!bret) {
 		lxc_container_put(c);
 		exit(EXIT_FAILURE);
 	}
@@ -209,8 +209,8 @@ int main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 		}
 
-		ret = c->set_config_item(c, "lxc.init.uid", buf);
-		if (ret < 0) {
+		bret = c->set_config_item(c, "lxc.init.uid", buf);
+		if (!bret) {
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}
@@ -225,8 +225,8 @@ int main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 		}
 
-		ret = c->set_config_item(c, "lxc.init.gid", buf);
-		if (ret < 0) {
+		bret = c->set_config_item(c, "lxc.init.gid", buf);
+		if (!bret) {
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}

--- a/src/lxc/tools/lxc_start.c
+++ b/src/lxc/tools/lxc_start.c
@@ -277,7 +277,7 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	if (lxc_config_define_load(&defines, c))
+	if (!lxc_config_define_load(&defines, c))
 		goto out;
 
 	if (!rcfile && !strcmp("/sbin/init", args[0])) {

--- a/src/lxc/tools/tool_utils.c
+++ b/src/lxc/tools/tool_utils.c
@@ -800,20 +800,20 @@ int lxc_config_define_add(struct lxc_list *defines, char *arg)
 	return 0;
 }
 
-int lxc_config_define_load(struct lxc_list *defines, struct lxc_container *c)
+bool lxc_config_define_load(struct lxc_list *defines, struct lxc_container *c)
 {
 	struct lxc_list *it;
-	int ret = 0;
+	bool bret = true;
 
 	lxc_list_for_each(it, defines) {
 		struct new_config_item *new_item = it->elem;
-		ret = c->set_config_item(c, new_item->key, new_item->val);
-		if (ret < 0)
+		bret = c->set_config_item(c, new_item->key, new_item->val);
+		if (!bret)
 			break;
 	}
 
 	lxc_config_define_free(defines);
-	return ret;
+	return bret;
 }
 
 void lxc_config_define_free(struct lxc_list *defines)

--- a/src/lxc/tools/tool_utils.h
+++ b/src/lxc/tools/tool_utils.h
@@ -160,8 +160,8 @@ extern char *get_template_path(const char *t);
 extern bool switch_to_ns(pid_t pid, const char *ns);
 
 extern int lxc_config_define_add(struct lxc_list *defines, char *arg);
-extern int lxc_config_define_load(struct lxc_list *defines,
-				  struct lxc_container *c);
+extern bool lxc_config_define_load(struct lxc_list *defines,
+				   struct lxc_container *c);
 extern void lxc_config_define_free(struct lxc_list *defines);
 extern int lxc_char_left_gc(const char *buffer, size_t len);
 extern int lxc_char_right_gc(const char *buffer, size_t len);


### PR DESCRIPTION
Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>

The command `lxc-execute --define lxc.environment='foo=bar' -n ubuntu --` was failing silently, with exit return code 1.

git bisect:
```
791e7a73a9bca8dbde19afb49f172a901ce0dd43 is the first bad commit
commit 791e7a73a9bca8dbde19afb49f172a901ce0dd43
Author: Christian Brauner <christian.brauner@ubuntu.com>
Date:   Fri Jan 12 15:31:03 2018 +0100

    tools: move lxc-execute to API symbols only
    
    Closes #2073.
    
    Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
```