### PR TITLE
lxc-oci: mkdir the download directory

### DIFF
--- a/templates/lxc-oci.in
+++ b/templates/lxc-oci.in
@@ -264,6 +264,7 @@ if [ "${OCI_USE_CACHE}" = "true" ]; then
 else
   DOWNLOAD_BASE=/tmp
 fi
+mkdir -p "${DOWNLOAD_BASE}"
 
 # Trap all exit signals
 trap cleanup EXIT HUP INT TERM


### PR DESCRIPTION
The directory might not exist on a fresh install.