### PR TITLE
Fix resource leak CID #1248106

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4497,6 +4497,8 @@ void suggest_default_idmap(void)
 	if (!urange || !grange) {
 		ERROR("You do not have subuids or subgids allocated");
 		ERROR("Unprivileged containers require subuids and subgids");
+		free(gname);
+		free(uname);
 		return;
 	}
 

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4082,8 +4082,10 @@ struct lxc_list *get_minimal_idmap(struct lxc_conf *conf)
 	return idmap;
 
 on_error:
-	if (idmap)
+	if (idmap) {
 		lxc_free_idmap(idmap);
+		free(id_map);
+	}
 	if (container_root_uid)
 		free(container_root_uid);
 	if (container_root_gid)

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -591,8 +591,10 @@ static char *is_wlan(const char *ifname)
 	fseek(f, 0, SEEK_END);
 	physlen = ftell(f);
 	fseek(f, 0, SEEK_SET);
-	if (physlen < 0)
+	if (physlen < 0) {
+		fclose(f);
 		goto bad;
+	}
 
 	physname = malloc(physlen + 1);
 	if (!physname) {


### PR DESCRIPTION
In function is_wlan() @ network.c, there is a file handle FILE* f.
There is a single exit point where the file handle is not fclose()-ed.
Elsewhere it is OK.
