### PR TITLE
fix logic for execute log file 

### DIFF
--- a/src/lxc/execute.c
+++ b/src/lxc/execute.c
@@ -38,10 +38,11 @@ lxc_log_define(lxc_execute, lxc_start);
 
 static int execute_start(struct lxc_handler *handler, void* data)
 {
-	int j, i = 0, log = -1;
+	int argc_add, j;
+	char **argv;
+	int argc = 0, i = 0, logfd = -1;
 	struct execute_args *my_args = data;
-	char **argv, *logfd;
-	int argc = 0, argc_add;
+	char logfile[LXC_PROC_PID_FD_LEN];
 
 	while (my_args->argv[argc++]);
 
@@ -49,8 +50,10 @@ static int execute_start(struct lxc_handler *handler, void* data)
 	argc_add = 5;
 	if (my_args->quiet)
 		argc_add++;
+
 	if (!handler->conf->rootfs.path)
 		argc_add += 2;
+
 	if (lxc_log_has_valid_level())
 		argc_add += 2;
 
@@ -72,24 +75,24 @@ static int execute_start(struct lxc_handler *handler, void* data)
 	}
 
 	if (current_config->logfd != -1 || lxc_log_fd != -1) {
+		int ret;
 		int to_dup = current_config->logfd;
 
 		if (current_config->logfd == -1)
 			to_dup = lxc_log_fd;
 
-		log = dup(to_dup);
-		if (log < 0) {
-			SYSERROR("dup of log fd failed");
+		logfd = dup(to_dup);
+		if (logfd < 0) {
+			SYSERROR("Failed to duplicate log file descriptor");
 			goto out2;
 		}
 
-		if (asprintf(&logfd, "/proc/1/fd/%d", log) < 0) {
-			ERROR("Couldn't allocate memory for log string");
+		ret = snprintf(logfile, sizeof(logfile), "/proc/1/fd/%d", logfd);
+		if (ret < 0 || (size_t)ret >= sizeof(logfile))
 			goto out3;
-		}
 
 		argv[i++] = "-o";
-		argv[i++] = logfd;
+		argv[i++] = logfile;
 	}
 
 	if (my_args->quiet)
@@ -110,9 +113,8 @@ static int execute_start(struct lxc_handler *handler, void* data)
 	execvp(argv[0], argv);
 	SYSERROR("Failed to exec %s", argv[0]);
 
-	free(logfd);
 out3:
-	close(log);
+	close(logfd);
 out2:
 	free(argv);
 out1:

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -101,6 +101,17 @@
 #define LXC_LINELEN 4096
 #define LXC_IDMAPLEN 4096
 #define LXC_MAX_BUFFER 4096
+/* /proc/       =    6
+ *                +
+ * <pid-as-str> =   LXC_NUMSTRLEN64
+ *                +
+ * /fd/         =    4
+ *                +
+ * <fd-as-str>  =   LXC_NUMSTRLEN64
+ *                +
+ * \0           =    1
+ */
+#define LXC_PROC_PID_FD_LEN (6 + LXC_NUMSTRLEN64 + 4 + LXC_NUMSTRLEN64 + 1)
 
 /* returns 1 on success, 0 if there were any failures */
 extern int lxc_rmdir_onedev(const char *path, const char *exclude);


### PR DESCRIPTION
The problem here is that lxc-init runs *inside* the container. So if a
person has the log file set to /home/$USER/foo, lxc-init ends up making a
directory /home/$USER/foo inside the container to put the log file in. What
we really want are the logs to be propagated from inside the container to
the outside. We accomplish this by passing an fd without O_CLOEXEC, and
telling lxc-init to log to that file.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>