### PR TITLE
More accurate error msg for template file

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -910,9 +910,24 @@ char *get_template_path(const char *t)
 	int ret, len;
 	char *tpath;
 
-	if (t[0] == '/' && access(t, X_OK) == 0) {
-		tpath = strdup(t);
-		return tpath;
+	if (t[0] == '/') {
+        	if (access(t, X_OK) == 0) {
+			tpath = strdup(t);
+			return tpath;
+		} else {
+			if (errno == EACCES) {
+				SYSERROR("cannot execute template %s", t);
+				return NULL;
+			}
+
+			if (errno == ENOENT) {
+				SYSERROR("template %s does not exist", t);
+				return NULL;
+			}
+
+			SYSERROR("Bad template pathname: %s", t);
+			return NULL;
+		}
 	}
 
 	len = strlen(LXCTEMPLATEDIR) + strlen(t) + strlen("/lxc-") + 1;

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -912,19 +912,8 @@ char *get_template_path(const char *t)
 
 	if (t[0] == '/') {
         	if (access(t, X_OK) == 0) {
-			tpath = strdup(t);
-			return tpath;
+			return strdup(t);
 		} else {
-			if (errno == EACCES) {
-				SYSERROR("cannot execute template %s", t);
-				return NULL;
-			}
-
-			if (errno == ENOENT) {
-				SYSERROR("template %s does not exist", t);
-				return NULL;
-			}
-
 			SYSERROR("Bad template pathname: %s", t);
 			return NULL;
 		}


### PR DESCRIPTION
When calling lxc-create, if the template exists but is not executable, we end with the following error messages which make believe that the template file does not exist when it is merely a execute access problem:

lxc-create: ctn00: utils.c: get_template_path: 918 No such file or directory - bad template: /.../lxc-busybox
lxc-create: ctn00: lxccontainer.c: do_lxcapi_create: 1786 Unknown template "/.../lxc-busybox"
lxc-create: ctn00: tools/lxc_create.c: main: 327 Failed to create container ctn00

Moreover, internally this triggers a useless access to (strace output):

access("/.../lxc-busybox", X_OK) = -1 ENOENT (No such file or directory)

With the above fix, we get a more explicit error message when the template file is missing the "execute" bit:

lxc-create: ctn: utils.c: get_template_path: 926 Permission denied - cannot execute template /h.../lxc-busybox
lxc-create: ctn: lxccontainer.c: do_lxcapi_create: 1816 Unknown template "/.../lxc-busybox"
lxc-create: ctn: tools/lxc_create.c: main: 331 Failed to create container ctn

With the above fix, we get a more explicit error message when the pathname of the template file is incorrect:

lxc-create: ctn: utils.c: get_template_path: 931 No such file or directory - template /.../lxc-busybox does not exist
lxc-create: ctn: lxccontainer.c: do_lxcapi_create: 1816 Unknown template "/.../lxc-busybox"
lxc-create: ctn: tools/lxc_create.c: main: 331 Failed to create container ctn

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>