### PR TITLE
lxccontainer: fix container copy

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3691,7 +3691,7 @@ static int clone_update_rootfs(struct clone_update_data *data)
 		}
 	} else { /* TODO come up with a better way */
 		free(bdev->dest);
-		bdev->dest = strdup(bdev->src);
+		bdev->dest = strdup(lxc_storage_get_path(bdev->src, bdev->type));
 	}
 
 	if (!lxc_list_empty(&conf->hooks[LXCHOOK_CLONE])) {


### PR DESCRIPTION
We need to strip the prefix from the container's source path before
trying to update the file.

Closes #2380.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>