### PR TITLE
start: enable pre-setns() kernels

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1392,3 +1392,24 @@ int set_stdfds(int fd)
 
 	return 0;
 }
+
+int lxc_preserve_ns(const int pid, const char *ns)
+{
+	int ret;
+/* 5 /proc + 21 /int_as_str + 3 /ns + 20 /NS_NAME + 1 \0 */
+#define __NS_PATH_LEN 50
+	char path[__NS_PATH_LEN];
+
+	/* This way we can use this function to also check whether namespaces
+	 * are supported by the kernel by passing in the NULL or the empty
+	 * string.
+	 */
+	ret = snprintf(path, __NS_PATH_LEN, "/proc/%d/ns%s%s", pid,
+		       !ns || strcmp(ns, "") == 0 ? "" : "/",
+		       !ns || strcmp(ns, "") == 0 ? "" : ns);
+	errno = EFBIG;
+	if (ret < 0 || (size_t)ret >= __NS_PATH_LEN)
+		return -EFBIG;
+
+	return open(path, O_RDONLY | O_CLOEXEC);
+}

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -319,4 +319,6 @@ int null_stdfds(void);
 int safe_mount(const char *src, const char *dest, const char *fstype,
 		unsigned long flags, const void *data, const char *rootfs);
 int set_stdfds(int fd);
+int lxc_preserve_ns(const int pid, const char *ns);
+
 #endif /* __LXC_UTILS_H */


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>

Closes #2356.
See https://discuss.linuxcontainers.org/t/failed-to-start-lxc-on-linux-kernel-2-6-32-220 .