### PR TITLE
confile: fix heap overflow issue

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -2048,8 +2048,8 @@ int append_unexp_config_line(const char *line, struct lxc_conf *conf)
 		if (!tmp)
 			return -1;
 
-		if (!conf->unexpanded_config)
-			*tmp = '\0';
+		memset(tmp + conf->unexpanded_alloced, 0, 1024);
+
 		conf->unexpanded_config = tmp;
 		conf->unexpanded_alloced += 1024;
 	}


### PR DESCRIPTION
Hello,

There is heap overflow issue when reading config file. This issue is detected by address sanitizer.

When realloc() is called to append config line to buffer, the buffer is not initialized.

So, strlcpy() accesses to invalid memory address. Here is backtrace,

==zone-launcher==1252==ERROR: AddressSanitizer: heap-buffer-overflow on address 0xb46a0d60 at pc 0xb617a629 bp 0xbe4099c0 sp 0xbe4099c4
READ of size 4 at 0xb46a0d60 thread T0
    #0 0xb617a627 in strlcpy
    #1 0xb617a6dd in strlcat
    #2 0xb6117ad9 in append_unexp_config_line
    #3 0xb6117cdb in parse_line
    #4 0xb614d27d in lxc_file_for_each_line_mmap
    #5 0xb611805b in lxc_config_read
    #6 0xb6130e53 in load_config_locked.isra.18
    #7 0xb6130f93 in do_lxcapi_load_config
    #8 0xb6133c29 in lxc_container_new

We added memset() to initialize buffer.

Thanks.

Signed-off-by: 2xsec <dh48.jeong@samsung.com>