### PR TITLE
Seccomp fixes

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -181,7 +181,7 @@ static int get_seccomp_arg_value(char *key, struct v2_rule_args *rule_args)
 	uint64_t mask = 0;
 	enum scmp_compare op = 0;
 	uint32_t index = 0;
-	char s[30] = {0};
+	char s[31] = {0};
 	char *tmp = NULL;
 
 	memset(s, 0, sizeof(s));

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -164,7 +164,6 @@ static enum scmp_compare parse_v2_rule_op(char *s)
 
 /* This function is used to parse the args string into the structure.
  * args string format:[index,value,op,valueTwo] or [index,value,op]
- * For one arguments, [index,value,valueTwo,op]
  * index: the index for syscall arguments (type uint)
  * value: the value for syscall arguments (type uint64)
  * op: the operator for syscall arguments(string),

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -183,7 +183,6 @@ static int get_seccomp_arg_value(char *key, struct v2_rule_args *rule_args)
 	char s[31] = {0};
 	char *tmp = NULL;
 
-	memset(s, 0, sizeof(s));
 	tmp = strchr(key, '[');
 	if (!tmp) {
 		ERROR("Failed to interpret args");

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1958,6 +1958,29 @@ int lxc_safe_ulong(const char *numstr, unsigned long *converted)
 	return 0;
 }
 
+int lxc_safe_uint64(const char *numstr, uint64_t *converted)
+{
+	char *err = NULL;
+	uint64_t u;
+
+	while (isspace(*numstr))
+		numstr++;
+
+	if (*numstr == '-')
+		return -EINVAL;
+
+	errno = 0;
+	u = strtoull(numstr, &err, 0);
+	if (errno == ERANGE && u == ULLONG_MAX)
+		return -ERANGE;
+
+	if (err == numstr || *err != '\0')
+		return -EINVAL;
+
+	*converted = u;
+	return 0;
+}
+
 int lxc_safe_int(const char *numstr, int *converted)
 {
 	char *err = NULL;

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -530,6 +530,7 @@ extern int lxc_safe_int(const char *numstr, int *converted);
 extern int lxc_safe_long(const char *numstr, long int *converted);
 extern int lxc_safe_long_long(const char *numstr, long long int *converted);
 extern int lxc_safe_ulong(const char *numstr, unsigned long *converted);
+extern int lxc_safe_uint64(const char *numstr, uint64_t *converted);
 /* Handles B, kb, MB, GB. Detects overflows and reports -ERANGE. */
 extern int parse_byte_size_string(const char *s, int64_t *converted);
 


### PR DESCRIPTION
The most important commit is eacebcc3cb8cf5d29556c85fe826096723475242, which fixes an integer overflow while parsing the argument filters.