### PR TITLE
utils: allow lxc-attach to set uid / gid

### DIFF
--- a/doc/lxc-attach.sgml.in
+++ b/doc/lxc-attach.sgml.in
@@ -60,6 +60,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <arg choice="opt">--clear-env</arg>
       <arg choice="opt">-v, --set-var <replaceable>variable</replaceable></arg>
       <arg choice="opt">--keep-var <replaceable>variable</replaceable></arg>
+      <arg choice="opt">-u, --uid <replaceable>uid</replaceable></arg>
+      <arg choice="opt">-g, --gid <replaceable>gid</replaceable></arg>
       <arg choice="opt">-- <replaceable>command</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -278,6 +280,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 	    specified in conjunction
 	    with <replaceable>--clear-env</replaceable>, and can be
 	    specified multiple times.
+	  </para>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+	<term>
+	  <option>--u, --uid <replaceable>uid</replaceable></option>
+	</term>
+	<listitem>
+	  <para>
+	    Executes the <replaceable>command</replaceable> with user ID
+	   <replaceable>uid</replaceable> inside the container.
+	  </para>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+	<term>
+	  <option>--g, --gid <replaceable>gid</replaceable></option>
+	</term>
+	<listitem>
+	  <para>
+	    Executes the <replaceable>command</replaceable> with group ID
+	   <replaceable>gid</replaceable> inside the container.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/doc/lxc-execute.sgml.in
+++ b/doc/lxc-execute.sgml.in
@@ -53,6 +53,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       <arg choice="opt">-d</arg>
       <arg choice="opt">-f <replaceable>config_file</replaceable></arg>
       <arg choice="opt">-s KEY=VAL</arg>
+      <arg choice="opt">-u, --uid <replaceable>uid</replaceable></arg>
+      <arg choice="opt">-g, --gid <replaceable>gid</replaceable></arg>
       <arg choice="opt">-- <replaceable>command</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -135,6 +137,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 	    Run the container as a daemon. As the container has no
 	    more tty, if an error occurs nothing will be displayed,
 	    the log file can be used to check the error.
+	  </para>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+	<term>
+	  <option>--u, --uid <replaceable>uid</replaceable></option>
+	</term>
+	<listitem>
+	  <para>
+	    Executes the <replaceable>command</replaceable> with user ID
+	   <replaceable>uid</replaceable> inside the container.
+	  </para>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+	<term>
+	  <option>--g, --gid <replaceable>gid</replaceable></option>
+	</term>
+	<listitem>
+	  <para>
+	    Executes the <replaceable>command</replaceable> with group ID
+	   <replaceable>gid</replaceable> inside the container.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -852,13 +852,6 @@ static int attach_child_main(struct attach_clone_payload *payload)
 	if (options->gid != (gid_t)-1)
 		new_gid = options->gid;
 
-	/* Try to set the {u,g}id combination. */
-	if (new_uid != 0 || new_gid != 0 || options->namespaces & CLONE_NEWUSER) {
-		ret = lxc_switch_uid_gid(new_uid, new_gid);
-		if (ret < 0)
-			goto on_error;
-	}
-
 	ret = lxc_setgroups(0, NULL);
 	if (ret < 0 && errno != EPERM)
 		goto on_error;
@@ -895,6 +888,13 @@ static int attach_child_main(struct attach_clone_payload *payload)
 			goto on_error;
 
 		TRACE("Loaded seccomp profile");
+	}
+
+	/* Try to set the {u,g}id combination. */
+	if (new_uid != 0 || new_gid != 0 || options->namespaces & CLONE_NEWUSER) {
+		ret = lxc_switch_uid_gid(new_uid, new_gid);
+		if (ret < 0)
+			goto on_error;
 	}
 
 	shutdown(payload->ipc_socket, SHUT_RDWR);

--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -72,6 +72,8 @@ static const struct option my_longopts[] = {
 	{"set-var", required_argument, 0, 'v'},
 	{"pty-log", required_argument, 0, 'L'},
 	{"rcfile", required_argument, 0, 'f'},
+	{"uid", required_argument, 0, 'u'},
+	{"gid", required_argument, 0, 'g'},
 	LXC_COMMON_OPTIONS
 };
 
@@ -122,6 +124,8 @@ Options :\n\
                     multiple times.\n\
   -f, --rcfile=FILE\n\
                     Load configuration file FILE\n\
+  -u, --uid=UID     Execute COMMAND with UID inside the container\n\
+  -g, --gid=GID     Execute COMMAND with GID inside the container\n\
 ",
 	.options      = my_longopts,
 	.parser       = my_parser,
@@ -186,6 +190,14 @@ static int my_parser(struct lxc_arguments *args, int c, char *arg)
 		break;
 	case 'f':
 		args->rcfile = arg;
+		break;
+	case 'u':
+		if (lxc_safe_uint(arg, &args->uid) < 0)
+			return -1;
+		break;
+	case 'g':
+		if (lxc_safe_uint(arg, &args->gid) < 0)
+			return -1;
 		break;
 	}
 
@@ -331,6 +343,14 @@ int main(int argc, char *argv[])
 		attach_options.log_fd = lxc_attach_create_log_file(my_args.console_log);
 		if (attach_options.log_fd < 0)
 			goto out;
+	}
+
+	if (my_args.uid) {
+		attach_options.uid = my_args.uid;
+	}
+
+	if (my_args.gid) {
+		attach_options.gid = my_args.gid;
 	}
 
 	if (command.program)


### PR DESCRIPTION
 - Allow lxc-attach to set UID / GID as requested in #2591
 - Rearrange order of actions on attach
 - Add documentation (also for lxc-execute which has the same params)

Signed-off-by: Disassembler <disassembler@dasm.cz>