### PR TITLE
coverity: #1425816

### DIFF
--- a/src/tests/concurrent.c
+++ b/src/tests/concurrent.c
@@ -175,6 +175,9 @@ int main(int argc, char *argv[]) {
         case 'm': {
             char *mode_tok, *tok, *saveptr = NULL;
 
+	    if (!optarg)
+                continue;
+
             modes = NULL;
             for (i = 0, mode_tok = optarg;
                  (tok = strtok_r(mode_tok, ",", &saveptr));


### PR DESCRIPTION
Hello,

fix "Explicit null dereferenced".

This is false positive because the optarg value is not null.

But coverity can not detect this. So, I add a contidtion to avoid this case.

Thanks.

Signed-off-by: 2xsec <dh48.jeong@samsung.com>