### PR TITLE
Revert "seccomp: make do_resolve_add_rule() more strict"

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -500,13 +500,13 @@ bool do_resolve_add_rule(uint32_t arch, char *line, scmp_filter_ctx ctx,
 	nr = seccomp_syscall_resolve_name(line);
 	if (nr == __NR_SCMP_ERROR) {
 		WARN("Failed to resolve syscall \"%s\"", line);
-		WARN("This syscall will NOT be blacklisted");
+		WARN("This syscall will NOT be handled by seccomp");
 		return true;
 	}
 
 	if (nr < 0) {
 		WARN("Got negative return value %d for syscall \"%s\"", nr, line);
-		WARN("This syscall will NOT be blacklisted");
+		WARN("This syscall will NOT be handled by seccomp");
 		return true;
 	}
 

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -500,12 +500,14 @@ bool do_resolve_add_rule(uint32_t arch, char *line, scmp_filter_ctx ctx,
 	nr = seccomp_syscall_resolve_name(line);
 	if (nr == __NR_SCMP_ERROR) {
 		WARN("Failed to resolve syscall \"%s\"", line);
-		return false;
+		WARN("This syscall will NOT be blacklisted");
+		return true;
 	}
 
 	if (nr < 0) {
 		WARN("Got negative return value %d for syscall \"%s\"", nr, line);
-		return false;
+		WARN("This syscall will NOT be blacklisted");
+		return true;
 	}
 
 	memset(&arg_cmp, 0, sizeof(arg_cmp));


### PR DESCRIPTION
This reverts commit dfddc8aa7ef3362212f8394995088a5f525730dd.

Closes #2376.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>