### PR TITLE
execute: do not check inherited fds again

### DIFF
--- a/src/lxc/execute.c
+++ b/src/lxc/execute.c
@@ -116,9 +116,6 @@ int lxc_execute(const char *name, char *const argv[], int quiet,
 {
 	struct execute_args args = {.argv = argv, .quiet = quiet};
 
-	if (lxc_check_inherited(handler->conf, false, &handler->conf->maincmd_fd, 1))
-		return -1;
-
 	handler->conf->is_execute = 1;
 	return __lxc_start(name, handler, &execute_start_ops, &args, lxcpath,
 			   backgrounded, error_num);


### PR DESCRIPTION
This is already done in do_lxcapi_start{l}() so a) no need to do it again here
and b) this would close the state socket pair sockets and corrupt memory.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>