### PR TITLE
 confile: add lxc.cgroup.keep

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1261,7 +1261,7 @@ int lxc_attach(const char *name, const char *lxcpath,
 		if (options->attach_flags & LXC_ATTACH_MOVE_TO_CGROUP) {
 			struct cgroup_ops *cgroup_ops;
 
-			cgroup_ops = cgroup_init(NULL);
+			cgroup_ops = cgroup_init(conf);
 			if (!cgroup_ops)
 				goto on_error;
 

--- a/src/lxc/cgroups/cgroup.c
+++ b/src/lxc/cgroups/cgroup.c
@@ -33,13 +33,13 @@
 
 lxc_log_define(cgroup, lxc);
 
-extern struct cgroup_ops *cgfsng_ops_init(void);
+extern struct cgroup_ops *cgfsng_ops_init(struct lxc_conf *conf);
 
-struct cgroup_ops *cgroup_init(struct lxc_handler *handler)
+struct cgroup_ops *cgroup_init(struct lxc_conf *conf)
 {
 	struct cgroup_ops *cgroup_ops;
 
-	cgroup_ops = cgfsng_ops_init();
+	cgroup_ops = cgfsng_ops_init(conf);
 	if (!cgroup_ops) {
 		ERROR("Failed to initialize cgroup driver");
 		return NULL;

--- a/src/lxc/cgroups/cgroup.h
+++ b/src/lxc/cgroups/cgroup.h
@@ -127,7 +127,7 @@ struct cgroup_ops {
 	bool (*create)(struct cgroup_ops *ops, struct lxc_handler *handler);
 	bool (*enter)(struct cgroup_ops *ops, pid_t pid);
 	const char *(*get_cgroup)(struct cgroup_ops *ops, const char *controller);
-	bool (*escape)(const struct cgroup_ops *ops);
+	bool (*escape)(const struct cgroup_ops *ops, struct lxc_conf *conf);
 	int (*num_hierarchies)(struct cgroup_ops *ops);
 	bool (*get_hierarchies)(struct cgroup_ops *ops, int n, char ***out);
 	int (*set)(struct cgroup_ops *ops, const char *filename,
@@ -145,7 +145,7 @@ struct cgroup_ops {
 	int (*nrtasks)(struct cgroup_ops *ops);
 };
 
-extern struct cgroup_ops *cgroup_init(struct lxc_handler *handler);
+extern struct cgroup_ops *cgroup_init(struct lxc_conf *conf);
 extern void cgroup_exit(struct cgroup_ops *ops);
 
 extern void prune_init_scope(char *cg);

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -76,6 +76,7 @@ struct lxc_cgroup {
 		struct /* meta */ {
 			char *controllers;
 			char *dir;
+			bool keep;
 		};
 	};
 };

--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -190,7 +190,7 @@ static void exec_criu(struct cgroup_ops *cgroup_ops, struct criu_opts *opts)
 	 * /actual/ root cgroup so that lxcfs thinks criu has enough rights to
 	 * see all cgroups.
 	 */
-	if (!cgroup_ops->escape(cgroup_ops)) {
+	if (!cgroup_ops->escape(cgroup_ops, opts->handler->conf)) {
 		ERROR("failed to escape cgroups");
 		return;
 	}
@@ -967,7 +967,7 @@ static void do_restore(struct lxc_container *c, int status_pipe, struct migrate_
 	if (lxc_init(c->name, handler) < 0)
 		goto out;
 
-	cgroup_ops = cgroup_init(NULL);
+	cgroup_ops = cgroup_init(c->lxc_conf);
 	if (!cgroup_ops)
 		goto out_fini_handler;
 	handler->cgroup_ops = cgroup_ops;
@@ -1272,7 +1272,7 @@ static bool do_dump(struct lxc_container *c, char *mode, struct migrate_opts *op
 
 		h.name = c->name;
 
-		cgroup_ops = cgroup_init(NULL);
+		cgroup_ops = cgroup_init(c->lxc_conf);
 		if (!cgroup_ops) {
 			ERROR("failed to cgroup_init()");
 			_exit(EXIT_FAILURE);

--- a/src/lxc/freezer.c
+++ b/src/lxc/freezer.c
@@ -42,7 +42,8 @@
 
 lxc_log_define(freezer, lxc);
 
-static int do_freeze_thaw(bool freeze, const char *name, const char *lxcpath)
+static int do_freeze_thaw(bool freeze, struct lxc_conf *conf, const char *name,
+			  const char *lxcpath)
 {
 	int ret;
 	char v[100];
@@ -51,7 +52,7 @@ static int do_freeze_thaw(bool freeze, const char *name, const char *lxcpath)
 	size_t state_len = 6;
 	lxc_state_t new_state = freeze ? FROZEN : THAWED;
 
-	cgroup_ops = cgroup_init(NULL);
+	cgroup_ops = cgroup_init(conf);
 	if (!cgroup_ops)
 		return -1;
 
@@ -85,14 +86,14 @@ static int do_freeze_thaw(bool freeze, const char *name, const char *lxcpath)
 	}
 }
 
-int lxc_freeze(const char *name, const char *lxcpath)
+int lxc_freeze(struct lxc_conf *conf, const char *name, const char *lxcpath)
 {
 	lxc_cmd_serve_state_clients(name, lxcpath, FREEZING);
 	lxc_monitor_send_state(name, FREEZING, lxcpath);
-	return do_freeze_thaw(true, name, lxcpath);
+	return do_freeze_thaw(true, conf, name, lxcpath);
 }
 
-int lxc_unfreeze(const char *name, const char *lxcpath)
+int lxc_unfreeze(struct lxc_conf *conf, const char *name, const char *lxcpath)
 {
-	return do_freeze_thaw(false, name, lxcpath);
+	return do_freeze_thaw(false, conf, name, lxcpath);
 }

--- a/src/lxc/lxc.h
+++ b/src/lxc/lxc.h
@@ -81,14 +81,16 @@ extern int lxc_monitor_close(int fd);
  * @name : the container name
  * Returns 0 on success, < 0 otherwise
  */
-extern int lxc_freeze(const char *name, const char *lxcpath);
+extern int lxc_freeze(struct lxc_conf *conf, const char *name,
+		      const char *lxcpath);
 
 /*
  * Unfreeze all previously frozen tasks.
  * @name : the name of the container
  * Return 0 on success, < 0 otherwise
  */
-extern int lxc_unfreeze(const char *name, const char *lxcpath);
+extern int lxc_unfreeze(struct lxc_conf *conf, const char *name,
+			const char *lxcpath);
 
 /*
  * Retrieve the container state

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -529,7 +529,7 @@ static bool do_lxcapi_freeze(struct lxc_container *c)
 	if (!c)
 		return false;
 
-	ret = lxc_freeze(c->name, c->config_path);
+	ret = lxc_freeze(c->lxc_conf, c->name, c->config_path);
 	if (ret < 0)
 		return false;
 
@@ -545,7 +545,7 @@ static bool do_lxcapi_unfreeze(struct lxc_container *c)
 	if (!c)
 		return false;
 
-	ret = lxc_unfreeze(c->name, c->config_path);
+	ret = lxc_unfreeze(c->lxc_conf, c->name, c->config_path);
 	if (ret < 0)
 		return false;
 
@@ -3263,7 +3263,7 @@ static bool do_lxcapi_set_cgroup_item(struct lxc_container *c, const char *subsy
 	if (is_stopped(c))
 		return false;
 
-	cgroup_ops = cgroup_init(NULL);
+	cgroup_ops = cgroup_init(c->lxc_conf);
 	if (!cgroup_ops)
 		return false;
 
@@ -3292,7 +3292,7 @@ static int do_lxcapi_get_cgroup_item(struct lxc_container *c, const char *subsys
 	if (is_stopped(c))
 		return -1;
 
-	cgroup_ops = cgroup_init(NULL);
+	cgroup_ops = cgroup_init(c->lxc_conf);
 	if (!cgroup_ops)
 		return -1;
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -856,7 +856,7 @@ int lxc_init(const char *name, struct lxc_handler *handler)
 	}
 	TRACE("Chowned console");
 
-	handler->cgroup_ops = cgroup_init(handler);
+	handler->cgroup_ops = cgroup_init(handler->conf);
 	if (!handler->cgroup_ops) {
 		ERROR("Failed to initialize cgroup driver");
 		goto out_delete_terminal;

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1694,11 +1694,6 @@ static int lxc_spawn(struct lxc_handler *handler)
 		}
 	}
 
-	if (!cgroup_init(handler)) {
-		ERROR("Failed initializing cgroup support");
-		goto out_delete_net;
-	}
-
 	if (!cgroup_ops->create(cgroup_ops, handler)) {
 		ERROR("Failed creating cgroups");
 		goto out_delete_net;

--- a/src/tests/cgpath.c
+++ b/src/tests/cgpath.c
@@ -80,7 +80,7 @@ static int test_running_container(const char *lxcpath,
 		goto err3;
 	}
 
-	cgroup_ops = cgroup_init(NULL);
+	cgroup_ops = cgroup_init(c->lxc_conf);
 	if (!cgroup_ops)
 		goto err3;
 


### PR DESCRIPTION
This adds the new lxc.cgroup.keep config key. The key can be used to instruct
LXC to not escape to never escape to the root cgroup. This makes it easy for
users to adhere to restrictions enforced by cgroup2 and systemd. Specifically,
this makes it possible to run LXC containers as systemd services.

Note that cgroup v1 is considered legacy and will not see additional
controllers being added to it. This means that it is safe to use
lxc.cgroup.keep as config key since there is no "keep" controller. The only way
a conflict can be introduced is if the user is creating a named controller. I
think this case can be safely ignored since it is super rare and also the users
problem.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
Cc: Felix Abecassis <fabecassis@nvidia.com>
Cc: Jonathan Calmels <jcalmels@nvidia.com>