### PR TITLE
compiler: add __hot attribute

### DIFF
--- a/src/lxc/compiler.h
+++ b/src/lxc/compiler.h
@@ -46,6 +46,10 @@
 #endif
 #endif
 
+#ifndef __hot
+#	define __hot __attribute__((hot))
+#endif
+
 #define __cgfsng_ops
 
 #endif /* __LXC_COMPILER_H */

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -70,12 +70,13 @@
 
 lxc_log_define(confile, lxc);
 
-#define lxc_config_define(name)                                                \
-	static int set_config_##name(const char *, const char *,               \
-				     struct lxc_conf *, void *);               \
-	static int get_config_##name(const char *, char *, int,                \
-				     struct lxc_conf *, void *);               \
-	static int clr_config_##name(const char *, struct lxc_conf *, void *);
+#define lxc_config_define(name)                                             \
+	__hot static int set_config_##name(const char *, const char *,      \
+					   struct lxc_conf *, void *);      \
+	__hot static int get_config_##name(const char *, char *, int,       \
+					   struct lxc_conf *, void *);      \
+	__hot static int clr_config_##name(const char *, struct lxc_conf *, \
+					   void *);
 
 lxc_config_define(autodev);
 lxc_config_define(apparmor_allow_incomplete);

--- a/src/lxc/parse.h
+++ b/src/lxc/parse.h
@@ -26,16 +26,18 @@
 #include <stdio.h>
 #include <sys/types.h>
 
+#include "compiler.h"
+
 typedef int (*lxc_dir_cb)(const char *name, const char *directory,
 			  const char *file, void *data);
 
 typedef int (*lxc_file_cb)(char *buffer, void *data);
 
-extern int lxc_file_for_each_line(const char *file, lxc_file_cb callback,
-				  void* data);
+__hot extern int lxc_file_for_each_line(const char *file, lxc_file_cb callback,
+					void *data);
 
-extern int lxc_file_for_each_line_mmap(const char *file, lxc_file_cb callback,
-				       void *data);
+__hot extern int lxc_file_for_each_line_mmap(const char *file,
+					     lxc_file_cb callback, void *data);
 
 /* mmap() wrapper. lxc_strmmap() will take care to \0-terminate files so that
  * normal string-handling functions can be used on the buffer. */


### PR DESCRIPTION
This instructs the compiler to better optimize the config parsing code.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>