### PR TITLE
terminal: enable local output processing

### DIFF
--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -509,7 +509,7 @@ int lxc_setup_tios(int fd, struct termios *oldtios)
 #ifdef IEXTEN
 	newtios.c_lflag &= ~IEXTEN;
 #endif
-	newtios.c_oflag &= ~OPOST;
+	newtios.c_oflag |= OPOST;
 	newtios.c_cc[VMIN] = 1;
 	newtios.c_cc[VTIME] = 0;
 


### PR DESCRIPTION
Signed-off-by: Jonathan Calmels <jcalmels@nvidia.com>

Not entirely sure why this was unset in the first place, but this fixes the logging output when doing something like: 

```
lxc-execute -l info -o /dev/stderr ubuntu
```