### PR TITLE
Fix compilation with static libcap and shared gnutls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -263,7 +263,7 @@ AM_CONDITIONAL([ENABLE_GNUTLS], [test "x$enable_gnutls" = "xyes"])
 
 AM_COND_IF([ENABLE_GNUTLS],
 	[AC_CHECK_HEADER([gnutls/gnutls.h],[],[AC_MSG_ERROR([You must install the GnuTLS development package in order to compile lxc])])
-	AC_CHECK_LIB([gnutls], [gnutls_hash_fast],[],[AC_MSG_ERROR([You must install the GnuTLS development package in order to compile lxc])])
+	AC_CHECK_LIB([gnutls], [gnutls_hash_fast],[true],[AC_MSG_ERROR([You must install the GnuTLS development package in order to compile lxc])])
 	AC_SUBST([GNUTLS_LIBS], [-lgnutls])])
 
 # SELinux

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -175,6 +175,10 @@ if ENABLE_APPARMOR
 AM_CFLAGS += -DHAVE_APPARMOR
 endif
 
+if ENABLE_GNUTLS
+AM_CFLAGS += -DHAVE_LIBGNUTLS
+endif
+
 if ENABLE_SELINUX
 AM_CFLAGS += -DHAVE_SELINUX
 endif
@@ -196,7 +200,7 @@ liblxc_la_LDFLAGS = \
 	-Wl,-soname,liblxc.so.$(firstword $(subst ., ,@LXC_ABI@)) \
 	-version-info @LXC_ABI_MAJOR@
 
-liblxc_la_LIBADD = $(CAP_LIBS) $(SELINUX_LIBS) $(SECCOMP_LIBS)
+liblxc_la_LIBADD = $(CAP_LIBS) $(GNUTLS_LIBS) $(SELINUX_LIBS) $(SECCOMP_LIBS)
 
 bin_SCRIPTS=
 
@@ -243,7 +247,7 @@ AM_LDFLAGS = -Wl,-E
 if ENABLE_RPATH
 AM_LDFLAGS += -Wl,-rpath -Wl,$(libdir)
 endif
-LDADD=liblxc.la @CAP_LIBS@ @SELINUX_LIBS@ @SECCOMP_LIBS@
+LDADD=liblxc.la @CAP_LIBS@ @GNUTLS_LIBS@ @SELINUX_LIBS@ @SECCOMP_LIBS@
 
 if ENABLE_TOOLS
 lxc_attach_SOURCES = tools/lxc_attach.c tools/arguments.c tools/tool_utils.c


### PR DESCRIPTION
Commit c06ed219c47098f34485d408410b6ecc94a40877 has broken
compilation with a static libcap and a shared gnutls.
This results in a build failure on init_lxc_static if gnutls is
a shared library as init_lxc_static is built with -all-static option
(see src/lxc/Makefile.am) and AC_CHECK_LIB adds gnutls to LIBS.

This commit fix the issue by removing default behavior of AC_CHECK_LIB
and handling manually GNUTLS_LIBS and HAVE_LIBGNUTLS

Fixes:
 - http://autobuild.buildroot.net/results/b655d6853c25a195df28d91512b3ffb6c654fc90

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>