### PR TITLE
Revert "conf: remove extra MS_BIND with sysfs:mixed"

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -690,6 +690,7 @@ static int lxc_mount_auto_mounts(struct lxc_conf *conf, int flags, struct lxc_ha
 		{ LXC_AUTO_SYS_MASK,  LXC_AUTO_SYS_RW,     "sysfs",                                          "%r/sys",                     "sysfs", 0,                                               NULL },
 		{ LXC_AUTO_SYS_MASK,  LXC_AUTO_SYS_RO,     "sysfs",                                          "%r/sys",                     "sysfs", MS_RDONLY,                                       NULL },
 		{ LXC_AUTO_SYS_MASK,  LXC_AUTO_SYS_MIXED,  "sysfs",                                          "%r/sys",                     "sysfs", MS_NODEV|MS_NOEXEC|MS_NOSUID,                    NULL },
+		{ LXC_AUTO_SYS_MASK,  LXC_AUTO_SYS_MIXED,  "%r/sys",                                         "%r/sys",                     NULL,    MS_BIND,                                         NULL },
 		{ LXC_AUTO_SYS_MASK,  LXC_AUTO_SYS_MIXED,  NULL,                                             "%r/sys",                     NULL,    MS_REMOUNT|MS_BIND|MS_RDONLY,                    NULL },
 		{ LXC_AUTO_SYS_MASK,  LXC_AUTO_SYS_MIXED,  "sysfs",                                          "%r/sys/devices/virtual/net", "sysfs", 0,                                               NULL },
 		{ LXC_AUTO_SYS_MASK,  LXC_AUTO_SYS_MIXED,  "%r/sys/devices/virtual/net/devices/virtual/net", "%r/sys/devices/virtual/net", NULL,    MS_BIND,                                         NULL },


### PR DESCRIPTION
The above commit reverted here confuses the mountall unit of privileged
Ubuntu 14.04 containers at startup so that they cannot finish booting.

This effectively reverts the commit fixing #2602.
@tommyknows, was there any actual breakage causing you to open #2602 or was it just about mount cleanliness? Because apparently removing that mount confuses 14.04 containers, and while that's certainly a bug on the container's side reverting this is the simplest solution if there's no harm in it. Otherwise if there was any breakage from the mount entry I'll instead make a patch to make this configurable.