### PR TITLE
conf: do not run the "mount" hooks twice

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3368,7 +3368,7 @@ int lxc_setup(struct lxc_handler *handler)
 	}
 
 	ret = run_lxc_hooks(name, "mount", lxc_conf, NULL);
-	if (run_lxc_hooks(name, "mount", lxc_conf, NULL)) {
+	if (ret < 0) {
 		ERROR("Failed to run mount hooks");
 		return -1;
 	}


### PR DESCRIPTION
Regression introduced by 8353b4c90ed18e570521134f2c60bef56a082b55

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>