### PR TITLE
lxccontainer: remove cgroup locking

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3277,12 +3277,7 @@ static bool do_lxcapi_set_cgroup_item(struct lxc_container *c, const char *subsy
 	if (!cgroup_ops)
 		return false;
 
-	if (container_disk_lock(c))
-		return false;
-
 	ret = cgroup_ops->set(cgroup_ops, subsys, value, c->name, c->config_path);
-
-	container_disk_unlock(c);
 
 	cgroup_exit(cgroup_ops);
 

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3301,13 +3301,8 @@ static int do_lxcapi_get_cgroup_item(struct lxc_container *c, const char *subsys
 	if (!cgroup_ops)
 		return -1;
 
-	if (container_disk_lock(c))
-		return -1;
-
 	ret = cgroup_ops->get(cgroup_ops, subsys, retv, inlen, c->name,
 			      c->config_path);
-
-	container_disk_unlock(c);
 
 	cgroup_exit(cgroup_ops);
 


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>