### PR TITLE
usernsexec: Make err out vebose for unshare error

### DIFF
--- a/src/lxc/cmd/lxc_usernsexec.c
+++ b/src/lxc/cmd/lxc_usernsexec.c
@@ -375,7 +375,8 @@ int main(int argc, char *argv[])
 
 		ret = unshare(flags);
 		if (ret < 0) {
-			perror("unshare");
+			fprintf(stderr,
+				"Failed to unshare mount and user namespace\n");
 			return 1;
 		}
 		buf[0] = '1';
@@ -399,8 +400,12 @@ int main(int argc, char *argv[])
 
 	close(pipe_fds1[1]);
 	close(pipe_fds2[0]);
-	if (lxc_read_nointr(pipe_fds1[0], buf, 1) < 1) {
+	ret = lxc_read_nointr(pipe_fds1[0], buf, 1);
+	if (ret < 0) {
 		perror("read pipe");
+		exit(EXIT_FAILURE);
+	} else if (ret == 0) {
+		fprintf(stderr, "Failed to read from pipe\n");
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
Currently if `lxc-usernsexec` is run on a kernel without user namespaces
enabled the error message is
```
unshare: Invalid argument
read pipe: Success
```
This error message 'Invalid argument' does not point at the root cause
of the error.  We can help the user out by giving a more detailed error
message and also not using perror() if errno==0.

Improve error message by
 - Printing unshare flags
 - Printing suggested cause of failure (user namespace not enabled)
 - Print error message with fprintf() if errno==0 (EOF)

With this applied error message is
```
unshare: CLONE_NEWNS | CLONE_NEWUSER
You may need to enable user namespaces
pipe closed by child
```
I'm not convinced this is the best message.  If this is judged a _real_ issue perhaps we can come up with something better.

thanks,
Tobin.

Signed-off-by: Tobin C. Harding <me@tobin.cc>