### PR TITLE
[RFC] conf: introduce lxc.rootfs.managed

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2760,6 +2760,7 @@ struct lxc_conf *lxc_conf_init(void)
 		free(new);
 		return NULL;
 	}
+	new->rootfs.managed = true;
 	new->logfd = -1;
 	lxc_list_init(&new->cgroup);
 	lxc_list_init(&new->cgroup2);

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -154,6 +154,7 @@ struct lxc_tty_info {
  * @options    : mount options
  * @mountflags : the portion of @options that are flags
  * @data       : the porition of @options that are not flags
+ * @managed    : whether it is managed by LXC
  */
 struct lxc_rootfs {
 	char *path;
@@ -162,6 +163,7 @@ struct lxc_rootfs {
 	char *options;
 	unsigned long mountflags;
 	char *data;
+	bool managed;
 };
 
 /*

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -141,6 +141,7 @@ lxc_config_define(no_new_privs);
 lxc_config_define(personality);
 lxc_config_define(prlimit);
 lxc_config_define(pty_max);
+lxc_config_define(rootfs_managed);
 lxc_config_define(rootfs_mount);
 lxc_config_define(rootfs_options);
 lxc_config_define(rootfs_path);
@@ -226,6 +227,7 @@ static struct lxc_config_t config[] = {
 	{ "lxc.no_new_privs",	           set_config_no_new_privs,                get_config_no_new_privs,                clr_config_no_new_privs,              },
 	{ "lxc.prlimit",                   set_config_prlimit,                     get_config_prlimit,                     clr_config_prlimit,                   },
 	{ "lxc.pty.max",                   set_config_pty_max,                     get_config_pty_max,                     clr_config_pty_max,                   },
+	{ "lxc.rootfs.managed",            set_config_rootfs_managed,              get_config_rootfs_managed,              clr_config_rootfs_managed,            },
 	{ "lxc.rootfs.mount",              set_config_rootfs_mount,                get_config_rootfs_mount,                clr_config_rootfs_mount,              },
 	{ "lxc.rootfs.options",            set_config_rootfs_options,              get_config_rootfs_options,              clr_config_rootfs_options,            },
 	{ "lxc.rootfs.path",               set_config_rootfs_path,                 get_config_rootfs_path,                 clr_config_rootfs_path,               },
@@ -2134,6 +2136,31 @@ static int set_config_rootfs_path(const char *key, const char *value,
 	return ret;
 }
 
+static int set_config_rootfs_managed(const char *key, const char *value,
+				     struct lxc_conf *lxc_conf, void *data)
+{
+	unsigned int val = 0;
+
+	if (lxc_config_value_empty(value)) {
+		lxc_conf->rootfs.managed = true;
+		return 0;
+	}
+
+	if (lxc_safe_uint(value, &val) < 0)
+		return -EINVAL;
+
+	switch (val) {
+	case 0:
+		lxc_conf->rootfs.managed = false;
+		return 0;
+	case 1:
+		lxc_conf->rootfs.managed = true;
+		return 0;
+	}
+
+	return -EINVAL;
+}
+
 static int set_config_rootfs_mount(const char *key, const char *value,
 				   struct lxc_conf *lxc_conf, void *data)
 {
@@ -3356,6 +3383,12 @@ static int get_config_rootfs_path(const char *key, char *retv, int inlen,
 	return lxc_get_conf_str(retv, inlen, c->rootfs.path);
 }
 
+static int get_config_rootfs_managed(const char *key, char *retv, int inlen,
+				     struct lxc_conf *c, void *data)
+{
+	return lxc_get_conf_bool(c, retv, inlen, c->rootfs.managed);
+}
+
 static int get_config_rootfs_mount(const char *key, char *retv, int inlen,
 				   struct lxc_conf *c, void *data)
 {
@@ -3973,6 +4006,13 @@ static inline int clr_config_rootfs_path(const char *key, struct lxc_conf *c,
 {
 	free(c->rootfs.path);
 	c->rootfs.path = NULL;
+	return 0;
+}
+
+static inline int clr_config_rootfs_managed(const char *key, struct lxc_conf *c,
+					    void *data)
+{
+	c->rootfs.managed = true;
 	return 0;
 }
 

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -672,6 +672,21 @@ int lxc_get_conf_str(char *retv, int inlen, const char *value)
 	return value_len;
 }
 
+int lxc_get_conf_bool(struct lxc_conf *c, char *retv, int inlen, bool v)
+{
+	int len;
+	int fulllen = 0;
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	strprint(retv, inlen, "%d", v);
+
+	return fulllen;
+}
+
 int lxc_get_conf_int(struct lxc_conf *c, char *retv, int inlen, int v)
 {
 	int len;

--- a/src/lxc/confile_utils.h
+++ b/src/lxc/confile_utils.h
@@ -86,6 +86,7 @@ extern bool lxc_config_net_hwaddr(const char *line);
 extern void update_hwaddr(const char *line);
 extern bool new_hwaddr(char *hwaddr);
 extern int lxc_get_conf_str(char *retv, int inlen, const char *value);
+extern int lxc_get_conf_bool(struct lxc_conf *c, char *retv, int inlen, bool v);
 extern int lxc_get_conf_int(struct lxc_conf *c, char *retv, int inlen, int v);
 extern int lxc_get_conf_size_t(struct lxc_conf *c, char *retv, int inlen, size_t v);
 extern int lxc_get_conf_uint64(struct lxc_conf *c, char *retv, int inlen, uint64_t v);

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -316,84 +316,55 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 
-	/* lxc.arch */
 	if (set_get_compare_clear_save_load(c, "lxc.arch", "x86_64", tmpf,
 					    true) < 0) {
 		lxc_error("%s\n", "lxc.arch");
 		goto non_test_error;
 	}
 
-	/* REMOVE IN LXC 3.0
-	   legacy ps keys
-	 */
-	if (set_get_compare_clear_save_load(c, "lxc.pty.max", "1000", tmpf, true) <
-	    0) {
+	if (set_get_compare_clear_save_load(c, "lxc.pty.max", "1000", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.pty.max");
 		goto non_test_error;
 	}
 
-	/* lxc.pty.max */
-	if (set_get_compare_clear_save_load(c, "lxc.pty.max", "1000", tmpf, true) <
-	    0) {
-		lxc_error("%s\n", "lxc.pty.max");
-		goto non_test_error;
-	}
-
-	/* lxc.tty.max */
-	if (set_get_compare_clear_save_load(c, "lxc.tty.max", "4", tmpf, true) <
-	    0) {
+	if (set_get_compare_clear_save_load(c, "lxc.tty.max", "4", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.tty.max");
 		goto non_test_error;
 	}
 
-	/* lxc.tty.dir */
-	if (set_get_compare_clear_save_load(c, "lxc.tty.dir", "not-dev", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.tty.dir", "not-dev", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.tty.dir");
 		goto non_test_error;
 	}
 
-	/* lxc.apparmor.profile */
-	if (set_get_compare_clear_save_load(c, "lxc.apparmor.profile", "unconfined",
-					    tmpf, true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.apparmor.profile", "unconfined", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.apparmor.profile");
 		goto non_test_error;
 	}
 
-	/* lxc.apparmor.allow_incomplete */
-	if (set_get_compare_clear_save_load(c, "lxc.apparmor.allow_incomplete", "1",
-					    tmpf, true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.apparmor.allow_incomplete", "1", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.apparmor.allow_incomplete");
 		goto non_test_error;
 	}
 
-	/* lxc.selinux.context */
-	if (set_get_compare_clear_save_load(c, "lxc.selinux.context", "system_u:system_r:lxc_t:s0:c22",
-					    tmpf, true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.selinux.context", "system_u:system_r:lxc_t:s0:c22", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.selinux.context");
 		goto non_test_error;
 	}
 
-	/* lxc.cgroup.cpuset.cpus */
 	if (set_get_compare_clear_save_load(c, "lxc.cgroup.cpuset.cpus",
 					    "1-100", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.cgroup.cpuset.cpus");
 		goto non_test_error;
 	}
 
-	/* lxc.cgroup */
 	if (!c->set_config_item(c, "lxc.cgroup.cpuset.cpus", "1-100")) {
-		lxc_error("%s\n", "failed to set config item "
-				  "\"lxc.cgroup.cpuset.cpus\" to \"1-100\"");
+		lxc_error("%s\n", "failed to set config item \"lxc.cgroup.cpuset.cpus\" to \"1-100\"");
 		return -1;
 	}
 
-	if (!c->set_config_item(c, "lxc.cgroup.memory.limit_in_bytes",
-				"123456789")) {
-		lxc_error(
-		    "%s\n",
-		    "failed to set config item "
-		    "\"lxc.cgroup.memory.limit_in_bytes\" to \"123456789\"");
+	if (!c->set_config_item(c, "lxc.cgroup.memory.limit_in_bytes", "123456789")) {
+		lxc_error("%s\n", "failed to set config item \"lxc.cgroup.memory.limit_in_bytes\" to \"123456789\"");
 		return -1;
 	}
 
@@ -410,21 +381,18 @@ int main(int argc, char *argv[])
 	 * chown the container's directory but we haven't created an on-disk
 	 * container. So let's test set-get-clear.
 	 */
-	if (set_get_compare_clear_save_load(
-		c, "lxc.idmap", "u 0 100000 1000000000", NULL, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.idmap", "u 0 100000 1000000000", NULL, false) < 0) {
 		lxc_error("%s\n", "lxc.idmap");
 		goto non_test_error;
 	}
 
 	if (!c->set_config_item(c, "lxc.idmap", "u 1 100000 10000000")) {
-		lxc_error("%s\n", "failed to set config item "
-				  "\"lxc.idmap\" to \"u 1 100000 10000000\"");
+		lxc_error("%s\n", "failed to set config item \"lxc.idmap\" to \"u 1 100000 10000000\"");
 		return -1;
 	}
 
 	if (!c->set_config_item(c, "lxc.idmap", "g 1 100000 10000000")) {
-		lxc_error("%s\n", "failed to set config item "
-				  "\"lxc.idmap\" to \"g 1 100000 10000000\"");
+		lxc_error("%s\n", "failed to set config item \"lxc.idmap\" to \"g 1 100000 10000000\"");
 		return -1;
 	}
 
@@ -436,23 +404,17 @@ int main(int argc, char *argv[])
 	c->clear_config(c);
 	c->lxc_conf = NULL;
 
-	/* lxc.log.level */
-	if (set_get_compare_clear_save_load(c, "lxc.log.level", "DEBUG", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.log.level", "DEBUG", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.log.level");
 		goto non_test_error;
 	}
 
-	/* lxc.log */
-	if (set_get_compare_clear_save_load(c, "lxc.log.file", "/some/path",
-					    tmpf, true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.log.file", "/some/path", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.log.file");
 		goto non_test_error;
 	}
 
-	/* lxc.mount.fstab */
-	if (set_get_compare_clear_save_load(c, "lxc.mount.fstab", "/some/path", NULL,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.mount.fstab", "/some/path", NULL, true) < 0) {
 		lxc_error("%s\n", "lxc.mount.fstab");
 		goto non_test_error;
 	}
@@ -461,9 +423,7 @@ int main(int argc, char *argv[])
 	 * Note that we cannot compare the values since the getter for
 	 * lxc.mount.auto does not preserve ordering.
 	 */
-	if (set_get_compare_clear_save_load(c, "lxc.mount.auto",
-					    "proc:rw sys:rw cgroup-full:rw",
-					    tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.mount.auto", "proc:rw sys:rw cgroup-full:rw", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.mount.auto");
 		goto non_test_error;
 	}
@@ -472,271 +432,195 @@ int main(int argc, char *argv[])
 	 * Note that we cannot compare the values since the getter for
 	 * lxc.mount.entry appends newlines.
 	 */
-	if (set_get_compare_clear_save_load(
-		c, "lxc.mount.entry",
-		"/dev/dri dev/dri none bind,optional,create=dir", tmpf,
-		false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.mount.entry", "/dev/dri dev/dri none bind,optional,create=dir", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.mount.entry");
 		goto non_test_error;
 	}
 
-	/* lxc.rootfs.path */
-	if (set_get_compare_clear_save_load(c, "lxc.rootfs.path", "/some/path", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.rootfs.path", "/some/path", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.rootfs.path");
 		goto non_test_error;
 	}
 
-	/* lxc.rootfs.mount */
-	if (set_get_compare_clear_save_load(c, "lxc.rootfs.mount", "/some/path",
-					    tmpf, true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.rootfs.mount", "/some/path", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.rootfs.mount");
 		goto non_test_error;
 	}
 
-	/* lxc.rootfs.options */
-	if (set_get_compare_clear_save_load(c, "lxc.rootfs.options",
-					    "ext4,discard", tmpf, true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.rootfs.options", "ext4,discard", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.rootfs.options");
 		goto non_test_error;
 	}
 
-	/* lxc.uts.name */
-	if (set_get_compare_clear_save_load(c, "lxc.uts.name", "the-shire", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.uts.name", "the-shire", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.uts.name");
 		goto non_test_error;
 	}
 
-	/* lxc.hook.pre-start */
 	if (set_get_compare_clear_save_load(
 		c, "lxc.hook.pre-start", "/some/pre-start", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.hook.pre-start");
 		goto non_test_error;
 	}
 
-	/* lxc.hook.pre-mount */
 	if (set_get_compare_clear_save_load(
 		c, "lxc.hook.pre-mount", "/some/pre-mount", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.hook.pre-mount");
 		goto non_test_error;
 	}
 
-	/* lxc.hook.mount */
-	if (set_get_compare_clear_save_load(c, "lxc.hook.mount", "/some/mount",
-					    tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.hook.mount", "/some/mount", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.hook.mount");
 		goto non_test_error;
 	}
 
-	/* lxc.hook.autodev */
-	if (set_get_compare_clear_save_load(c, "lxc.hook.autodev",
-					    "/some/autodev", tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.hook.autodev", "/some/autodev", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.hook.autodev");
 		goto non_test_error;
 	}
 
-	/* lxc.hook.start */
-	if (set_get_compare_clear_save_load(c, "lxc.hook.start", "/some/start",
-					    tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.hook.start", "/some/start", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.hook.start");
 		goto non_test_error;
 	}
 
-	/* lxc.hook.stop */
-	if (set_get_compare_clear_save_load(c, "lxc.hook.stop", "/some/stop",
-					    tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.hook.stop", "/some/stop", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.hook.stop");
 		goto non_test_error;
 	}
 
-	/* lxc.hook.post-stop */
-	if (set_get_compare_clear_save_load(
-		c, "lxc.hook.post-stop", "/some/post-stop", tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.hook.post-stop", "/some/post-stop", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.hook.post-stop");
 		goto non_test_error;
 	}
 
-	/* lxc.hook.clone */
-	if (set_get_compare_clear_save_load(c, "lxc.hook.clone", "/some/clone",
-					    tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.hook.clone", "/some/clone", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.hook.clone");
 		goto non_test_error;
 	}
 
-	/* lxc.hook.destroy */
-	if (set_get_compare_clear_save_load(c, "lxc.hook.destroy",
-					    "/some/destroy", tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.hook.destroy", "/some/destroy", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.hook.destroy");
 		goto non_test_error;
 	}
 
-	/* lxc.cap.drop */
-	if (set_get_compare_clear_save_load(c, "lxc.cap.drop",
-					    "sys_module mknod setuid net_raw",
-					    tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.cap.drop", "sys_module mknod setuid net_raw", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.cap.drop");
 		goto non_test_error;
 	}
 
-	/* lxc.cap.keep */
-	if (set_get_compare_clear_save_load(c, "lxc.cap.keep",
-					    "sys_module mknod setuid net_raw",
-					    tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.cap.keep", "sys_module mknod setuid net_raw", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.cap.keep");
 		goto non_test_error;
 	}
 
-	/* lxc.console.path */
-	if (set_get_compare_clear_save_load(c, "lxc.console.path", "none", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.console.path", "none", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.console.path");
 		goto non_test_error;
 	}
 
-	/* lxc.console.logfile */
-	if (set_get_compare_clear_save_load(c, "lxc.console.logfile",
-					    "/some/logfile", tmpf, true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.console.logfile", "/some/logfile", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.console.logfile");
 		goto non_test_error;
 	}
 
-	/* lxc.seccomp.profile */
-	if (set_get_compare_clear_save_load(
-		c, "lxc.seccomp.profile", "/some/seccomp/file", tmpf, true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.seccomp.profile", "/some/seccomp/file", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.seccomp.profile");
 		goto non_test_error;
 	}
 
-	/* lxc.autodev */
 	if (set_get_compare_clear_save_load(c, "lxc.autodev", "1", tmpf, true) <
 	    0) {
 		lxc_error("%s\n", "lxc.autodev");
 		goto non_test_error;
 	}
 
-	/* lxc.signal.halt */
-	if (set_get_compare_clear_save_load(c, "lxc.signal.halt", "1", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.signal.halt", "1", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.signal.halt");
 		goto non_test_error;
 	}
 
-	/* lxc.signal.reboot */
-	if (set_get_compare_clear_save_load(c, "lxc.signal.reboot", "1", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.signal.reboot", "1", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.signal.reboot");
 		goto non_test_error;
 	}
 
-	/* lxc.signal.stop */
-	if (set_get_compare_clear_save_load(c, "lxc.signal.stop", "1", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.signal.stop", "1", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.signal.stop");
 		goto non_test_error;
 	}
 
-	/* lxc.start.auto */
-	if (set_get_compare_clear_save_load(c, "lxc.start.auto", "1", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.start.auto", "1", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.start.auto");
 		goto non_test_error;
 	}
 
-	/* lxc.start.delay */
-	if (set_get_compare_clear_save_load(c, "lxc.start.delay", "5", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.start.delay", "5", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.start.delay");
 		goto non_test_error;
 	}
 
-	/* lxc.start.order */
-	if (set_get_compare_clear_save_load(c, "lxc.start.order", "1", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.start.order", "1", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.start.order");
 		goto non_test_error;
 	}
 
-	/* lxc.log.syslog */
-	if (set_get_compare_clear_save_load(c, "lxc.log.syslog", "local0", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.log.syslog", "local0", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.log.syslog");
 		goto non_test_error;
 	}
 
-	/* lxc.monitor.unshare */
-	if (set_get_compare_clear_save_load(c, "lxc.monitor.unshare", "1", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.monitor.unshare", "1", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.monitor.unshare");
 		goto non_test_error;
 	}
 
-	/* lxc.group */
-	if (set_get_compare_clear_save_load(
-		c, "lxc.group", "some,container,groups", tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.group", "some,container,groups", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.group");
 		goto non_test_error;
 	}
 
-	/* lxc.environment */
-	if (set_get_compare_clear_save_load(c, "lxc.environment", "FOO=BAR",
-					    tmpf, false) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.environment", "FOO=BAR", tmpf, false) < 0) {
 		lxc_error("%s\n", "lxc.environment");
 		goto non_test_error;
 	}
 
-	/* lxc.init.cmd */
-	if (set_get_compare_clear_save_load(c, "lxc.init.cmd", "/bin/bash",
-					    tmpf, true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.init.cmd", "/bin/bash", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.init.cmd");
 		goto non_test_error;
 	}
 
-	/* lxc.init.uid */
-	if (set_get_compare_clear_save_load(c, "lxc.init.uid", "1000", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.init.uid", "1000", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.init.uid");
 		goto non_test_error;
 	}
 
-	/* lxc.init.gid */
-	if (set_get_compare_clear_save_load(c, "lxc.init.gid", "1000", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.init.gid", "1000", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.init.gid");
 		goto non_test_error;
 	}
 
-	/* lxc.ephemeral */
-	if (set_get_compare_clear_save_load(c, "lxc.ephemeral", "1", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.ephemeral", "1", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.ephemeral");
 		goto non_test_error;
 	}
 
-	/* lxc.no_new_privs */
-	if (set_get_compare_clear_save_load(c, "lxc.no_new_privs", "1", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.no_new_privs", "1", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.no_new_privs");
 		goto non_test_error;
 	}
 
-	/* lxc.sysctl */
-	if (set_get_compare_clear_save_load(c, "lxc.sysctl.net.core.somaxconn", "256", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.sysctl.net.core.somaxconn", "256", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.sysctl.net.core.somaxconn");
 		goto non_test_error;
 	}
 
-	/* lxc.proc */
-	if (set_get_compare_clear_save_load(c, "lxc.proc.oom_score_adj", "10", tmpf,
-					    true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.proc.oom_score_adj", "10", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.proc.oom_score_adj");
 		goto non_test_error;
 	}
 
-	/* lxc.prlimit.nofile */
-	if (set_get_compare_clear_save_load(c, "lxc.prlimit.nofile", "65536",
-					    tmpf, true) < 0) {
+	if (set_get_compare_clear_save_load(c, "lxc.prlimit.nofile", "65536", tmpf, true) < 0) {
 		lxc_error("%s\n", "lxc.prlimit.nofile");
 		goto non_test_error;
 	}
@@ -746,145 +630,117 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.type", "veth",
-					    tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.type", "veth", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.2.type", "none",
-					    tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.2.type", "none", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.2.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.3.type", "empty",
-					    tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.3.type", "empty", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.3.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.4.type", "vlan",
-					    tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.4.type", "vlan", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.4.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.type", "macvlan",
-					    tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.type", "macvlan", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.1000.type", "phys",
-					    tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.1000.type", "phys", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.1000.type");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.flags", "up",
-					    tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.flags", "up", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.flags");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.name", "eth0",
-					    tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.name", "eth0", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.name");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.link", "bla",
-					    tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.link", "bla", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.link");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load_network(
-		c, "lxc.net.0.macvlan.mode", "private", tmpf, true,
-		"macvlan")) {
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.macvlan.mode", "private", tmpf, true, "macvlan")) {
 		lxc_error("%s\n", "lxc.net.0.macvlan.mode");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load_network(
-		c, "lxc.net.0.macvlan.mode", "vepa", tmpf, true,
-		"macvlan")) {
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.macvlan.mode", "vepa", tmpf, true, "macvlan")) {
 		lxc_error("%s\n", "lxc.net.0.macvlan.mode");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load_network(
-		c, "lxc.net.0.macvlan.mode", "bridge", tmpf, true,
-		"macvlan")) {
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.macvlan.mode", "bridge", tmpf, true, "macvlan")) {
 		lxc_error("%s\n", "lxc.net.0.macvlan.mode");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load_network(
-		c, "lxc.net.0.veth.pair", "clusterfuck", tmpf, true,
-		"veth")) {
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.veth.pair", "clusterfuck", tmpf, true, "veth")) {
 		lxc_error("%s\n", "lxc.net.0.veth.pair");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.script.up",
-					    "/some/up/path", tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.script.up", "/some/up/path", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.script.up");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.script.down",
-					    "/some/down/path", tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.script.down", "/some/down/path", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.script.down");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.hwaddr",
-					    "52:54:00:80:7a:5d", tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.hwaddr", "52:54:00:80:7a:5d", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.hwaddr");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.mtu", "2000",
-					    tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.mtu", "2000", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.mtu");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.vlan.id",
-						    "2", tmpf, true, "vlan")) {
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.vlan.id", "2", tmpf, true, "vlan")) {
 		lxc_error("%s\n", "lxc.net.0.vlan.id");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv4.gateway",
-					    "10.0.2.2", tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv4.gateway", "10.0.2.2", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.ipv4.gateway");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv6.gateway",
-					    "2003:db8:1::1", tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv6.gateway", "2003:db8:1::1", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.ipv6.gateway");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv4.address",
-					    "10.0.2.3/24", tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv4.address", "10.0.2.3/24", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.ipv4.address");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(
-		c, "lxc.net.0.ipv6.address", "2003:db8:1:0:214:1234:fe0b:3596/64",
-		tmpf, true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv6.address", "2003:db8:1:0:214:1234:fe0b:3596/64", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.ipv6.address");
 		goto non_test_error;
 	}
 
