### PR TITLE
start: set exit status in lxc_fini()

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -1069,7 +1069,6 @@ reboot:
 		ret = lxc_execute(c->name, argv, 1, handler, c->config_path, daemonize);
 	else
 		ret = lxc_start(c->name, argv, handler, c->config_path, daemonize);
-	c->error_num = handler->exit_status;
 
 	if (conf->reboot == 1) {
 		INFO("Container requested reboot");

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1920,6 +1920,7 @@ int __lxc_start(const char *name, struct lxc_handler *handler,
 
 	lxc_monitor_send_exit_code(name, status, handler->lxcpath);
 	lxc_error_set_and_log(handler->pid, status);
+	c->error_num = handler->exit_status;
 
 out_fini:
 	lxc_delete_network(handler);


### PR DESCRIPTION
Felix reported a use-after free when setting the exit status:

```
 Breakpoint 1, lxc_free_handler (handler=handler@entry=0x62b2d0) at start.c:635
 635     {
 (gdb) bt
 #0  lxc_free_handler (handler=handler@entry=0x62b2d0) at start.c:635
 #1  0x00007ffff7b5e28a in lxc_fini (name=name@entry=0x60ae50 "ubuntu", handler=handler@entry=0x62b2d0) at start.c:1001
 #2  0x00007ffff7b5e866 in __lxc_start (name=name@entry=0x60ae50 "ubuntu", handler=handler@entry=0x62b2d0, ops=ops@entry=0x7ffff7dd5840 <execute_start_ops>, data=data@entry=0x7fffffffc7e0,
     lxcpath=lxcpath@entry=0x627ac0 "/home/fabecassis/.local/share/lxc", backgrounded=backgrounded@entry=false) at start.c:1931
 #3  0x00007ffff7b6035c in lxc_execute (name=0x60ae50 "ubuntu", argv=argv@entry=0x7fffffffe278, quiet=quiet@entry=1, handler=handler@entry=0x62b2d0, lxcpath=0x627ac0 "/home/fabecassis/.local/share/lxc",
     backgrounded=backgrounded@entry=false) at execute.c:131
 #4  0x00007ffff7ba2113 in do_lxcapi_start (c=c@entry=0x627cf0, useinit=useinit@entry=1, argv=argv@entry=0x7fffffffe278) at lxccontainer.c:1069
 #5  0x00007ffff7ba29ee in lxcapi_start (c=0x627cf0, useinit=1, argv=0x7fffffffe278) at lxccontainer.c:1105
 #6  0x0000000000402705 in main (argc=<optimized out>, argv=<optimized out>) at tools/lxc_execute.c:241
```

Fix this by setting c->error_num in lxc_fini() before we free the handler.

Closes #2218.

Reported-by: Felix Abecassis <fabecassis@nvidia.com>
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>