### PR TITLE
autotools: fix lxc-{create,copy} build

### DIFF
--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -42,6 +42,7 @@ noinst_HEADERS = api_extensions.h \
 		 terminal.h \
 		 ../tests/lxctest.h \
 		 tools/arguments.h \
+		 storage/storage_utils.h \
 		 utils.h
 
 if IS_BIONIC
@@ -323,7 +324,8 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 lxc_ls_SOURCES = tools/lxc_ls.c \
 		 tools/arguments.c tools/arguments.h
 lxc_copy_SOURCES = tools/lxc_copy.c \
-		   tools/arguments.c tools/arguments.h
+		   tools/arguments.c tools/arguments.h \
+		   storage/storage_utils.c storage/storage_utils.h
 lxc_start_SOURCES = tools/lxc_start.c \
 		    tools/arguments.c tools/arguments.h
 lxc_stop_SOURCES = tools/lxc_stop.c \
@@ -337,7 +339,8 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 lxc_wait_SOURCES = tools/lxc_wait.c \
 		   tools/arguments.c tools/arguments.h
 lxc_create_SOURCES = tools/lxc_create.c \
-		     tools/arguments.c tools/arguments.h
+		     tools/arguments.c tools/arguments.h \
+		     storage/storage_utils.c storage/storage_utils.h
 lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       tools/arguments.c tools/arguments.h
 lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \


### PR DESCRIPTION
After commit 2b670df lxc-create and lxc-copy fails with "undefined
symbol: get_fssize".

Closes #2730

Signed-off-by: Radostin Stoyanov <rstoyanov1@gmail.com>