### PR TITLE
compiler: remove deprecated and unneeded header

### DIFF
--- a/src/include/prlimit.h
+++ b/src/include/prlimit.h
@@ -30,7 +30,6 @@
 #define _PRLIMIT_H
 
 #include <linux/resource.h>
-#include <sys/cdefs.h>
 #include <sys/types.h>
 
 #define RLIM_SAVED_CUR RLIM_INFINITY

--- a/src/lxc/compiler.h
+++ b/src/lxc/compiler.h
@@ -23,7 +23,6 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
 #endif
-#include <sys/cdefs.h>
 
 #include "config.h"
 


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>