### PR TITLE
attach: don't shutdown ipc socket in child

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -728,7 +728,6 @@ struct attach_clone_payload {
 static void lxc_put_attach_clone_payload(struct attach_clone_payload *p)
 {
 	if (p->ipc_socket >= 0) {
-		shutdown(p->ipc_socket, SHUT_RDWR);
 		close(p->ipc_socket);
 		p->ipc_socket = -EBADF;
 	}
@@ -906,7 +905,6 @@ static int attach_child_main(struct attach_clone_payload *payload)
 		TRACE("Loaded seccomp profile");
 	}
 
-	shutdown(payload->ipc_socket, SHUT_RDWR);
 	close(payload->ipc_socket);
 	payload->ipc_socket = -EBADF;
 	lxc_proc_put_context_info(init_ctx);


### PR DESCRIPTION
shutdown() affects sockets even across forked processes. The
attached child process doesn't have any interest in using the
IPC socket, so just close it in the child process and let the
intermediate process handle shutting it down.

This fixes a bug seen with lxc exec in crbug.com/884244

Signed-off-by: Stephen Barber <smbarber@chromium.org>