### PR TITLE
netns_ifaddrs: only use struct rtnl_link_stats64

### DIFF
--- a/src/include/netns_ifaddrs.c
+++ b/src/include/netns_ifaddrs.c
@@ -233,16 +233,13 @@ static int nl_msg_to_ifaddr(void *pctx, bool *netnsid_aware, struct nlmsghdr *h)
 #if HAVE_STRUCT_RTNL_LINK_STATS64
 			case IFLA_STATS64:
 				ifs->ifa.ifa_stats_type = IFLA_STATS64;
-				memcpy(&ifs->ifa.ifa_stats64, __RTA_DATA(rta),
-				       __RTA_DATALEN(rta));
-				break;
 #else
 			case IFLA_STATS:
 				ifs->ifa.ifa_stats_type = IFLA_STATS;
-				memcpy(&ifs->ifa.ifa_stats32, __RTA_DATA(rta),
+#endif
+				memcpy(&ifs->ifa.ifa_stats, __RTA_DATA(rta),
 				       __RTA_DATALEN(rta));
 				break;
-#endif
 			case IFLA_MTU:
 				memcpy(&ifs->ifa.ifa_mtu, __RTA_DATA(rta),
 				       sizeof(int));

--- a/src/include/netns_ifaddrs.h
+++ b/src/include/netns_ifaddrs.h
@@ -40,8 +40,11 @@ struct netns_ifaddrs {
 
 	/* These fields are not present struct ifaddrs. */
 	int ifa_stats_type;
-	struct rtnl_link_stats ifa_stats32;
-	struct rtnl_link_stats64 ifa_stats64;
+#if HAVE_STRUCT_RTNL_LINK_STATS64
+	struct rtnl_link_stats64 ifa_stats;
+#else
+	struct rtnl_link_stats ifa_stats;
+#endif
 };
 
 #define __ifa_broadaddr ifa_ifu.ifu_broadaddr


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>