### PR TITLE
conf: va_end was not called.

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -530,8 +530,10 @@ int run_script(const char *name, const char *section, const char *script, ...)
 		int len = size - ret;
 		int rc;
 		rc = snprintf(buffer + ret, len, " %s", p);
-		if (rc < 0 || rc >= len)
+		if (rc < 0 || rc >= len) {
+			va_end(ap);
 			return -1;
+		}
 		ret += rc;
 	}
 	va_end(ap);


### PR DESCRIPTION
Hello,

Function 'va_end' was not called before conf.534 inside function 'run_script'.
Function 'va_start' was called at conf.c:528.

Signed-off-by: Donghwa Jeong <dh48.jeong@samsung.com>