### PR TITLE
Fixed resource leak in suggest_default_idmap()

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4497,6 +4497,8 @@ void suggest_default_idmap(void)
 	if (!urange || !grange) {
 		ERROR("You do not have subuids or subgids allocated");
 		ERROR("Unprivileged containers require subuids and subgids");
+		free(gname);
+		free(uname);
 		return;
 	}
 


### PR DESCRIPTION
Every exit point in function suggest_default_idmap() @ conf.c makes
sure to free the dynamically allocated strings uname and gname.
The flagged exit point does not free neither of them.
The two Coverity reports mention "uname" and "gname" respectively.
