### PR TITLE
string_utils: fix global buffer overflow issue

### DIFF
--- a/src/lxc/string_utils.c
+++ b/src/lxc/string_utils.c
@@ -784,24 +784,32 @@ char *must_make_path(const char *first, ...)
 	char *cur, *dest;
 	size_t full_len = strlen(first);
 	size_t buf_len;
+	size_t cur_len;
 
 	dest = must_copy_string(first);
+	cur_len = full_len;
 
 	va_start(args, first);
 	while ((cur = va_arg(args, char *)) != NULL) {
-		full_len += strlen(cur);
+		buf_len = strlen(cur);
+
+		full_len += buf_len;
 		if (cur[0] != '/')
 			full_len++;
 
-		buf_len = full_len + 1;
-		dest = must_realloc(dest, buf_len);
+		dest = must_realloc(dest, full_len + 1);
 
-		if (cur[0] != '/')
-			(void)strlcat(dest, "/", buf_len);
-		(void)strlcat(dest, cur, buf_len);
+		if (cur[0] != '/') {
+			memcpy(dest + cur_len, "/", 1);
+			cur_len++;
+		}
+
+		memcpy(dest + cur_len, cur, buf_len);
+		cur_len += buf_len;
 	}
 	va_end(args);
 
+	dest[cur_len] = '\0';
 	return dest;
 }
 
@@ -812,23 +820,32 @@ char *must_append_path(char *first, ...)
 	va_list args;
 	char *dest = first;
 	size_t buf_len;
+	size_t cur_len;
 
 	full_len = strlen(first);
+	cur_len = full_len;
+
 	va_start(args, first);
 	while ((cur = va_arg(args, char *)) != NULL) {
-		full_len += strlen(cur);
+		buf_len = strlen(cur);
+
+		full_len += buf_len;
 		if (cur[0] != '/')
 			full_len++;
 
-		buf_len = full_len + 1;
-		dest = must_realloc(dest, buf_len);
+		dest = must_realloc(dest, full_len + 1);
 
-		if (cur[0] != '/')
-			(void)strlcat(dest, "/", buf_len);
-		(void)strlcat(dest, cur, buf_len);
+		if (cur[0] != '/') {
+			memcpy(dest + cur_len, "/", 1);
+			cur_len++;
+		}
+
+		memcpy(dest + cur_len, cur, buf_len);
+		cur_len += buf_len;
 	}
 	va_end(args);
 
+	dest[cur_len] = '\0';
 	return dest;
 }
 


### PR DESCRIPTION
Hello,

There is additional overflow issue using must_make_path with realloc(). This issue is also detected by the address sanitizer.

We fixed this issue and must_append_path() also.

==zone-launcher==1030==ERROR: AddressSanitizer: global-buffer-overflow on address 0xb60f3ee0 at pc 0xb60a78d1 bp 0xbe16e5b0 sp 0xbe16e5b4
READ of size 4 at 0xb60f3ee0 thread T0
    #0 0xb60a78cf in strlcpy
    #1 0xb60a794d in strlcat
    #2 0xb6095305 in must_make_path
    #3 0xb5fe6079 in __do_cgroup_enter.isra.9
    #4 0xb60702c9 in __lxc_start
    #5 0xb6070cc9 in lxc_start
    #6 0xb6042577 in do_lxcapi_start
    #7 0xb604351d in lxcapi_start
    #8 0x4d1b31 in main
    #9 0xb5cdc867 in __libc_start_main

Thanks.

Signed-off-by: 2xsec <dh48.jeong@samsung.com>