### PR TITLE
cgfsng: remove freezer requirement

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -703,11 +703,6 @@ static bool all_controllers_found(struct cgroup_ops *ops)
 	char **cur;
 	struct hierarchy **hlist = ops->hierarchies;
 
-	if (!controller_found(hlist, "freezer")) {
-		ERROR("No freezer controller mountpoint found");
-		return false;
-	}
-
 	if (!ops->cgroup_use)
 		return true;
 


### PR DESCRIPTION
The freezer controller has been made optional in all other codepaths so
don't require it.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>