### PR TITLE
confile: satisfy gcc-8

### DIFF
--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -621,10 +621,14 @@ bool new_hwaddr(char *hwaddr)
 
 int lxc_get_conf_str(char *retv, int inlen, const char *value)
 {
+	size_t value_len;
+
 	if (!value)
 		return 0;
-	if (retv && inlen >= strlen(value) + 1)
-		strncpy(retv, value, strlen(value) + 1);
+
+	value_len = strlen(value);
+	if (retv && inlen >= value_len + 1)
+		memcpy(retv, value, value_len + 1);
 
 	return strlen(value);
 }


### PR DESCRIPTION
Apparently -Werror=stringop-overflow will trigger an error here even though
this is completely valid since we now that we're definitely copying a \0-byte.
Work around this gcc-8 quirk by using memcpy(). This shouldn't trigger the
warning.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>