### PR TITLE
attach: fix missing pthread.h include

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -29,6 +29,7 @@
 #include <grp.h>
 #include <linux/unistd.h>
 #include <pwd.h>
+#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>