### PR TITLE
support tls in cross-compile

### DIFF
--- a/config/tls.m4
+++ b/config/tls.m4
@@ -5,7 +5,7 @@
 AC_DEFUN([LXC_CHECK_TLS],
 [
     AC_MSG_CHECKING(for TLS)
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[ static __thread int val; int main() { return 0; } ]])],[have_tls=yes],[have_tls=no],[have_tls=no ])
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[ static __thread int val; int main() { return 0; } ]])],[have_tls=yes],[have_tls=no],[have_tls=no ])
     AC_MSG_RESULT($have_tls)
     if test "$have_tls" = "yes"; then
         AC_DEFINE([HAVE_TLS],[1],[Define if the compiler supports __thread])


### PR DESCRIPTION
AC_RUN_IFELSE will fail in cross-compile,
we can use AC_COMPILE_IFELSE replace.

Signed-off-by: duguhaotian <duguhaotian@gmail.com>