### PR TITLE
fix signal sending in lxc.init

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -380,18 +380,18 @@ static int signal_handler(int fd, uint32_t events, void *data,
 		return hdlr->init_died ? LXC_MAINLOOP_CLOSE : 0;
 	}
 
+	if (siginfo.ssi_signo != SIGCHLD) {
+		kill(hdlr->pid, siginfo.ssi_signo);
+		INFO("Forwarded signal %d to pid %d", siginfo.ssi_signo, hdlr->pid);
+		return hdlr->init_died ? LXC_MAINLOOP_CLOSE : 0;
+	}
+
 	/* More robustness, protect ourself from a SIGCHLD sent
 	 * by a process different from the container init.
 	 */
 	if (siginfo.ssi_pid != hdlr->pid) {
 		NOTICE("Received %d from pid %d instead of container init %d",
 		       siginfo.ssi_signo, siginfo.ssi_pid, hdlr->pid);
-		return hdlr->init_died ? LXC_MAINLOOP_CLOSE : 0;
-	}
-
-	if (siginfo.ssi_signo != SIGCHLD) {
-		kill(hdlr->pid, siginfo.ssi_signo);
-		INFO("Forwarded signal %d to pid %d", siginfo.ssi_signo, hdlr->pid);
 		return hdlr->init_died ? LXC_MAINLOOP_CLOSE : 0;
 	}
 


### PR DESCRIPTION
The problem here is that these two clauses were ordered backwards: we first
check if the signal came from not the init pid, and if it did, then we give
a notice and return. The comment notes that this is intended to protect
against SIGCHLD, but we don't in fact know if the signal is a SIGCHLD yet,
because that's tested in the next hunk.

The symptom is that if I e.g. send SIGTERM from the outside world to the
container init, it ignores it and gives this notice. If we re-order these
clauses, it forwards non SIGCHLD signals, and ignores SIGCHLD signals from
things that aren't the real container process.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>