### PR TITLE
Declare loop variable outside of 'for' statement

### DIFF
--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -228,7 +228,8 @@ extern int __build_bug_on_failed;
 #endif
 
 #define lxc_iterate_parts(__iterator, __splitme, __separators)                  \
-	for (char *__p = NULL, *__it = strtok_r(__splitme, __separators, &__p); \
+	char *__p, *__it;                                                       \
+	for (__p = NULL, __it = strtok_r(__splitme, __separators, &__p);        \
 	     (__iterator = __it);                                               \
 	     __iterator = __it = strtok_r(NULL, __separators, &__p))
 


### PR DESCRIPTION
This fixes a build failure on CentOS 7 (#2615):
```
  ./macro.h:135:2: error: 'for' loop initial declarations are only allowed in C99 mode
    for (char *__p = NULL, *__it = strtok_r(__splitme, __separators, &__p); \
    ^
```