### PR TITLE
cmd: Fix up checkpatch warnings

### DIFF
--- a/src/lxc/cmd/lxc_init.c
+++ b/src/lxc/cmd/lxc_init.c
@@ -550,9 +550,8 @@ static int arguments_parse(struct arguments *args, int argc,
 	args->argc = argc - optind;
 
 	/* If no lxcpath was given, use default */
-	if (!args->lxcpath) {
+	if (!args->lxcpath)
 		args->lxcpath = lxc_global_config_value("lxc.lxcpath");
-	}
 
 	/* Check the command options */
 	if (!args->name) {

--- a/src/lxc/cmd/lxc_init.c
+++ b/src/lxc/cmd/lxc_init.c
@@ -91,7 +91,7 @@ struct arguments {
 };
 
 static int arguments_parse(struct arguments *my_args, int argc,
-			       char *const argv[]);
+			   char *const argv[]);
 
 static struct arguments my_args = {
 	.options   = long_options,
@@ -500,11 +500,10 @@ Mandatory or optional arguments to long options are also mandatory or optional\n
 for any corresponding short options.\n\
 \n\
 See the lxc-init man page for further information.\n\n");
-
 }
 
 static int arguments_parse(struct arguments *args, int argc,
-			       char *const argv[])
+			   char *const argv[])
 {
 	while (true) {
 		int c;

--- a/src/lxc/cmd/lxc_init.c
+++ b/src/lxc/cmd/lxc_init.c
@@ -473,13 +473,13 @@ static void print_usage(const struct option longopts[])
 	exit(0);
 }
 
-static void print_version()
+static void print_version(void)
 {
 	printf("%s\n", LXC_VERSION);
 	exit(0);
 }
 
-static void print_help()
+static void print_help(void)
 {
 	fprintf(stderr, "\
 Usage: lxc-init --name=NAME -- COMMAND\n\

--- a/src/lxc/cmd/lxc_init.c
+++ b/src/lxc/cmd/lxc_init.c
@@ -73,7 +73,7 @@ static struct option long_options[] = {
 	    { "lxcpath",     required_argument, 0, 'P'         },
 	    { 0,             0,                 0, 0           }
 	};
-static char short_options[] = "n:hqo:l:P:";
+static const char short_options[] = "n:hqo:l:P:";
 
 struct arguments {
 	const struct option *options;

--- a/src/lxc/cmd/lxc_init.c
+++ b/src/lxc/cmd/lxc_init.c
@@ -468,7 +468,7 @@ out:
 static void print_usage(const struct option longopts[])
 
 {
-	fprintf(stderr, "Usage: lxc-init [-n|--name=NAME] [-h|--help] [--usage] [--version] \n\
+	fprintf(stderr, "Usage: lxc-init [-n|--name=NAME] [-h|--help] [--usage] [--version]\n\
 		[-q|--quiet] [-o|--logfile=LOGFILE] [-l|--logpriority=LOGPRIORITY] [-P|--lxcpath=LXCPATH]\n");
 	exit(0);
 }

--- a/src/lxc/cmd/lxc_init.c
+++ b/src/lxc/cmd/lxc_init.c
@@ -47,7 +47,7 @@
 
 /* option keys for long only options */
 #define OPT_USAGE 0x1000
-#define OPT_VERSION OPT_USAGE - 1
+#define OPT_VERSION (OPT_USAGE - 1)
 
 #define QUOTE(macro) #macro
 #define QUOTEVAL(macro) QUOTE(macro)

--- a/src/lxc/cmd/lxc_monitord.c
+++ b/src/lxc/cmd/lxc_monitord.c
@@ -89,7 +89,7 @@ static int lxc_monitord_fifo_create(struct lxc_monitor *mon)
 	if (ret < 0)
 		return ret;
 
-	ret = mknod(fifo_path, S_IFIFO|S_IRUSR|S_IWUSR, 0);
+	ret = mknod(fifo_path, S_IFIFO | S_IRUSR | S_IWUSR, 0);
 	if (ret < 0 && errno != EEXIST) {
 		SYSINFO("Failed to mknod monitor fifo %s", fifo_path);
 		return -1;

--- a/src/lxc/cmd/lxc_monitord.c
+++ b/src/lxc/cmd/lxc_monitord.c
@@ -208,7 +208,7 @@ static int lxc_monitord_sock_accept(int fd, uint32_t events, void *data,
 
 		clientfds = realloc(mon->clientfds,
 				    (mon->clientfds_size + CLIENTFDS_CHUNK) * sizeof(mon->clientfds[0]));
-		if (clientfds == NULL) {
+		if (!clientfds) {
 			ERROR("Failed to realloc memory for %d client file descriptors",
 			      mon->clientfds_size + CLIENTFDS_CHUNK);
 			goto err1;

--- a/src/lxc/cmd/lxc_user_nic.c
+++ b/src/lxc/cmd/lxc_user_nic.c
@@ -219,7 +219,7 @@ static char **get_groupnames(void)
 				usernic_error("%s", "Could not find matched group record\n");
 
 			usernic_error("Failed to get group name: %s(%u)\n",
-			      strerror(errno), group_ids[i]);
+				      strerror(errno), group_ids[i]);
 			free(buf);
 			free(group_ids);
 			free_groupnames(groupnames);

--- a/src/lxc/cmd/lxc_user_nic.c
+++ b/src/lxc/cmd/lxc_user_nic.c
@@ -687,7 +687,7 @@ static bool cull_entries(int fd, char *name, char *net_type, char *net_link,
 static int count_entries(char *buf, off_t len, char *name, char *net_type, char *net_link)
 {
 	int count = 0;
-	bool owner = false;;
+	bool owner = false;
 	char *buf_end;
 
 	buf_end = &buf[len];

--- a/src/lxc/cmd/lxc_user_nic.c
+++ b/src/lxc/cmd/lxc_user_nic.c
@@ -512,7 +512,8 @@ static int instantiate_veth(char *veth1, char *veth2)
 
 	/* Changing the high byte of the mac address to 0xfe, the bridge
 	 * interface will always keep the host's mac address and not take the
-	 * mac address of a container. */
+	 * mac address of a container.
+	 */
 	ret = setup_private_host_hw_addr(veth1);
 	if (ret < 0)
 		usernic_error("Failed to change mac address of host interface "

--- a/src/lxc/cmd/lxc_user_nic.c
+++ b/src/lxc/cmd/lxc_user_nic.c
@@ -752,7 +752,7 @@ static char *get_nic_if_avail(int fd, struct alloted_s *names, int pid,
 		lxc_strmunmap(buf, sb.st_size);
 	}
 
-	if (owner == NULL)
+	if (!owner)
 		return NULL;
 
 	ret = snprintf(nicname, sizeof(nicname), "vethXXXXXX");


### PR DESCRIPTION
This is the remainder of the fixes found by checkpatch for `cmd/`.  The warnings left are either contentious or not demanded by our coding style.

- Use parenthesis around complex macro i.e. `(foo + 1)` instead of `foo + 1`.
- Use 'void' instead of empty parameter list i.e. `static int fn(void)` .
- Do not use braces for single statement block.
- Fix all whitespace issues as a single patch since these are easy to review.
- Use 'const' for static string constant.
- Remove unnecessary whitespace in string (separate patch because this only subjectively better).
- Put trailing */ on a separate line (standard comment format).
- Remove accidental duplicate semicolon 
- Do not use comparison to NULL i.e. `if (!foo)` instead of `if (foo == NULL)`.

All patches build cleanly but no further testing done.

thanks,
Tobin.

Signed-off-by: Tobin C. Harding <me@tobin.cc>