### PR TITLE
security: fix too wide or inconsistent non-owner permissions

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1778,10 +1778,10 @@ static int lxc_setup_dev_console(const struct lxc_rootfs *rootfs,
 		return -errno;
 	}
 
-	ret = fchmod(console->slave, S_IXUSR | S_IXGRP | S_IXOTH);
+	ret = fchmod(console->slave, S_IXUSR | S_IXGRP);
 	if (ret < 0) {
 		SYSERROR("Failed to set mode \"0%o\" to \"%s\"",
-			 S_IXUSR | S_IXGRP | S_IXOTH, console->name);
+			 S_IXUSR | S_IXGRP, console->name);
 		return -errno;
 	}
 
@@ -1848,10 +1848,10 @@ static int lxc_setup_ttydir_console(const struct lxc_rootfs *rootfs,
 		return -errno;
 	}
 
-	ret = fchmod(console->slave, S_IXUSR | S_IXGRP | S_IXOTH);
+	ret = fchmod(console->slave, S_IXUSR | S_IXGRP);
 	if (ret < 0) {
 		SYSERROR("Failed to set mode \"0%o\" to \"%s\"",
-			 S_IXUSR | S_IXGRP | S_IXOTH, console->name);
+			 S_IXUSR | S_IXGRP, console->name);
 		return -errno;
 	}
 

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2639,7 +2639,7 @@ static bool do_lxcapi_save_config(struct lxc_container *c, const char *alt_file)
 		return false;
 
 	fd = open(alt_file, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC,
-		  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+		  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
 	if (fd < 0)
 		goto on_error;
 
@@ -3841,7 +3841,7 @@ static struct lxc_container *do_lxcapi_clone(struct lxc_container *c, const char
 	}
 
 	fd = open(newpath, O_WRONLY | O_CREAT | O_CLOEXEC,
-		  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+		  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
 	if (fd < 0) {
 		SYSERROR("Failed to open \"%s\"", newpath);
 		goto out;

--- a/src/lxc/tools/lxc_unshare.c
+++ b/src/lxc/tools/lxc_unshare.c
@@ -249,7 +249,7 @@ static void lxc_setup_fs(void)
 
 	/* if /dev has been populated by us, /dev/shm does not exist */
 	if (access("/dev/shm", F_OK))
-		(void)mkdir("/dev/shm", 0777);
+		(void)mkdir("/dev/shm", 0770);
 
 	/* if we can't mount /dev/shm, continue anyway */
 	(void)mount_fs("shmfs", "/dev/shm", "tmpfs");
@@ -257,7 +257,7 @@ static void lxc_setup_fs(void)
 	/* If we were able to mount /dev/shm, then /dev exists */
 	/* Sure, but it's read-only per config :) */
 	if (access("/dev/mqueue", F_OK))
-		(void)mkdir("/dev/mqueue", 0666);
+		(void)mkdir("/dev/mqueue", 0660);
 
 	/* continue even without posix message queue support */
 	(void)mount_fs("mqueue", "/dev/mqueue", "mqueue");


### PR DESCRIPTION
Hello,

Some resources have too wide or inconsistent non-owner permissions.

So, we remove the permissions of others.

Thanks. 

Signed-off-by: 2xsec <dh48.jeong@samsung.com>