### PR TITLE
execute: pass /proc/self/fd/<nr>

### DIFF
--- a/src/lxc/execute.c
+++ b/src/lxc/execute.c
@@ -95,7 +95,7 @@ static int execute_start(struct lxc_handler *handler, void* data)
 			goto out2;
 		}
 
-		ret = snprintf(logfile, sizeof(logfile), "/proc/1/fd/%d", logfd);
+		ret = snprintf(logfile, sizeof(logfile), "/proc/self/fd/%d", logfd);
 		if (ret < 0 || (size_t)ret >= sizeof(logfile))
 			goto out3;
 


### PR DESCRIPTION
Passing /proc/1/fd/<nr> presupposes that CLONE_NEWPID was specified. This isn't
the case when users use lxc.namespace.keep = pid to inherit pid namespaces.
Pass /proc/self/fd/<nr> instead.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
Reported-by: Mrinal Dhillon <mdhillon@juniper.net>