### PR TITLE
parse: prefault config file with MAP_POPULATE

### DIFF
--- a/src/lxc/parse.c
+++ b/src/lxc/parse.c
@@ -88,7 +88,8 @@ int lxc_file_for_each_line_mmap(const char *file, lxc_file_cb callback,
 		return 0;
 	}
 
-	buf = lxc_strmmap(NULL, st.st_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+	buf = lxc_strmmap(NULL, st.st_size, PROT_READ | PROT_WRITE,
+			  MAP_PRIVATE | MAP_POPULATE, fd, 0);
 	if (buf == MAP_FAILED) {
 		close(fd);
 		return -1;


### PR DESCRIPTION
When we call lxc_file_for_each_line_mmap() we will always parse the
whole config file. Prefault it in case it is really long to optimize
performance.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>