### PR TITLE
seccomp: leak fixup

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -54,8 +54,10 @@ static int parse_config_v1(FILE *f, struct lxc_conf *conf)
 		int nr;
 
 		ret = sscanf(line, "%d", &nr);
-		if (ret != 1)
-			return -1;
+		if (ret != 1) {
+			ret = -1;
+			break;
+		}
 
 #if HAVE_SCMP_FILTER_CTX
 		ret = seccomp_rule_add(conf->seccomp_ctx, SCMP_ACT_ALLOW, nr, 0);


### PR DESCRIPTION
Fix an error case not free()ing the line forgotten during
the move from fgets() on a static buffer to using getline.

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>
Fixes: ccf8d128e430 ("seccomp: parse_config_v1()")