### PR TITLE
conf: mount devpts without "max" on EINVAL

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1612,7 +1612,7 @@ static const struct id_map *find_mapped_nsid_entry(struct lxc_conf *conf, unsign
 static int lxc_setup_devpts(struct lxc_conf *conf)
 {
 	int ret;
-	const char *default_devpts_mntopts = "gid=5,newinstance,ptmxmode=0666,mode=0620";
+	char default_devpts_mntopts[] = "gid=5,newinstance,ptmxmode=0666,mode=0620";
 	char devpts_mntopts[256];
 
 	if (conf->pty_max <= 0) {
@@ -1642,9 +1642,20 @@ static int lxc_setup_devpts(struct lxc_conf *conf)
 	/* mount new devpts instance */
 	ret = mount("devpts", "/dev/pts", "devpts", MS_NOSUID | MS_NOEXEC, devpts_mntopts);
 	if (ret < 0) {
+		/* try mounting without "max" */
+		if (errno == EINVAL) {
+			devpts_mntopts[sizeof(default_devpts_mntopts) - 1] = '\0';
+			ret = mount("devpts", "/dev/pts", "devpts",
+				    MS_NOSUID | MS_NOEXEC, devpts_mntopts);
+			if (ret < 0) {
+				SYSERROR("Failed to mount new devpts instance");
+				return -1;
+			}
+		}
+
 		/* try mounting without gid=5 */
-		ret = mount("devpts", "/dev/pts", "devpts",
-			    MS_NOSUID | MS_NOEXEC, devpts_mntopts + sizeof("gid=5"));
+		ret = mount("devpts", "/dev/pts", "devpts", MS_NOSUID | MS_NOEXEC,
+			    devpts_mntopts + sizeof("gid=5"));
 		if (ret < 0) {
 			SYSERROR("Failed to mount new devpts instance");
 			return -1;


### PR DESCRIPTION
The "max" option to devpts got introduced in kernel 3.4.

Closes #2490.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>