### PR TITLE
Avoid risk of "too far memory read"

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -896,7 +896,7 @@ static int lxc_cmd_add_state_client_callback(int fd, struct lxc_cmd_req *req,
 	if (req->datalen < 0)
 		goto reap_client_fd;
 
-	if (req->datalen > (sizeof(lxc_state_t) * MAX_STATE))
+	if (req->datalen != (sizeof(lxc_state_t) * MAX_STATE))
 		goto reap_client_fd;
 
 	if (!req->data)


### PR DESCRIPTION
As we call "lxc_add_state_client(fd, handler, (lxc_state_t *)req->data)"
which supposes that the last parameter is a table of MAX_STATE
entries when calling memcpy():
memcpy(newclient->states, states, sizeof(newclient->states))

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>