### PR TITLE
tools: restore lxc-create log behavior

### DIFF
--- a/src/lxc/tools/lxc_create.c
+++ b/src/lxc/tools/lxc_create.c
@@ -230,7 +230,10 @@ int main(int argc, char *argv[])
 	/* Only create log if explicitly instructed */
 	if (my_args.log_file || my_args.log_priority) {
 		log.name = my_args.name;
-		log.file = my_args.log_file;
+		if (!my_args.log_file)
+			log.file = "none";
+		else
+			log.file = my_args.log_file;
 		log.level = my_args.log_priority;
 		log.prefix = my_args.progname;
 		log.quiet = my_args.quiet;


### PR DESCRIPTION
Older versions of lxc-create used to set log_file to "none" when a log priority
but no log file was specified on the command line. Let's restore this behavior.

Closes #2392.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>