### PR TITLE
log: add strerror_r macro

### DIFF
--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -293,6 +293,27 @@ ATTR_UNUSED static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 	(lxc_log_priority_to_string(lxc_log_category_##name.priority))
 
 /*
+ * Helper macro to define errno string.
+ */
+#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !defined(_GNU_SOURCE)
+#define lxc_log_strerror_r                                               \
+	char errno_buf[MAXPATHLEN / 2] = {"Failed to get errno string"}; \
+	char *ptr = errno_buf;                                           \
+	{                                                                \
+		(void)strerror_r(errno, errno_buf, sizeof(errno_buf));   \
+	}
+#else
+#define lxc_log_strerror_r                                               \
+	char errno_buf[MAXPATHLEN / 2] = {"Failed to get errno string"}; \
+	char *ptr;                                                       \
+	{                                                                \
+		ptr = strerror_r(errno, errno_buf, sizeof(errno_buf));   \
+		if (!ptr)                                                \
+			ptr = errno_buf;                                 \
+	}
+#endif
+
+/*
  * top categories
  */
 #define TRACE(format, ...) do {						\
@@ -340,11 +361,41 @@ ATTR_UNUSED static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 	LXC_FATAL(&locinfo, format, ##__VA_ARGS__);			\
 } while (0)
 
+#define SYSTRACE(format, ...)                              \
+	do {                                               \
+		lxc_log_strerror_r;                        \
+		TRACE("%s - " format, ptr, ##__VA_ARGS__); \
+	} while (0)
 
+#define SYSDEBUG(format, ...)                              \
+	do {                                               \
+		lxc_log_strerror_r;                        \
+		DEBUG("%s - " format, ptr, ##__VA_ARGS__); \
+	} while (0)
 
-#define SYSERROR(format, ...) do {				    	\
-	ERROR("%s - " format, strerror(errno), ##__VA_ARGS__);		\
-} while (0)
+#define SYSINFO(format, ...)                              \
+	do {                                              \
+		lxc_log_strerror_r;                       \
+		INFO("%s - " format, ptr, ##__VA_ARGS__); \
+	} while (0)
+
+#define SYSNOTICE(format, ...)                              \
+	do {                                                \
+		lxc_log_strerror_r;                         \
+		NOTICE("%s - " format, ptr, ##__VA_ARGS__); \
+	} while (0)
+
+#define SYSWARN(format, ...)                              \
+	do {                                              \
+		lxc_log_strerror_r;                       \
+		WARN("%s - " format, ptr, ##__VA_ARGS__); \
+	} while (0)
+
+#define SYSERROR(format, ...)                              \
+	do {                                               \
+		lxc_log_strerror_r;                        \
+		ERROR("%s - " format, ptr, ##__VA_ARGS__); \
+	} while (0)
 
 extern int lxc_log_fd;
 

--- a/src/lxc/lsm/apparmor.c
+++ b/src/lxc/lsm/apparmor.c
@@ -18,6 +18,7 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/lxc/lsm/lsm.c
+++ b/src/lxc/lsm/lsm.c
@@ -21,6 +21,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/lxc/lsm/selinux.c
+++ b/src/lxc/lsm/selinux.c
@@ -21,6 +21,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <stdlib.h>
 #include <stdbool.h>

--- a/src/lxc/monitor.c
+++ b/src/lxc/monitor.c
@@ -22,6 +22,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>

--- a/src/lxc/state.c
+++ b/src/lxc/state.c
@@ -21,6 +21,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/src/lxc/sync.c
+++ b/src/lxc/sync.c
@@ -21,6 +21,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#define _GNU_SOURCE
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <unistd.h>

--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -21,6 +21,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <lxc/lxccontainer.h>


### PR DESCRIPTION
Hello,

We add a log macro to use strerror_r() for thread safe.

For that, _GNU_SOURCE define is added to some source files.

Please review it then let us know your opinion.

Thanks.

Signed-off-by: 2xsec <dh48.jeong@samsung.com>