### PR TITLE
Fix resource leak CID #1425836

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4497,6 +4497,8 @@ void suggest_default_idmap(void)
 	if (!urange || !grange) {
 		ERROR("You do not have subuids or subgids allocated");
 		ERROR("Unprivileged containers require subuids and subgids");
+		free(gname);
+		free(uname);
 		return;
 	}
 

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4082,8 +4082,10 @@ struct lxc_list *get_minimal_idmap(struct lxc_conf *conf)
 	return idmap;
 
 on_error:
-	if (idmap)
+	if (idmap) {
 		lxc_free_idmap(idmap);
+		free(id_map);
+	}
 	if (container_root_uid)
 		free(container_root_uid);
 	if (container_root_gid)


### PR DESCRIPTION
In function userns_exec_full() @ conf.c, there is the following
pointer that is used in a double-linked list, struct lxc_list *idmap = NULL;

This pointer is malloc()-ed, and then additional objects are added to
the list using lxc_list_add_tail().
At the end of the function, the dynamically allocated memory is freed with lxc_free_idmap(idmap);

lxc_free_idmap(idmap) does not free memory of the initial memory
allocation for "idmap", therefore there is a memory leak.

The function lxc_free_idmap() is used in another place as well, and at
that place it does not free() the initial pointer (correct behaviour).
Therefore, there is a need for a free() in the function
userns_exec_full() @ conf.c.