### PR TITLE
move some comments in lxc.spec.in

### DIFF
--- a/lxc.spec.in
+++ b/lxc.spec.in
@@ -29,9 +29,9 @@
 # BuildRequires systemd-units on fedora and rhel
 %if 0%{?fedora} >= 14 || 0%{?rhel} >= 7
 BuildRequires: systemd-units
+%endif
 #
 # BuildRequires systemd on openSUSE and SUSE
-%endif
 %if 0%{?suse_version} >= 1210
 BuildRequires: systemd
 %endif


### PR DESCRIPTION
Hello,

Some comments for BuildRequires field are moved in lxc.spec.in.

Thanks.

Signed-off-by: 2xsec <dh48.jeong@samsung.com>