### PR TITLE
add default log priority & cleanups

### DIFF
--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -127,13 +127,13 @@ static int log_append_syslog(const struct lxc_log_appender *appender,
 	}
 
 	syslog(lxc_log_priority_to_syslog(event->priority),
-		"%s%s %s - %s:%s:%d - %s" ,
-		log_container_name ? log_container_name : "",
-		log_container_name ? ":" : "",
-		event->category,
-		event->locinfo->file, event->locinfo->func,
-		event->locinfo->line,
-		msg);
+	       "%s%s %s - %s:%s:%d - %s" ,
+	       log_container_name ? log_container_name : "",
+	       log_container_name ? ":" : "",
+	       event->category,
+	       event->locinfo->file, event->locinfo->func,
+	       event->locinfo->line,
+	       msg);
 	free(msg);
 
 	return 0;
@@ -156,10 +156,10 @@ static int log_append_stderr(const struct lxc_log_appender *appender,
 #endif
 
 	fprintf(stderr, "%s: %s%s", log_prefix,
-		log_container_name ? log_container_name : "",
-		log_container_name ? ": " : "");
+	        log_container_name ? log_container_name : "",
+	        log_container_name ? ": " : "");
 	fprintf(stderr, "%s: %s: %d ", event->locinfo->file,
-		event->locinfo->func, event->locinfo->line);
+	        event->locinfo->func, event->locinfo->line);
 	vfprintf(stderr, event->fmt, *event->vap);
 	fprintf(stderr, "\n");
 
@@ -167,7 +167,7 @@ static int log_append_stderr(const struct lxc_log_appender *appender,
 }
 
 /*---------------------------------------------------------------------------*/
-int lxc_unix_epoch_to_utc(char *buf, size_t bufsize, const struct timespec *time)
+static int lxc_unix_epoch_to_utc(char *buf, size_t bufsize, const struct timespec *time)
 {
 	int64_t epoch_to_days, z, era, doe, yoe, year, doy, mp, day, month,
 	    d_in_s, hours, h_in_s, minutes, seconds;
@@ -315,16 +315,15 @@ static int log_append_logfile(const struct lxc_log_appender *appender,
 		return 0;
 
 	n = snprintf(buffer, sizeof(buffer),
-			"%s%s%s %s %-8s %s - %s:%s:%d - ",
-			log_prefix,
-			log_container_name ? " " : "",
-			log_container_name ? log_container_name : "",
-			date_time,
-			lxc_log_priority_to_string(event->priority),
-			event->category,
-			event->locinfo->file, event->locinfo->func,
-			event->locinfo->line);
-
+		     "%s%s%s %s %-8s %s - %s:%s:%d - ",
+		     log_prefix,
+		     log_container_name ? " " : "",
+		     log_container_name ? log_container_name : "",
+		     date_time,
+		     lxc_log_priority_to_string(event->priority),
+		     event->category,
+		     event->locinfo->file, event->locinfo->func,
+		     event->locinfo->line);
 	if (n < 0)
 		return n;
 
@@ -493,23 +492,6 @@ static char *build_log_path(const char *name, const char *lxcpath)
 	return p;
 }
 
