### PR TITLE
conf.c: fix memory leak and mount error

### DIFF
--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -462,5 +462,6 @@ extern int lxc_clear_sysctls(struct lxc_conf *c, const char *key);
 extern int setup_proc_filesystem(struct lxc_list *procs, pid_t pid);
 extern int lxc_clear_procs(struct lxc_conf *c, const char *key);
 extern int lxc_clear_apparmor_raw(struct lxc_conf *c);
+extern int lxc_clear_namespace(struct lxc_conf *c);
 
 #endif /* __LXC_CONF_H */


### PR DESCRIPTION
1. cleanup namespace memory
2. fix bug when ro mount not setted, mount propagation will be skipped.

Signed-off-by: t00416110 <tanyifeng1@huawei.com>