### PR TITLE
Fix temp file creation.

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2288,7 +2288,9 @@ FILE *make_anonymous_mount_file(struct lxc_list *mount)
 	if (fd < 0) {
 		if (errno != ENOSYS)
 			return NULL;
-		fd = lxc_make_tmpfile((char *){P_tmpdir "/.lxc_mount_file"}, true);
+
+		char template[] = P_tmpdir "/.lxc_mount_file_XXXXXX";
+		fd = lxc_make_tmpfile(template, true);
 		if (fd < 0) {
 			SYSERROR("Could not create temporary mount file");
 			return NULL;

--- a/src/lxc/ringbuf.c
+++ b/src/lxc/ringbuf.c
@@ -55,7 +55,8 @@ int lxc_ringbuf_create(struct lxc_ringbuf *buf, size_t size)
 		if (errno != ENOSYS)
 			goto on_error;
 
-		memfd = lxc_make_tmpfile((char *){P_tmpdir"/.lxc_ringbuf_XXXXXX"}, true);
+		char template[] = P_tmpdir "/.lxc_ringbuf_XXXXXX";
+		memfd = lxc_make_tmpfile(template, true);
 	}
 	if (memfd < 0)
 		goto on_error;


### PR DESCRIPTION
lxc_make_tmpfile() uses mkstemp() internally, and thus expects the
template to contain 'XXXXXX' and be writable.

The existing code in make_anonymous_mount_file() did not work in
case the memfd_create() syscall was not available.

Furthermore, mkstemp() modifies its template argument, hence it
should not be a constant, or undefined behavior can happen. Fixed
both occurrences.