### PR TITLE
Also pass action scripts to CRIU on checkpointing

### DIFF
--- a/src/lxc/tools/lxc_checkpoint.c
+++ b/src/lxc/tools/lxc_checkpoint.c
@@ -169,6 +169,7 @@ static bool checkpoint(struct lxc_container *c)
 	opts.stop = stop;
 	opts.verbose = verbose;
 	opts.predump_dir = predump_dir;
+	opts.action_script = actionscript_path;
 
 	if (pre_dump)
 		mode = MIGRATE_PRE_DUMP;


### PR DESCRIPTION
I noticed that support for passing action scripts to CRIU via lxc-checkpoint was added in #2236 , but the action script is only passed to CRIU in restore mode. This change adds passing of the action script in checkpoint mode as well.