### PR TITLE
start: change log level

### DIFF
--- a/src/lxc/file_utils.c
+++ b/src/lxc/file_utils.c
@@ -302,7 +302,7 @@ FILE *fopen_cloexec(const char *path, const char *mode)
 			open_mode |= O_EXCL;
 	open_mode |= O_CLOEXEC;
 
-	fd = open(path, open_mode, 0666);
+	fd = open(path, open_mode, 0660);
 	if (fd < 0)
 		return NULL;
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1798,7 +1798,7 @@ static int lxc_spawn(struct lxc_handler *handler)
 
 		ret = lxc_netns_set_nsid(handler->nsfd[LXC_NS_NET]);
 		if (ret < 0)
-			SYSERROR("Failed to allocate new network namespace id");
+			SYSWARN("Failed to allocate new network namespace id");
 		else
 			TRACE("Allocated new network namespace id");
 	}


### PR DESCRIPTION
Hello,

When nsid setting is failed, error level log is printed. But lxc_spawn() is working.

So, we changed a log level of this operation to sys warning.

Thanks.

Signed-off-by: 2xsec <dh48.jeong@samsung.com>