### PR TITLE
Fix memory leak in cgroup_exit

### DIFF
--- a/src/lxc/cgroups/cgroup.c
+++ b/src/lxc/cgroups/cgroup.c
@@ -96,6 +96,8 @@ void cgroup_exit(struct cgroup_ops *ops)
 	}
 	free(ops->hierarchies);
 
+	free(ops);
+
 	return;
 }
 


### PR DESCRIPTION
Add free memory pointed by struct cgroup_ops *ops

Signed-off-by: LiFeng <lifeng68@huawei.com>