### PR TITLE
lxc/tools/lxc_monitor: include missing <stddef.h>

### DIFF
--- a/src/lxc/tools/lxc_monitor.c
+++ b/src/lxc/tools/lxc_monitor.c
@@ -30,6 +30,7 @@
 #include <libgen.h>
 #include <poll.h>
 #include <regex.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
lxc_monitor.c uses offsetof(), so it should include
<stddef.h>. Otherwise the build fails with the musl C library:

tools/lxc_monitor.c: In function ‘lxc_abstract_unix_connect’:
tools/lxc_monitor.c:324:9: warning: implicit declaration of function ‘offsetof’ [-Wimplicit-function-declaration]
         offsetof(struct sockaddr_un, sun_path) + len + 1);
         ^~~~~~~~
tools/lxc_monitor.c:324:18: error: expected expression before ‘struct’
         offsetof(struct sockaddr_un, sun_path) + len + 1);
                  ^~~~~~

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>