-void lxc_log_close(void)
-{
-	closelog();
-
-	free(log_vmname);
-	log_vmname = NULL;
-
-	if (lxc_log_fd == -1)
-		return;
-
-	close(lxc_log_fd);
-	lxc_log_fd = -1;
-
-	free(log_fname);
-	log_fname = NULL;
-}
-
 /*
  * This can be called:
  *   1. when a program calls lxc_log_init with no logfile parameter (in which
@@ -565,39 +547,6 @@ static int _lxc_log_set_file(const char *name, const char *lxcpath, int create_d
 	ret = __lxc_log_set_file(logfile, create_dirs);
 	free(logfile);
 	return ret;
-}
-
-int lxc_log_syslog(int facility)
-{
-	struct lxc_log_appender *appender;
-
-	openlog(log_prefix, LOG_PID, facility);
-	if (!lxc_log_category_lxc.appender) {
-		lxc_log_category_lxc.appender = &log_appender_syslog;
-		return 0;
-	}
-
-	appender = lxc_log_category_lxc.appender;
-	/* Check if syslog was already added, to avoid creating a loop */
-	while (appender) {
-		if (appender == &log_appender_syslog) {
-			/* not an error: openlog re-opened the connection */
-			return 0;
-		}
-		appender = appender->next;
-	}
-
-	appender = lxc_log_category_lxc.appender;
-	while (appender->next != NULL)
-		appender = appender->next;
-	appender->next = &log_appender_syslog;
-
-	return 0;
-}
-
-inline void lxc_log_enable_syslog(void)
-{
-	syslog_enable = 1;
 }
 
 /*
@@ -673,6 +622,56 @@ int lxc_log_init(struct lxc_log *log)
 	}
 
 	return ret;
+}
+
+void lxc_log_close(void)
+{
+	closelog();
+
+	free(log_vmname);
+	log_vmname = NULL;
+
+	if (lxc_log_fd == -1)
+		return;
+
+	close(lxc_log_fd);
+	lxc_log_fd = -1;
+
+	free(log_fname);
+	log_fname = NULL;
+}
+
+int lxc_log_syslog(int facility)
+{
+	struct lxc_log_appender *appender;
+
+	openlog(log_prefix, LOG_PID, facility);
+	if (!lxc_log_category_lxc.appender) {
+		lxc_log_category_lxc.appender = &log_appender_syslog;
+		return 0;
+	}
+
+	appender = lxc_log_category_lxc.appender;
+	/* Check if syslog was already added, to avoid creating a loop */
+	while (appender) {
+		if (appender == &log_appender_syslog) {
+			/* not an error: openlog re-opened the connection */
+			return 0;
+		}
+		appender = appender->next;
+	}
+
+	appender = lxc_log_category_lxc.appender;
+	while (appender->next != NULL)
+		appender = appender->next;
+	appender->next = &log_appender_syslog;
+
+	return 0;
+}
+
+inline void lxc_log_enable_syslog(void)
+{
+	syslog_enable = 1;
 }
 
 /*

--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -431,14 +431,14 @@ ATTR_UNUSED static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 
 extern int lxc_log_fd;
 
-extern int lxc_log_set_file(int *fd, const char *fname);
 extern int lxc_log_syslog(int facility);
 extern void lxc_log_enable_syslog(void);
 extern int lxc_log_set_level(int *dest, int level);
-extern void lxc_log_set_prefix(const char *prefix);
-extern const char *lxc_log_get_file(void);
 extern int lxc_log_get_level(void);
 extern bool lxc_log_has_valid_level(void);
+extern int lxc_log_set_file(int *fd, const char *fname);
+extern const char *lxc_log_get_file(void);
+extern void lxc_log_set_prefix(const char *prefix);
 extern const char *lxc_log_get_prefix(void);
 extern void lxc_log_options_no_override();
 #endif

--- a/src/lxc/tools/arguments.c
+++ b/src/lxc/tools/arguments.c
@@ -192,6 +192,7 @@ extern int lxc_arguments_parse(struct lxc_arguments *args, int argc,
 			       char *const argv[])
 {
 	int ret = 0;
+	bool logfile = false;
 	char shortopts[256];
 
 	ret = build_shortopts(args->options, shortopts, sizeof(shortopts));
@@ -215,9 +216,14 @@ extern int lxc_arguments_parse(struct lxc_arguments *args, int argc,
 			break;
 		case 'o':
 			args->log_file = optarg;
+			logfile = true;
 			break;
 		case 'l':
 			args->log_priority = optarg;
+			if (!logfile &&
+			    args->log_file &&
+			    strcmp(args->log_file, "none") == 0)
+			    args->log_file = NULL;
 			break;
 		case 'q':
 			args->quiet = 1;

--- a/src/lxc/tools/lxc_unshare.c
+++ b/src/lxc/tools/lxc_unshare.c
@@ -102,6 +102,8 @@ Options :\n\
 	.options      = my_longopts,
 	.parser       = my_parser,
 	.checker      = NULL,
+	.log_priority = "ERROR",
+	.log_file     = "none",
 	.daemonize    = 0,
 	.pidfile      = NULL,
 };
@@ -325,19 +327,16 @@ int main(int argc, char *argv[])
 	if (lxc_arguments_parse(&my_args, argc, argv))
 		exit(EXIT_FAILURE);
 
-	/* Only create log if explicitly instructed */
-	if (my_args.log_file || my_args.log_priority) {
-		log.name = my_args.name;
-		log.file = my_args.log_file;
-		log.level = my_args.log_priority;
-		log.prefix = my_args.progname;
-		log.quiet = my_args.quiet;
-		log.lxcpath = my_args.lxcpath[0];
+	log.name = my_args.name;
+	log.file = my_args.log_file;
+	log.level = my_args.log_priority;
+	log.prefix = my_args.progname;
+	log.quiet = my_args.quiet;
+	log.lxcpath = my_args.lxcpath[0];
 
-		if (lxc_log_init(&log)) {
-			free_ifname_list();
-			exit(EXIT_FAILURE);
-		}
+	if (lxc_log_init(&log)) {
+		free_ifname_list();
+		exit(EXIT_FAILURE);
 	}
 
 	if (!*my_args.argv) {


### PR DESCRIPTION
Hello,

I have a proposal for default log priority by used tools.

Now, user does not specify log priority or log file using -l or -o options, any logs are not printed.

So, I added default log priority without logfiles.
(If user specify log priority & log file explicitly, behavior is the same as before.)

If this is merged, I'll apply default log priority as error level to all tools.

Thanks.