### PR TITLE
confile: expand lxc.environment

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -2445,6 +2445,13 @@ dev/null proc/kcore none bind,relative 0 0
               lxc.environment = APP_ENV=production
               lxc.environment = SYSLOG_SERVER=192.0.2.42
             </programlisting>
+            <para>
+            It is possible to inherit host environment variables by setting the
+            name of the variable without a "=" sign. For example:
+            </para>
+            <programlisting>
+              lxc.environment = PATH
+            </programlisting>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1096,7 +1096,21 @@ static int set_config_environment(const char *key, const char *value,
 	if (!list_item)
 		goto on_error;
 
-	list_item->elem = strdup(value);
+	if (!strchr(value, '=')) {
+		const char *env_val;
+		const char *env_key = value;
+		const char *env_var[3] = {0};
+
+		env_val = getenv(env_key);
+		if (!env_val)
+			goto on_error;
+
+		env_var[0] = env_key;
+		env_var[1] = env_val;
+		list_item->elem = lxc_string_join("=", env_var, false);
+	} else {
+		list_item->elem = strdup(value);
+	}
 
 	if (!list_item->elem)
 		goto on_error;


### PR DESCRIPTION
When a bare environment variable is specified then retrieve the value from the
current environment. For example, setting

lxc.environment = PATH

will cause LXC to inherit the value of PATH from the current environment.

Suggested-by: Jonathan Calmels <jcalmels@nvidia.com>
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>