### PR TITLE
start: do not init ns_clone_flags to -1

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -619,8 +619,6 @@ void lxc_zero_handler(struct lxc_handler *handler)
 
 	memset(handler, 0, sizeof(struct lxc_handler));
 
-	handler->ns_clone_flags = -1;
-
 	handler->pinfd = -1;
 
 	handler->sigfd = -1;


### PR DESCRIPTION
ns_clone_flags is used as a bitmask so initializing it to -1 is a bad idea.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>