### PR TITLE
config: allow read-write /sys in user namespace

### DIFF
--- a/config/templates/userns.conf.in
+++ b/config/templates/userns.conf.in
@@ -8,3 +8,6 @@ lxc.cap.keep =
 
 # We can't move bind-mounts, so don't use /dev/lxc/
 lxc.tty.dir =
+
+# Setup the default mounts
+lxc.mount.auto = sys:rw


### PR DESCRIPTION
Unprivileged containers can safely mount /sys as read-write. This also allows
systemd-udevd to be started in unprivileged containers.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>