### PR TITLE
Fix tool_utils.c build when HAVE_SETNS is unset

### DIFF
--- a/src/lxc/tools/arguments.h
+++ b/src/lxc/tools/arguments.h
@@ -22,8 +22,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __LXC_ARGUMENTS_H
-#define __LXC_ARGUMENTS_H
+#ifndef __LXC_TOOLS_ARGUMENTS_H
+#define __LXC_TOOLS_ARGUMENTS_H
 
 #include <getopt.h>
 #include <stdbool.h>
@@ -177,4 +177,4 @@ extern int lxc_arguments_str_to_int(struct lxc_arguments *args,
 
 extern bool lxc_setup_shared_ns(struct lxc_arguments *args, struct lxc_container *c);
 
-#endif /* __LXC_ARGUMENTS_H */
+#endif /* __LXC_TOOLS_ARGUMENTS_H */

--- a/src/lxc/tools/tool_list.h
+++ b/src/lxc/tools/tool_list.h
@@ -21,8 +21,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef __LXC_LIST_H
-#define __LXC_LIST_H
+#ifndef __LXC_TOOLS_LIST_H
+#define __LXC_TOOLS_LIST_H
 
 #include <stdio.h>
 
@@ -164,4 +164,4 @@ static inline size_t lxc_list_len(struct lxc_list *list)
 	 return i;
 }
 
-#endif /* __LXC_LIST_H */
+#endif /* __LXC_TOOLS_LIST_H */

--- a/src/lxc/tools/tool_utils.h
+++ b/src/lxc/tools/tool_utils.h
@@ -17,8 +17,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __LXC_UTILS_H
-#define __LXC_UTILS_H
+#ifndef __LXC_TOOLS_UTILS_H
+#define __LXC_TOOLS_UTILS_H
 
 /* Properly support loop devices on 32bit systems. */
 #define _FILE_OFFSET_BITS 64
@@ -201,4 +201,4 @@ int clone(int (*fn)(void *), void *child_stack,
 
 extern pid_t lxc_clone(int (*fn)(void *), void *arg, int flags);
 
-#endif /* __LXC_UTILS_H */
+#endif /* __LXC_TOOLS_UTILS_H */

--- a/src/lxc/tools/tool_utils.h
+++ b/src/lxc/tools/tool_utils.h
@@ -109,6 +109,37 @@ extern signed long lxc_config_parse_arch(const char *arch);
 extern int lxc_namespace_2_cloneflag(const char *namespace);
 extern int lxc_fill_namespace_flags(char *flaglist, int *flags);
 
+#if !defined(__NR_setns) && !defined(__NR_set_ns)
+	#if defined(__x86_64__)
+		#define __NR_setns 308
+	#elif defined(__i386__)
+		#define __NR_setns 346
+	#elif defined(__arm__)
+		#define __NR_setns 375
+	#elif defined(__aarch64__)
+		#define __NR_setns 375
+	#elif defined(__powerpc__)
+		#define __NR_setns 350
+	#elif defined(__s390__)
+		#define __NR_setns 339
+	#endif
+#endif
+
+/* Define setns() if missing from the C library */
+#ifndef HAVE_SETNS
+static inline int setns(int fd, int nstype)
+{
+#ifdef __NR_setns
+	return syscall(__NR_setns, fd, nstype);
+#elif defined(__NR_set_ns)
+	return syscall(__NR_set_ns, fd, nstype);
+#else
+	errno = ENOSYS;
+	return -1;
+#endif
+}
+#endif
+
 #if HAVE_LIBCAP
 #include <sys/capability.h>
 


### PR DESCRIPTION
When HAVE_SETNS is unset the tool_utils.c can't be build because it can't find setns(). The inline setns() is defined in lxc/utils.h but isn't defined in lxc/tools/tool_utils.h. The patch fixes it. Another minor patch fixes headers in lxc/tools to use their own defines to disable double including ( __LXC_TOOLS_UTILS_H).