### PR TITLE
 confile: fix incorrect strncmp

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -2402,7 +2402,7 @@ static struct new_config_item *parse_new_conf_line(char *buffer)
 	line += lxc_char_left_gc(line, strlen(line));
 
 	/* martian option - don't add it to the config itself */
-	if (strncmp(line, "lxc.", strlen(line)))
+	if (strncmp(line, "lxc.", 4))
 		goto on_error;
 
 	ret = -1;


### PR DESCRIPTION
Passing additional configuration options with "--define" was broken.

Result of git bisect:
d899f11b7bfb14c4b532bc801de89c8fb46307d4 is the first bad commit

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>