### PR TITLE
conf: the atime flags are locked in userns

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -609,9 +609,6 @@ unsigned long add_required_remount_flags(const char *s, const char *d,
 	struct statvfs sb;
 	unsigned long required_flags = 0;
 
-	if (!(flags & MS_REMOUNT))
-		return flags;
-
 	if (!s)
 		s = d;
 
@@ -622,14 +619,27 @@ unsigned long add_required_remount_flags(const char *s, const char *d,
 	if (ret < 0)
 		return flags;
 
-	if (sb.f_flag & MS_NOSUID)
-		required_flags |= MS_NOSUID;
-	if (sb.f_flag & MS_NODEV)
-		required_flags |= MS_NODEV;
-	if (sb.f_flag & MS_RDONLY)
-		required_flags |= MS_RDONLY;
-	if (sb.f_flag & MS_NOEXEC)
-		required_flags |= MS_NOEXEC;
+	if (flags & MS_REMOUNT) {
+		if (sb.f_flag & MS_NOSUID)
+			required_flags |= MS_NOSUID;
+		if (sb.f_flag & MS_NODEV)
+			required_flags |= MS_NODEV;
+		if (sb.f_flag & MS_RDONLY)
+			required_flags |= MS_RDONLY;
+		if (sb.f_flag & MS_NOEXEC)
+			required_flags |= MS_NOEXEC;
+	}
+
+	if (sb.f_flag & MS_NOATIME)
+		required_flags |= MS_NOATIME;
+	if (sb.f_flag & MS_NODIRATIME)
+		required_flags |= MS_NODIRATIME;
+	if (sb.f_flag & MS_LAZYTIME)
+		required_flags |= MS_LAZYTIME;
+	if (sb.f_flag & MS_RELATIME)
+		required_flags |= MS_RELATIME;
+	if (sb.f_flag & MS_STRICTATIME)
+		required_flags |= MS_STRICTATIME;
 
 	return flags | required_flags;
 #else


### PR DESCRIPTION
This means they need to be added for remount and for fresh mounts.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>