### PR TITLE
autools: use -fno-strict-aliasing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -694,6 +694,7 @@ AX_CHECK_COMPILE_FLAG([-fdiagnostics-color], [CFLAGS="$CFLAGS -fdiagnostics-colo
 AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough], [CFLAGS="$CFLAGS -Wimplicit-fallthrough"],,[-Werror])
 AX_CHECK_COMPILE_FLAG([-Wcast-align], [CFLAGS="$CFLAGS -Wcast-align"],,[-Werror])
 AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes], [CFLAGS="$CFLAGS -Wstrict-prototypes"],,[-Werror])
+AX_CHECK_COMPILE_FLAG([-fno-strict-aliasing], [CFLAGS="$CFLAGS -fno-strict-aliasing"],,[-Werror])
 
 AX_CHECK_LINK_FLAG([-z relro], [LDLAGS="$LDLAGS -z relro"],,[])
 AX_CHECK_LINK_FLAG([-z now], [LDLAGS="$LDLAGS -z now"],,[])


### PR DESCRIPTION
The gcc implementation and the C standard are not to be considered sane
in this respect. We don't want to risk reordering of writes when the
compiler incorrectly *thinks* two types do not alias each other.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>