### PR TITLE
Makefile: don't allow undefined symbols

### DIFF
--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -214,6 +214,7 @@ liblxc_la_CFLAGS = -fPIC \
 		   -pthread
 
 liblxc_la_LDFLAGS = -pthread \
+		    -Wl,-no-undefined \
 		    -Wl,-soname,liblxc.so.$(firstword $(subst ., ,@LXC_ABI@)) \
 		    -version-info @LXC_ABI_MAJOR@
 
@@ -410,7 +411,8 @@ pam_cgfs_la_LIBADD = $(AM_LIBS) \
 pam_cgfs_la_LDFLAGS = $(AM_LDFLAGS) \
 		      -avoid-version \
 		      -module \
-		      -shared
+		      -shared \
+		      -Wl,-no-undefined
 endif
 endif
 


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>