-	if (set_get_compare_clear_save_load(c, "lxc.cgroup.dir", "lxd", tmpf,
-					    true)) {
+	if (set_get_compare_clear_save_load(c, "lxc.cgroup.dir", "lxd", tmpf, true)) {
 		lxc_error("%s\n", "lxc.cgroup.dir");
 		goto non_test_error;
 	}

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -773,6 +773,11 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
+	if (set_get_compare_clear_save_load(c, "lxc.rootfs.managed", "1", tmpf, true) < 0) {
+		lxc_error("%s\n", "lxc.rootfs.managed");
+		goto non_test_error;
+	}
+
 	fret = EXIT_SUCCESS;
 
 non_test_error:


### PR DESCRIPTION
This introduces a new config key lxc.rootfs.managed which can be used to
indicate whether this LXC instance is managing the container storage. If LXC is
not managing the storage then LXC will not modify the container storage.
For example, an API call to c->destroy(c) will then run any destroy hooks but
will not destroy the actual rootfs (Unless, of course, the hook does so behind
LXC's back.).

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
CC: Wolfgang Bumiller <w.bumiller@proxmox.com>
CC: Stéphane Graber <stgraber@ubuntu.com>
CC: Serge Hallyn <serge@hallyn.com>
CC: 2xsec <dh48.jeong@samsung.com>