### PR TITLE
netns: allocate network namespace id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
  - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
  - sudo add-apt-repository ppa:ubuntu-lxc/daily -y
  - sudo apt-get update -qq
- - sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev python3-dev python3-setuptools docbook2x libgnutls-dev libselinux1-dev
+ - sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev python3-dev python3-setuptools docbook2x libgnutls-dev libselinux1-dev linux-libc-dev
 script:
  - ./autogen.sh
  - rm -Rf build

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -183,4 +183,8 @@ extern int __build_bug_on_failed;
 #define IFLA_IF_NETNSID 46
 #endif
 
+#ifndef RTM_NEWNSID
+#define RTM_NEWNSID 88
+#endif
+
 #endif /* __LXC_MACRO_H */

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -142,4 +142,45 @@ extern int __build_bug_on_failed;
 
 #define prctl_arg(x) ((unsigned long)x)
 
+/* networking */
+#ifndef IFLA_LINKMODE
+#define IFLA_LINKMODE 17
+#endif
+
+#ifndef IFLA_LINKINFO
+#define IFLA_LINKINFO 18
+#endif
+
+#ifndef IFLA_NET_NS_PID
+#define IFLA_NET_NS_PID 19
+#endif
+
+#ifndef IFLA_INFO_KIND
+#define IFLA_INFO_KIND 1
+#endif
+
+#ifndef IFLA_VLAN_ID
+#define IFLA_VLAN_ID 1
+#endif
+
+#ifndef IFLA_INFO_DATA
+#define IFLA_INFO_DATA 2
+#endif
+
+#ifndef VETH_INFO_PEER
+#define VETH_INFO_PEER 1
+#endif
+
+#ifndef IFLA_MACVLAN_MODE
+#define IFLA_MACVLAN_MODE 1
+#endif
+
+#ifndef IFLA_NEW_NETNSID
+#define IFLA_NEW_NETNSID 45
+#endif
+
+#ifndef IFLA_IF_NETNSID
+#define IFLA_IF_NETNSID 46
+#endif
+
 #endif /* __LXC_MACRO_H */

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -31,7 +31,6 @@
 #include <time.h>
 #include <unistd.h>
 #include <arpa/inet.h>
-#include <linux/net_namespace.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/sockios.h>
@@ -3183,6 +3182,16 @@ int addattr(struct nlmsghdr *n, int maxlen, int type, const void *data, int alen
 	return 0;
 }
 
+/* Attributes of RTM_NEWNSID/RTM_GETNSID messages */
+enum {
+	LXC_NETNSA_NONE,
+#define LXC_NETNSA_NSID_NOT_ASSIGNED -1
+	LXC_NETNSA_NSID,
+	LXC_NETNSA_PID,
+	LXC_NETNSA_FD,
+	__LXC_NETNSA_MAX,
+};
+
 int lxc_netns_set_nsid(int fd)
 {
 	ssize_t ret;
@@ -3210,8 +3219,8 @@ int lxc_netns_set_nsid(int fd)
 	l_hdr->nlmsg_seq = RTM_NEWNSID;
 	l_msg->rtgen_family = AF_UNSPEC;
 
-	addattr(l_hdr, 1024, NETNSA_FD, &fd, sizeof(__u32));
-	addattr(l_hdr, 1024, NETNSA_NSID, &nsid, sizeof(__u32));
+	addattr(l_hdr, 1024, LXC_NETNSA_FD, &fd, sizeof(__u32));
+	addattr(l_hdr, 1024, LXC_NETNSA_NSID, &nsid, sizeof(__u32));
 
 	memset(&l_addr, 0, sizeof(l_addr));
 	l_addr.nl_family = AF_NETLINK;

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -64,46 +64,6 @@
 #include "include/strlcpy.h"
 #endif
 
-#ifndef IFLA_LINKMODE
-#define IFLA_LINKMODE 17
-#endif
-
-#ifndef IFLA_LINKINFO
-#define IFLA_LINKINFO 18
-#endif
-
-#ifndef IFLA_NET_NS_PID
-#define IFLA_NET_NS_PID 19
-#endif
-
-#ifndef IFLA_INFO_KIND
-#define IFLA_INFO_KIND 1
-#endif
-
-#ifndef IFLA_VLAN_ID
-#define IFLA_VLAN_ID 1
-#endif
-
-#ifndef IFLA_INFO_DATA
-#define IFLA_INFO_DATA 2
-#endif
-
-#ifndef VETH_INFO_PEER
-#define VETH_INFO_PEER 1
-#endif
-
-#ifndef IFLA_MACVLAN_MODE
-#define IFLA_MACVLAN_MODE 1
-#endif
-
-#ifndef IFLA_NEW_NETNSID
-#define IFLA_NEW_NETNSID 45
-#endif
-
-#ifndef IFLA_IF_NETNSID
-#define IFLA_IF_NETNSID 46
-#endif
-
 lxc_log_define(network, lxc);
 
 typedef int (*instantiate_cb)(struct lxc_handler *, struct lxc_netdev *);

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -272,5 +272,6 @@ extern int lxc_network_send_veth_names_to_child(struct lxc_handler *handler);
 extern int lxc_network_recv_veth_names_from_parent(struct lxc_handler *handler);
 extern int lxc_network_send_name_and_ifindex_to_parent(struct lxc_handler *handler);
 extern int lxc_network_recv_name_and_ifindex_from_child(struct lxc_handler *handler);
+extern int lxc_netns_set_nsid(int netns_fd);
 
 #endif /* __LXC_NETWORK_H */

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1818,6 +1818,13 @@ static int lxc_spawn(struct lxc_handler *handler)
 	} else {
 		handler->nsfd[LXC_NS_NET] = ret;
 		DEBUG("Preserved net namespace via fd %d", ret);
+
+		ret = lxc_netns_set_nsid(handler->nsfd[LXC_NS_NET]);
+		if (ret < 0) {
+			ERROR("Failed to allocate new network namespace id: %d", ret);
+			goto out_delete_net;
+		}
+		TRACE("Allocated new network namespace id");
 	}
 
 	/* Create the network configuration. */


### PR DESCRIPTION
Start to allocate a new network namespace id for each container.

Relates to lxc/lxd#4831.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>