### PR TITLE
fix #2742: lxc-cgroup not giving output

### DIFF
--- a/src/lxc/tools/lxc_cgroup.c
+++ b/src/lxc/tools/lxc_cgroup.c
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 		}
 
-		INFO("%*s", ret, buffer);
+		printf("%*s", ret, buffer);
 	}
 
 	lxc_container_put(c);

--- a/src/lxc/tools/lxc_cgroup.c
+++ b/src/lxc/tools/lxc_cgroup.c
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 		}
 
-		printf("%*s", ret, buffer);
+		printf("%*s\n", ret, buffer);
 	}
 
 	lxc_container_put(c);


### PR DESCRIPTION
lxc-cgroup fails to provide any output since the latest version ( #2742 ), this should fix it

Signed-off-by: Oguz Bektas <o.bektas@proxmox.com>