### PR TITLE
Update lxc.spec.in

### DIFF
--- a/lxc.spec.in
+++ b/lxc.spec.in
@@ -239,7 +239,8 @@ fi
 %endif
 %{_datadir}/doc/*
 %{_datadir}/lxc/*
-%{_sysconfdir}/bash_completion.d
+#%{_sysconfdir}/bash_completion.d
+/usr/share/bash-completion/completions/lxc
 %config(noreplace) %{_sysconfdir}/lxc/*
 %config(noreplace) %{_sysconfdir}/sysconfig/*
 


### PR DESCRIPTION
```
Processing files: lxc-3.1.0-1.el7.x86_64
error: File not found: /root/rpmbuild/BUILDROOT/lxc-3.1.0-1.el7.x86_64/etc/bash_completion.d


RPM build errors:
    File not found: /root/rpmbuild/BUILDROOT/lxc-3.1.0-1.el7.x86_64/etc/bash_completion.d
[root@localhost SPECS]# 

```