### PR TITLE
BASH Completions rename not fully propagated

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -494,7 +494,7 @@ AM_CONDITIONAL([ENABLE_BASH], [test "x$enable_bash" = "xyes"])
 AM_COND_IF([ENABLE_BASH],
 	[AC_MSG_CHECKING([bash completion directory])
 	PKG_CHECK_VAR(bashcompdir, [bash-completion], [completionsdir], ,
-		bashcompdir="${sysconfdir}/bash_completion.d")
+		bashcompdir="/usr/share/bash-completion/completions")
 	AC_MSG_RESULT([$bashcompdir])
 	AC_SUBST(bashcompdir)
 	])

--- a/lxc.spec.in
+++ b/lxc.spec.in
@@ -251,7 +251,7 @@ fi
 %endif
 %{_datadir}/doc/*
 %{_datadir}/lxc/*
-%{_sysconfdir}/bash_completion.d
+%{_usr}/share/bash-completion/completions/*
 %config(noreplace) %{_sysconfdir}/lxc/*
 %config(noreplace) %{_sysconfdir}/sysconfig/*
 


### PR DESCRIPTION
Running on both the master and on the stable-2.0, I couldn't run "make rpm".  I would get the following error:

```
Processing files: lxc-2.0.9-1.el7.centos.x86_64
error: File not found: /home/user/rpmbuild/BUILDROOT/lxc-2.0.9-1.el7.centos.x86_64/etc/bash_completion.d
```

I tried commending out the lxc.spec.in line and I got: 

```
Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/user/rpmbuild/BUILDROOT/lxc-2.0.9-1.el7.centos.x86_64
error: Installed (but unpackaged) file(s) found:
   /usr/share/bash-completion/completions/lxc
```

The fix was to fix the naming.  RPM building now working for CentOS.