### PR TITLE
clear ONLCR flag for container pty

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -24,6 +24,7 @@
 #define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
+#include <termios.h>
 #include <grp.h>
 #include <pwd.h>
 #include <signal.h>
@@ -979,12 +980,19 @@ static int lxc_attach_terminal(struct lxc_conf *conf,
 			       struct lxc_terminal *terminal)
 {
 	int ret;
+	struct termios oldtios;
 
 	lxc_terminal_init(terminal);
 
 	ret = lxc_terminal_create(terminal);
 	if (ret < 0) {
 		SYSERROR("Failed to create terminal");
+		return -1;
+	}
+
+	ret = lxc_setup_tios(terminal->master, &oldtios);
+	if (ret < 0) {
+		SYSERROR("Failed to setup terminal");
 		return -1;
 	}
 

--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -509,6 +509,7 @@ int lxc_setup_tios(int fd, struct termios *oldtios)
 #ifdef IEXTEN
 	newtios.c_lflag &= ~IEXTEN;
 #endif
+	newtios.c_oflag &= ~ONLCR;
 	newtios.c_oflag |= OPOST;
 	newtios.c_cc[VMIN] = 1;
 	newtios.c_cc[VTIME] = 0;
@@ -897,6 +898,7 @@ int lxc_terminal_setup(struct lxc_conf *conf)
 {
 	int ret;
 	struct lxc_terminal *terminal = &conf->console;
+	struct termios oldtios;
 
 	if (terminal->path && strcmp(terminal->path, "none") == 0) {
 		INFO("No terminal requested");
@@ -904,6 +906,10 @@ int lxc_terminal_setup(struct lxc_conf *conf)
 	}
 
 	ret = lxc_terminal_create(terminal);
+	if (ret < 0)
+		return -1;
+
+	ret = lxc_setup_tios(terminal->master, &oldtios);
 	if (ret < 0)
 		return -1;
 


### PR DESCRIPTION
now container pty output log, use \r\n as a newline flag.
This is a windows type, so we need to change it. By clear
ONLCR can reach it.


Before do this.
```
# echo "" > /tmp/haozi.log
# lxc-start -P /var/lib/test/ -L /tmp/haozi.log --name haozi -- cat /proc/self/cgroup | od -c
0000000
# od -c /tmp/haozi.log
0000000  \n   1   2   :   f   i   l   e   s   :   /   l   x   c   /   h
0000020   a   o   z   i  \r  \n   1   1   :   p   i   d   s   :   /   l
0000040   x   c   /   h   a   o   z   i  \r  \n   1   0   :   m   e   m
0000060   o   r   y   :   /   l   x   c   /   h   a   o   z   i  \r  \n
0000100   9   :   h   u   g   e   t   l   b   :   /   l   x   c   /   h
0000120   a   o   z   i  \r  \n   8   :   p   e   r   f   _   e   v   e
0000140   n   t   :   /   l   x   c   /   h   a   o   z   i  \r  \n   7
0000160   :   c   p   u   s   e   t   :   /   l   x   c   /   h   a   o
0000200   z   i  \r  \n   6   :   d   e   v   i   c   e   s   :   /   l
0000220   x   c   /   h   a   o   z   i  \r  \n   5   :   f   r   e   e
0000240   z   e   r   :   /   l   x   c   /   h   a   o   z   i  \r  \n
0000260   4   :   b   l   k   i   o   :   /   l   x   c   /   h   a   o
0000300   z   i  \r  \n   3   :   c   p   u   a   c   c   t   ,   c   p
0000320   u   :   /   l   x   c   /   h   a   o   z   i  \r  \n   2   :
0000340   n   e   t   _   p   r   i   o   ,   n   e   t   _   c   l   s
0000360   :   /   l   x   c   /   h   a   o   z   i  \r  \n   1   :   n
0000400   a   m   e   =   s   y   s   t   e   m   d   :   /   l   x   c
0000420   /   h   a   o   z   i  \r  \n
```

After we got this

```
# echo "" > /tmp/haozi.log
# lxc-start -P /var/lib/test -L /tmp/haozi.log --name haozi -- cat /proc/self/cgroup | od -c
0000000
# od -c /tmp/haozi.log
0000000  \n   1   2   :   f   i   l   e   s   :   /   l   x   c   /   h
0000020   a   o   z   i  \n   1   1   :   p   i   d   s   :   /   l   x
0000040   c   /   h   a   o   z   i  \n   1   0   :   m   e   m   o   r
0000060   y   :   /   l   x   c   /   h   a   o   z   i  \n   9   :   h
0000100   u   g   e   t   l   b   :   /   l   x   c   /   h   a   o   z
0000120   i  \n   8   :   p   e   r   f   _   e   v   e   n   t   :   /
0000140   l   x   c   /   h   a   o   z   i  \n   7   :   c   p   u   s
0000160   e   t   :   /   l   x   c   /   h   a   o   z   i  \n   6   :
0000200   d   e   v   i   c   e   s   :   /   l   x   c   /   h   a   o
0000220   z   i  \n   5   :   f   r   e   e   z   e   r   :   /   l   x
0000240   c   /   h   a   o   z   i  \n   4   :   b   l   k   i   o   :
0000260   /   l   x   c   /   h   a   o   z   i  \n   3   :   c   p   u
0000300   a   c   c   t   ,   c   p   u   :   /   l   x   c   /   h   a
0000320   o   z   i  \n   2   :   n   e   t   _   p   r   i   o   ,   n
0000340   e   t   _   c   l   s   :   /   l   x   c   /   h   a   o   z
0000360   i  \n   1   :   n   a   m   e   =   s   y   s   t   e   m   d
0000400   :   /   l   x   c   /   h   a   o   z   i  \n
```

Signed-off-by: duguhaotian <duguhaotian@gmail.com>