### PR TITLE
cgroups: implement monitor cgroup deletion

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1327,7 +1327,7 @@ __cgfsng_ops static inline bool cgfsng_monitor_create(struct cgroup_ops *ops,
 							struct lxc_handler *handler)
 {
 	char *monitor_cgroup, *offset, *tmp;
-	int idx = 0;
+	int i, idx = 0;
 	size_t len;
 	bool bret = false;
 	struct lxc_conf *conf = handler->conf;
@@ -1359,7 +1359,7 @@ __cgfsng_ops static inline bool cgfsng_monitor_create(struct cgroup_ops *ops,
 				goto on_error;
 		}
 
-		for (int i = 0; ops->hierarchies[i]; i++) {
+		for (i = 0; ops->hierarchies[i]; i++) {
 			if (!monitor_create_path_for_hierarchy(ops->hierarchies[i], monitor_cgroup)) {
 				ERROR("Failed to create cgroup \"%s\"", ops->hierarchies[i]->monitor_full_path);
 				free(ops->hierarchies[i]->container_full_path);
@@ -1372,7 +1372,7 @@ __cgfsng_ops static inline bool cgfsng_monitor_create(struct cgroup_ops *ops,
 				break;
 			}
 		}
-	} while (idx > 0 && idx < 1000);
+	} while (ops->hierarchies[i] && idx > 0 && idx < 1000);
 
 	if (idx < 1000)
 		bret = true;

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1159,12 +1159,12 @@ __cgfsng_ops static void cgfsng_monitor_destroy(struct cgroup_ops *ops,
 			pivot_path = must_make_path(h->mountpoint,
 						    h->container_base_path,
 						    conf->cgroup_meta.dir,
-						    "lxc.pivot",
+						    PIVOT_CGROUP,
 						    "cgroup.procs", NULL);
 		else
 			pivot_path = must_make_path(h->mountpoint,
 						    h->container_base_path,
-						    "lxc.pivot",
+						    PIVOT_CGROUP,
 						    "cgroup.procs", NULL);
 
 		ret = mkdir_p(pivot_path, 0755);
@@ -2714,7 +2714,7 @@ __cgfsng_ops static bool cgfsng_data_init(struct cgroup_ops *ops)
 		return false;
 	}
 	ops->cgroup_pattern = must_copy_string(cgroup_pattern);
-	ops->monitor_pattern = must_copy_string("lxc.monitor");
+	ops->monitor_pattern = MONITOR_CGROUP;
 
 	return true;
 }

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1465,10 +1465,10 @@ __cgfsng_ops static bool __do_cgroup_enter(struct cgroup_ops *ops, pid_t pid,
 					     bool monitor)
 {
 	int len;
-	char pidstr[25];
+	char pidstr[INTTYPE_TO_STRLEN(pid_t)];
 
-	len = snprintf(pidstr, 25, "%d", pid);
-	if (len < 0 || len >= 25)
+	len = snprintf(pidstr, sizeof(pidstr), "%d", pid);
+	if (len < 0 || (size_t)len >= sizeof(pidstr))
 		return false;
 
 	for (int i = 0; ops->hierarchies[i]; i++) {
@@ -2097,10 +2097,10 @@ __cgfsng_ops static bool cgfsng_attach(struct cgroup_ops *ops, const char *name,
 					 const char *lxcpath, pid_t pid)
 {
 	int i, len, ret;
-	char pidstr[25];
+	char pidstr[INTTYPE_TO_STRLEN(pid_t)];
 
-	len = snprintf(pidstr, 25, "%d", pid);
-	if (len < 0 || len >= 25)
+	len = snprintf(pidstr, sizeof(pidstr), "%d", pid);
+	if (len < 0 || (size_t)len >= sizeof(pidstr))
 		return false;
 
 	for (i = 0; ops->hierarchies[i]; i++) {

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1111,7 +1111,8 @@ static int cgroup_rmdir_wrapper(void *data)
 	return cgroup_rmdir(arg->hierarchies, arg->container_cgroup);
 }
 
-__cgfsng_ops static void cgfsng_destroy(struct cgroup_ops *ops, struct lxc_handler *handler)
+__cgfsng_ops__ static void cgfsng_payload_destroy(struct cgroup_ops *ops,
+		struct lxc_handler *handler)
 {
 	int ret;
 	struct generic_userns_exec_data wrap;
@@ -2681,7 +2682,7 @@ struct cgroup_ops *cgfsng_ops_init(struct lxc_conf *conf)
 	}
 
 	cgfsng_ops->data_init = cgfsng_data_init;
-	cgfsng_ops->destroy = cgfsng_destroy;
+	cgfsng_ops->destroy = cgfsng_payload_destroy;
 	cgfsng_ops->monitor_create = cgfsng_monitor_create;
 	cgfsng_ops->monitor_enter = cgfsng_monitor_enter;
 	cgfsng_ops->payload_create = cgfsng_payload_create;

--- a/src/lxc/cgroups/cgroup.c
+++ b/src/lxc/cgroups/cgroup.c
@@ -76,7 +76,6 @@ void cgroup_exit(struct cgroup_ops *ops)
 
 	free(ops->cgroup_pattern);
 	free(ops->container_cgroup);
-	free(ops->monitor_pattern);
 
 	for (it = ops->hierarchies; it && *it; it++) {
 		char **ctrlr;

--- a/src/lxc/cgroups/cgroup.h
+++ b/src/lxc/cgroups/cgroup.h
@@ -28,6 +28,10 @@
 #include <stddef.h>
 #include <sys/types.h>
 
+#define PAYLOAD_CGROUP "lxc.payload"
+#define MONITOR_CGROUP "lxc.monitor"
+#define PIVOT_CGROUP "lxc.pivot"
+
 struct lxc_handler;
 struct lxc_conf;
 struct lxc_list;
@@ -96,6 +100,8 @@ struct cgroup_ops {
 	char **cgroup_use;
 	char *cgroup_pattern;
 	char *container_cgroup;
+
+	/* Static memory, do not free.*/
 	char *monitor_pattern;
 
 	/* @hierarchies

--- a/src/lxc/cgroups/cgroup.h
+++ b/src/lxc/cgroups/cgroup.h
@@ -129,7 +129,8 @@ struct cgroup_ops {
 	cgroup_layout_t cgroup_layout;
 
 	bool (*data_init)(struct cgroup_ops *ops);
-	void (*destroy)(struct cgroup_ops *ops, struct lxc_handler *handler);
+	void (*payload_destroy)(struct cgroup_ops *ops, struct lxc_handler *handler);
+	void (*monitor_destroy)(struct cgroup_ops *ops, struct lxc_handler *handler);
 	bool (*monitor_create)(struct cgroup_ops *ops, struct lxc_handler *handler);
 	bool (*monitor_enter)(struct cgroup_ops *ops, pid_t pid);
 	bool (*payload_create)(struct cgroup_ops *ops, struct lxc_handler *handler);

--- a/src/lxc/start.h
+++ b/src/lxc/start.h
@@ -103,6 +103,9 @@ struct lxc_handler {
 	/* The child's pid. */
 	pid_t pid;
 
+	/* The monitor's pid. */
+	pid_t monitor_pid;
+
 	/* Whether the child has already exited. */
 	bool init_died;
 


### PR DESCRIPTION
Since we switched to the new cgroup scoping scheme that places the
container payload into `lxc.payload/<container-name>` and
`lxc.monitor/<container-name>` deletion becomes slightly more complicated.
The monitor will be able to `rm_rf(lxc.payload/<container-name>)` but will
not be able to `rm_rf(lxc.monitor/<container-name>)` since it will be
located in that cgroup and it will thus be populated.
My current solution to this is to create a lxc.pivot cgroup that only
exists so that the monitor process on container stop can pivot into it,
call `rm_rf(lxc.monitor/<container-name>)` and can then exit. This group
has not function whatsoever apart from this and can thus be shared by
all monitor processes.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>