### PR TITLE
tools: fix quiet option is not working

### DIFF
--- a/src/lxc/tools/lxc_cgroup.c
+++ b/src/lxc/tools/lxc_cgroup.c
@@ -37,7 +37,7 @@
 static int my_checker(const struct lxc_arguments* args)
 {
 	if (!args->argc) {
-		lxc_error(args, "missing state object");
+		lxc_error(args, "Missing state object");
 		return -1;
 	}
 
@@ -95,44 +95,48 @@ int main(int argc, char *argv[])
 	if (my_args.rcfile) {
 		c->clear_config(c);
 		if (!c->load_config(c, my_args.rcfile)) {
-			fprintf(stderr, "Failed to load rcfile\n");
+			lxc_error(&my_args, "Failed to load rcfile");
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}
+
 		c->configfile = strdup(my_args.rcfile);
 		if (!c->configfile) {
-			fprintf(stderr, "Out of memory setting new config filename\n");
+			lxc_error(&my_args, "Out of memory setting new config filename");
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}
 	}
 
 	if (!c->may_control(c)) {
-		fprintf(stderr, "Insufficent privileges to control %s:%s\n", my_args.lxcpath[0], my_args.name);
+		lxc_error(&my_args, "Insufficent privileges to control %s:%s", my_args.lxcpath[0], my_args.name);
 		lxc_container_put(c);
 		exit(EXIT_FAILURE);
 	}
 
 	if (!c->is_running(c)) {
-		fprintf(stderr, "'%s:%s' is not running\n", my_args.lxcpath[0], my_args.name);
+		lxc_error(&my_args, "'%s:%s' is not running", my_args.lxcpath[0], my_args.name);
 		lxc_container_put(c);
 		exit(EXIT_FAILURE);
 	}
 
 	if ((my_args.argc) > 1) {
 		value = my_args.argv[1];
+
 		if (!c->set_cgroup_item(c, state_object, value)) {
-			fprintf(stderr, "failed to assign '%s' value to '%s' for '%s'\n",
-				value, state_object, my_args.name);
+			lxc_error(&my_args, "Failed to assign '%s' value to '%s' for '%s'",
+			          value, state_object, my_args.name);
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}
 	} else {
 		char buffer[TOOL_MAXPATHLEN];
-		int ret = c->get_cgroup_item(c, state_object, buffer, TOOL_MAXPATHLEN);
+		int ret;
+
+		ret = c->get_cgroup_item(c, state_object, buffer, TOOL_MAXPATHLEN);
 		if (ret < 0) {
-			fprintf(stderr, "failed to retrieve value of '%s' for '%s:%s'\n",
-			      state_object, my_args.lxcpath[0], my_args.name);
+			lxc_error(&my_args, "Failed to retrieve value of '%s' for '%s:%s'",
+			          state_object, my_args.lxcpath[0], my_args.name);
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}

--- a/src/lxc/tools/lxc_freeze.c
+++ b/src/lxc/tools/lxc_freeze.c
@@ -75,33 +75,33 @@ int main(int argc, char *argv[])
 
 	c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c) {
-		fprintf(stderr, "No such container: %s:%s\n", my_args.lxcpath[0], my_args.name);
+		lxc_error(&my_args, "No such container: %s:%s", my_args.lxcpath[0], my_args.name);
 		exit(EXIT_FAILURE);
 	}
 
 	if (my_args.rcfile) {
 		c->clear_config(c);
 		if (!c->load_config(c, my_args.rcfile)) {
-			fprintf(stderr, "Failed to load rcfile\n");
+			lxc_error(&my_args, "Failed to load rcfile");
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}
 		c->configfile = strdup(my_args.rcfile);
 		if (!c->configfile) {
-			fprintf(stderr, "Out of memory setting new config filename\n");
+			lxc_error(&my_args, "Out of memory setting new config filename");
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}
 	}
 
 	if (!c->may_control(c)) {
-		fprintf(stderr, "Insufficent privileges to control %s:%s\n", my_args.lxcpath[0], my_args.name);
+		lxc_error(&my_args, "Insufficent privileges to control %s:%s", my_args.lxcpath[0], my_args.name);
 		lxc_container_put(c);
 		exit(EXIT_FAILURE);
 	}
 
 	if (!c->freeze(c)) {
-		fprintf(stderr, "Failed to freeze %s:%s\n", my_args.lxcpath[0], my_args.name);
+		lxc_error(&my_args, "Failed to freeze %s:%s", my_args.lxcpath[0], my_args.name);
 		lxc_container_put(c);
 		exit(EXIT_FAILURE);
 	}

--- a/src/lxc/tools/lxc_start.c
+++ b/src/lxc/tools/lxc_start.c
@@ -47,7 +47,7 @@
 
 static struct lxc_list defines;
 
-static int ensure_path(char **confpath, const char *path)
+static int ensure_path(struct lxc_arguments *args, char **confpath, const char *path)
 {
 	int err = -1, fd;
 	char *fullpath = NULL;
@@ -56,21 +56,23 @@ static int ensure_path(char **confpath, const char *path)
 		if (access(path, W_OK)) {
 			fd = creat(path, 0600);
 			if (fd < 0 && errno != EEXIST) {
-				fprintf(stderr, "failed to create '%s'\n", path);
+				lxc_error(args, "Failed to create '%s'", path);
 				goto err;
 			}
+
 			if (fd >= 0)
 				close(fd);
 		}
 
 		fullpath = realpath(path, NULL);
 		if (!fullpath) {
-			fprintf(stderr, "failed to get the real path of '%s'\n", path);
+			lxc_error(args, "Failed to get the real path of '%s'", path);
 			goto err;
 		}
 
 		*confpath = fullpath;
 	}
+
 	err = EXIT_SUCCESS;
 
 err:
@@ -204,8 +206,7 @@ int main(int argc, char *argv[])
 
 	lxcpath = my_args.lxcpath[0];
 	if (access(lxcpath, O_RDONLY) < 0) {
-		if (!my_args.quiet)
-			fprintf(stderr, "You lack access to %s\n", lxcpath);
+		lxc_error(&my_args, "You lack access to %s", lxcpath);
 		exit(err);
 	}
 
@@ -218,20 +219,24 @@ int main(int argc, char *argv[])
 	/* rcfile is specified in the cli option */
 	if (my_args.rcfile) {
 		rcfile = (char *)my_args.rcfile;
+
 		c = lxc_container_new(my_args.name, lxcpath);
 		if (!c) {
-			fprintf(stderr, "Failed to create lxc_container\n");
+			lxc_error(&my_args, "Failed to create lxc_container");
 			exit(err);
 		}
+
 		c->clear_config(c);
+
 		if (!c->load_config(c, rcfile)) {
-			fprintf(stderr, "Failed to load rcfile\n");
+			lxc_error(&my_args, "Failed to load rcfile");
 			lxc_container_put(c);
 			exit(err);
 		}
+
 		c->configfile = strdup(my_args.rcfile);
 		if (!c->configfile) {
-			fprintf(stderr, "Out of memory setting new config filename\n");
+			lxc_error(&my_args, "Out of memory setting new config filename");
 			goto out;
 		}
 	} else {
@@ -239,7 +244,7 @@ int main(int argc, char *argv[])
 
 		rc = asprintf(&rcfile, "%s/%s/config", lxcpath, my_args.name);
 		if (rc == -1) {
-			fprintf(stderr, "failed to allocate memory\n");
+			lxc_error(&my_args, "Failed to allocate memory");
 			exit(err);
 		}
 
@@ -248,9 +253,10 @@ int main(int argc, char *argv[])
 			free(rcfile);
 			rcfile = NULL;
 		}
+
 		c = lxc_container_new(my_args.name, lxcpath);
 		if (!c) {
-			fprintf(stderr, "Failed to create lxc_container\n");
+			lxc_error(&my_args, "Failed to create lxc_container");
 			exit(err);
 		}
 	}
