### PR TITLE
utils: make keyring allocation failure non-fatal

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1807,7 +1807,6 @@ int lxc_setup_keyring(void)
 			break;
 		default:
 			SYSERROR("Failed to create kernel keyring");
-			ret = -1;
 			break;
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>