### PR TITLE
btrfs: fix btrfs containers

### DIFF
--- a/src/lxc/storage/btrfs.c
+++ b/src/lxc/storage/btrfs.c
@@ -366,6 +366,7 @@ int btrfs_snapshot(const char *orig, const char *new)
 		goto out;
 
 	memset(&args, 0, sizeof(args));
+	args.fd = fd;
 	retlen = strlcpy(args.name, newname, BTRFS_SUBVOL_NAME_MAX);
 	if (retlen >= BTRFS_SUBVOL_NAME_MAX)
 		goto out;


### PR DESCRIPTION
Closes #2655.

Fixes: 9de31d5a1394 ("tree-wide: s/strncpy()/strlcpy()/g")
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>