### PR TITLE
Seccomp fixup part 2

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -114,6 +114,9 @@ static uint32_t get_v2_default_action(char *line)
 		ret_action = SCMP_ACT_ALLOW;
 	} else if (strncmp(line, "trap", 4) == 0) {
 		ret_action = SCMP_ACT_TRAP;
+	} else if (line[0]) {
+		ERROR("Unrecognized seccomp action: %s", line);
+		return -2;
 	}
 
 	return ret_action;

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -257,6 +257,11 @@ static int parse_v2_rules(char *line, uint32_t def_action,
 
 	/* read optional action which follows the syscall */
 	rules->action = get_v2_action(tmp, def_action);
+	if (rules->action == -1) {
+		ERROR("Failed to interpret action");
+		ret = -1;
+		goto out;
+	}
 
 	ret = 0;
 	rules->args_num = 0;


### PR DESCRIPTION
See individual commits.
Let me know if you prefer commit 2 to keep separate `line` pointers in the v1/v2 functions as I'm not sure this fits your style (as the parent's buffer is `realloc()`ed, and `free()`d inside the callees.