### PR TITLE
lxc_init: s/SYSDEBUG()/SYSERROR()/g in remove_self

### DIFF
--- a/src/lxc/cmd/lxc_init.c
+++ b/src/lxc/cmd/lxc_init.c
@@ -201,20 +201,20 @@ static void remove_self(void)
 
 	n = readlink("/proc/self/exe", path, sizeof(path));
 	if (n < 0 || n >= MAXPATHLEN) {
-		SYSERROR("Failed to readlink \"/proc/self/exe\"");
+		SYSDEBUG("Failed to readlink \"/proc/self/exe\"");
 		return;
 	}
 	path[n] = '\0';
 
 	ret = umount2(path, MNT_DETACH);
 	if (ret < 0) {
-		SYSERROR("Failed to unmount \"%s\"", path);
+		SYSDEBUG("Failed to unmount \"%s\"", path);
 		return;
 	}
 
 	ret = unlink(path);
 	if (ret < 0) {
-		SYSERROR("Failed to unlink \"%s\"", path);
+		SYSDEBUG("Failed to unlink \"%s\"", path);
 		return;
 	}
 }


### PR DESCRIPTION
Since we switched to execveat() whenever possible in
commit 4b5b3a2a299b ("execute: use execveat() syscall if supported")
it is unlikely that remove_self() has any job to do at all. So dumb down the
error levels.

Closes #2536.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>