### PR TITLE
attach: fix double free

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -172,7 +172,6 @@ static void lxc_proc_put_context_info(struct lxc_proc_context_info *ctx)
 
 	lxc_proc_close_ns_fd(ctx);
 	free(ctx);
-	ctx = NULL;
 }
 
 /**
@@ -908,6 +907,7 @@ static int attach_child_main(struct attach_clone_payload *payload)
 	close(payload->ipc_socket);
 	payload->ipc_socket = -EBADF;
 	lxc_proc_put_context_info(init_ctx);
+	payload->init_ctx = NULL;
 
 	/* The following is done after the communication socket is shut down.
 	 * That way, all errors that might (though unlikely) occur up until this


### PR DESCRIPTION
Hello,

There is a double free issue.

This is caused by init_ctx free of payload when lxc_terminal_prepare_login() is failed.

(gdb) 
960		if (options->attach_flags & LXC_ATTACH_TERMINAL) {
(gdb) 
961			ret = lxc_terminal_prepare_login(payload->terminal_slave_fd);
(gdb) 
962			if (ret < 0) {
(gdb) 
963				SYSERROR("Failed to prepare terminal file descriptor %d", payload->terminal_slave_fd);
(gdb) 
964				goto on_error;
(gdb) p ret
$1 = -1
(gdb) p payload->terminal_slave_fd
$2 = 10
(gdb) n
973		lxc_put_attach_clone_payload(payload);
(gdb) 
*** Error in `/usr/local/bin/lxc-attach': double free or corruption (out): 0x000000000060ff70 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7ffff73957e5]
/lib/x86_64-linux-gnu/libc.so.6(+0x8037a)[0x7ffff739e37a]
/lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7ffff73a253c]
/usr/local/lib/liblxc.so.1(+0x7598d)[0x7ffff7b8098d]
/usr/local/lib/liblxc.so.1(+0x7729e)[0x7ffff7b8229e]
/usr/local/lib/liblxc.so.1(+0x77ab6)[0x7ffff7b82ab6]
/usr/local/lib/liblxc.so.1(lxc_attach+0x150b)[0x7ffff7b842b4]
/usr/local/lib/liblxc.so.1(+0x987bb)[0x7ffff7ba37bb]
/usr/local/bin/lxc-attach(main+0x498)[0x40313e]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7ffff733e830]
/usr/local/bin/lxc-attach(_start+0x29)[0x4026a9]
======= Memory map: ======
...

Signed-off-by: Donghwa Jeong <dh48.jeong@samsung.com>