### PR TITLE
replace read & write syscalls with nointr functions

### DIFF
--- a/src/lxc/caps.c
+++ b/src/lxc/caps.c
@@ -33,6 +33,7 @@
 
 #include "caps.h"
 #include "config.h"
+#include "file_utils.h"
 #include "log.h"
 #include "macro.h"
 
@@ -299,11 +300,8 @@ static long int _real_caps_last_cap(void)
 		char *ptr;
 		char buf[INTTYPE_TO_STRLEN(int)] = {0};
 
-	again:
-		n = read(fd, buf, STRARRAYLEN(buf));
-		if (n < 0 && errno == EINTR) {
-			goto again;
-		} else if (n >= 0) {
+		n = lxc_read_nointr(fd, buf, STRARRAYLEN(buf));
+		if (n >= 0) {
 			errno = 0;
 			result = strtol(buf, &ptr, 10);
 			if (!ptr || (*ptr != '\0' && *ptr != '\n') || errno != 0)

--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -41,6 +41,7 @@
 
 #include "caps.h"
 #include "config.h"
+#include "file_utils.h"
 #include "log.h"
 #include "lxccontainer.h"
 #include "utils.h"
@@ -360,12 +361,7 @@ static int log_append_logfile(const struct lxc_log_appender *appender,
 
 	buffer[n] = '\n';
 
-again:
-	ret = write(fd_to_use, buffer, n + 1);
-	if (ret < 0 && errno == EINTR)
-		goto again;
-
-	return ret;
+	return lxc_write_nointr(fd_to_use, buffer, n + 1);
 }
 
 #if HAVE_DLOG


### PR DESCRIPTION
Hello,

read & write syscalls are replaced to nointr functions.

Thanks.