### PR TITLE
tools: fix lxc-execute command parsing

### DIFF
--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -129,6 +129,7 @@ static bool set_argv(struct lxc_container *c, struct lxc_arguments *args)
 	char buf[MAXPATHLEN];
 	char **components, **p;
 
+	buf[0] = '\0';
 	ret = c->get_config_item(c, "lxc.execute.cmd", buf, MAXPATHLEN);
 	if (ret < 0)
 		return false;


### PR DESCRIPTION
Initialize buf to avoid parsing random data later on.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>