### PR TITLE
start: handle missing CLONE_NEWCGROUP

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1252,10 +1252,16 @@ static int do_start(void *data)
 	if (handler->ns_clone_flags & CLONE_NEWCGROUP) {
 		ret = unshare(CLONE_NEWCGROUP);
 		if (ret < 0) {
-			INFO("Failed to unshare CLONE_NEWCGROUP");
-			goto out_warn_father;
+			if (errno != EINVAL) {
+				SYSERROR("Failed to unshare CLONE_NEWCGROUP");
+				goto out_warn_father;
+			}
+
+			handler->ns_clone_flags &= ~CLONE_NEWCGROUP;
+			SYSINFO("Kernel does not support CLONE_NEWCGROUP");
+		} else {
+			INFO("Unshared CLONE_NEWCGROUP");
 		}
-		INFO("Unshared CLONE_NEWCGROUP");
 	}
 
 	/* Add the requested environment variables to the current environment to


### PR DESCRIPTION
If cgroup namespaces are not supported we should just record it in the
log and move on.

Cc: Ondrej Kubik <ondrej.kubik@canonical.com>
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>