### PR TITLE
checkpoint: fix running do_dump()

### DIFF
--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -174,7 +174,8 @@ static int cmp_version(const char *v1, const char *v2)
 	return -1;
 }
 
-static void exec_criu(struct cgroup_ops *cgroup_ops, struct criu_opts *opts)
+static void exec_criu(struct cgroup_ops *cgroup_ops, struct lxc_conf *conf,
+		      struct criu_opts *opts)
 {
 	char **argv, log[PATH_MAX];
 	int static_args = 23, argc = 0, i, ret;
@@ -193,7 +194,7 @@ static void exec_criu(struct cgroup_ops *cgroup_ops, struct criu_opts *opts)
 	 * /actual/ root cgroup so that lxcfs thinks criu has enough rights to
 	 * see all cgroups.
 	 */
-	if (!cgroup_ops->escape(cgroup_ops, opts->handler->conf)) {
+	if (!cgroup_ops->escape(cgroup_ops, conf)) {
 		ERROR("failed to escape cgroups");
 		return;
 	}
@@ -1065,7 +1066,7 @@ static void do_restore(struct lxc_container *c, int status_pipe, struct migrate_
 		os.console_name = c->lxc_conf->console.name;
 
 		/* exec_criu() returning is an error */
-		exec_criu(cgroup_ops, &os);
+		exec_criu(cgroup_ops, c->lxc_conf, &os);
 		umount(rootfs->mount);
 		rmdir(rootfs->mount);
 		goto out_fini_handler;
@@ -1266,14 +1267,9 @@ static bool do_dump(struct lxc_container *c, char *mode, struct migrate_opts *op
 
 	if (pid == 0) {
 		struct criu_opts os;
-		struct lxc_handler h;
 		struct cgroup_ops *cgroup_ops;
 
 		close(criuout[0]);
-
-		lxc_zero_handler(&h);
-
-		h.name = c->name;
 
 		cgroup_ops = cgroup_init(c->lxc_conf);
 		if (!cgroup_ops) {
@@ -1281,7 +1277,6 @@ static bool do_dump(struct lxc_container *c, char *mode, struct migrate_opts *op
 			_exit(EXIT_FAILURE);
 			return -1;
 		}
-		h.cgroup_ops = cgroup_ops;
 
 		os.pipefd = criuout[1];
 		os.action = mode;
@@ -1289,6 +1284,7 @@ static bool do_dump(struct lxc_container *c, char *mode, struct migrate_opts *op
 		os.c = c;
 		os.console_name = c->lxc_conf->console.path;
 		os.criu_version = criu_version;
+		os.handler = NULL;
 
 		ret = save_tty_major_minor(opts->directory, c, os.tty_id, sizeof(os.tty_id));
 		if (ret < 0) {
@@ -1297,7 +1293,7 @@ static bool do_dump(struct lxc_container *c, char *mode, struct migrate_opts *op
 		}
 
 		/* exec_criu() returning is an error */
-		exec_criu(cgroup_ops, &os);
+		exec_criu(cgroup_ops, c->lxc_conf, &os);
 		free(criu_version);
 		_exit(EXIT_FAILURE);
 	} else {


### PR DESCRIPTION
Testing `lxc <container> stop --stateful` crashed LXD:
```
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0xe8 pc=0x7f3198ff0592]

runtime stack:
runtime.throw(0x117fe4a, 0x2a)
	/opt/rh/go-toolset-1.10/root/usr/lib/go-toolset-1.10-golang/src/runtime/panic.go:616 +0x81
runtime.sigpanic()
	/opt/rh/go-toolset-1.10/root/usr/lib/go-toolset-1.10-golang/src/runtime/signal_unix.go:372 +0x28e

goroutine 375 [syscall]:
runtime.cgocall(0xef38e3, 0xc420731630, 0x29)
	/opt/rh/go-toolset-1.10/root/usr/lib/go-toolset-1.10-golang/src/runtime/cgocall.go:128 +0x64 fp=0xc4207315f0 sp=0xc4207315b8 pc=0x410fc4
gopkg.in/lxc/go-lxc%2ev2._Cfunc_go_lxc_migrate(0x7f316c001220, 0xc400000001, 0xc420302460, 0xc4205d6080, 0x0)
	_cgo_gotypes.go:752 +0x4d fp=0xc420731630 sp=0xc4207315f0 pc=0x909d7d
gopkg.in/lxc/go-lxc%2ev2.(*Container).Migrate.func4(0x7f316c001220, 0xc400000001, 0xc420302460, 0xc4205d6080, 0x0)
	/share/go/src/gopkg.in/lxc/go-lxc.v2/container.go:1798 +0x160 fp=0xc420731668 sp=0xc420731630 pc=0x91b970
gopkg.in/lxc/go-lxc%2ev2.(*Container).Migrate(0xc4207a52f0, 0x1, 0xc42051ec00, 0x20, 0x0, 0x0, 0x0, 0x0, 0x101, 0x10000000, ...)
	/share/go/src/gopkg.in/lxc/go-lxc.v2/container.go:1798 +0x29f fp=0xc420731760 sp=0xc420731668 pc=0x9160ef
```
The commit 5a087e056f94 introduced a second parameter (conf) to the
cgroup escape() function which was never set in do_dump(). Instead of
taking it from opts->handler->conf it is now used from c->lxc_conf.

Fixes: 5a087e056f94 ("cgroups: don't escape if lxc.cgroup.keep is true")
Suggested-by: Christian Brauner <christian.brauner@ubuntu.com>
Signed-off-by: Adrian Reber <areber@redhat.com>