### PR TITLE
change log macro of error case from lxc_ambient_caps_up/down

### DIFF
--- a/src/lxc/caps.c
+++ b/src/lxc/caps.c
@@ -114,7 +114,6 @@ int lxc_caps_up(void)
 	}
 
 	for (cap = 0; cap <= CAP_LAST_CAP; cap++) {
-
 		cap_flag_value_t flag;
 
 		ret = cap_get_flag(caps, cap, CAP_PERMITTED, &flag);
@@ -201,8 +200,10 @@ int lxc_ambient_caps_up(void)
 	}
 
 	cap_names = cap_to_text(caps, NULL);
-	if (!cap_names)
+	if (!cap_names) {
+		SYSWARN("Failed to convert capabilities %d", cap);
 		goto out;
+	}
 
 	TRACE("Raised %s in inheritable and ambient capability set", cap_names);
 
@@ -311,6 +312,7 @@ static int _real_caps_last_cap(void)
 		if ((n = read(fd, buf, 31)) >= 0) {
 			buf[n] = '\0';
 			errno = 0;
+
 			result = strtol(buf, &ptr, 10);
 			if (!ptr || (*ptr != '\0' && *ptr != '\n') || errno != 0)
 				result = -1;
@@ -323,7 +325,10 @@ static int _real_caps_last_cap(void)
 	* each capability indiviually from the kernel */
 	if (result < 0) {
 		int cap = 0;
-		while (prctl(PR_CAPBSET_READ, cap) >= 0) cap++;
+
+		while (prctl(PR_CAPBSET_READ, cap) >= 0)
+			cap++;
+
 		result = cap - 1;
 	}
 
@@ -333,7 +338,9 @@ static int _real_caps_last_cap(void)
 int lxc_caps_last_cap(void)
 {
 	static int last_cap = -1;
-	if (last_cap < 0) last_cap = _real_caps_last_cap();
+
+	if (last_cap < 0)
+		last_cap = _real_caps_last_cap();
 
 	return last_cap;
 }

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1074,7 +1074,7 @@ static int do_start(void *data)
 
 	ret = lxc_ambient_caps_up();
 	if (ret < 0) {
-		SYSERROR("Failed to raise ambient capabilities");
+		ERROR("Failed to raise ambient capabilities");
 		goto out_warn_father;
 	}
 
@@ -1379,7 +1379,7 @@ static int do_start(void *data)
 
 	ret = lxc_ambient_caps_down();
 	if (ret < 0) {
-		SYSERROR("Failed to clear ambient capabilities");
+		ERROR("Failed to clear ambient capabilities");
 		goto out_warn_father;
 	}
 


### PR DESCRIPTION
Hello,

change log macro of error case from lxc_ambient_caps_up/down.

because all errno strings are printed in lxc_amvient_caps_up / down() functions.

Thanks.

Signed-off-by: 2xsec <dh48.jeong@samsung.com>