### PR TITLE
/etc/resolv.conf grows indefinitely

### DIFF
--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -164,7 +164,10 @@ case "\$1" in
 
     [ -n "\$domain" ] && echo search \$domain > /etc/resolv.conf
     for i in \$dns ; do
-      echo nameserver \$i >> /etc/resolv.conf
+      grep "nameserver \$i" /etc/resolv.conf > /dev/null 2>&1
+      if [ \$? -ne 0 ]; then
+        echo nameserver \$i >> /etc/resolv.conf
+      fi
     done
     ;;
 esac


### PR DESCRIPTION
This file grows indefinitely : upon each DHCP lease renew,
the "nameserver ..dns..." line is added at the end of the file.
Make a "grep" in the file to make sure that the same line
does not already exist.

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>