### PR TITLE
Fixed resource leak in is_wlan() at network.c

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -591,8 +591,10 @@ static char *is_wlan(const char *ifname)
 	fseek(f, 0, SEEK_END);
 	physlen = ftell(f);
 	fseek(f, 0, SEEK_SET);
-	if (physlen < 0)
+	if (physlen < 0) {
+		fclose(f);
 		goto bad;
+	}
 
 	physname = malloc(physlen + 1);
 	if (!physname) {


### PR DESCRIPTION
In function is_wlan() @ network.c, there is a file handle FILE* f.
There is one exit point in the function where the file handle is not fclose()-ed.
