### PR TITLE
Create /var/run

### DIFF
--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -69,6 +69,7 @@ ${rootfs}/sys \
 ${rootfs}/mnt \
 ${rootfs}/tmp \
 ${rootfs}/var/log \
+${rootfs}/var/run \
 ${rootfs}/usr/share/udhcpc \
 ${rootfs}/dev/pts \
 ${rootfs}/dev/shm \


### PR DESCRIPTION
Some programs like "who" need this directory
to work (this permits the of /var/run/utmp file).

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>