### PR TITLE
Patch lxc-update-config

### DIFF
--- a/src/lxc/cmd/lxc-update-config.in
+++ b/src/lxc/cmd/lxc-update-config.in
@@ -102,7 +102,10 @@ while read -r LINE; do
 	# one we bump IDX and replace any "lxc.network.<subkey>" keys we
 	# encounter with "lxc.network.<IDX>.<subkey>".
 	echo "${LINE}" | grep -q "lxc.network.type" && IDX=$((IDX+1))
-	sed -i -e "${LINE_NUM} s/\([[:blank:]*]\|#*\)\(lxc\.network\)\.\([^[:digit:]*]\)/\1lxc\.net\.${IDX}\.\3/g" "${CONFIGPATH}"
+	sed -i \
+-e "${LINE_NUM} s/\([[:blank:]*]\|#*\)\(lxc\.network\)\(\.ipv[[:digit:]]\)\([[:blank:]]*\)=\(.*\)/\1lxc\.net\.${IDX}\3\.address\4=\5/g" \
+-e "${LINE_NUM} s/\([[:blank:]*]\|#*\)\(lxc\.network\)\.\([^[:digit:]*]\)/\1lxc\.net\.${IDX}\.\3/g" \
+	"${CONFIGPATH}"
 done < "${TMPFILE}"
 
 rm "${TMPFILE}"


### PR DESCRIPTION
The current script doesn't generate a valid configuration for
lxc.network.ipv4 key, it lacking an .address part which lead to:

parse.c: lxc_file_for_each_line: 58 Failed to parse config: lxc.net.0.ipv4 = 192.168.10.101/24

Signed-off-by: Julien Surloppe <julien@surloppe.fr>