### PR TITLE
terminal: remove sigwinch command

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -665,7 +665,7 @@ static int lxc_cmd_stop_callback(int fd, struct lxc_cmd_req *req,
 }
 
 /*
- * lxc_cmd_terminal_winch: To process as if a SIGWINCH were received
+ * lxc_cmd_terminal_winch: noop
  *
  * @name      : name of container to connect to
  * @lxcpath   : the lxcpath in which the container is running
@@ -674,26 +674,14 @@ static int lxc_cmd_stop_callback(int fd, struct lxc_cmd_req *req,
  */
 int lxc_cmd_terminal_winch(const char *name, const char *lxcpath)
 {
-	int ret, stopped;
-	struct lxc_cmd_rr cmd = {
-		.req = { .cmd = LXC_CMD_TERMINAL_WINCH },
-	};
-
-	ret = lxc_cmd(name, &cmd, &stopped, lxcpath, NULL);
-	if (ret < 0)
-		return ret;
-
 	return 0;
 }
 
 static int lxc_cmd_terminal_winch_callback(int fd, struct lxc_cmd_req *req,
 					   struct lxc_handler *handler)
 {
-	struct lxc_cmd_rsp rsp = { .data = 0 };
-
-	lxc_terminal_sigwinch(SIGWINCH);
-
-	return lxc_cmd_rsp_send(fd, &rsp);
+	/* should never be called */
+	return -1;
 }
 
 /*

--- a/src/lxc/terminal.h
+++ b/src/lxc/terminal.h
@@ -68,12 +68,6 @@ struct lxc_terminal_state {
 	 */
 	int saw_escape;
 
-	/* Name of the container to forward the SIGWINCH event to. */
-	const char *winch_proxy;
-
-	/* Path of the container to forward the SIGWINCH event to. */
-	const char *winch_proxy_lxcpath;
-
 	/* File descriptor that accepts signals. If set to -1 no signal handler
 	 * could be installed. This also means that the sigset_t oldmask member
 	 * is meaningless.


### PR DESCRIPTION
SIGWINCH is handled in lxc_terminal_signalfd_cb().

I cannot for the life of me figure out what this is supposed to do.
Afaict, it scans a global list that is totally unnecessary and also
let's say you have 100 ttys and for a single one SIGWINCH is sent. In
that case the whole list is walked and two ioctl()s are performed: one
to get window size one to set window size. For 99 of them the window
size hasn't changed.
If we see issues we can revert!

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>