### PR TITLE
conf: fix misreading issue of proc mountinfo

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3262,7 +3262,7 @@ void remount_all_slave(const char *name)
 	fclose(f);
 	free(line);
 
-	if (ret && remove("/tmp/lxc_mountinfo.txt") < 0)
+	if (ret && remove(path) < 0)
 		SYSERROR("Failed to remove \"%s\"", path);
 }
 

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -414,7 +414,7 @@ extern int userns_exec_full(struct lxc_conf *conf, int (*fn)(void *),
 extern int parse_mntopts(const char *mntopts, unsigned long *mntflags,
 			 char **mntdata);
 extern void tmp_proc_unmount(struct lxc_conf *lxc_conf);
-extern void remount_all_slave(void);
+extern void remount_all_slave(const char *name);
 extern void suggest_default_idmap(void);
 extern FILE *make_anonymous_mount_file(struct lxc_list *mount);
 extern struct lxc_list *sort_cgroup_settings(struct lxc_list *cgroup_settings);

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1872,7 +1872,7 @@ int __lxc_start(const char *name, struct lxc_handler *handler,
 			}
 			INFO("Unshared CLONE_NEWNS");
 
-			remount_all_slave();
+			remount_all_slave(name);
 			ret = do_rootfs_setup(conf, name, lxcpath);
 			if (ret < 0) {
 				ERROR("Error setting up rootfs mount as root before spawn");


### PR DESCRIPTION
Hello,

While a container reads mountinfo from proc fs, the mountinfo can be changed by kernel anytime.

It caused the critical issues on our device. So, we changed some logic for reading mountinfo.

Please review it. Thanks.

Signed-off-by: Donghwa Jeong <dh48.jeong@samsung.com>