### PR TITLE
conf: use SYSERROR on lxc_write_to_file errors

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2681,8 +2681,8 @@ int setup_sysctl_parameters(struct lxc_list *sysctls)
 		ret = lxc_write_to_file(filename, elem->value,
 					strlen(elem->value), false, 0666);
 		if (ret < 0) {
-			ERROR("Failed to setup sysctl parameters %s to %s",
-			      elem->key, elem->value);
+			SYSERROR("Failed to setup sysctl parameters %s to %s",
+			         elem->key, elem->value);
 			return -1;
 		}
 	}
@@ -2716,8 +2716,8 @@ int setup_proc_filesystem(struct lxc_list *procs, pid_t pid)
 		ret = lxc_write_to_file(filename, elem->value,
 					strlen(elem->value), false, 0666);
 		if (ret < 0) {
-			ERROR("Failed to setup proc filesystem %s to %s",
-			      elem->filename, elem->value);
+			SYSERROR("Failed to setup proc filesystem %s to %s",
+			         elem->filename, elem->value);
 			return -1;
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>