### PR TITLE
log: enable per-thread container name prefix

### DIFF
--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -228,6 +228,8 @@ struct lxc_state_client {
 };
 
 struct lxc_conf {
+	/* Pointer to the name of the container. Do not free! */
+	const char *name;
 	int is_execute;
 	char *fstab;
 	unsigned int tty;

--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -102,6 +102,12 @@ static int log_append_syslog(const struct lxc_log_appender *appender,
 	char *msg;
 	int rc, len;
 	va_list args;
+	const char *log_container_name = log_vmname;
+
+#ifndef NO_LXC_CONF
+	if (current_config && !log_container_name)
+		log_container_name = current_config->name;
+#endif
 
 	if (!syslog_enable)
 		return 0;
@@ -109,9 +115,11 @@ static int log_append_syslog(const struct lxc_log_appender *appender,
 	va_copy(args, *event->vap);
 	len = vsnprintf(NULL, 0, event->fmt, args) + 1;
 	va_end(args);
+
 	msg = malloc(len * sizeof(char));
 	if (msg == NULL)
 		return 0;
+
 	rc = vsnprintf(msg, len, event->fmt, *event->vap);
 	if (rc == -1 || rc >= len) {
 		free(msg);
@@ -120,13 +128,14 @@ static int log_append_syslog(const struct lxc_log_appender *appender,
 
 	syslog(lxc_log_priority_to_syslog(event->priority),
 		"%s%s %s - %s:%s:%d - %s" ,
-		log_vmname ? log_vmname : "",
-		log_vmname ? ":" : "",
+		log_container_name ? log_container_name : "",
+		log_container_name ? ":" : "",
 		event->category,
 		event->locinfo->file, event->locinfo->func,
 		event->locinfo->line,
 		msg);
 	free(msg);
+
 	return 0;
 }
 
@@ -134,13 +143,26 @@ static int log_append_syslog(const struct lxc_log_appender *appender,
 static int log_append_stderr(const struct lxc_log_appender *appender,
 			     struct lxc_log_event *event)
 {
+	const char *log_container_name;
+
 	if (event->priority < LXC_LOG_LEVEL_ERROR)
 		return 0;
 
-	fprintf(stderr, "%s: %s%s", log_prefix, log_vmname ? log_vmname : "", log_vmname ? ": " : "");
-	fprintf(stderr, "%s: %s: %d ", event->locinfo->file, event->locinfo->func, event->locinfo->line);
+	log_container_name = log_vmname;
+
+#ifndef NO_LXC_CONF
+	if (current_config && !log_container_name)
+		log_container_name = current_config->name;
+#endif
+
+	fprintf(stderr, "%s: %s%s", log_prefix,
+		log_container_name ? log_container_name : "",
+		log_container_name ? ": " : "");
+	fprintf(stderr, "%s: %s: %d ", event->locinfo->file,
+		event->locinfo->func, event->locinfo->line);
 	vfprintf(stderr, event->fmt, *event->vap);
 	fprintf(stderr, "\n");
+
 	return 0;
 }
 
@@ -270,10 +292,16 @@ static int log_append_logfile(const struct lxc_log_appender *appender,
 	char date_time[LXC_LOG_TIME_SIZE];
 	int n, ret;
 	int fd_to_use = -1;
+	const char *log_container_name = log_vmname;
 
 #ifndef NO_LXC_CONF
-	if (!lxc_log_use_global_fd && current_config)
-		fd_to_use = current_config->logfd;
+	if (current_config) {
+		if (!lxc_log_use_global_fd)
+			fd_to_use = current_config->logfd;
+
+		if (!log_container_name)
+			log_container_name = current_config->name;
+	}
 #endif
 
 	if (fd_to_use == -1)
@@ -288,8 +316,8 @@ static int log_append_logfile(const struct lxc_log_appender *appender,
 	n = snprintf(buffer, sizeof(buffer),
 			"%s%s%s %s %-8s %s - %s:%s:%d - ",
 			log_prefix,
-			log_vmname ? " " : "",
-			log_vmname ? log_vmname : "",
+			log_container_name ? " " : "",
+			log_container_name ? log_container_name : "",
 			date_time,
 			lxc_log_priority_to_string(event->priority),
 			event->category,

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -595,6 +595,8 @@ static bool load_config_locked(struct lxc_container *c, const char *fname)
 	if (lxc_config_read(fname, c->lxc_conf, false) != 0)
 		return false;
 
+	c->lxc_conf->name = c->name;
+
 	return true;
 }
 


### PR DESCRIPTION
When using the LXC API multi-thread and users initialize a log:

struct lxc_log log;
log.name = "my-log";
lxc_log_init(&log);

all threads will have the same "my-log" prefix even though thy might call
lxc_container_new() in separate threads. There is currently no easy way to
handle per-thread container name prefixes.
To handle this carry a reference to the name of the container in struct
lxc_conf and if no log.name was set, use it by default. This way each thread
will get the container it is currently working on as a log-prefix.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
Reported-by: duguhaotian <duguhaotian@gmail.com>