### PR TITLE
Mount injection API 

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2714,6 +2714,8 @@ struct lxc_conf *lxc_conf_init(void)
 	new->lsm_aa_profile = NULL;
 	new->lsm_se_context = NULL;
 	new->tmp_umount_proc = false;
+	new->lxc_shmount.path_host = NULL;
+	new->lxc_shmount.path_cont = NULL;
 
 	/* if running in a new user namespace, init and COMMAND
 	 * default to running as UID/GID 0 when using lxc-execute */
@@ -4041,6 +4043,8 @@ void lxc_conf_free(struct lxc_conf *conf)
 	lxc_clear_procs(conf, "lxc.proc");
 	free(conf->cgroup_meta.dir);
 	free(conf->cgroup_meta.controllers);
+	free(conf->lxc_shmount.path_host);
+	free(conf->lxc_shmount.path_cont);
 	free(conf);
 }
 

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -648,22 +648,21 @@ unsigned long add_required_remount_flags(const char *s, const char *d,
 #endif
 }
 
-static int add_shmount_to_list(struct lxc_conf *conf) {
+static int add_shmount_to_list(struct lxc_conf *conf)
+{
 	char new_mount[MAXPATHLEN];
 	/* Offset for the leading '/' since the path_cont
-	 * is absolute inside the container */
-	int ret = -1, offset = 1;
+	 * is absolute inside the container.
+	 */
+	int offset = 1, ret = -1;
 
-	ret = snprintf(new_mount, sizeof(new_mount), "%s %s none bind,create=dir 0 0",
-				   conf->shmount.path_host, conf->shmount.path_cont + offset);
+	ret = snprintf(new_mount, sizeof(new_mount),
+		       "%s %s none bind,create=dir 0 0", conf->shmount.path_host,
+		       conf->shmount.path_cont + offset);
 	if (ret < 0 || (size_t)ret >= sizeof(new_mount))
 		return -1;
 
-	ret = add_elem_to_mount_list(new_mount, conf);
-	if (ret < 0)
-		ERROR("Failed to add new mount \"%s\" to the config", new_mount);
-
-	return ret;
+	return add_elem_to_mount_list(new_mount, conf);
 }
 
 static int lxc_mount_auto_mounts(struct lxc_conf *conf, int flags, struct lxc_handler *handler)
@@ -806,7 +805,7 @@ static int lxc_mount_auto_mounts(struct lxc_conf *conf, int flags, struct lxc_ha
 		int ret = add_shmount_to_list(conf);
 		if (ret < 0) {
 			ERROR("Failed to add shmount entry to container config");
-			return ret;
+			return -1;
 		}
 	}
 

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -650,19 +650,13 @@ unsigned long add_required_remount_flags(const char *s, const char *d,
 
 static int add_shmount_to_list(struct lxc_conf *conf) {
 	char new_mount[MAXPATHLEN];
-	size_t len_mount;
 	/* Offset for the leading '/' since the path_cont
 	 * is absolute inside the container */
 	int ret = -1, offset = 1;
 
-	/* +1 for the separating whitespace */
-	len_mount = strlen(conf->shmount.path_host) + 1
-			+ strlen(conf->shmount.path_cont) - offset
-			+ sizeof(" none bind,create=dir 0 0") - 1;
-
-	ret = snprintf(new_mount, len_mount + 1, "%s %s none bind,create=dir 0 0",
+	ret = snprintf(new_mount, sizeof(new_mount), "%s %s none bind,create=dir 0 0",
 				   conf->shmount.path_host, conf->shmount.path_cont + offset);
-	if (ret < 0 || (size_t)ret >= len_mount + 1)
+	if (ret < 0 || (size_t)ret >= sizeof(new_mount))
 		return -1;
 
 	ret = add_elem_to_mount_list(new_mount, conf);

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -656,12 +656,12 @@ static int add_shmount_to_list(struct lxc_conf *conf) {
 	int ret = -1, offset = 1;
 
 	/* +1 for the separating whitespace */
-	len_mount = strlen(conf->lxc_shmount.path_host) + 1
-			+ strlen(conf->lxc_shmount.path_cont) - offset
+	len_mount = strlen(conf->shmount.path_host) + 1
+			+ strlen(conf->shmount.path_cont) - offset
 			+ sizeof(" none bind,create=dir 0 0") - 1;
 
 	ret = snprintf(new_mount, len_mount + 1, "%s %s none bind,create=dir 0 0",
-				   conf->lxc_shmount.path_host, conf->lxc_shmount.path_cont + offset);
+				   conf->shmount.path_host, conf->shmount.path_cont + offset);
 	if (ret < 0 || (size_t)ret >= len_mount + 1)
 		return -1;
 
@@ -2747,8 +2747,9 @@ struct lxc_conf *lxc_conf_init(void)
 	new->lsm_aa_profile = NULL;
 	new->lsm_se_context = NULL;
 	new->tmp_umount_proc = false;
-	new->lxc_shmount.path_host = NULL;
-	new->lxc_shmount.path_cont = NULL;
+	new->tmp_umount_proc = 0;
+	new->shmount.path_host = NULL;
+	new->shmount.path_cont = NULL;
 
 	/* if running in a new user namespace, init and COMMAND
 	 * default to running as UID/GID 0 when using lxc-execute */
@@ -4076,8 +4077,8 @@ void lxc_conf_free(struct lxc_conf *conf)
 	lxc_clear_procs(conf, "lxc.proc");
 	free(conf->cgroup_meta.dir);
 	free(conf->cgroup_meta.controllers);
-	free(conf->lxc_shmount.path_host);
-	free(conf->lxc_shmount.path_cont);
+	free(conf->shmount.path_host);
+	free(conf->shmount.path_cont);
 	free(conf);
 }
 

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -23,6 +23,7 @@
 
 #define _GNU_SOURCE
 #include "config.h"
+#include "confile.h"
 
 #include <arpa/inet.h>
 #include <dirent.h>
@@ -647,6 +648,30 @@ unsigned long add_required_remount_flags(const char *s, const char *d,
 #endif
 }
 
+static int add_shmount_to_list(struct lxc_conf *conf) {
+	char new_mount[MAXPATHLEN];
+	size_t len_mount;
+	/* Offset for the leading '/' since the path_cont
+	 * is absolute inside the container */
+	int ret = -1, offset = 1;
+
+	/* +1 for the separating whitespace */
+	len_mount = strlen(conf->lxc_shmount.path_host) + 1
+			+ strlen(conf->lxc_shmount.path_cont) - offset
+			+ sizeof(" none bind,create=dir 0 0") - 1;
+
+	ret = snprintf(new_mount, len_mount + 1, "%s %s none bind,create=dir 0 0",
+				   conf->lxc_shmount.path_host, conf->lxc_shmount.path_cont + offset);
+	if (ret < 0 || (size_t)ret >= len_mount + 1)
+		return -1;
+
+	ret = add_elem_to_mount_list(new_mount, conf);
+	if (ret < 0)
+		ERROR("Failed to add new mount \"%s\" to the config", new_mount);
+
+	return ret;
+}
+
 static int lxc_mount_auto_mounts(struct lxc_conf *conf, int flags, struct lxc_handler *handler)
 {
 	int i, r;
@@ -780,6 +805,14 @@ static int lxc_mount_auto_mounts(struct lxc_conf *conf, int flags, struct lxc_ha
 						cg_flags)) {
 			SYSERROR("Failed to mount \"/sys/fs/cgroup\"");
 			return -1;
+		}
+	}
+
+	if (flags & LXC_AUTO_SHMOUNTS_MASK) {
+		int ret = add_shmount_to_list(conf);
+		if (ret < 0) {
+			ERROR("Failed to add shmount entry to container config");
+			return ret;
 		}
 	}
 

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -189,6 +189,9 @@ enum {
 	LXC_AUTO_CGROUP_FULL_NOSPEC   = 0x0E0, /* /sys/fs/cgroup (full mount, r/w or mixed, depending on caps) */
 	LXC_AUTO_CGROUP_FORCE         = 0x100, /* mount cgroups even when cgroup namespaces are supported */
 	LXC_AUTO_CGROUP_MASK          = 0x1F0, /* all known cgroup options, doe not contain LXC_AUTO_CGROUP_FORCE */
+
+	LXC_AUTO_SHMOUNTS             = 0x200, /* shared mount point */
+	LXC_AUTO_SHMOUNTS_MASK        = 0x200, /* shared mount point mask */
 	LXC_AUTO_ALL_MASK             = 0x1FF, /* all known settings */
 };
 
@@ -367,6 +370,13 @@ struct lxc_conf {
 
 	/* procs */
 	struct lxc_list procs;
+
+	struct lxc_shmount {
+		/* Absolute path to the shared mount point on the host */
+		char *path_host;
+		/* Absolute path (in the container) to the shared mount point */
+		char *path_cont;
+	} lxc_shmount;
 };
 
 extern int write_id_mapping(enum idtype idtype, pid_t pid, const char *buf,

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -371,12 +371,12 @@ struct lxc_conf {
 	/* procs */
 	struct lxc_list procs;
 
-	struct lxc_shmount {
+	struct shmount {
 		/* Absolute path to the shared mount point on the host */
 		char *path_host;
 		/* Absolute path (in the container) to the shared mount point */
 		char *path_cont;
-	} lxc_shmount;
+	} shmount;
 };
 
 extern int write_id_mapping(enum idtype idtype, pid_t pid, const char *buf,

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1704,12 +1704,12 @@ static int set_config_mount_auto(const char *key, const char *value,
 		lxc_conf->auto_mounts &= ~allowed_auto_mounts[i].mask;
 		lxc_conf->auto_mounts |= allowed_auto_mounts[i].flag;
 		if (is_shmounts) {
-			lxc_conf->lxc_shmount.path_host = strdup(token + (sizeof("shmounts:") - 1));
-			if (strcmp(lxc_conf->lxc_shmount.path_host, "") == 0) {
+			lxc_conf->shmount.path_host = strdup(token + (sizeof("shmounts:") - 1));
+			if (strcmp(lxc_conf->shmount.path_host, "") == 0) {
 				ERROR("Invalid shmounts path: empty");
 				break;
 			}
-			lxc_conf->lxc_shmount.path_cont = strdup("/dev/.lxc-mounts");
+			lxc_conf->shmount.path_cont = strdup("/dev/.lxc-mounts");
 		}
 	}
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1659,6 +1659,7 @@ static int set_config_mount_auto(const char *key, const char *value,
 	    { "cgroup-full:mixed:force", LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_FULL_MIXED | LXC_AUTO_CGROUP_FORCE  },
 	    { "cgroup-full:ro:force",    LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_FULL_RO | LXC_AUTO_CGROUP_FORCE     },
 	    { "cgroup-full:rw:force",    LXC_AUTO_CGROUP_MASK, LXC_AUTO_CGROUP_FULL_RW | LXC_AUTO_CGROUP_FORCE     },
+	    { "shmounts:",               LXC_AUTO_SHMOUNTS_MASK, LXC_AUTO_SHMOUNTS                                 },
 	    /* For adding anything that is just a single on/off, but has no
 	    *  options: keep mask and flag identical and just define the enum
 	    *  value as an unused bit so far

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1689,8 +1689,8 @@ static int set_config_mount_auto(const char *key, const char *value,
 			if (!strcmp(allowed_auto_mounts[i].token, token))
 				break;
 
-			if (strcmp("shmounts:", allowed_auto_mounts[i].token) == 0
-					&& strncmp("shmounts:", token, sizeof("shmounts:") - 1) == 0) {
+			if (strcmp("shmounts:", allowed_auto_mounts[i].token) == 0 &&
+			    strncmp("shmounts:", token, sizeof("shmounts:") - 1) == 0) {
 				is_shmounts = true;
 				break;
 			}
@@ -1705,11 +1705,21 @@ static int set_config_mount_auto(const char *key, const char *value,
 		lxc_conf->auto_mounts |= allowed_auto_mounts[i].flag;
 		if (is_shmounts) {
 			lxc_conf->shmount.path_host = strdup(token + (sizeof("shmounts:") - 1));
+			if (!lxc_conf->shmount.path_host) {
+				SYSERROR("Failed to copy shmounts host path");
+				break;
+			}
+
 			if (strcmp(lxc_conf->shmount.path_host, "") == 0) {
 				ERROR("Invalid shmounts path: empty");
 				break;
 			}
+
 			lxc_conf->shmount.path_cont = strdup("/dev/.lxc-mounts");
+			if(!lxc_conf->shmount.path_cont) {
+				SYSERROR("Failed to copy shmounts container path");
+				break;
+			}
 		}
 	}
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1677,6 +1677,8 @@ static int set_config_mount_auto(const char *key, const char *value,
 		return -1;
 
 	for (autoptr = autos;; autoptr = NULL) {
+		bool is_shmounts = false;
+
 		token = strtok_r(autoptr, " \t", &sptr);
 		if (!token) {
 			ret = 0;
@@ -1686,6 +1688,12 @@ static int set_config_mount_auto(const char *key, const char *value,
 		for (i = 0; allowed_auto_mounts[i].token; i++) {
 			if (!strcmp(allowed_auto_mounts[i].token, token))
 				break;
+
+			if (strcmp("shmounts:", allowed_auto_mounts[i].token) == 0
+					&& strncmp("shmounts:", token, sizeof("shmounts:") - 1) == 0) {
+				is_shmounts = true;
+				break;
+			}
 		}
 
 		if (!allowed_auto_mounts[i].token) {
@@ -1695,6 +1703,14 @@ static int set_config_mount_auto(const char *key, const char *value,
 
 		lxc_conf->auto_mounts &= ~allowed_auto_mounts[i].mask;
 		lxc_conf->auto_mounts |= allowed_auto_mounts[i].flag;
+		if (is_shmounts) {
+			lxc_conf->lxc_shmount.path_host = strdup(token + (sizeof("shmounts:") - 1));
+			if (strcmp(lxc_conf->lxc_shmount.path_host, "") == 0) {
+				ERROR("Invalid shmounts path: empty");
+				break;
+			}
+			lxc_conf->lxc_shmount.path_cont = strdup("/dev/.lxc-mounts");
+		}
 	}
 
 	free(autos);
@@ -1724,6 +1740,10 @@ static int set_config_mount(const char *key, const char *value,
 	lxc_list_add_tail(&lxc_conf->mount_list, mntlist);
 
 	return 0;
+}
+
+int add_elem_to_mount_list(const char *value, struct lxc_conf *lxc_conf) {
+	return set_config_mount(NULL, value, lxc_conf, NULL);
 }
 
 static int set_config_cap_keep(const char *key, const char *value,

--- a/src/lxc/confile.h
+++ b/src/lxc/confile.h
@@ -28,7 +28,9 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+
 #include <lxc/attach_options.h>
+#include <lxc/lxccontainer.h>
 
 struct lxc_conf;
 struct lxc_list;

--- a/src/lxc/confile.h
+++ b/src/lxc/confile.h
@@ -121,4 +121,6 @@ bool clone_update_unexp_ovl_paths(struct lxc_conf *conf, const char *oldpath,
 
 extern bool network_new_hwaddrs(struct lxc_conf *conf);
 
+extern int add_elem_to_mount_list(const char *value, struct lxc_conf *lxc_conf);
+
 #endif /* __LXC_CONFILE_H */

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4966,13 +4966,13 @@ static int do_lxcapi_mount(struct lxc_container *c, const char *source,
 		return -EINVAL;
 	}
 
-	if (!c->lxc_conf->lxc_shmount.path_host) {
+	if (!c->lxc_conf->shmount.path_host) {
 		ERROR("Host path to shared mountpoint must be specified in the config\n");
 		return -EINVAL;
 	}
-	len = strlen(c->lxc_conf->lxc_shmount.path_host) + sizeof("/.lxcmount_XXXXXX") - 1;
+	len = strlen(c->lxc_conf->shmount.path_host) + sizeof("/.lxcmount_XXXXXX") - 1;
 
-	ret = snprintf(template, len + 1, "%s/.lxcmount_XXXXXX", c->lxc_conf->lxc_shmount.path_host);
+	ret = snprintf(template, len + 1, "%s/.lxcmount_XXXXXX", c->lxc_conf->shmount.path_host);
 	if (ret < 0 || (size_t)ret >= len + 1) {
 		SYSERROR("Error writing shmounts tempdir name");
 		goto out;
@@ -5048,8 +5048,8 @@ static int do_lxcapi_mount(struct lxc_container *c, const char *source,
 		if (!suff)
 			_exit(EXIT_FAILURE);
 
-		len = strlen(c->lxc_conf->lxc_shmount.path_cont) + sizeof("/.lxcmount_XXXXXX") - 1;
-		ret = snprintf(path, len + 1, "%s%s", c->lxc_conf->lxc_shmount.path_cont, suff);
+		len = strlen(c->lxc_conf->shmount.path_cont) + sizeof("/.lxcmount_XXXXXX") - 1;
+		ret = snprintf(path, len + 1, "%s%s", c->lxc_conf->shmount.path_cont, suff);
 		if (ret < 0 || (size_t)ret >= len + 1) {
 			SYSERROR("Error writing container mountpoint name");
 			_exit(EXIT_FAILURE);
@@ -5087,7 +5087,7 @@ WRAP_API_6(int, lxcapi_mount, const char *, const char *, const char *,
 	   unsigned long, const void *, struct lxc_mount *)
 
 static int do_lxcapi_umount(struct lxc_container *c, const char *target,
-			    unsigned long mountflags, struct lxc_mount *mnt)
+				unsigned long flags, struct lxc_mount *mnt)
 {
 	pid_t pid, init_pid;
 	int ret = -1;
@@ -5125,7 +5125,7 @@ static int do_lxcapi_umount(struct lxc_container *c, const char *target,
 		}
 
 		/* Do the unmount */
-		ret = umount2(target, mountflags);
+		ret = umount2(target, flags);
 		if (ret < 0) {
 			SYSERROR("Failed to umount \"%s\"", target);
 			_exit(EXIT_FAILURE);

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4955,7 +4955,6 @@ static int do_lxcapi_mount(struct lxc_container *c, const char *source,
 			   struct lxc_mount *mnt)
 {
 	char *suff, *sret;
-	size_t len;
 	char template[MAXPATHLEN], path[MAXPATHLEN];
 	pid_t pid, init_pid;
 	struct stat sb;
@@ -4970,10 +4969,9 @@ static int do_lxcapi_mount(struct lxc_container *c, const char *source,
 		ERROR("Host path to shared mountpoint must be specified in the config\n");
 		return -EINVAL;
 	}
-	len = strlen(c->lxc_conf->shmount.path_host) + sizeof("/.lxcmount_XXXXXX") - 1;
 
-	ret = snprintf(template, len + 1, "%s/.lxcmount_XXXXXX", c->lxc_conf->shmount.path_host);
-	if (ret < 0 || (size_t)ret >= len + 1) {
+	ret = snprintf(template, sizeof(template), "%s/.lxcmount_XXXXXX", c->lxc_conf->shmount.path_host);
+	if (ret < 0 || (size_t)ret >= sizeof(template)) {
 		SYSERROR("Error writing shmounts tempdir name");
 		goto out;
 	}
@@ -5048,9 +5046,8 @@ static int do_lxcapi_mount(struct lxc_container *c, const char *source,
 		if (!suff)
 			_exit(EXIT_FAILURE);
 
-		len = strlen(c->lxc_conf->shmount.path_cont) + sizeof("/.lxcmount_XXXXXX") - 1;
-		ret = snprintf(path, len + 1, "%s%s", c->lxc_conf->shmount.path_cont, suff);
-		if (ret < 0 || (size_t)ret >= len + 1) {
+		ret = snprintf(path, sizeof(path), "%s%s", c->lxc_conf->shmount.path_cont, suff);
+		if (ret < 0 || (size_t)ret >= sizeof(path)) {
 			SYSERROR("Error writing container mountpoint name");
 			_exit(EXIT_FAILURE);
 		}

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -42,6 +42,7 @@ extern "C" {
 #define LXC_CLONE_MAXFLAGS        (1 << 5) /*!< Number of \c LXC_CLONE_* flags */
 #define LXC_CREATE_QUIET          (1 << 0) /*!< Redirect \c stdin to \c /dev/zero and \c stdout and \c stderr to \c /dev/null */
 #define LXC_CREATE_MAXFLAGS       (1 << 1) /*!< Number of \c LXC_CREATE* flags */
+#define LXC_MOUNT_API_V1		   1
 
 struct bdev_specs;
 
@@ -52,6 +53,10 @@ struct lxc_lock;
 struct migrate_opts;
 
 struct lxc_console_log;
+
+struct lxc_mount {
+	int version;
+};
 
 /*!
  * An LXC container.
@@ -846,6 +851,14 @@ struct lxc_container {
 	 * \return \c true if the container was rebooted successfully, else \c false.
 	 */
 	bool (*reboot2)(struct lxc_container *c, int timeout);
+
+	/*!
+	 * \brief Mount the host's path `source` onto the container's path `target`.
+	 */
+	int (*mount)(struct lxc_container *c,
+				 const char *source, const char *target,
+				 const char *filesystemtype, unsigned long mountflags,
+				 const void *data, struct lxc_mount *mnt);
 };
 
 /*!

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -859,6 +859,12 @@ struct lxc_container {
 				 const char *source, const char *target,
 				 const char *filesystemtype, unsigned long mountflags,
 				 const void *data, struct lxc_mount *mnt);
+
+	/*!
+	 * \brief Unmount the container's path `target`.
+	 */
+	int (*umount)(struct lxc_container *c, const char *target,
+				  unsigned long mountflags, struct lxc_mount *mnt);
 };
 
 /*!

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1529,6 +1529,70 @@ static inline int do_share_ns(void *arg)
 	return 0;
 }
 
+static int lxc_setup_shmount(struct lxc_conf *conf) {
+	size_t len_cont;
+	char *full_cont_path;
+	int ret = -1;
+
+	/* Construct the shmount path under the container root */
+	/* +1 for slash */
+	len_cont = strlen(conf->rootfs.mount) + 1 + strlen(conf->lxc_shmount.path_cont);
+	/* +1 for the terminating '\0' */
+	full_cont_path = malloc(len_cont + 1);
+	if(!full_cont_path) {
+		SYSERROR("Not enough memory");
+		return -ENOMEM;
+	}
+	ret = snprintf(full_cont_path, len_cont + 1, "%s/%s", conf->rootfs.mount, conf->lxc_shmount.path_cont);
+	if (ret < 0 || ret >= len_cont + 1) {
+		SYSERROR("Failed to create filename");
+		free(full_cont_path);
+		return -1;
+	}
+
+	/* Check if shmount point is already set up */
+	if (is_shared_mountpoint(conf->lxc_shmount.path_host)) {
+		INFO("Path \"%s\" is already MS_SHARED. Reusing", conf->lxc_shmount.path_host);
+		free(full_cont_path);
+		return 0;
+	}
+
+	/* Create host and cont mount paths */
+	ret = mkdir_p(conf->lxc_shmount.path_host, 0711);
+	if (ret < 0 && errno != EEXIST) {
+		SYSERROR("Failed to create directory \"%s\"", conf->lxc_shmount.path_host);
+		free(full_cont_path);
+		return ret;
+	}
+
+	ret = mkdir_p(full_cont_path, 0711);
+	if (ret < 0 && errno != EEXIST) {
+		SYSERROR("Failed to create directory \"%s\"", full_cont_path);
+		free(full_cont_path);
+		return ret;
+	}
+
+	/* Prepare host mountpoint */
+	ret = mount("tmpfs", conf->lxc_shmount.path_host, "tmpfs",
+				0, "size=100k,mode=0711");
+	if (ret < 0) {
+		SYSERROR("Failed to mount \"%s\"", conf->lxc_shmount.path_host);
+		free(full_cont_path);
+		return ret;
+	}
+	ret = mount(conf->lxc_shmount.path_host, conf->lxc_shmount.path_host, "none",
+				MS_REC | MS_SHARED, "");
+	if (ret < 0) {
+		SYSERROR("Failed to make shared \"%s\"", conf->lxc_shmount.path_host);
+		free(full_cont_path);
+		return ret;
+	}
+
+	INFO("Made shared mount point \"%s\"", conf->lxc_shmount.path_host);
+	free(full_cont_path);
+	return 0;
+}
+
 /* lxc_spawn() performs crucial setup tasks and clone()s the new process which
  * exec()s the requested container binary.
  * Note that lxc_spawn() runs in the parent namespaces. Any operations performed
@@ -1604,6 +1668,25 @@ static int lxc_spawn(struct lxc_handler *handler)
 				return -1;
 			}
 		}
+	}
+
+	if (conf->lxc_shmount.path_host && !conf->lxc_shmount.path_cont) {
+			ERROR("Missing the container side path to the shared mount point");
+			lxc_sync_fini(handler);
+			return -1;
+	}
+	if (conf->lxc_shmount.path_host) {
+		ret = lxc_setup_shmount(conf);
+		if (ret < 0) {
+			ERROR("Failed to setup shared mount point");
+			lxc_sync_fini(handler);
+			return -1;
+		}
+	}
+
+	if (!cgroup_init(handler)) {
+		ERROR("Failed initializing cgroup support");
+		goto out_delete_net;
 	}
 
 	if (!cgroup_ops->create(cgroup_ops, handler)) {

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1536,14 +1536,14 @@ static int lxc_setup_shmount(struct lxc_conf *conf) {
 
 	/* Construct the shmount path under the container root */
 	/* +1 for slash */
-	len_cont = strlen(conf->rootfs.mount) + 1 + strlen(conf->lxc_shmount.path_cont);
+	len_cont = strlen(conf->rootfs.mount) + 1 + strlen(conf->shmount.path_cont);
 	/* +1 for the terminating '\0' */
 	full_cont_path = malloc(len_cont + 1);
 	if(!full_cont_path) {
 		SYSERROR("Not enough memory");
 		return -ENOMEM;
 	}
-	ret = snprintf(full_cont_path, len_cont + 1, "%s/%s", conf->rootfs.mount, conf->lxc_shmount.path_cont);
+	ret = snprintf(full_cont_path, len_cont + 1, "%s/%s", conf->rootfs.mount, conf->shmount.path_cont);
 	if (ret < 0 || ret >= len_cont + 1) {
 		SYSERROR("Failed to create filename");
 		free(full_cont_path);
@@ -1551,16 +1551,16 @@ static int lxc_setup_shmount(struct lxc_conf *conf) {
 	}
 
 	/* Check if shmount point is already set up */
-	if (is_shared_mountpoint(conf->lxc_shmount.path_host)) {
-		INFO("Path \"%s\" is already MS_SHARED. Reusing", conf->lxc_shmount.path_host);
+	if (is_shared_mountpoint(conf->shmount.path_host)) {
+		INFO("Path \"%s\" is already MS_SHARED. Reusing", conf->shmount.path_host);
 		free(full_cont_path);
 		return 0;
 	}
 
 	/* Create host and cont mount paths */
-	ret = mkdir_p(conf->lxc_shmount.path_host, 0711);
+	ret = mkdir_p(conf->shmount.path_host, 0711);
 	if (ret < 0 && errno != EEXIST) {
-		SYSERROR("Failed to create directory \"%s\"", conf->lxc_shmount.path_host);
+		SYSERROR("Failed to create directory \"%s\"", conf->shmount.path_host);
 		free(full_cont_path);
 		return ret;
 	}
@@ -1573,22 +1573,22 @@ static int lxc_setup_shmount(struct lxc_conf *conf) {
 	}
 
 	/* Prepare host mountpoint */
-	ret = mount("tmpfs", conf->lxc_shmount.path_host, "tmpfs",
+	ret = mount("tmpfs", conf->shmount.path_host, "tmpfs",
 				0, "size=100k,mode=0711");
 	if (ret < 0) {
-		SYSERROR("Failed to mount \"%s\"", conf->lxc_shmount.path_host);
+		SYSERROR("Failed to mount \"%s\"", conf->shmount.path_host);
 		free(full_cont_path);
 		return ret;
 	}
-	ret = mount(conf->lxc_shmount.path_host, conf->lxc_shmount.path_host, "none",
+	ret = mount(conf->shmount.path_host, conf->shmount.path_host, "none",
 				MS_REC | MS_SHARED, "");
 	if (ret < 0) {
-		SYSERROR("Failed to make shared \"%s\"", conf->lxc_shmount.path_host);
+		SYSERROR("Failed to make shared \"%s\"", conf->shmount.path_host);
 		free(full_cont_path);
 		return ret;
 	}
 
-	INFO("Made shared mount point \"%s\"", conf->lxc_shmount.path_host);
+	INFO("Made shared mount point \"%s\"", conf->shmount.path_host);
 	free(full_cont_path);
 	return 0;
 }
@@ -1670,12 +1670,12 @@ static int lxc_spawn(struct lxc_handler *handler)
 		}
 	}
 
-	if (conf->lxc_shmount.path_host && !conf->lxc_shmount.path_cont) {
+	if (conf->shmount.path_host && !conf->shmount.path_cont) {
 			ERROR("Missing the container side path to the shared mount point");
 			lxc_sync_fini(handler);
 			return -1;
 	}
-	if (conf->lxc_shmount.path_host) {
+	if (conf->shmount.path_host) {
 		ret = lxc_setup_shmount(conf);
 		if (ret < 0) {
 			ERROR("Failed to setup shared mount point");

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -502,6 +502,7 @@ extern bool dir_exists(const char *path);
 #define FNV1A_64_INIT ((uint64_t)0xcbf29ce484222325ULL)
 extern uint64_t fnv_64a_buf(void *buf, size_t len, uint64_t hval);
 
+extern bool is_shared_mountpoint(const char *path);
 extern int detect_shared_rootfs(void);
 extern bool detect_ramfs_rootfs(void);
 extern char *on_path(const char *cmd, const char *rootfs);

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -33,6 +33,7 @@ lxc_test_state_server_SOURCES = state_server.c lxctest.h
 lxc_test_share_ns_SOURCES = share_ns.c lxctest.h
 lxc_test_criu_check_feature_SOURCES = criu_check_feature.c lxctest.h
 lxc_test_raw_clone_SOURCES = lxc_raw_clone.c lxctest.h
+lxc_test_mount_injection_SOURCES = mount_injection.c
 
 AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	-DLXCPATH=\"$(LXCPATH)\" \
@@ -64,7 +65,8 @@ bin_PROGRAMS = lxc-test-containertests lxc-test-locktests lxc-test-startone \
 	lxc-test-apparmor lxc-test-utils lxc-test-parse-config-file \
 	lxc-test-config-jump-table lxc-test-shortlived \
 	lxc-test-api-reboot lxc-test-state-server lxc-test-share-ns \
-	lxc-test-criu-check-feature lxc-test-raw-clone
+	lxc-test-criu-check-feature lxc-test-raw-clone \
+	lxc-test-mount-injection
 
 bin_SCRIPTS =
 if ENABLE_TOOLS
@@ -121,6 +123,7 @@ EXTRA_DIST = \
 	lxc-test-unpriv \
 	lxc-test-utils.c \
 	may_control.c \
+	mount_injection.c \
 	parse_config_file.c \
 	saveconfig.c \
 	shortlived.c \

--- a/src/tests/mount_injection.c
+++ b/src/tests/mount_injection.c
@@ -1,0 +1,304 @@
+/* mount_injection
+ *
+ * Copyright © 2018 Elizaveta Tretiakova <elizabet.tretyakova@gmail.com>.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <lxc/lxccontainer.h>
+#include <lxc/list.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "lxctest.h"
+#include "utils.h"
+
+#define NAME "mount_injection_test-"
+#define TEMPLATE P_tmpdir"/mount_injection_XXXXXX"
+
+struct mountinfo_strings {
+	const char *mount_root;
+	const char *mount_point;
+	const char *fstype;
+	const char *mount_source;
+	const char *message;
+};
+
+static int comp_field(char *line, const char *str, int nfields)
+{
+	char *p, *p2;
+	int i, ret;
+
+	if(!line)
+		return -1;
+
+	if (!str)
+		return 0;
+
+	for (p = line, i = 0; p && i < nfields; i++)
+		p = strchr(p + 1, ' ');
+	if (!p)
+		return -1;
+	p2 = strchr(p + 1, ' ');
+	if (p2)
+		*p2 = '\0';
+	ret = strcmp(p + 1, str);
+	if (p2)
+		*p2 = ' ';
+	return ret;
+}
+
+static int find_in_proc_mounts(void *data)
+{
+	char buf[LXC_LINELEN];
+	FILE *f;
+	struct mountinfo_strings *strs = (struct mountinfo_strings *) data;
+
+	fprintf(stderr, "%s", strs->message);
+
+	f = fopen("/proc/self/mountinfo", "r");
+	if (!f)
+		return 0;
+	while (fgets(buf, LXC_LINELEN, f)) {
+		if (comp_field(buf, strs->mount_root, 3) == 0 && comp_field(buf, strs->mount_point, 4) == 0) {
+			char *buf2 = strchr(buf, '-');
+			if (comp_field(buf2, strs->fstype, 1) == 0 && comp_field(buf2, strs->mount_source, 2) == 0) {
+				fclose(f);
+				fprintf(stderr, "OK\n");
+				_exit(EXIT_SUCCESS);
+			}
+		}
+	}
+	fclose(f);
+	fprintf(stderr, "ERR\n");
+	_exit(EXIT_FAILURE);
+}
+
+static int check_containers_mountinfo(struct lxc_container *c, struct mountinfo_strings *d)
+{
+	pid_t pid;
+	int ret = -1;
+	lxc_attach_options_t attach_options = LXC_ATTACH_OPTIONS_DEFAULT;
+
+	ret = c->attach(c, find_in_proc_mounts, d, &attach_options, &pid);
+	if (ret < 0) {
+		fprintf(stderr, "Check of the container's mountinfo failed\n");
+		return ret;
+	}
+
+	ret = wait_for_pid(pid);
+	if (ret < 0)
+		fprintf(stderr, "Attached function failed");
+
+	return ret;
+}
+
+/* config_items: NULL-terminated array of config pairs */
+static int perform_container_test(const char *name, const char *config_items[])
+{
+	int i;
+	char *sret;
+	char template_log[sizeof(TEMPLATE)], template_dir[sizeof(TEMPLATE)],
+			device_message[sizeof("Check urandom device injected into "" - ") - 1 + strlen(name) + 1],
+			dir_message[sizeof("Check dir "" injected into "" - ") - 1 + sizeof(TEMPLATE) - 1 + strlen(name) + 1];
+	struct lxc_container *c;
+	struct lxc_mount mnt;
+	struct lxc_log log;
+	int ret = -1, dev_msg_size = sizeof("Check urandom device injected into "" - ") - 1 + strlen(name) + 1,
+			dir_msg_size = sizeof("Check dir "" injected into "" - ") - 1 + sizeof(TEMPLATE) - 1 + strlen(name) + 1;
+	struct mountinfo_strings device = {
+		.mount_root = "/",
+		.mount_point = "/mnt/mount_injection_test_urandom",
+		.fstype = "devtmpfs",
+		.mount_source = "/dev/urandom",
+		.message = ""
+	}, dir = {
+		.mount_root = template_dir,
+		.mount_point = template_dir,
+		.fstype = "ext4",
+		.mount_source = NULL,
+		.message = ""
+	};
+
+	/* Temp paths and messages setup */
+	strcpy(template_dir, TEMPLATE);
+	sret = mkdtemp(template_dir);
+	if (!sret) {
+		lxc_error("Failed to create temporary src file for container %s\n", name);
+		exit(EXIT_FAILURE);
+	}
+
+	ret = snprintf(device_message, dev_msg_size, "Check urandom device injected into %s - ", name);
+	if (ret < 0 || ret >= dev_msg_size) {
+		fprintf(stderr, "Failed to create message for dev\n");
+		exit(EXIT_FAILURE);
+	}
+	device.message = &device_message[0];
+
+	ret = snprintf(dir_message, dir_msg_size, "Check dir %s injected into %s - ", template_dir, name);
+	if (ret < 0 || ret >= dir_msg_size) {
+		fprintf(stderr, "Failed to create message for dir\n");
+		exit(EXIT_FAILURE);
+	}
+	dir.message = &dir_message[0];
+
+	/* Setup logging*/
+	strcpy(template_log, TEMPLATE);
+	i = lxc_make_tmpfile(template_log, false);
+	if (i < 0) {
+		lxc_error("Failed to create temporary log file for container %s\n", name);
+		exit(EXIT_FAILURE);
+	} else {
+		lxc_debug("Using \"%s\" as temporary log file for container %s\n", template_log, name);
+		close(i);
+	}
+
+	log.name = name;
+	log.file = template_log;
+	log.level = "TRACE";
+	log.prefix = "mount-injection";
+	log.quiet = false;
+	log.lxcpath = NULL;
+	if (lxc_log_init(&log))
+		exit(EXIT_FAILURE);
+
+	/* Container setup */
+	c = lxc_container_new(name, NULL);
+	if (!c) {
+		fprintf(stderr, "Unable to instantiate container (%s)...\n", name);
+		goto out;
+	}
+
+	if (c->is_defined(c)) {
+		fprintf(stderr, "Container (%s) already exists\n", name);
+		goto out;
+	}
+
+	for (i = 0; config_items[i]; i += 2) {
+		if (!c->set_config_item(c, config_items[i], config_items[i + 1])) {
+			fprintf(stderr, "Failed to set \"%s\" config option to \"%s\"\n", config_items[i], config_items[i + 1]);
+			goto out;
+		}
+	}
+
+	if (!c->create(c, "busybox", NULL, NULL, 1, NULL)) {
+		fprintf(stderr, "Creating the container (%s) failed...\n", name);
+		goto out;
+	}
+
+	c->want_daemonize(c, true);
+
+	if (!c->start(c, false, NULL)) {
+		fprintf(stderr, "Starting the container (%s) failed...\n", name);
+		goto out;
+	}
+
+	mnt.version = LXC_MOUNT_API_V1;
+
+	/* Check device mounted */
+	ret = c->mount(c, "/dev/urandom", "/mnt/mount_injection_test_urandom", "devtmpfs", 0, NULL, &mnt);
+	if (ret < 0) {
+		fprintf(stderr, "Failed to mount \"/dev/urandom\"\n");
+		goto out;
+	}
+
+	ret = check_containers_mountinfo(c, &device);
+	if (ret < 0)
+		goto out;
+
+	/* Check dir mounted */
+	ret = c->mount(c, template_dir, template_dir, "ext4", MS_BIND, NULL, &mnt);
+	if (ret < 0) {
+		fprintf(stderr, "Failed to mount \"%s\"\n", template_dir);
+		goto out;
+	}
+
+	ret = check_containers_mountinfo(c, &dir);
+	if (ret < 0)
+		goto out;
+
+	if (!c->stop(c)) {
+		fprintf(stderr, "Stopping the container (%s) failed...\n", name);
+		goto out;
+	}
+
+	if (!c->destroy(c)) {
+		fprintf(stderr, "Destroying the container (%s) failed...\n", name);
+		goto out;
+	}
+
+	ret = 0;
+out:
+	lxc_container_put(c);
+
+	if (ret != 0) {
+		int fd;
+
+		fd = open(template_log, O_RDONLY);
+		if (fd >= 0) {
+			char buf[4096];
+			ssize_t buflen;
+			while ((buflen = read(fd, buf, 1024)) > 0) {
+				buflen = write(STDERR_FILENO, buf, buflen);
+				if (buflen <= 0)
+					break;
+			}
+			close(fd);
+		}
+	}
+
+	unlink(template_log);
+	unlink(template_dir);
+
+	return ret;
+}
+
+static int do_priv_container_test()
+{
+	const char *config_items[] = {"lxc.mount.auto", "shmounts:/tmp/mount_injection_test", NULL};
+	return perform_container_test(NAME"privileged", config_items);
+}
+
+static int do_unpriv_container_test()
+{
+	const char *config_items[] = {
+		"lxc.mount.auto", "shmounts:/tmp/mount_injection_test",
+		"lxc.init.uid", "100000",
+		"lxc.init.gid", "100000",
+		NULL
+	};
+	return perform_container_test(NAME"unprivileged", config_items);
+}
+
+int main(int argc, char *argv[])
+{
+	if (do_priv_container_test()) {
+		fprintf(stderr, "Privileged mount injection test failed\n");
+		return -1;
+	}
+	if(do_unpriv_container_test()) {
+		fprintf(stderr, "Unprivileged mount injection test failed\n");
+		return -1;
+	}
+	return 0;
+}


### PR DESCRIPTION
Hi there!
This is an initial step for moving the mount injection stuff from LXD to LXC. 
In this PR, the new `lxc_container` API method `mount` is introduced, alongside with the supporting config option `shmounts` for `lxc.mount.auto` (because in order to enable mount injection in the running container, a shared mount point is established between on a startup) and the necessary utils.

UPD: also introduce the `umount` API method.