@@ -260,23 +266,23 @@ int main(int argc, char *argv[])
 	 * to be created for it to be started. You can just pass a configuration
 	 * file as argument and start the container right away.
 	 */
-
 	if (!c->may_control(c)) {
-		fprintf(stderr, "Insufficent privileges to control %s\n", c->name);
+		lxc_error(&my_args, "Insufficent privileges to control %s", c->name);
 		goto out;
 	}
 
 	if (c->is_running(c)) {
-		fprintf(stderr, "Container is already running.\n");
+		lxc_error(&my_args, "Container is already running.");
 		err = EXIT_SUCCESS;
 		goto out;
 	}
+
 	/*
 	 * We should use set_config_item() over &defines, which would handle
 	 * unset c->lxc_conf for us and let us not use lxc_config_define_load()
 	 */
 	if (!c->lxc_conf) {
-		fprintf(stderr, "No container config specified\n");
+		lxc_error(&my_args, "No container config specified");
 		goto out;
 	}
 
@@ -284,13 +290,13 @@ int main(int argc, char *argv[])
 		goto out;
 
 	if (!rcfile && !strcmp("/sbin/init", args[0])) {
-		fprintf(stderr, "Executing '/sbin/init' with no configuration file may crash the host\n");
+		lxc_error(&my_args, "Executing '/sbin/init' with no configuration file may crash the host");
 		goto out;
 	}
 
 	if (my_args.pidfile != NULL) {
-		if (ensure_path(&c->pidfile, my_args.pidfile) < 0) {
-			fprintf(stderr, "failed to ensure pidfile '%s'\n", my_args.pidfile);
+		if (ensure_path(&my_args, &c->pidfile, my_args.pidfile) < 0) {
+			lxc_error(&my_args, "Failed to ensure pidfile '%s'", my_args.pidfile);
 			goto out;
 		}
 	}
@@ -317,13 +323,15 @@ int main(int argc, char *argv[])
 		err = c->start(c, 0, NULL) ? EXIT_SUCCESS : EXIT_FAILURE;
 	else
 		err = c->start(c, 0, args) ? EXIT_SUCCESS : EXIT_FAILURE;
-
 	if (err) {
-		fprintf(stderr, "The container failed to start.\n");
+		lxc_error(&my_args, "The container failed to start.");
+
 		if (my_args.daemonize)
-			fprintf(stderr, "To get more details, run the container in foreground mode.\n");
-		fprintf(stderr, "Additional information can be obtained by setting the "
-		      "--logfile and --logpriority options.\n");
+			lxc_error(&my_args, "To get more details, run the container in foreground mode.");
+
+		lxc_error(&my_args, "Additional information can be obtained by setting the "
+		          "--logfile and --logpriority options.\n");
+
 		err = c->error_num;
 		lxc_container_put(c);
 		exit(err);

--- a/src/lxc/tools/lxc_stop.c
+++ b/src/lxc/tools/lxc_stop.c
@@ -130,56 +130,59 @@ int main(int argc, char *argv[])
 
 	/* some checks */
 	if (!my_args.hardstop && my_args.timeout < -1) {
-		fprintf(stderr, "invalid timeout\n");
+		lxc_error(&my_args, "Invalid timeout");
 		exit(ret);
 	}
 
 	if (my_args.hardstop && my_args.nokill) {
-		fprintf(stderr, "-k can't be used with --nokill\n");
+		lxc_error(&my_args, "-k can't be used with --nokill");
 		exit(ret);
 	}
 
 	if (my_args.hardstop && my_args.reboot) {
-		fprintf(stderr, "-k can't be used with -r\n");
+		lxc_error(&my_args, "-k can't be used with -r");
 		exit(ret);
 	}
 
 	if (my_args.hardstop && my_args.timeout) {
-		fprintf(stderr, "-k doesn't allow timeouts\n");
+		lxc_error(&my_args, "-k doesn't allow timeouts");
 		exit(ret);
 	}
 
 	if (my_args.nolock && !my_args.hardstop) {
-		fprintf(stderr, "--nolock may only be used with -k\n");
+		lxc_error(&my_args, "--nolock may only be used with -k");
 		exit(ret);
 	}
 
 	c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c) {
-		fprintf(stderr, "Error opening container\n");
+		lxc_error(&my_args, "Error opening container");
 		goto out;
 	}
 
 	if (my_args.rcfile) {
 		c->clear_config(c);
+
 		if (!c->load_config(c, my_args.rcfile)) {
-			fprintf(stderr, "Failed to load rcfile\n");
+			lxc_error(&my_args, "Failed to load rcfile");
 			goto out;
 		}
+
 		c->configfile = strdup(my_args.rcfile);
 		if (!c->configfile) {
-			fprintf(stderr, "Out of memory setting new config filename\n");
+			lxc_error(&my_args, "Out of memory setting new config filename");
 			goto out;
 		}
 	}
 
 	if (!c->may_control(c)) {
-		fprintf(stderr, "Insufficent privileges to control %s\n", c->name);
+		lxc_error(&my_args, "Insufficent privileges to control %s", c->name);
 		goto out;
 	}
 
 	if (!c->is_running(c)) {
-		fprintf(stderr, "%s is not running\n", c->name);
+		lxc_error(&my_args, "%s is not running", c->name);
+
 		/* Per our manpage we need to exit with exit code:
 		 * 2: The specified container exists but was not running.
 		 */
@@ -200,6 +203,7 @@ int main(int argc, char *argv[])
 			ret = EXIT_FAILURE;
 		else
 			ret = EXIT_SUCCESS;
+
 		goto out;
 	}
 

--- a/src/lxc/tools/lxc_unfreeze.c
+++ b/src/lxc/tools/lxc_unfreeze.c
@@ -75,33 +75,35 @@ int main(int argc, char *argv[])
 
 	c = lxc_container_new(my_args.name, my_args.lxcpath[0]);
 	if (!c) {
-		fprintf(stderr, "No such container: %s:%s\n", my_args.lxcpath[0], my_args.name);
+		lxc_error(&my_args, "No such container: %s:%s", my_args.lxcpath[0], my_args.name);
 		exit(EXIT_FAILURE);
 	}
 
 	if (!c->may_control(c)) {
-		fprintf(stderr, "Insufficent privileges to control %s:%s\n", my_args.lxcpath[0], my_args.name);
+		lxc_error(&my_args, "Insufficent privileges to control %s:%s", my_args.lxcpath[0], my_args.name);
 		lxc_container_put(c);
 		exit(EXIT_FAILURE);
 	}
 
 	if (my_args.rcfile) {
 		c->clear_config(c);
+
 		if (!c->load_config(c, my_args.rcfile)) {
-			fprintf(stderr, "Failed to load rcfile\n");
+			lxc_error(&my_args, "Failed to load rcfile");
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}
+
 		c->configfile = strdup(my_args.rcfile);
 		if (!c->configfile) {
-			fprintf(stderr, "Out of memory setting new config filename\n");
+			lxc_error(&my_args, "Out of memory setting new config filename");
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}
 	}
 
 	if (!c->unfreeze(c)) {
-		fprintf(stderr, "Failed to unfreeze %s:%s\n", my_args.lxcpath[0], my_args.name);
+		lxc_error(&my_args, "Failed to unfreeze %s:%s", my_args.lxcpath[0], my_args.name);
 		lxc_container_put(c);
 		exit(EXIT_FAILURE);
 	}

--- a/src/lxc/tools/lxc_wait.c
+++ b/src/lxc/tools/lxc_wait.c
@@ -35,21 +35,23 @@
 #include "arguments.h"
 #include "tool_utils.h"
 
-static int my_checker(const struct lxc_arguments* args)
+static int my_checker(const struct lxc_arguments *args)
 {
 	if (!args->states) {
 		lxc_error(args, "missing state option to wait for.");
 		return -1;
 	}
+
 	return 0;
 }
 
-static int my_parser(struct lxc_arguments* args, int c, char* arg)
+static int my_parser(struct lxc_arguments *args, int c, char *arg)
 {
 	switch (c) {
 	case 's': args->states = optarg; break;
 	case 't': args->timeout = atol(optarg); break;
 	}
+
 	return 0;
 }
 
@@ -105,21 +107,23 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 
 	if (!c->may_control(c)) {
-		fprintf(stderr, "Insufficent privileges to control %s\n", c->name);
+		lxc_error(&my_args, "Insufficent privileges to control %s", c->name);
 		lxc_container_put(c);
 		exit(EXIT_FAILURE);
 	}
 
 	if (my_args.rcfile) {
 		c->clear_config(c);
+
 		if (!c->load_config(c, my_args.rcfile)) {
-			fprintf(stderr, "Failed to load rcfile\n");
+			lxc_error(&my_args, "Failed to load rcfile");
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}
+
 		c->configfile = strdup(my_args.rcfile);
 		if (!c->configfile) {
-			fprintf(stderr, "Out of memory setting new config filename\n");
+			lxc_error(&my_args, "Out of memory setting new config filename");
 			lxc_container_put(c);
 			exit(EXIT_FAILURE);
 		}
@@ -129,5 +133,6 @@ int main(int argc, char *argv[])
 		lxc_container_put(c);
 		exit(EXIT_FAILURE);
 	}
+
 	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Hello,

Currently, a quiet option of tools is not working because of using fprintf directly.

So, we change fprintf or print to lxc_error log with some cleanups.

And lxc_sys_error is added to print errno string additionally.

Thanks.

Signed-off-by: 2xsec <dh48.jeong@samsung.com>