### PR TITLE
More accurate error msg for template file

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -910,9 +910,13 @@ char *get_template_path(const char *t)
 	int ret, len;
 	char *tpath;
 
-	if (t[0] == '/' && access(t, X_OK) == 0) {
-		tpath = strdup(t);
-		return tpath;
+	if (t[0] == '/') {
+		if (access(t, X_OK) == 0) {
+			return strdup(t);
+		} else {
+			SYSERROR("Bad template pathname: %s", t);
+			return NULL;
+		}
 	}
 
 	len = strlen(LXCTEMPLATEDIR) + strlen(t) + strlen("/lxc-") + 1;


### PR DESCRIPTION
When calling lxc-create, if the template exists but is not executable, we end with the following error messages which make believe that the template file does not exist when it is merely a execute access problem:

lxc-create: ctn00: utils.c: get_template_path: 918 No such file or directory - bad template: /.../lxc-busybox
lxc-create: ctn00: lxccontainer.c: do_lxcapi_create: 1786 Unknown template "/.../lxc-busybox"
lxc-create: ctn00: tools/lxc_create.c: main: 327 Failed to create container ctn00

Actually internally the errno is lost as the following code triggers a useless access to (strace output):

access("/.../lxc-busybox", X_OK) = -1 ENOENT (No such file or directory)

With the above fix, we get a more explicit error message when the template file is missing the "execute" bit:

lxc-create: bbc: utils.c: get_template_path: 917 Permission denied - Bad template pathname: /tmp/azerty
lxc-create: bbc: lxccontainer.c: do_lxcapi_create: 1816 Unknown template "/tmp/azerty"
lxc-create: bbc: tools/lxc_create.c: main: 331 Failed to create container bbc

With the above fix, we get a more explicit error message when the pathname of the template file is incorrect:

lxc-create: bbc: utils.c: get_template_path: 917 No such file or directory - Bad template pathname: /tmp/qwerty
lxc-create: bbc: lxccontainer.c: do_lxcapi_create: 1816 Unknown template "/tmp/qwerty"
lxc-create: bbc: tools/lxc_create.c: main: 331 Failed to create container bbc

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>