### PR TITLE
freezer: non-functional changes

### DIFF
--- a/src/lxc/freezer.c
+++ b/src/lxc/freezer.c
@@ -51,11 +51,11 @@ static int do_freeze_thaw(bool freeze, struct lxc_conf *conf, const char *name,
 	int ret;
 	char v[100];
 	struct cgroup_ops *cgroup_ops;
-        const char *state;
+	const char *state;
 	size_t state_len;
 	lxc_state_t new_state = freeze ? FROZEN : THAWED;
 
-        state = lxc_state2str(new_state);
+	state = lxc_state2str(new_state);
 	state_len = strlen(state);
 
 	cgroup_ops = cgroup_init(conf);
@@ -65,19 +65,21 @@ static int do_freeze_thaw(bool freeze, struct lxc_conf *conf, const char *name,
 	ret = cgroup_ops->set(cgroup_ops, "freezer.state", state, name, lxcpath);
 	if (ret < 0) {
 		cgroup_exit(cgroup_ops);
-		ERROR("Failed to %s %s", (new_state == FROZEN ? "freeze" : "unfreeze"), name);
+		ERROR("Failed to %s %s",
+		      (new_state == FROZEN ? "freeze" : "unfreeze"), name);
 		return -1;
 	}
 
 	for (;;) {
-		ret = cgroup_ops->get(cgroup_ops, "freezer.state", v, sizeof(v), name, lxcpath);
+		ret = cgroup_ops->get(cgroup_ops, "freezer.state", v, sizeof(v),
+				      name, lxcpath);
 		if (ret < 0) {
 			cgroup_exit(cgroup_ops);
 			ERROR("Failed to get freezer state of %s", name);
 			return -1;
 		}
 
-		v[sizeof(v)-1] = '\0';
+		v[sizeof(v) - 1] = '\0';
 		v[lxc_char_right_gc(v, strlen(v))] = '\0';
 
 		ret = strncmp(v, state, state_len);

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -527,15 +527,12 @@ static bool do_lxcapi_freeze(struct lxc_container *c)
 	int ret;
 	lxc_state_t s;
 
-	if (!c)
+	if (!c || !c->lxc_conf)
 		return false;
 
 	s = lxc_getstate(c->name, c->config_path);
-	if (s != FROZEN) {
-	  ret = lxc_freeze(c->lxc_conf, c->name, c->config_path);
-	  if (ret < 0)
-	    return false;
-	}
+	if (s != FROZEN)
+		return lxc_freeze(c->lxc_conf, c->name, c->config_path) == 0;
 
 	return true;
 }
@@ -547,15 +544,12 @@ static bool do_lxcapi_unfreeze(struct lxc_container *c)
 	int ret;
 	lxc_state_t s;
 
-	if (!c)
+	if (!c || !c->lxc_conf)
 		return false;
 
 	s = lxc_getstate(c->name, c->config_path);
-	if (s == FROZEN) {
-	  ret = lxc_unfreeze(c->lxc_conf, c->name, c->config_path);
-	  if (ret < 0)
-	    return false;
-	}
+	if (s == FROZEN)
+		return lxc_unfreeze(c->lxc_conf, c->name, c->config_path) == 0;
 
 	return true;
 }


### PR DESCRIPTION
Fix the coding style in a few files.

Fixes: db1228b35f3e ("Avoid hardcoded string length")
Fixes: 71fc9c046816 ("Avoid risk of "too far memory read"")
Fixes: 2341916a0367 ("Avoid double lxc-freeze/unfreeze")
Fixes: 9eb9ce3e4778 ("Update freezer.c")
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>