### PR TITLE
remove leading whitespace from log files

### DIFF
--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -282,7 +282,7 @@ static int log_append_logfile(const struct lxc_log_appender *appender,
 		return 0;
 
 	n = snprintf(buffer, sizeof(buffer),
-			"%15s%s%s %s %-8s %s - %s:%s:%d - ",
+			"%s%s%s %s %-8s %s - %s:%s:%d - ",
 			log_prefix,
 			log_vmname ? " " : "",
 			log_vmname ? log_vmname : "",


### PR DESCRIPTION
This has annoyed me for a long time, 3.0 seems like the time to fix it :).

I think the way that the log prefix was intended to be used was perhaps a
dynamic prefix per file, but we don't do that today; we include the
filename later in the log message. Instead, we use it as the tool name,
which for liblxc is always "lxc", but could also be things like
"lxc-cgroup" or whatever. There is absolutely no reason to pad this, since
it is always the same for every log file (in fact, we could probably get
rid of the prefix all together, but that seems slightly more drastic).

Instead, let's just drop this padding. Hopefully this will save thousands
of hours of slight annoyance and right scrolling in various pastebins.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>