### PR TITLE
tree-wide: remove unneded log prefixes

### DIFF
--- a/src/lxc/af_unix.c
+++ b/src/lxc/af_unix.c
@@ -40,7 +40,7 @@
 #include "include/strlcpy.h"
 #endif
 
-lxc_log_define(lxc_af_unix, lxc);
+lxc_log_define(af_unix, lxc);
 
 int lxc_abstract_unix_open(const char *path, int type, int flags)
 {

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -87,7 +87,7 @@
 #define MS_SLAVE (1 << 19)
 #endif
 
-lxc_log_define(lxc_attach, lxc);
+lxc_log_define(attach, lxc);
 
 /* /proc/pid-to-str/status\0 = (5 + 21 + 7 + 1) */
 #define __PROC_STATUS_LEN (5 + (LXC_NUMSTRLEN64) + 7 + 1)

--- a/src/lxc/caps.c
+++ b/src/lxc/caps.c
@@ -34,7 +34,7 @@
 #include "caps.h"
 #include "log.h"
 
-lxc_log_define(lxc_caps, lxc);
+lxc_log_define(caps, lxc);
 
 #if HAVE_LIBCAP
 

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -66,7 +66,7 @@
 #include "include/strlcat.h"
 #endif
 
-lxc_log_define(lxc_cgfsng, lxc);
+lxc_log_define(cgfsng, cgroup);
 
 static void free_string_list(char **clist)
 {

--- a/src/lxc/cgroups/cgroup.c
+++ b/src/lxc/cgroups/cgroup.c
@@ -30,7 +30,7 @@
 #include "log.h"
 #include "start.h"
 
-lxc_log_define(lxc_cgroup, lxc);
+lxc_log_define(cgroup, lxc);
 
 extern struct cgroup_ops *cgfsng_ops_init(void);
 

--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -76,7 +76,7 @@
  * container.
  */
 
-lxc_log_define(lxc_commands, lxc);
+lxc_log_define(commands, lxc);
 
 static const char *lxc_cmd_str(lxc_cmd_t cmd)
 {

--- a/src/lxc/commands_utils.c
+++ b/src/lxc/commands_utils.c
@@ -38,7 +38,7 @@
 #include "state.h"
 #include "utils.h"
 
-lxc_log_define(lxc_commands_utils, lxc);
+lxc_log_define(commands_utils, lxc);
 
 int lxc_cmd_sock_rcv_state(int state_client_fd, int timeout)
 {

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -118,7 +118,7 @@
 #define MS_LAZYTIME (1<<25)
 #endif
 
-lxc_log_define(lxc_conf, lxc);
+lxc_log_define(conf, lxc);
 
 /* The lxc_conf of the container currently being worked on in an API call.
  * This is used in the error calls.

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -73,7 +73,7 @@
 #include "include/strlcat.h"
 #endif
 
-lxc_log_define(lxc_confile, lxc);
+lxc_log_define(confile, lxc);
 
 #define lxc_config_define(name)                                                \
 	static int set_config_##name(const char *, const char *,               \

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -40,7 +40,7 @@
 #include "include/strlcpy.h"
 #endif
 
-lxc_log_define(lxc_confile_utils, lxc);
+lxc_log_define(confile_utils, lxc);
 
 int parse_idmaps(const char *idmap, char *type, unsigned long *nsid,
 		 unsigned long *hostid, unsigned long *range)

--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -63,7 +63,7 @@
 #define CRIU_IN_FLIGHT_SUPPORT	"2.4"
 #define CRIU_EXTERNAL_NOT_VETH	"2.8"
 
-lxc_log_define(lxc_criu, lxc);
+lxc_log_define(criu, lxc);
 
 struct criu_opts {
 	/* the thing to hook to stdout and stderr for logging */

--- a/src/lxc/error.c
+++ b/src/lxc/error.c
@@ -28,7 +28,7 @@
 #include "error.h"
 #include "log.h"
 
-lxc_log_define(lxc_error, lxc);
+lxc_log_define(error, lxc);
 
 /*---------------------------------------------------------------------------*/
 /* lxc_error_set_and_log

--- a/src/lxc/execute.c
+++ b/src/lxc/execute.c
@@ -34,7 +34,7 @@
 #include "start.h"
 #include "utils.h"
 
-lxc_log_define(lxc_execute, lxc_start);
+lxc_log_define(execute, start);
 
 static int execute_start(struct lxc_handler *handler, void* data)
 {

--- a/src/lxc/freezer.c
+++ b/src/lxc/freezer.c
@@ -40,7 +40,7 @@
 #include "parse.h"
 #include "state.h"
 
-lxc_log_define(lxc_freezer, lxc);
+lxc_log_define(freezer, lxc);
 
 static int do_freeze_thaw(bool freeze, const char *name, const char *lxcpath)
 {

--- a/src/lxc/initutils.c
+++ b/src/lxc/initutils.c
@@ -31,7 +31,7 @@
 #include "include/strlcpy.h"
 #endif
 
-lxc_log_define(lxc_initutils, lxc);
+lxc_log_define(initutils, lxc);
 
 static char *copy_global_config_value(char *p)
 {

--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -66,7 +66,7 @@ static char log_prefix[LXC_LOG_PREFIX_SIZE] = "lxc";
 static char *log_fname = NULL;
 static char *log_vmname = NULL;
 
-lxc_log_define(lxc_log, lxc);
+lxc_log_define(log, lxc);
 
 static int lxc_log_priority_to_syslog(int priority)
 {

--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -72,9 +72,9 @@ enum lxc_loglevel {
 
 /* location information of the logging event */
 struct lxc_log_locinfo {
-	const char	*file;
-	const char	*func;
-	int		line;
+	const char *file;
+	const char *func;
+	int line;
 };
 
 #define LXC_LOG_LOCINFO_INIT						\
@@ -82,31 +82,31 @@ struct lxc_log_locinfo {
 
 /* brief logging event object */
 struct lxc_log_event {
-	const char*		category;
-	int			priority;
-	struct timespec		timestamp;
-	struct lxc_log_locinfo	*locinfo;
-	const char		*fmt;
-	va_list			*vap;
+	const char *category;
+	int priority;
+	struct timespec timestamp;
+	struct lxc_log_locinfo *locinfo;
+	const char *fmt;
+	va_list *vap;
 };
 
 /* log appender object */
 struct lxc_log_appender {
-	const char*	name;
+	const char *name;
 	int (*append)(const struct lxc_log_appender *, struct lxc_log_event *);
 
 	/*
 	 * appenders can be stacked
 	 */
-	struct lxc_log_appender	*next;
+	struct lxc_log_appender *next;
 };
 
 /* log category object */
 struct lxc_log_category {
-	const char			*name;
-	int				priority;
-	struct lxc_log_appender		*appender;
-	const struct lxc_log_category	*parent;
+	const char *name;
+	int priority;
+	struct lxc_log_appender *appender;
+	const struct lxc_log_category *parent;
 };
 
 #ifndef NO_LXC_CONF
@@ -117,18 +117,16 @@ extern int lxc_log_use_global_fd;
  * Returns true if the chained priority is equal to or higher than
  * given priority.
  */
-static inline int
-lxc_log_priority_is_enabled(const struct lxc_log_category* category,
-			   int priority)
+static inline int lxc_log_priority_is_enabled(const struct lxc_log_category *category,
+					      int priority)
 {
-	while (category->priority == LXC_LOG_LEVEL_NOTSET &&
-	       category->parent)
+	while (category->priority == LXC_LOG_LEVEL_NOTSET && category->parent)
 		category = category->parent;
 
 	int cmp_prio = category->priority;
 #ifndef NO_LXC_CONF
 	if (!lxc_log_use_global_fd && current_config &&
-			current_config->loglevel != LXC_LOG_LEVEL_NOTSET)
+	    current_config->loglevel != LXC_LOG_LEVEL_NOTSET)
 		cmp_prio = current_config->loglevel;
 #endif
 
@@ -138,79 +136,114 @@ lxc_log_priority_is_enabled(const struct lxc_log_category* category,
 /*
  * converts a priority to a literal string
  */
-static inline const char* lxc_log_priority_to_string(int priority)
+static inline const char *lxc_log_priority_to_string(int priority)
 {
 	switch (priority) {
-	case LXC_LOG_LEVEL_TRACE:	return "TRACE";
-	case LXC_LOG_LEVEL_DEBUG:	return "DEBUG";
-	case LXC_LOG_LEVEL_INFO:	return "INFO";
-	case LXC_LOG_LEVEL_NOTICE:	return "NOTICE";
-	case LXC_LOG_LEVEL_WARN:	return "WARN";
-	case LXC_LOG_LEVEL_ERROR:	return "ERROR";
-	case LXC_LOG_LEVEL_CRIT:	return "CRIT";
-	case LXC_LOG_LEVEL_ALERT:	return "ALERT";
-	case LXC_LOG_LEVEL_FATAL:	return "FATAL";
-	default:
-		return "NOTSET";
+	case LXC_LOG_LEVEL_TRACE:
+		return "TRACE";
+	case LXC_LOG_LEVEL_DEBUG:
+		return "DEBUG";
+	case LXC_LOG_LEVEL_INFO:
+		return "INFO";
+	case LXC_LOG_LEVEL_NOTICE:
+		return "NOTICE";
+	case LXC_LOG_LEVEL_WARN:
+		return "WARN";
+	case LXC_LOG_LEVEL_ERROR:
+		return "ERROR";
+	case LXC_LOG_LEVEL_CRIT:
+		return "CRIT";
+	case LXC_LOG_LEVEL_ALERT:
+		return "ALERT";
+	case LXC_LOG_LEVEL_FATAL:
+		return "FATAL";
 	}
+
+	return "NOTSET";
 }
 
-static inline const char* lxc_syslog_priority_to_string(int priority)
+static inline const char *lxc_syslog_priority_to_string(int priority)
 {
 	switch (priority) {
-	case LOG_DAEMON: return "daemon";
-	case LOG_LOCAL0: return "local0";
-	case LOG_LOCAL1: return "local1";
-	case LOG_LOCAL2: return "local2";
-	case LOG_LOCAL3: return "local3";
-	case LOG_LOCAL4: return "local4";
-	case LOG_LOCAL5: return "local5";
-	case LOG_LOCAL6: return "local6";
-	case LOG_LOCAL7: return "local7";
-	default:
-		return "NOTSET";
+	case LOG_DAEMON:
+		return "daemon";
+	case LOG_LOCAL0:
+		return "local0";
+	case LOG_LOCAL1:
+		return "local1";
+	case LOG_LOCAL2:
+		return "local2";
+	case LOG_LOCAL3:
+		return "local3";
+	case LOG_LOCAL4:
+		return "local4";
+	case LOG_LOCAL5:
+		return "local5";
+	case LOG_LOCAL6:
+		return "local6";
+	case LOG_LOCAL7:
+		return "local7";
 	}
+
+	return "NOTSET";
 }
 
 /*
  * converts a literal priority to an int
  */
-static inline int lxc_log_priority_to_int(const char* name)
+static inline int lxc_log_priority_to_int(const char *name)
 {
-	if (!strcasecmp("TRACE",  name)) return LXC_LOG_LEVEL_TRACE;
-	if (!strcasecmp("DEBUG",  name)) return LXC_LOG_LEVEL_DEBUG;
-	if (!strcasecmp("INFO",   name)) return LXC_LOG_LEVEL_INFO;
-	if (!strcasecmp("NOTICE", name)) return LXC_LOG_LEVEL_NOTICE;
-	if (!strcasecmp("WARN",   name)) return LXC_LOG_LEVEL_WARN;
-	if (!strcasecmp("ERROR",  name)) return LXC_LOG_LEVEL_ERROR;
-	if (!strcasecmp("CRIT",   name)) return LXC_LOG_LEVEL_CRIT;
-	if (!strcasecmp("ALERT",  name)) return LXC_LOG_LEVEL_ALERT;
-	if (!strcasecmp("FATAL",  name)) return LXC_LOG_LEVEL_FATAL;
+	if (strcasecmp("TRACE", name) == 0)
+		return LXC_LOG_LEVEL_TRACE;
+	if (strcasecmp("DEBUG", name) == 0)
+		return LXC_LOG_LEVEL_DEBUG;
+	if (strcasecmp("INFO", name) == 0)
+		return LXC_LOG_LEVEL_INFO;
+	if (strcasecmp("NOTICE", name) == 0)
+		return LXC_LOG_LEVEL_NOTICE;
+	if (strcasecmp("WARN", name) == 0)
+		return LXC_LOG_LEVEL_WARN;
+	if (strcasecmp("ERROR", name) == 0)
+		return LXC_LOG_LEVEL_ERROR;
+	if (strcasecmp("CRIT", name) == 0)
+		return LXC_LOG_LEVEL_CRIT;
+	if (strcasecmp("ALERT", name) == 0)
+		return LXC_LOG_LEVEL_ALERT;
+	if (strcasecmp("FATAL", name) == 0)
+		return LXC_LOG_LEVEL_FATAL;
 
 	return LXC_LOG_LEVEL_NOTSET;
 }
 
-static inline int lxc_syslog_priority_to_int(const char* name)
+static inline int lxc_syslog_priority_to_int(const char *name)
 {
-	if (!strcasecmp("daemon", name)) return LOG_DAEMON;
-	if (!strcasecmp("local0", name)) return LOG_LOCAL0;
-	if (!strcasecmp("local1", name)) return LOG_LOCAL1;
-	if (!strcasecmp("local2", name)) return LOG_LOCAL2;
-	if (!strcasecmp("local3", name)) return LOG_LOCAL3;
-	if (!strcasecmp("local4", name)) return LOG_LOCAL4;
-	if (!strcasecmp("local5", name)) return LOG_LOCAL5;
-	if (!strcasecmp("local6", name)) return LOG_LOCAL6;
-	if (!strcasecmp("local7", name)) return LOG_LOCAL7;
+	if (strcasecmp("daemon", name) == 0)
+		return LOG_DAEMON;
+	if (strcasecmp("local0", name) == 0)
+		return LOG_LOCAL0;
+	if (strcasecmp("local1", name) == 0)
+		return LOG_LOCAL1;
+	if (strcasecmp("local2", name) == 0)
+		return LOG_LOCAL2;
+	if (strcasecmp("local3", name) == 0)
+		return LOG_LOCAL3;
+	if (strcasecmp("local4", name) == 0)
+		return LOG_LOCAL4;
+	if (strcasecmp("local5", name) == 0)
+		return LOG_LOCAL5;
+	if (strcasecmp("local6", name) == 0)
+		return LOG_LOCAL6;
+	if (strcasecmp("local7", name) == 0)
+		return LOG_LOCAL7;
 
 	return -EINVAL;
 }
 
-static inline void
-__lxc_log_append(const struct lxc_log_appender *appender,
-		struct lxc_log_event* event)
+static inline void __lxc_log_append(const struct lxc_log_appender *appender,
+				    struct lxc_log_event *event)
 {
-	va_list va, *va_keep;
-	va_keep = event->vap;
+	va_list va;
+	va_list *va_keep = event->vap;
 
 	while (appender) {
 		va_copy(va, *va_keep);
@@ -221,9 +254,8 @@ __lxc_log_append(const struct lxc_log_appender *appender,
 	}
 }
 
-static inline void
-__lxc_log(const struct lxc_log_category* category,
-	  struct lxc_log_event* event)
+static inline void __lxc_log(const struct lxc_log_category *category,
+			     struct lxc_log_event *event)
 {
 	while (category) {
 		__lxc_log_append(category->appender, event);
@@ -234,34 +266,34 @@ __lxc_log(const struct lxc_log_category* category,
 /*
  * Helper macro to define log functions.
  */
-#define lxc_log_priority_define(acategory, LEVEL)			\
-									\
-ATTR_UNUSED static inline void LXC_##LEVEL(struct lxc_log_locinfo *,		\
-	const char *, ...) __attribute__ ((format (printf, 2, 3)));	\
-									\
+#define lxc_log_priority_define(acategory, LEVEL)				\
+										\
+ATTR_UNUSED __attribute__ ((format (printf, 2, 3)))				\
+static inline void LXC_##LEVEL(struct lxc_log_locinfo *, const char *, ...);	\
+										\
 ATTR_UNUSED static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
-				  const char* format, ...)		\
-{									\
-	if (lxc_log_priority_is_enabled(acategory, 			\
-					LXC_LOG_LEVEL_##LEVEL)) {	\
-		struct lxc_log_event evt = {				\
-			.category	= (acategory)->name,		\
-			.priority	= LXC_LOG_LEVEL_##LEVEL,	\
-			.fmt		= format,			\
-			.locinfo	= locinfo			\
-		};							\
-		va_list va_ref;						\
-									\
-		/* clock_gettime() is explicitly marked as MT-Safe	\
-		 * without restrictions. So let's use it for our	\
-		 * logging stamps. */					\
-		clock_gettime(CLOCK_REALTIME, &evt.timestamp);		\
-									\
-		va_start(va_ref, format);				\
-		evt.vap = &va_ref;					\
-		__lxc_log(acategory, &evt);				\
-		va_end(va_ref);						\
-	}								\
+					   const char* format, ...)		\
+{										\
+	if (lxc_log_priority_is_enabled(acategory, LXC_LOG_LEVEL_##LEVEL)) {	\
+		va_list va_ref;							\
+		struct lxc_log_event evt = {					\
+			.category	= (acategory)->name,			\
+			.priority	= LXC_LOG_LEVEL_##LEVEL,		\
+			.fmt		= format,				\
+			.locinfo	= locinfo				\
+		};								\
+										\
+		/* clock_gettime() is explicitly marked as MT-Safe		\
+		 * without restrictions. So let's use it for our		\
+		 * logging stamps.						\
+		 */								\
+		(void)clock_gettime(CLOCK_REALTIME, &evt.timestamp);		\
+										\
+		va_start(va_ref, format);					\
+		evt.vap = &va_ref;						\
+		__lxc_log(acategory, &evt);					\
+		va_end(va_ref);							\
+	}									\
 }
 
 /*
@@ -271,7 +303,7 @@ ATTR_UNUSED static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 	extern struct lxc_log_category lxc_log_category_##parent;	\
 	struct lxc_log_category lxc_log_category_##name = {		\
 		#name,							\
-		LXC_LOG_LEVEL_NOTSET,				\
+		LXC_LOG_LEVEL_NOTSET,					\
 		NULL,							\
 		&lxc_log_category_##parent				\
 	};

--- a/src/lxc/lsm/apparmor.c
+++ b/src/lxc/lsm/apparmor.c
@@ -33,7 +33,7 @@
 #include "conf.h"
 #include "utils.h"
 
-lxc_log_define(lxc_apparmor, lxc);
+lxc_log_define(apparmor, lsm);
 
 /* set by lsm_apparmor_drv_init if true */
 static int aa_enabled = 0;

--- a/src/lxc/lsm/lsm.c
+++ b/src/lxc/lsm/lsm.c
@@ -32,7 +32,7 @@
 #include "log.h"
 #include "lsm.h"
 
-lxc_log_define(lxc_lsm, lxc);
+lxc_log_define(lsm, lxc);
 
 static struct lsm_drv *drv = NULL;
 

--- a/src/lxc/lsm/selinux.c
+++ b/src/lxc/lsm/selinux.c
@@ -36,7 +36,7 @@
 
 #define DEFAULT_LABEL "unconfined_t"
 
-lxc_log_define(lxc_lsm_selinux, lxc);
+lxc_log_define(selinux, lsm);
 
 /*
  * selinux_process_label_get: Get SELinux context of a process

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -104,7 +104,7 @@ static int faccessat(int __fd, const char *__file, int __type, int __flag)
 }
 #endif
 
-lxc_log_define(lxc_container, lxc);
+lxc_log_define(lxccontainer, lxc);
 
 static bool do_lxcapi_destroy(struct lxc_container *c);
 static const char *lxcapi_get_config_path(struct lxc_container *c);

--- a/src/lxc/lxclock.c
+++ b/src/lxc/lxclock.c
@@ -40,7 +40,7 @@
 
 #define MAX_STACKDEPTH 25
 
-lxc_log_define(lxc_lock, lxc);
+lxc_log_define(lxclock, lxc);
 
 #ifdef MUTEX_DEBUGGING
 static pthread_mutex_t thread_mutex = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;

--- a/src/lxc/monitor.c
+++ b/src/lxc/monitor.c
@@ -54,7 +54,7 @@
 #include "include/strlcpy.h"
 #endif
 
-lxc_log_define(lxc_monitor, lxc);
+lxc_log_define(monitor, lxc);
 
 /* routines used by monitor publishers (containers) */
 int lxc_monitor_fifo_name(const char *lxcpath, char *fifo_path, size_t fifo_path_sz,

--- a/src/lxc/namespace.c
+++ b/src/lxc/namespace.c
@@ -37,7 +37,7 @@
 #include "namespace.h"
 #include "utils.h"
 
-lxc_log_define(lxc_namespace, lxc);
+lxc_log_define(namespace, lxc);
 
 struct clone_arg {
 	int (*fn)(void *);

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -95,7 +95,7 @@
 #define IFLA_MACVLAN_MODE 1
 #endif
 
-lxc_log_define(lxc_network, lxc);
+lxc_log_define(network, lxc);
 
 typedef int (*instantiate_cb)(struct lxc_handler *, struct lxc_netdev *);
 

--- a/src/lxc/parse.c
+++ b/src/lxc/parse.c
@@ -35,7 +35,7 @@
 #include "utils.h"
 #include "log.h"
 
-lxc_log_define(lxc_parse, lxc);
+lxc_log_define(parse, lxc);
 
 void *lxc_strmmap(void *addr, size_t length, int prot, int flags, int fd,
 		  off_t offset)

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -42,7 +42,7 @@
 #define MIPS_ARCH_N64 lxc_seccomp_arch_mips64
 #endif
 
-lxc_log_define(lxc_seccomp, lxc);
+lxc_log_define(seccomp, lxc);
 
 static int parse_config_v1(FILE *f, char *line, size_t *line_bufsz, struct lxc_conf *conf)
 {

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -94,7 +94,7 @@
 #include "include/strlcpy.h"
 #endif
 
-lxc_log_define(lxc_start, lxc);
+lxc_log_define(start, lxc);
 
 extern void mod_all_rdeps(struct lxc_container *c, bool inc);
 static bool do_destroy_container(struct lxc_handler *handler);

--- a/src/lxc/state.c
+++ b/src/lxc/state.c
@@ -44,7 +44,7 @@
 #include "monitor.h"
 #include "start.h"
 
-lxc_log_define(lxc_state, lxc);
+lxc_log_define(state, lxc);
 
 static const char *const strstate[] = {
     "STOPPED",  "STARTING", "RUNNING", "STOPPING",

--- a/src/lxc/sync.c
+++ b/src/lxc/sync.c
@@ -32,7 +32,7 @@
 #include "log.h"
 #include "start.h"
 
-lxc_log_define(lxc_sync, lxc);
+lxc_log_define(sync, lxc);
 
 static int __sync_wait(int fd, int sequence)
 {

--- a/src/lxc/tools/arguments.c
+++ b/src/lxc/tools/arguments.c
@@ -38,6 +38,7 @@
 
 #include "arguments.h"
 #include "namespace.h"
+#include "initutils.h"
 
 static int build_shortopts(const struct option *a_options, char *a_shortopts,
 			   size_t a_size)
@@ -184,13 +185,6 @@ static int lxc_arguments_lxcpath_add(struct lxc_arguments *args,
 	}
 	args->lxcpath[args->lxcpath_cnt++] = lxcpath;
 	return 0;
-}
-
-void remove_trailing_slashes(char *p)
-{
-	int l = strlen(p);
-	while (--l >= 0 && (p[l] == '/' || p[l] == '\n'))
-		p[l] = '\0';
 }
 
 extern int lxc_arguments_parse(struct lxc_arguments *args, int argc,

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -67,7 +67,7 @@
 #define O_NOFOLLOW  00400000
 #endif
 
-lxc_log_define(lxc_utils, lxc);
+lxc_log_define(utils, lxc);
 
 /*
  * if path is btrfs, tries to remove it and any subvolumes beneath it


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>