### PR TITLE
tree-wide: s/sigprocmask/pthread_sigmask()/g

### DIFF
--- a/src/lxc/cmd/lxc_init.c
+++ b/src/lxc/cmd/lxc_init.c
@@ -25,6 +25,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <libgen.h>
+#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -266,7 +267,7 @@ int main(int argc, char *argv[])
 	if (ret < 0)
 		exit(EXIT_FAILURE);
 
-	ret = sigprocmask(SIG_SETMASK, &mask, &omask);
+	ret = pthread_sigmask(SIG_SETMASK, &mask, &omask);
 	if (ret < 0)
 		exit(EXIT_FAILURE);
 
@@ -340,7 +341,7 @@ int main(int argc, char *argv[])
 			}
 		}
 
-		ret = sigprocmask(SIG_SETMASK, &omask, NULL);
+		ret = pthread_sigmask(SIG_SETMASK, &omask, NULL);
 		if (ret < 0) {
 			SYSERROR("Failed to set signal mask");
 			exit(EXIT_FAILURE);
@@ -368,7 +369,7 @@ int main(int argc, char *argv[])
 	if (ret < 0)
 		exit(EXIT_FAILURE);
 
-	ret = sigprocmask(SIG_SETMASK, &omask, NULL);
+	ret = pthread_sigmask(SIG_SETMASK, &omask, NULL);
 	if (ret < 0) {
 		SYSERROR("Failed to set signal mask");
 		exit(EXIT_FAILURE);

--- a/src/lxc/cmd/lxc_monitord.c
+++ b/src/lxc/cmd/lxc_monitord.c
@@ -24,6 +24,7 @@
 #define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -386,7 +387,7 @@ int main(int argc, char *argv[])
 	    sigdelset(&mask, SIGSEGV) ||
 	    sigdelset(&mask, SIGBUS)  ||
 	    sigdelset(&mask, SIGTERM) ||
-	    sigprocmask(SIG_BLOCK, &mask, NULL)) {
+	    pthread_sigmask(SIG_BLOCK, &mask, NULL)) {
 		SYSERROR("Failed to set signal mask.");
 		exit(EXIT_FAILURE);
 	}

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2000,11 +2000,10 @@ static bool do_lxcapi_shutdown(struct lxc_container *c, int timeout)
 		return true;
 
 	/* Detect whether we should send SIGRTMIN + 3 (e.g. systemd). */
-	if (task_blocking_signal(pid, (SIGRTMIN + 3)))
-		haltsignal = (SIGRTMIN + 3);
-
 	if (c->lxc_conf && c->lxc_conf->haltsignal)
 		haltsignal = c->lxc_conf->haltsignal;
+	else if (task_blocking_signal(pid, (SIGRTMIN + 3)))
+		haltsignal = (SIGRTMIN + 3);
 
 	/* Add a new state client before sending the shutdown signal so that we
 	 * don't miss a state.

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -32,6 +32,7 @@
 #include <fcntl.h>
 #include <grp.h>
 #include <poll.h>
+#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -314,7 +315,7 @@ static int setup_signal_fd(sigset_t *oldmask)
 			return -EBADF;
 	}
 
-	ret = sigprocmask(SIG_BLOCK, &mask, oldmask);
+	ret = pthread_sigmask(SIG_BLOCK, &mask, oldmask);
 	if (ret < 0) {
 		SYSERROR("Failed to set signal mask");
 		return -EBADF;
@@ -860,7 +861,7 @@ int lxc_init(const char *name, struct lxc_handler *handler)
 	return 0;
 
 out_restore_sigmask:
-	sigprocmask(SIG_SETMASK, &handler->oldmask, NULL);
+	pthread_sigmask(SIG_SETMASK, &handler->oldmask, NULL);
 out_delete_tty:
 	lxc_delete_tty(&conf->ttys);
 out_aborting:
@@ -986,7 +987,7 @@ void lxc_fini(const char *name, struct lxc_handler *handler)
 	}
 
 	/* Reset mask set by setup_signal_fd. */
-	ret = sigprocmask(SIG_SETMASK, &handler->oldmask, NULL);
+	ret = pthread_sigmask(SIG_SETMASK, &handler->oldmask, NULL);
 	if (ret < 0)
 		WARN("%s - Failed to restore signal mask", strerror(errno));
 
@@ -1064,7 +1065,7 @@ static int do_start(void *data)
 		goto out_warn_father;
 	}
 
-	ret = sigprocmask(SIG_SETMASK, &handler->oldmask, NULL);
+	ret = pthread_sigmask(SIG_SETMASK, &handler->oldmask, NULL);
 	if (ret < 0) {
 		SYSERROR("Failed to set signal mask");
 		goto out_warn_father;

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1814,17 +1814,16 @@ int lxc_count_file_lines(const char *fn)
 
 /* Check whether a signal is blocked by a process. */
 /* /proc/pid-to-str/status\0 = (5 + 21 + 7 + 1) */
-#define __PROC_STATUS_LEN (5 + (LXC_NUMSTRLEN64) + 7 + 1)
+#define __PROC_STATUS_LEN (6 + (LXC_NUMSTRLEN64) + 7 + 1)
 bool task_blocking_signal(pid_t pid, int signal)
 {
-	bool bret = false;
-	char *line = NULL;
+	int ret;
+	char status[__PROC_STATUS_LEN];
+	FILE *f;
 	long unsigned int sigblk = 0;
 	size_t n = 0;
-	int ret;
-	FILE *f;
-
-	char status[__PROC_STATUS_LEN];
+	bool bret = false;
+	char *line = NULL;
 
 	ret = snprintf(status, __PROC_STATUS_LEN, "/proc/%d/status", pid);
 	if (ret < 0 || ret >= __PROC_STATUS_LEN)
@@ -1835,10 +1834,10 @@ bool task_blocking_signal(pid_t pid, int signal)
 		return bret;
 
 	while (getline(&line, &n, f) != -1) {
-		if (strncmp(line, "SigBlk:\t", 8))
+		if (strncmp(line, "SigBlk:", 7))
 			continue;
 
-		if (sscanf(line + 8, "%lx", &sigblk) != 1)
+		if (sscanf(line + 7, "%lx", &sigblk) != 1)
 			goto out;
 	}
 

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -31,6 +31,7 @@
 #include <grp.h>
 #include <inttypes.h>
 #include <libgen.h>
+#include <pthread.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -495,7 +496,7 @@ struct lxc_popen_FILE *lxc_popen(const char *command)
 		if (ret < 0)
 			_exit(EXIT_FAILURE);
 
-		ret = sigprocmask(SIG_UNBLOCK, &mask, NULL);
+		ret = pthread_sigmask(SIG_UNBLOCK, &mask, NULL);
 		if (ret < 0)
 			_exit(EXIT_FAILURE);
 


### PR DESCRIPTION
The behavior of sigprocmask() is unspecified in multi-threaded programs. Let's
use pthread_sigmask() instead.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>