### PR TITLE
Fixing compile error when compiling for android

### DIFF
--- a/src/include/lxcmntent.c
+++ b/src/include/lxcmntent.c
@@ -24,6 +24,7 @@
 #include <alloca.h>
 #include <mntent.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "../lxc/macro.h"
 


### PR DESCRIPTION
Fixing compile error when compiling for android 

```
	mv -f $depbase.Tpo $depbase.Po
../include/lxcmntent.c:145:30: error: implicitly declaring library function 'malloc' with type 'void *(unsigned long)' [-Werror,-Wimplicit-function-declaration]
                getmntent_buffer = (char *)malloc(LXC_MAX_BUFFER);
                                           ^
../include/lxcmntent.c:145:30: note: include the header <stdlib.h> or explicitly provide a declaration for 'malloc'
1 error generated.
```

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>