### PR TITLE
cmd: Lint with cppcheck

### DIFF
--- a/src/lxc/cmd/lxc_user_nic.c
+++ b/src/lxc/cmd/lxc_user_nic.c
@@ -862,12 +862,12 @@ again:
 static char *lxc_secure_rename_in_ns(int pid, char *oldname, char *newname,
 				     int *container_veth_ifidx)
 {
-	int ret;
+	int ofd, ret;
 	pid_t pid_self;
 	uid_t ruid, suid, euid;
 	char ifname[IFNAMSIZ];
 	char *string_ret = NULL, *name = NULL;
-	int fd = -1, ifindex = -1, ofd = -1;
+	int fd = -1, ifindex = -1;
 
 	pid_self = lxc_raw_getpid();
 
@@ -1035,11 +1035,10 @@ struct user_nic_args {
 
 static bool is_privileged_over_netns(int netns_fd)
 {
-	int ret;
+	int ofd, ret;
 	pid_t pid_self;
 	uid_t euid, ruid, suid;
 	bool bret = false;
-	int ofd = -1;
 
 	pid_self = lxc_raw_getpid();
 

--- a/src/lxc/cmd/lxc_user_nic.c
+++ b/src/lxc/cmd/lxc_user_nic.c
@@ -707,7 +707,6 @@ static char *get_nic_if_avail(int fd, struct alloted_s *names, int pid,
 	char nicname[IFNAMSIZ];
 	struct stat sb;
 	struct alloted_s *n;
-	int count = 0;
 	char *buf = NULL;
 
 	for (n = names; n != NULL; n = n->next)
@@ -735,6 +734,8 @@ static char *get_nic_if_avail(int fd, struct alloted_s *names, int pid,
 		owner = NULL;
 
 		for (n = names; n != NULL; n = n->next) {
+			int count;
+
 			count = count_entries(buf, sb.st_size, n->name, intype, br);
 			if (count >= n->allowed)
 				continue;


### PR DESCRIPTION
Run linter `cppcheck` over `src/lxc/cmd`.

This is i tiny PR to see if `LXC` is into using cppcheck for linting.  Patch one makes a change that is directly related to the discussion in #2542 (in regards to declaring/initializing local variables).  Patch 2 is a stylistic change reducing the scope of a variable (and minuscule amounts of required cognitive load).  Please be harsh to critique these changes, I'll follow on the ruling here with further linting if deemed useful.

thanks,
Tobin. 

Signed-off-by: Tobin C. Harding <me@tobin.cc>