### PR TITLE
cgfsng: do not free container_full_path on error

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1319,8 +1319,6 @@ again:
 		if (!create_path_for_hierarchy(ops->hierarchies[i], container_cgroup)) {
 			int j;
 			ERROR("Failed to create cgroup \"%s\"", ops->hierarchies[i]->container_full_path);
-			free(ops->hierarchies[i]->container_full_path);
-			ops->hierarchies[i]->container_full_path = NULL;
 			for (j = 0; j < i; j++)
 				remove_path_for_hierarchy(ops->hierarchies[j], container_cgroup);
 			idx++;


### PR DESCRIPTION
Closes #2741.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>