### PR TITLE
[log] support use container name as log_vmname

### DIFF
--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -358,4 +358,6 @@ extern int lxc_log_get_level(void);
 extern bool lxc_log_has_valid_level(void);
 extern const char *lxc_log_get_prefix(void);
 extern void lxc_log_options_no_override();
+extern void lxc_log_set_container_name(const char *name);
+extern void lxc_log_free_container_name();
 #endif

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -359,6 +359,7 @@ int lxc_container_put(struct lxc_container *c)
 
 	container_mem_unlock(c);
 
+	lxc_log_free_container_name();
 	return 0;
 }
 
@@ -4782,6 +4783,7 @@ struct lxc_container *lxc_container_new(const char *name, const char *configpath
 		goto err;
 	}
 
+	lxc_log_set_container_name(name);
 	if (ongoing_create(c) == 2) {
 		ERROR("Failed to complete container creation for %s", c->name);
 		container_destroy(c, NULL);


### PR DESCRIPTION
enhance readability of logs, use container name as log_vmname.
Now we use log config to implement.
But if we use API in mutl-threads, this function will failure.

We can use thread-local variable to store container name,
when we call lxc_container_new set this thread-local variable,
and when we call lxc_container_put to free this thread-local variable.

Signed-off-by: duguhaotian <duguhaotian@gmail.com>