### PR TITLE
Adds -qq flags to lvcreate commands

### DIFF
--- a/src/lxc/storage/lvm.c
+++ b/src/lxc/storage/lvm.c
@@ -75,11 +75,11 @@ static int lvm_create_exec_wrapper(void *data)
 
 	(void)setenv("LVM_SUPPRESS_FD_WARNINGS", "1", 1);
 	if (args->thinpool)
-		execlp("lvcreate", "lvcreate", "--thinpool", args->thinpool,
+		execlp("lvcreate", "lvcreate", "-qq", "--thinpool", args->thinpool,
 		       "-V", args->size, args->vg, "-n", args->lv,
 		       (char *)NULL);
 	else
-		execlp("lvcreate", "lvcreate", "-L", args->size, args->vg, "-n",
+		execlp("lvcreate", "lvcreate", "-qq", "-L", args->size, args->vg, "-n",
 		       args->lv, (char *)NULL);
 
 	return -1;


### PR DESCRIPTION
Adds `-qq` flags to lvcreate commands to avoid answer 'no' to any questions the LVM subsystem asks to avoid hanging the `lxc-create` command.

See http://man7.org/linux/man-pages/man8/lvcreate.8.html

```
       -q|--quiet ...
              Suppress output and log messages. Overrides --debug and
              --verbose.  Repeat once to also suppress any prompts with
              answer 'no'.
```

Fixes: https://github.com/lxc/lxc/issues/2346