### PR TITLE
CMD log macros: append a newline

### DIFF
--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -452,16 +452,16 @@ ATTR_UNUSED static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 		ERROR("%s - " format, ptr, ##__VA_ARGS__); \
 	} while (0)
 
-#define CMD_SYSERROR(format, ...)                                    \
-	do {                                                         \
-		lxc_log_strerror_r;                                  \
-		fprintf(stderr, "%s - " format, ptr, ##__VA_ARGS__); \
+#define CMD_SYSERROR(format, ...)                                      \
+	do {                                                           \
+		lxc_log_strerror_r;                                    \
+		fprintf(stderr, "%s - \n" format, ptr, ##__VA_ARGS__); \
 	} while (0)
 
-#define CMD_SYSINFO(format, ...)                            \
-	do {                                                \
-		lxc_log_strerror_r;                         \
-		printf("%s - " format, ptr, ##__VA_ARGS__); \
+#define CMD_SYSINFO(format, ...)                              \
+	do {                                                  \
+		lxc_log_strerror_r;                           \
+		printf("%s - \n" format, ptr, ##__VA_ARGS__); \
 	} while (0)
 
 extern int lxc_log_fd;


### PR DESCRIPTION
The log appenders for the regular log macros append a newline as necessary,
and the usage of these is written so it does to. So, let's add a newline.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>