### PR TITLE
apparmor: Allow /usr/lib* paths for mount and pivot_root

### DIFF
--- a/config/apparmor/abstractions/start-container
+++ b/config/apparmor/abstractions/start-container
@@ -9,8 +9,8 @@
   ptrace,
 
   # currently blocked by apparmor bug
-  mount -> /usr/lib/*/lxc/{**,},
-  mount -> /usr/lib/lxc/{**,},
+  mount -> /usr/lib*/*/lxc/{**,},
+  mount -> /usr/lib*/lxc/{**,},
   mount fstype=devpts -> /dev/pts/,
   mount options=bind /dev/pts/ptmx/ -> /dev/ptmx/,
   mount options=bind /dev/pts/** -> /dev/**,
@@ -34,10 +34,10 @@
   # This may look a bit redundant, however it appears we need all of
   # them if we want things to work properly on all combinations of kernel
   # and userspace parser...
-  pivot_root /usr/lib/lxc/,
-  pivot_root /usr/lib/*/lxc/,
-  pivot_root /usr/lib/lxc/**,
-  pivot_root /usr/lib/*/lxc/**,
+  pivot_root /usr/lib*/lxc/,
+  pivot_root /usr/lib*/*/lxc/,
+  pivot_root /usr/lib*/lxc/**,
+  pivot_root /usr/lib*/*/lxc/**,
 
   change_profile -> lxc-*,
   change_profile -> unconfined,


### PR DESCRIPTION
openSUSE Leap 15 is using --libdir=/usr/lib64 when building for
x86_64 so we need to allow this path in the apparmor profiles.

Link: https://bugzilla.opensuse.org/show_bug.cgi?id=1099239
Signed-off-by: Markos Chandras <mchandras@suse.de>