### PR TITLE
utils: move recursive_destroy() from cfgsng to utils.

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1040,62 +1040,6 @@ static void lxc_cgfsng_print_basecg_debuginfo(char *basecginfo, char **klist,
 		TRACE("named subsystem %d: %s", k, *it);
 }
 
-static int recursive_destroy(char *dirname)
-{
-	int ret;
-	struct dirent *direntp;
-	DIR *dir;
-	int r = 0;
-
-	dir = opendir(dirname);
-	if (!dir)
-		return -1;
-
-	while ((direntp = readdir(dir))) {
-		char *pathname;
-		struct stat mystat;
-
-		if (!strcmp(direntp->d_name, ".") ||
-		    !strcmp(direntp->d_name, ".."))
-			continue;
-
-		pathname = must_make_path(dirname, direntp->d_name, NULL);
-
-		ret = lstat(pathname, &mystat);
-		if (ret < 0) {
-			if (!r)
-				WARN("Failed to stat \"%s\"", pathname);
-			r = -1;
-			goto next;
-		}
-
-		if (!S_ISDIR(mystat.st_mode))
-			goto next;
-
-		ret = recursive_destroy(pathname);
-		if (ret < 0)
-			r = -1;
-	next:
-		free(pathname);
-	}
-
-	ret = rmdir(dirname);
-	if (ret < 0) {
-		if (!r)
-			SYSWARN("Failed to delete \"%s\"", dirname);
-		r = -1;
-	}
-
-	ret = closedir(dir);
-	if (ret < 0) {
-		if (!r)
-			SYSWARN("Failed to delete \"%s\"", dirname);
-		r = -1;
-	}
-
-	return r;
-}
-
 static int cgroup_rmdir(struct hierarchy **hierarchies,
 			const char *container_cgroup)
 {

--- a/src/lxc/sync.c
+++ b/src/lxc/sync.c
@@ -60,7 +60,7 @@ static int __sync_wait(int fd, int sequence)
 	}
 
 	if (sync != sequence) {
-		ERROR("Invalid sequence number %d. expected %d",
+		ERROR("Invalid sequence number %d. Expected sequence number %d",
 		      sync, sequence);
 		return -1;
 	}

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -2708,3 +2708,63 @@ int fd_cloexec(int fd, bool cloexec)
 
 	return 0;
 }
+
+int recursive_destroy(char *dirname)
+{
+	int ret;
+	struct dirent *direntp;
+	DIR *dir;
+	int r = 0;
+
+	dir = opendir(dirname);
+	if (!dir)
+		return -1;
+
+	while ((direntp = readdir(dir))) {
+		char *pathname;
+		struct stat mystat;
+
+		if (!strcmp(direntp->d_name, ".") ||
+		    !strcmp(direntp->d_name, ".."))
+			continue;
+
+		pathname = must_make_path(dirname, direntp->d_name, NULL);
+
+		ret = lstat(pathname, &mystat);
+		if (ret < 0) {
+			if (!r)
+				WARN("Failed to stat \"%s\"", pathname);
+
+			r = -1;
+			goto next;
+		}
+
+		if (!S_ISDIR(mystat.st_mode))
+			goto next;
+
+		ret = recursive_destroy(pathname);
+		if (ret < 0)
+			r = -1;
+
+	next:
+		free(pathname);
+	}
+
+	ret = rmdir(dirname);
+	if (ret < 0) {
+		if (!r)
+			SYSWARN("Failed to delete \"%s\"", dirname);
+
+		r = -1;
+	}
+
+	ret = closedir(dir);
+	if (ret < 0) {
+		if (!r)
+			SYSWARN("Failed to delete \"%s\"", dirname);
+
+		r = -1;
+	}
+
+	return r;
+}

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -616,5 +616,6 @@ static inline pid_t lxc_raw_gettid(void)
 /* Set a signal the child process will receive after the parent has died. */
 extern int lxc_set_death_signal(int signal);
 extern int fd_cloexec(int fd, bool cloexec);
+extern int recursive_destroy(char *dirname);
 
 #endif /* __LXC_UTILS_H */


### PR DESCRIPTION
Hello,

The recursive_destroy() is moved to utils.

And rm_r() is removed from lxc_ls.c

Thanks.

Signed-off-by: 2xsec <dh48.jeong@samsung.com>