### PR TITLE
templates: actually create DOWNLOAD_TEMP directory

### DIFF
--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -320,7 +320,7 @@ fi
 if ! command -V mktemp >/dev/null 2>&1; then
   DOWNLOAD_TEMP="${DOWNLOAD_TEMP}/tmp/lxc-download.$$"
 else
-  DOWNLOAD_TEMP="${DOWNLOAD_TEMP}$(mktemp -d)"
+  DOWNLOAD_TEMP="$(mktemp -p ${DOWNLOAD_TEMP} -d)"
 fi
 
 # Simply list images


### PR DESCRIPTION
The way 'mktemp' is currently used you will get a temp directory in
$TMPDIR or '/tmp' and DOWNLOAD_TEMP will not be pointing to an actual
directory. This will result in the wget operations failing and the
container will fail to create:

    ERROR: Failed to download http://....

Instead we want to use the '-p' option for mktemp to set the base path
and this will ensure that the temp directory is created in the correct
location and DOWNLOAD_TEMP will be consistent with this location.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>