### PR TITLE
storage/loop.c: integer overflow

### DIFF
--- a/src/lxc/storage/loop.c
+++ b/src/lxc/storage/loop.c
@@ -297,6 +297,7 @@ int loop_umount(struct lxc_storage *bdev)
 static int do_loop_create(const char *path, uint64_t size, const char *fstype)
 {
 	int fd, ret;
+	off_t ret_size;
 	char cmd_output[MAXPATHLEN];
 	const char *cmd_args[2] = {fstype, path};
 
@@ -307,8 +308,8 @@ static int do_loop_create(const char *path, uint64_t size, const char *fstype)
 		return -1;
 	}
 
-	ret = lseek(fd, size, SEEK_SET);
-	if (ret < 0) {
+	ret_size = lseek(fd, size, SEEK_SET);
+	if (ret_size < 0) {
 		SYSERROR("Failed to seek to set new loop file size for loop "
 			 "file \"%s\"", path);
 		close(fd);


### PR DESCRIPTION
The issue was introduced in PR (https://github.com/lxc/lxc/pull/1705):

Previous code:
```
  if (lseek(fd, size, SEEK_SET) < 0) {
    SYSERROR("Error seeking to set new loop file size");
    close(fd);
    return -1;
  }
```
New code:
```
  int fd, ret;

  [...]

  ret = lseek(fd, size, SEEK_SET);
  if (ret < 0) {
    SYSERROR("Failed to seek to set new loop file size for loop "
       "file \"%s\"", path);
    close(fd);
    return -1;
  }
```

Based on http://man7.org/linux/man-pages/man2/lseek.2.html:
> Upon successful completion, lseek() returns the resulting offset location as measured in bytes from the beginning of the file.

Because `size` is `uint64_t`, it's very easy to overflow `res` and as a result the code will success randomly (if overflow is >0 it will pass it it's <0 it will fail).

Example from strace:
```
[...]
[pid  5561] lseek(4, 53687091200, SEEK_SET) = 53687091200
[pid  5561] close(4)                    = 0
[pid  5561] exit_group(1)               = ?
[pid  5561] +++ exited with 1 +++
[...]
```

This PR fix issues (https://github.com/lxc/lxc/issues/1872).

Signed-off-by: Lukasz Jagiello <lukasz@wikia-inc.com>