### PR TITLE
confile: add lxc.seccomp.allow_nesting

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -1823,6 +1823,19 @@ dev/null proc/kcore none bind,relative 0 0
              </para>
           </listitem>
         </varlistentry>
+        <varlistentry>
+          <term>
+            <option>lxc.seccomp.allow_nesting</option>
+          </term>
+          <listitem>
+            <para>
+	      If this flag is set to 1, then seccomp filters will be stacked
+	      regardless of whether a seccomp profile is already loaded.
+	      This allows nested containers to load their own seccomp profile.
+	      The default setting is 0.
+             </para>
+          </listitem>
+        </varlistentry>
       </variablelist>
     </refsect2>
 

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -41,6 +41,7 @@ static char *api_extensions[] = {
 	"mount_injection",
 	"cgroup_relative",
 	"mount_injection_file",
+	"seccomp_allow_nesting",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -296,6 +296,7 @@ struct lxc_conf {
 	char *lsm_se_context;
 	bool tmp_umount_proc;
 	char *seccomp;  /* filename with the seccomp rules */
+	unsigned int seccomp_allow_nesting;
 #if HAVE_SCMP_FILTER_CTX
 	scmp_filter_ctx seccomp_ctx;
 #endif

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1096,13 +1096,16 @@ bad_line:
  *   1. seccomp is not enabled in the kernel
  *   2. a seccomp policy is already enabled for this task
  */
-static bool use_seccomp(void)
+static bool use_seccomp(const struct lxc_conf *conf)
 {
 	int ret, v;
 	FILE *f;
 	size_t line_bufsz = 0;
 	char *line = NULL;
 	bool already_enabled = false, found = false;
+
+	if (conf->seccomp_allow_nesting > 0)
+		return true;
 
 	f = fopen("/proc/self/status", "r");
 	if (!f)
@@ -1143,7 +1146,7 @@ int lxc_read_seccomp_config(struct lxc_conf *conf)
 	if (!conf->seccomp)
 		return 0;
 
-	if (!use_seccomp())
+	if (!use_seccomp(conf))
 		return 0;
 
 #if HAVE_SCMP_FILTER_CTX
@@ -1198,7 +1201,7 @@ int lxc_seccomp_load(struct lxc_conf *conf)
 	if (!conf->seccomp)
 		return 0;
 
-	if (!use_seccomp())
+	if (!use_seccomp(conf))
 		return 0;
 
 #if HAVE_SCMP_FILTER_CTX


### PR DESCRIPTION
This adds the lxc.seccomp.allow_nesting api extension. If
lxc.seccomp.allow_nesting is set to 1 then seccomp profiles will be
stacked. This way nested containers can load their own seccomp policy on
top of the policy that the outer container might have applied.

Cc: Simon Fels <simon.fels@canonical.com>
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>