### PR TITLE
Fixing hooks functionality Android where 'sh' is placed under /system

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -447,7 +447,12 @@ struct lxc_popen_FILE *lxc_popen(const char *command)
 		if (ret < 0)
 			_exit(EXIT_FAILURE);
 
-		execl("/bin/sh", "sh", "-c", command, (char *)NULL);
+		/* check if /bin/sh exist, otherwise try Android location /system/bin/sh */
+		if (file_exists("/bin/sh"))
+			execl("/bin/sh", "sh", "-c", command, (char *)NULL);
+		else
+			execl("/system/bin/sh", "sh", "-c", command, (char *)NULL);
+
 		_exit(127);
 	}
 


### PR DESCRIPTION
On android system sh is located at /system/bin/sh
If /bin/sh does not exist, try /system/bin/sh

Signed-off-by: ondra <ondrak@localhost.localdomain>