### PR TITLE
Revert "Set c to NULL after freeing it"

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -299,7 +299,6 @@ static void lxc_container_free(struct lxc_container *c)
 	c->config_path = NULL;
 
 	free(c);
-	c = NULL;
 }
 
 /* Consider the following case:


### PR DESCRIPTION
Reverts lxc/lxc#2763 as it is unnecessary to set c to NULL after free in this case.

See; https://github.com/lxc/lxc/pull/2763#issuecomment-450723571