### PR TITLE
stringutils: include stdarg for va_list

### DIFF
--- a/src/lxc/string_utils.h
+++ b/src/lxc/string_utils.h
@@ -20,6 +20,8 @@
 #ifndef __LXC_STRING_UTILS_H
 #define __LXC_STRING_UTILS_H
 
+#include <stdarg.h>
+
 #include "config.h"
 
 #include "initutils.h"


### PR DESCRIPTION
Fixes:
 - http://autobuild.buildroot.org/results/0b90e7dca2984652842832a41abad93ac49a9b86

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>