### PR TITLE
wishlist: prefix veth interface name with uid info

### DIFF
--- a/src/lxc/cmd/lxc_user_nic.c
+++ b/src/lxc/cmd/lxc_user_nic.c
@@ -711,6 +711,7 @@ static char *get_nic_if_avail(int fd, struct alloted_s *names, int pid,
 	struct stat sb;
 	struct alloted_s *n;
 	char *buf = NULL;
+	uid_t uid;
 
 	for (n = names; n != NULL; n = n->next)
 		cull_entries(fd, n->name, intype, br, NULL, NULL);
@@ -753,7 +754,13 @@ static char *get_nic_if_avail(int fd, struct alloted_s *names, int pid,
 	if (!owner)
 		return NULL;
 
-	ret = snprintf(nicname, sizeof(nicname), "vethXXXXXX");
+        uid = getuid();
+        /* for POSIX integer uids the network device name schema is vethUID_XXXXX */
+        if (uid > 0 && uid <= 65536) {
+	        ret = snprintf(nicname, sizeof(nicname), "veth%d_XXXXX", uid);
+	} else {
+	        ret = snprintf(nicname, sizeof(nicname), "vethXXXXXX");
+	}
 	if (ret < 0 || (size_t)ret >= sizeof(nicname))
 		return NULL;
 

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -1953,8 +1953,6 @@ char *lxc_mkifname(char *template)
 	char name[IFNAMSIZ];
 	bool exists = false;
 	size_t i = 0;
-	uid_t uid = getuid();
-	unsigned int uidpad;
 #ifdef HAVE_RAND_R
 	unsigned int seed;
 
@@ -1980,21 +1978,14 @@ char *lxc_mkifname(char *template)
 		(void)strlcpy(name, template, IFNAMSIZ);
 
 		exists = false;
-		uidpad = (unsigned int) uid;
 
 		for (i = 0; i < strlen(name); i++) {
 			if (name[i] == 'X') {
-				/* insert max 4 chars UID info, 1679615 = base36 'ZZZZ' */
-				if (uidpad > 0 && uidpad <= 1679615) {
-					name[i] = padchar[uidpad % strlen(padchar)];
-					uidpad /= strlen(padchar);
-				} else {
 #ifdef HAVE_RAND_R
-					name[i] = padchar[rand_r(&seed) % strlen(padchar)];
+				name[i] = padchar[rand_r(&seed) % strlen(padchar)];
 #else
-					name[i] = padchar[rand() % strlen(padchar)];
+				name[i] = padchar[rand() % strlen(padchar)];
 #endif
-				}
 			}
 		}
 


### PR DESCRIPTION
For unprivileged containers, LXC auto-generates a random veth device name (the lxc.network.veth.pair option has no effect). With this patch, the auto-generated name will be prefixed with the reverse-ordered base36-encoded UID of the calling user. This makes it possible to narrow down your firewall rules.

Example: For LXC containers started by uid 713 the veth device name will always start with 'vethTJ' (decimal 713 = 'JT' base36). Now one can insert an iptables rule like 'iptables -i vethTJ+ ...'.

For uids up to 1679615 this will decrease the randomness of the device name to 1295, so make sure to limit the total number of veth bridges per unprivileged user (/etc/lxc/lxc-usernet) to a number well below this (side note: anyone using an LXC setup with 1000+ veth bridges per user?)

(actually, I do not expect this patch to be merged, maybe this is helpful as a starting point for further discussion)

Signed-off-by: Hajo Noerenberg <hajo-github@noerenberg.de>