### PR TITLE
Add details of build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Without considering distribution specific details a simple
 
     ./autogen.sh && ./configure && make && sudo make install
 
-is usually sufficient.
+is usually sufficient. If you get build problems, make sure the following dependencies are installed: `libtool pkg-config automake m4`. 
 
 In order to test current git master of LXC it is usually a good idea to compile with
 


### PR DESCRIPTION
The details I added can help you build lxc if you encounter problems with dependecies not being met. I listed the dependencies that I had to add for a clean Ubuntu 16.04. 