### PR TITLE
trivial fix: unprivileged veth devices (e.g. vethFWABHX) never contain 'Z' char

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -1982,9 +1982,9 @@ char *lxc_mkifname(char *template)
 		for (i = 0; i < strlen(name); i++) {
 			if (name[i] == 'X') {
 #ifdef HAVE_RAND_R
-				name[i] = padchar[rand_r(&seed) % (strlen(padchar) - 1)];
+				name[i] = padchar[rand_r(&seed) % strlen(padchar)];
 #else
-				name[i] = padchar[rand() % (strlen(padchar) - 1)];
+				name[i] = padchar[rand() % strlen(padchar)];
 #endif
 			}
 		}


### PR DESCRIPTION
unprivileged veth devices (e.g. vethFWABHX) never contain 'Z' character in the randomly generated device name part because for modulo one does not need to substract 1 from strlen().