### PR TITLE
apparmor: allow various remount,bind options

### DIFF
--- a/config/apparmor/abstractions/container-base
+++ b/config/apparmor/abstractions/container-base
@@ -120,6 +120,16 @@
   mount options=(rw,bind) /sy[^s]*{,/**},
   mount options=(rw,bind) /sys?*{,/**},
 
+  # allow various ro-bind-*re*-mounts
+  mount options=(ro,remount,bind),
+  mount options=(ro,remount,bind,nosuid),
+  mount options=(ro,remount,bind,noexec),
+  mount options=(ro,remount,bind,nodev),
+  mount options=(ro,remount,bind,nosuid,noexec),
+  mount options=(ro,remount,bind,noexec,nodev),
+  mount options=(ro,remount,bind,nodev,nosuid),
+  mount options=(ro,remount,bind,nosuid,noexec,nodev),
+
   # allow moving mounts except for /proc, /sys and /dev
   mount options=(rw,move) /[^spd]*{,/**},
   mount options=(rw,move) /d[^e]*{,/**},

--- a/config/apparmor/abstractions/container-base.in
+++ b/config/apparmor/abstractions/container-base.in
@@ -119,6 +119,16 @@
   mount options=(rw,bind) /sy[^s]*{,/**},
   mount options=(rw,bind) /sys?*{,/**},
 
+  # allow various ro-bind-*re*-mounts
+  mount options=(ro,remount,bind),
+  mount options=(ro,remount,bind,nosuid),
+  mount options=(ro,remount,bind,noexec),
+  mount options=(ro,remount,bind,nodev),
+  mount options=(ro,remount,bind,nosuid,noexec),
+  mount options=(ro,remount,bind,noexec,nodev),
+  mount options=(ro,remount,bind,nodev,nosuid),
+  mount options=(ro,remount,bind,nosuid,noexec,nodev),
+
   # allow moving mounts except for /proc, /sys and /dev
   mount options=(rw,move) /[^spd]*{,/**},
   mount options=(rw,move) /d[^e]*{,/**},
@@ -136,4 +146,3 @@
   mount options=(rw,move) /s[^y]*{,/**},
   mount options=(rw,move) /sy[^s]*{,/**},
   mount options=(rw,move) /sys?*{,/**},
-


### PR DESCRIPTION
RW bind mounts need to be restricted for some paths in
order to avoid MAC restriction bypasses, but read-only bind
mounts shouldn't have that problem.

Additionally, combinations of 'nosuid', 'nodev' and
'noexec' flags shouldn't be a problem either and are
required with newer systemd versions, so let's allow those
as long as they're combined with 'ro,remount,bind'.

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>
(cherry picked from commit e6ec0a9e71aa68c9fd67c691a62aaae87e356cef)