### PR TITLE
Unprivileged's incompatibility with type=none docs

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -430,7 +430,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               network devices are usable in the container.  It also
               means that if both the container and host have upstart as
               init, 'halt' in a container (for instance) will shut down the
-              host.
+              host. Note that unprivileged containers do not work with this
+	      setting due to an inability to mount sysfs. An unsafe workaround
+	      would be to bind mount the host's sysfs.
             </para>
 
             <para>


### PR DESCRIPTION
Unprivileged containers are not compatible with sharing the 
host namespace due to an inability to mount sysfs. Add docs
in lxc.container.conf to document that.
Refs #2463

Signed-off-by: Alexandros Kosiaris <akosiaris@gmail.com>