### PR TITLE
tree-wide: wipe alloca() from the codebase

### DIFF
--- a/src/include/lxcmntent.c
+++ b/src/include/lxcmntent.c
@@ -21,7 +21,7 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
 #endif
-#include <alloca.h>
+#include <errno.h>
 #include <mntent.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -160,14 +160,17 @@ FILE *setmntent(const char *file, const char *mode)
 	 * I/O functions and "e" to set FD_CLOEXEC.
 	 */
 	size_t modelen = strlen(mode);
-	char *newmode;
+	char newmode[256];
 
-	newmode = alloca(modelen + 3);
+	if (modelen >= (sizeof(newmode) - 3)) {
+		errno = -EFBIG;
+		return NULL;
+	}
 
 	memcpy(newmode, mode, modelen);
 	memcpy(newmode + modelen, "ce", 3);
 
-	return fopen (file, newmode);
+	return fopen(file, newmode);
 }
 
 /* Close a stream opened with `setmntent'. */

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -368,9 +368,11 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		       log.c log.h \
+		       memory_utils.h \
 		       network.c network.h \
 		       parse.c parse.h \
 		       raw_syscalls.c raw_syscalls.h \
+		       string_utils.c string_utils.h \
 		       syscall_wrappers.h
 lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 conf.c conf.h \

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -21,6 +21,7 @@ noinst_HEADERS = api_extensions.h \
 		 lxc.h \
 		 lxclock.h \
 		 macro.h \
+		 memory_utils.h \
 		 monitor.h \
 		 namespace.h \
 		 raw_syscalls.h \
@@ -112,6 +113,7 @@ liblxc_la_SOURCES = af_unix.c af_unix.h \
 		    lxclock.c lxclock.h \
 		    lxcseccomp.h \
 		    macro.h \
+		    memory_utils.h \
 		    mainloop.c mainloop.h \
 		    namespace.c namespace.h \
 		    nl.c nl.h \

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -433,6 +433,7 @@ pam_LTLIBRARIES = pam_cgfs.la
 pam_cgfs_la_SOURCES = pam/pam_cgfs.c \
 		      file_utils.c file_utils.h \
 		      macro.h \
+		      memory_utils.h \
 		      string_utils.c string_utils.h
 
 if !HAVE_STRLCAT

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -58,6 +58,7 @@
 #include "config.h"
 #include "log.h"
 #include "macro.h"
+#include "memory_utils.h"
 #include "storage/storage.h"
 #include "utils.h"
 
@@ -888,15 +889,18 @@ static bool controller_in_clist(char *cgline, char *c)
 		return false;
 
 	len = eol - cgline;
-	tmp = alloca(len + 1);
+	tmp = must_realloc(NULL, len + 1);
 	memcpy(tmp, cgline, len);
 	tmp[len] = '\0';
 
 	lxc_iterate_parts(tok, tmp, ",") {
-		if (strcmp(tok, c) == 0)
+		if (strcmp(tok, c) == 0) {
+			free(tmp);
 			return true;
+		}
 	}
 
+	free(tmp);
 	return false;
 }
 
@@ -2209,15 +2213,12 @@ __cgfsng_ops static int cgfsng_get(struct cgroup_ops *ops, const char *filename,
 				     char *value, size_t len, const char *name,
 				     const char *lxcpath)
 {
-	int ret = -1;
-	size_t controller_len;
-	char *controller, *p, *path;
+	__do_free char *controller;
+	char *p, *path;
 	struct hierarchy *h;
+	int ret = -1;
 
-	controller_len = strlen(filename);
-	controller = alloca(controller_len + 1);
-	(void)strlcpy(controller, filename, controller_len + 1);
-
+	controller = must_copy_string(filename);
 	p = strchr(controller, '.');
 	if (p)
 		*p = '\0';
@@ -2248,15 +2249,12 @@ __cgfsng_ops static int cgfsng_set(struct cgroup_ops *ops,
 				     const char *filename, const char *value,
 				     const char *name, const char *lxcpath)
 {
-	int ret = -1;
-	size_t controller_len;
-	char *controller, *p, *path;
+	__do_free char *controller;
+	char *p, *path;
 	struct hierarchy *h;
+	int ret = -1;
 
-	controller_len = strlen(filename);
-	controller = alloca(controller_len + 1);
-	(void)strlcpy(controller, filename, controller_len + 1);
-
+	controller = must_copy_string(filename);
 	p = strchr(controller, '.');
 	if (p)
 		*p = '\0';
@@ -2363,18 +2361,14 @@ out:
 static int cg_legacy_set_data(struct cgroup_ops *ops, const char *filename,
 			      const char *value)
 {
-	size_t len;
+	__do_free char *controller;
 	char *fullpath, *p;
 	/* "b|c <2^64-1>:<2^64-1> r|w|m" = 47 chars max */
 	char converted_value[50];
 	struct hierarchy *h;
 	int ret = 0;
-	char *controller = NULL;
 
-	len = strlen(filename);
-	controller = alloca(len + 1);
-	(void)strlcpy(controller, filename, len + 1);
-
+	controller = must_copy_string(filename);
 	p = strchr(controller, '.');
 	if (p)
 		*p = '\0';

--- a/src/lxc/cmd/lxc_user_nic.c
+++ b/src/lxc/cmd/lxc_user_nic.c
@@ -49,9 +49,11 @@
 
 #include "config.h"
 #include "log.h"
+#include "memory_utils.h"
 #include "network.h"
 #include "parse.h"
 #include "raw_syscalls.h"
+#include "string_utils.h"
 #include "syscall_wrappers.h"
 #include "utils.h"
 
@@ -838,13 +840,12 @@ static char *get_nic_if_avail(int fd, struct alloted_s *names, int pid,
 
 static bool create_db_dir(char *fnam)
 {
-	int ret;
+	__do_free char *copy;
 	char *p;
-	size_t len;
+	int ret;
 
-	len = strlen(fnam);
-	p = alloca(len + 1);
-	(void)strlcpy(p, fnam, len + 1);
+	copy = must_copy_string(fnam);
+	p = copy;
 	fnam = p;
 	p = p + 1;
 

--- a/src/lxc/commands_utils.c
+++ b/src/lxc/commands_utils.c
@@ -38,6 +38,7 @@
 #include "initutils.h"
 #include "log.h"
 #include "lxclock.h"
+#include "memory_utils.h"
 #include "monitor.h"
 #include "state.h"
 #include "utils.h"
@@ -102,9 +103,9 @@ int lxc_make_abstract_socket_name(char *path, size_t pathlen,
 				  const char *hashed_sock_name,
 				  const char *suffix)
 {
+	__do_free char *tmppath = NULL;
 	const char *name;
 	char *offset;
-	char *tmppath;
 	size_t len;
 	size_t tmplen;
 	uint64_t hash;
@@ -153,7 +154,7 @@ int lxc_make_abstract_socket_name(char *path, size_t pathlen,
 
 	/* ret >= len; lxcpath or name is too long.  hash both */
 	tmplen = strlen(name) + strlen(lxcpath) + 2;
-	tmppath = alloca(tmplen);
+	tmppath = must_realloc(NULL, tmplen);
 	ret = snprintf(tmppath, tmplen, "%s/%s", lxcpath, name);
 	if (ret < 0 || (size_t)ret >= tmplen) {
 		ERROR("Failed to create abstract socket name");

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -53,6 +53,7 @@
 #include "../include/netns_ifaddrs.h"
 #include "log.h"
 #include "lxcseccomp.h"
+#include "memory_utils.h"
 #include "network.h"
 #include "parse.h"
 #include "storage.h"
@@ -2710,12 +2711,12 @@ int write_config(int fd, const struct lxc_conf *conf)
 bool do_append_unexp_config_line(struct lxc_conf *conf, const char *key,
 				 const char *v)
 {
+	__do_free char *tmp;
 	int ret;
 	size_t len;
-	char *tmp;
 
 	len = strlen(key) + strlen(v) + 4;
-	tmp = alloca(len);
+	tmp = must_realloc(NULL, len);
 
 	if (lxc_config_value_empty(v))
 		ret = snprintf(tmp, len, "%s =", key);
@@ -2777,21 +2778,23 @@ bool clone_update_unexp_ovl_paths(struct lxc_conf *conf, const char *oldpath,
 				  const char *newpath, const char *oldname,
 				  const char *newname, const char *ovldir)
 {
+	__do_free char *newdir = NULL,
+							 *olddir = NULL;
 	int ret;
-	char *lend, *newdir, *olddir, *p, *q;
+	char *lend, *p, *q;
 	size_t newdirlen, olddirlen;
 	char *lstart = conf->unexpanded_config;
 	const char *key = "lxc.mount.entry";
 
 	olddirlen = strlen(ovldir) + strlen(oldpath) + strlen(oldname) + 2;
-	olddir = alloca(olddirlen + 1);
+	olddir = must_realloc(NULL, olddirlen + 1);
 	ret = snprintf(olddir, olddirlen + 1, "%s=%s/%s", ovldir, oldpath,
 		       oldname);
 	if (ret < 0 || ret >= olddirlen + 1)
 		return false;
 
 	newdirlen = strlen(ovldir) + strlen(newpath) + strlen(newname) + 2;
-	newdir = alloca(newdirlen + 1);
+	newdir = must_realloc(NULL, newdirlen + 1);
 	ret = snprintf(newdir, newdirlen + 1, "%s=%s/%s", ovldir, newpath,
 		       newname);
 	if (ret < 0 || ret >= newdirlen + 1)
@@ -2885,20 +2888,22 @@ bool clone_update_unexp_hooks(struct lxc_conf *conf, const char *oldpath,
 			      const char *newpath, const char *oldname,
 			      const char *newname)
 {
+	__do_free char *newdir = NULL,
+							 *olddir = NULL;
 	int ret;
-	char *lend, *newdir, *olddir, *p;
+	char *lend, *p;
 	char *lstart = conf->unexpanded_config;
 	size_t newdirlen, olddirlen;
 	const char *key = "lxc.hook";
 
 	olddirlen = strlen(oldpath) + strlen(oldname) + 1;
-	olddir = alloca(olddirlen + 1);
+	olddir = must_realloc(NULL, olddirlen + 1);
 	ret = snprintf(olddir, olddirlen + 1, "%s/%s", oldpath, oldname);
 	if (ret < 0 || ret >= olddirlen + 1)
 		return false;
 
 	newdirlen = strlen(newpath) + strlen(newname) + 1;
-	newdir = alloca(newdirlen + 1);
+	newdir = must_realloc(NULL, newdirlen + 1);
 	ret = snprintf(newdir, newdirlen + 1, "%s/%s", newpath, newname);
 	if (ret < 0 || ret >= newdirlen + 1)
 		return false;

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -61,6 +61,7 @@
 #include "lxc.h"
 #include "lxccontainer.h"
 #include "lxclock.h"
+#include "memory_utils.h"
 #include "monitor.h"
 #include "namespace.h"
 #include "network.h"
@@ -120,13 +121,13 @@ static bool do_lxcapi_save_config(struct lxc_container *c, const char *alt_file)
 
 static bool config_file_exists(const char *lxcpath, const char *cname)
 {
+	__do_free char *fname;
 	int ret;
 	size_t len;
-	char *fname;
 
 	/* $lxcpath + '/' + $cname + '/config' + \0 */
 	len = strlen(lxcpath) + strlen(cname) + 9;
-	fname = alloca(len);
+	fname = must_realloc(NULL, len);
 	ret = snprintf(fname, len, "%s/%s/config", lxcpath, cname);
 	if (ret < 0 || (size_t)ret >= len)
 		return false;
@@ -144,13 +145,13 @@ static bool config_file_exists(const char *lxcpath, const char *cname)
  */
 static int ongoing_create(struct lxc_container *c)
 {
+	__do_free char *path;
 	int fd, ret;
 	size_t len;
-	char *path;
 	struct flock lk = {0};
 
 	len = strlen(c->config_path) + strlen(c->name) + 10;
-	path = alloca(len);
+	path = must_realloc(NULL, len);
 	ret = snprintf(path, len, "%s/%s/partial", c->config_path, c->name);
 	if (ret < 0 || (size_t)ret >= len)
 		return -1;
@@ -190,14 +191,14 @@ static int ongoing_create(struct lxc_container *c)
 
 static int create_partial(struct lxc_container *c)
 {
+	__do_free char *path;
 	int fd, ret;
 	size_t len;
-	char *path;
 	struct flock lk = {0};
 
 	/* $lxcpath + '/' + $name + '/partial' + \0 */
 	len = strlen(c->config_path) + strlen(c->name) + 10;
-	path = alloca(len);
+	path = must_realloc(NULL, len);
 	ret = snprintf(path, len, "%s/%s/partial", c->config_path, c->name);
 	if (ret < 0 || (size_t)ret >= len)
 		return -1;
@@ -227,15 +228,15 @@ static int create_partial(struct lxc_container *c)
 
 static void remove_partial(struct lxc_container *c, int fd)
 {
+	__do_free char *path;
 	int ret;
 	size_t len;
-	char *path;
 
 	close(fd);
 
 	/* $lxcpath + '/' + $name + '/partial' + \0 */
 	len = strlen(c->config_path) + strlen(c->name) + 10;
-	path = alloca(len);
+	path = must_realloc(NULL, len);
 	ret = snprintf(path, len, "%s/%s/partial", c->config_path, c->name);
 	if (ret < 0 || (size_t)ret >= len)
 		return;
@@ -768,26 +769,22 @@ static void push_arg(char ***argp, char *arg, int *nargs)
 
 static char **split_init_cmd(const char *incmd)
 {
-	size_t len, retlen;
-	char *copy, *p;
+	__do_free char *copy = NULL;
+	char *p;
 	char **argv;
 	int nargs = 0;
 
 	if (!incmd)
 		return NULL;
 
-	len = strlen(incmd) + 1;
-	copy = alloca(len);
-	retlen = strlcpy(copy, incmd, len);
-	if (retlen >= len)
-		return NULL;
+	copy = must_copy_string(incmd);
 
 	do {
 		argv = malloc(sizeof(char *));
 	} while (!argv);
 
 	argv[0] = NULL;
-	lxc_iterate_parts(p, copy, " ")
+	lxc_iterate_parts (p, copy, " ")
 		push_arg(&argv, p, &nargs);
 
 	if (nargs == 0) {
@@ -1209,9 +1206,9 @@ WRAP_API(bool, lxcapi_stop)
 
 static int do_create_container_dir(const char *path, struct lxc_conf *conf)
 {
+	__do_free char *p = NULL;
 	int lasterr;
 	size_t len;
-	char *p;
 	int ret = -1;
 
 	mode_t mask = umask(0002);
@@ -1226,9 +1223,7 @@ static int do_create_container_dir(const char *path, struct lxc_conf *conf)
 		ret = 0;
 	}
 
-	len = strlen(path);
-	p = alloca(len + 1);
-	(void)strlcpy(p, path, len + 1);
+	p = must_copy_string(path);
 
 	if (!lxc_list_empty(&conf->id_map)) {
 		ret = chown_mapped_root(p, conf);
@@ -1270,9 +1265,9 @@ static struct lxc_storage *do_storage_create(struct lxc_container *c,
 					     const char *type,
 					     struct bdev_specs *specs)
 {
+	__do_free char *dest;
 	int ret;
 	size_t len;
-	char *dest;
 	struct lxc_storage *bdev;
 
 	/* rootfs.path or lxcpath/lxcname/rootfs */
@@ -1280,12 +1275,12 @@ static struct lxc_storage *do_storage_create(struct lxc_container *c,
 	    (access(c->lxc_conf->rootfs.path, F_OK) == 0)) {
 		const char *rpath = c->lxc_conf->rootfs.path;
 		len = strlen(rpath) + 1;
-		dest = alloca(len);
+		dest = must_realloc(NULL, len);
 		ret = snprintf(dest, len, "%s", rpath);
 	} else {
 		const char *lxcpath = do_lxcapi_get_config_path(c);
 		len = strlen(c->name) + strlen(lxcpath) + 9;
-		dest = alloca(len);
+		dest = must_realloc(NULL, len);
 		ret = snprintf(dest, len, "%s/%s/rootfs", lxcpath, c->name);
 	}
 	if (ret < 0 || (size_t)ret >= len)
@@ -3407,12 +3402,12 @@ err:
 
 static int copyhooks(struct lxc_container *oldc, struct lxc_container *c)
 {
+	__do_free char *cpath;
 	int i, len, ret;
 	struct lxc_list *it;
-	char *cpath;
 
 	len = strlen(oldc->config_path) + strlen(oldc->name) + 3;
-	cpath = alloca(len);
+	cpath = must_realloc(NULL, len);
 	ret = snprintf(cpath, len, "%s/%s/", oldc->config_path, oldc->name);
 	if (ret < 0 || ret >= len)
 		return -1;
@@ -3570,13 +3565,14 @@ static bool add_rdepends(struct lxc_container *c, struct lxc_container *c0)
 bool should_default_to_snapshot(struct lxc_container *c0,
 				struct lxc_container *c1)
 {
+	__do_free char *p0, *p1;
 	int ret;
 	size_t l0 = strlen(c0->config_path) + strlen(c0->name) + 2;
 	size_t l1 = strlen(c1->config_path) + strlen(c1->name) + 2;
-	char *p0 = alloca(l0 + 1);
-	char *p1 = alloca(l1 + 1);
 	char *rootfs = c0->lxc_conf->rootfs.path;
 
+	p0 = must_realloc(NULL, l0 + 1);
+	p1 = must_realloc(NULL, l1 + 1);
 	ret = snprintf(p0, l0, "%s/%s", c0->config_path, c0->name);
 	if (ret < 0 || ret >= l0)
 		return false;
@@ -4098,11 +4094,11 @@ static int lxcapi_attach_run_wait(struct lxc_container *c, lxc_attach_options_t 
 
 static int get_next_index(const char *lxcpath, char *cname)
 {
-	char *fname;
+	__do_free char *fname;
 	struct stat sb;
 	int i = 0, ret;
 
-	fname = alloca(strlen(lxcpath) + 20);
+	fname = must_realloc(NULL, strlen(lxcpath) + 20);
 
 	while (1) {
 		sprintf(fname, "%s/snap%d", lxcpath, i);
@@ -4148,6 +4144,7 @@ static bool get_snappath_dir(struct lxc_container *c, char *snappath)
 
 static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
 {
+	__do_free char *dfnam = NULL;
 	int i, flags, ret;
 	time_t timer;
 	struct tm tm_info;
@@ -4211,7 +4208,7 @@ static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
 
 	strftime(buffer, 25, "%Y:%m:%d %H:%M:%S", &tm_info);
 
-	char *dfnam = alloca(strlen(snappath) + strlen(newname) + 5);
+	dfnam = must_realloc(NULL, strlen(snappath) + strlen(newname) + 5);
 	sprintf(dfnam, "%s/%s/ts", snappath, newname);
 	f = fopen(dfnam, "w");
 	if (!f) {
@@ -4232,10 +4229,11 @@ static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
 	}
 
 	if (commentfile) {
+		__do_free char *path;
 		/* $p / $name / comment \0 */
 		int len = strlen(snappath) + strlen(newname) + 10;
-		char *path = alloca(len);
 
+		path = must_realloc(NULL, len);
 		sprintf(path, "%s/%s/comment", snappath, newname);
 		return copy_file(commentfile, path) < 0 ? -1 : i;
 	}

--- a/src/lxc/memory_utils.h
+++ b/src/lxc/memory_utils.h
@@ -1,0 +1,32 @@
+/* liblxcapi
+ *
+ * Copyright © 2019 Christian Brauner <christian.brauner@ubuntu.com>.
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __LXC_MEMORY_UTILS_H
+#define __LXC_MEMORY_UTILS_H
+
+#include <stdlib.h>
+
+static inline void __auto_free__(void *p)
+{
+	free(*(void **)p);
+}
+
+#define __do_free __attribute__((__cleanup__(__auto_free__)))
+
+#endif /* __LXC_MEMORY_UTILS_H */

--- a/src/lxc/monitor.c
+++ b/src/lxc/monitor.c
@@ -49,6 +49,7 @@
 #include "log.h"
 #include "lxclock.h"
 #include "macro.h"
+#include "memory_utils.h"
 #include "monitor.h"
 #include "state.h"
 #include "utils.h"
@@ -170,9 +171,9 @@ int lxc_monitor_close(int fd)
  */
 int lxc_monitor_sock_name(const char *lxcpath, struct sockaddr_un *addr)
 {
+	__do_free char *path;
 	size_t len;
 	int ret;
-	char *path;
 	uint64_t hash;
 
 	/* addr.sun_path is only 108 bytes, so we hash the full name and
@@ -183,7 +184,7 @@ int lxc_monitor_sock_name(const char *lxcpath, struct sockaddr_un *addr)
 
 	/* strlen("lxc/") + strlen("/monitor-sock") + 1 = 18 */
 	len = strlen(lxcpath) + 18;
-	path = alloca(len);
+	path = must_realloc(NULL, len);
 	ret = snprintf(path, len, "lxc/%s/monitor-sock", lxcpath);
 	if (ret < 0 || (size_t)ret >= len) {
 		ERROR("Failed to create name for monitor socket");

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -54,6 +54,7 @@
 #include "file_utils.h"
 #include "log.h"
 #include "macro.h"
+#include "memory_utils.h"
 #include "network.h"
 #include "nl.h"
 #include "raw_syscalls.h"
@@ -549,15 +550,15 @@ out:
 #define PHYSNAME "/sys/class/net/%s/phy80211/name"
 static char *is_wlan(const char *ifname)
 {
+	__do_free char *path;
 	int i, ret;
 	long physlen;
 	size_t len;
-	char *path;
 	FILE *f;
 	char *physname = NULL;
 
 	len = strlen(ifname) + strlen(PHYSNAME) - 1;
-	path = alloca(len + 1);
+	path = must_realloc(NULL, len + 1);
 	ret = snprintf(path, len, PHYSNAME, ifname);
 	if (ret < 0 || (size_t)ret >= len)
 		goto bad;

--- a/src/lxc/pam/pam_cgfs.c
+++ b/src/lxc/pam/pam_cgfs.c
@@ -59,6 +59,7 @@
 #include "config.h"
 #include "file_utils.h"
 #include "macro.h"
+#include "memory_utils.h"
 #include "string_utils.h"
 
 #define PAM_SM_SESSION
@@ -845,8 +846,9 @@ static char **cgv1_get_proc_mountinfo_controllers(char **klist, char **nlist, ch
 /* Check if a cgroupfs v2 controller is present in the string @cgline. */
 static bool cgv1_controller_in_clist(char *cgline, char *c)
 {
+	__do_free char *tmp = NULL;
 	size_t len;
-	char *tok, *eol, *tmp;
+	char *tok, *eol;
 	char *saveptr = NULL;
 
 	eol = strchr(cgline, ':');
@@ -854,7 +856,7 @@ static bool cgv1_controller_in_clist(char *cgline, char *c)
 		return false;
 
 	len = eol - cgline;
-	tmp = alloca(len + 1);
+	tmp = must_realloc(NULL, len + 1);
 	memcpy(tmp, cgline, len);
 	tmp[len] = '\0';
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -26,7 +26,6 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
 #endif
-#include <alloca.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -67,6 +66,7 @@
 #include "lxcseccomp.h"
 #include "macro.h"
 #include "mainloop.h"
+#include "memory_utils.h"
 #include "monitor.h"
 #include "namespace.h"
 #include "network.h"
@@ -97,16 +97,13 @@ static void lxc_destroy_container_on_signal(struct lxc_handler *handler,
 
 static void print_top_failing_dir(const char *path)
 {
+	__do_free char *copy;
 	int ret;
-	size_t len;
-	char *copy, *e, *p, saved;
+	char *e, *p, saved;
 
-	len = strlen(path);
-	copy = alloca(len + 1);
-	(void)strlcpy(copy, path, len + 1);
-
+	copy = must_copy_string(path);
 	p = copy;
-	e = copy + len;
+	e = copy + strlen(path);
 
 	while (p < e) {
 		while (p < e && *p == '/')

--- a/src/lxc/storage/loop.c
+++ b/src/lxc/storage/loop.c
@@ -39,6 +39,7 @@
 #include "config.h"
 #include "log.h"
 #include "loop.h"
+#include "memory_utils.h"
 #include "storage.h"
 #include "storage_utils.h"
 #include "utils.h"
@@ -56,9 +57,9 @@ int loop_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
 		    const char *lxcpath, int snap, uint64_t newsize,
 		    struct lxc_conf *conf)
 {
+	__do_free char *srcdev = NULL;
 	uint64_t size = newsize;
 	int len, ret;
-	char *srcdev;
 	char fstype[100] = "ext4";
 
 	if (snap) {
@@ -70,7 +71,7 @@ int loop_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
 		return -1;
 
 	len = strlen(lxcpath) + strlen(cname) + strlen("rootdev") + 3;
-	srcdev = alloca(len);
+	srcdev = must_realloc(NULL, len);
 	ret = snprintf(srcdev, len, "%s/%s/rootdev", lxcpath, cname);
 	if (ret < 0 || ret >= len) {
 		ERROR("Failed to create string");
@@ -136,10 +137,10 @@ int loop_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
 int loop_create(struct lxc_storage *bdev, const char *dest, const char *n,
 		struct bdev_specs *specs)
 {
+	__do_free char *srcdev;
 	const char *fstype;
 	uint64_t sz;
 	int ret, len;
-	char *srcdev;
 
 	if (!specs)
 		return -1;
@@ -148,7 +149,7 @@ int loop_create(struct lxc_storage *bdev, const char *dest, const char *n,
 	 * be <lxcpath>/<lxcname>/rootdev, and <src> will be "loop:<srcdev>".
 	 */
 	len = strlen(dest) + 2;
-	srcdev = alloca(len);
+	srcdev = must_realloc(NULL, len);
 
 	ret = snprintf(srcdev, len, "%s", dest);
 	if (ret < 0 || ret >= len) {

--- a/src/lxc/storage/nbd.c
+++ b/src/lxc/storage/nbd.c
@@ -35,6 +35,7 @@
 
 #include "config.h"
 #include "log.h"
+#include "memory_utils.h"
 #include "nbd.h"
 #include "storage.h"
 #include "storage_utils.h"
@@ -61,14 +62,11 @@ static bool wait_for_partition(const char *path);
 
 bool attach_nbd(char *src, struct lxc_conf *conf)
 {
-	char *orig, *p, path[50];
+	__do_free char *orig;
+	char *p, path[50];
 	int i = 0;
-	size_t len;
 
-	len = strlen(src);
-	orig = alloca(len + 1);
-	(void)strlcpy(orig, src, len + 1);
-
+	orig = must_copy_string(src);
 	/* if path is followed by a partition, drop that for now */
 	p = strchr(orig, ':');
 	if (p)

--- a/src/lxc/storage/overlay.c
+++ b/src/lxc/storage/overlay.c
@@ -35,6 +35,7 @@
 #include "log.h"
 #include "lxccontainer.h"
 #include "macro.h"
+#include "memory_utils.h"
 #include "overlay.h"
 #include "rsync.h"
 #include "storage.h"
@@ -491,8 +492,10 @@ bool ovl_detect(const char *path)
 
 int ovl_mount(struct lxc_storage *bdev)
 {
-	char *tmp, *options, *dup, *lower, *upper;
-	char *options_work, *work, *lastslash;
+	__do_free char *options = NULL,
+							 *options_work = NULL;
+	char *tmp, *dup, *lower, *upper;
+	char *work, *lastslash;
 	int lastslashidx;
 	size_t len, len2;
 	unsigned long mntflags;
@@ -602,27 +605,27 @@ int ovl_mount(struct lxc_storage *bdev)
 	if (mntdata) {
 		len = strlen(lower) + strlen(upper) +
 		      strlen("upperdir=,lowerdir=,") + strlen(mntdata) + 1;
-		options = alloca(len);
+		options = must_realloc(NULL, len);
 		ret = snprintf(options, len, "upperdir=%s,lowerdir=%s,%s",
 			       upper, lower, mntdata);
 
 		len2 = strlen(lower) + strlen(upper) + strlen(work) +
 		       strlen("upperdir=,lowerdir=,workdir=") +
 		       strlen(mntdata) + 1;
-		options_work = alloca(len2);
+		options_work = must_realloc(NULL, len2);
 		ret2 = snprintf(options, len2,
 				"upperdir=%s,lowerdir=%s,workdir=%s,%s", upper,
 				lower, work, mntdata);
 	} else {
 		len = strlen(lower) + strlen(upper) +
 		      strlen("upperdir=,lowerdir=") + 1;
-		options = alloca(len);
+		options = must_realloc(NULL, len);
 		ret = snprintf(options, len, "upperdir=%s,lowerdir=%s", upper,
 			       lower);
 
 		len2 = strlen(lower) + strlen(upper) + strlen(work) +
 		       strlen("upperdir=,lowerdir=,workdir=") + 1;
-		options_work = alloca(len2);
+		options_work = must_realloc(NULL, len2);
 		ret2 = snprintf(options_work, len2,
 				"upperdir=%s,lowerdir=%s,workdir=%s", upper,
 				lower, work);

--- a/src/lxc/storage/rbd.c
+++ b/src/lxc/storage/rbd.c
@@ -33,6 +33,7 @@
 
 #include "config.h"
 #include "log.h"
+#include "memory_utils.h"
 #include "storage.h"
 #include "storage_utils.h"
 #include "utils.h"
@@ -195,9 +196,9 @@ int rbd_create(struct lxc_storage *bdev, const char *dest, const char *n,
 
 int rbd_destroy(struct lxc_storage *orig)
 {
+	__do_free char *rbdfullname = NULL;
 	int ret;
 	const char *src;
-	char *rbdfullname;
 	char cmd_output[PATH_MAX];
 	struct rbd_args args = {0};
 	size_t len;
@@ -215,7 +216,7 @@ int rbd_destroy(struct lxc_storage *orig)
 	}
 
 	len = strlen(src);
-	rbdfullname = alloca(len - 8);
+	rbdfullname = must_realloc(NULL, len - 8);
 	(void)strlcpy(rbdfullname, &src[9], len - 8);
 	args.rbd_name = rbdfullname;
 

--- a/src/lxc/storage/storage.c
+++ b/src/lxc/storage/storage.c
@@ -51,6 +51,7 @@
 #include "lvm.h"
 #include "lxc.h"
 #include "lxclock.h"
+#include "memory_utils.h"
 #include "namespace.h"
 #include "nbd.h"
 #include "overlay.h"
@@ -567,13 +568,11 @@ struct lxc_storage *storage_create(const char *dest, const char *type,
 
 	/* -B lvm,dir */
 	if (strchr(type, ',')) {
-		char *dup, *token;
+		__do_free char *dup;
+		char *token;
 		size_t len;
 
-		len = strlen(type);
-		dup = alloca(len + 1);
-		(void)strlcpy(dup, type, len + 1);
-
+		dup = must_copy_string(type);
 		lxc_iterate_parts(token, dup, ",") {
 			bdev = do_storage_create(dest, token, cname, specs);
 			if (bdev)

--- a/src/lxc/string_utils.c
+++ b/src/lxc/string_utils.c
@@ -46,6 +46,7 @@
 #include "config.h"
 #include "lxclock.h"
 #include "macro.h"
+#include "memory_utils.h"
 #include "namespace.h"
 #include "parse.h"
 #include "string_utils.h"
@@ -321,17 +322,14 @@ char *lxc_append_paths(const char *first, const char *second)
 
 bool lxc_string_in_list(const char *needle, const char *haystack, char _sep)
 {
-	char *token, *str;
+	__do_free char *str = NULL;
+	char *token;
 	char sep[2] = { _sep, '\0' };
-	size_t len;
 
 	if (!haystack || !needle)
 		return 0;
 
-	len = strlen(haystack);
-	str = alloca(len + 1);
-	(void)strlcpy(str, haystack, len + 1);
-
+	str = must_copy_string(haystack);
 	lxc_iterate_parts(token, str, sep)
 		if (strcmp(needle, token) == 0)
 			return 1;
@@ -341,21 +339,18 @@ bool lxc_string_in_list(const char *needle, const char *haystack, char _sep)
 
 char **lxc_string_split(const char *string, char _sep)
 {
-	char *token, *str;
+	__do_free char *str = NULL;
+	char *token;
 	char sep[2] = {_sep, '\0'};
 	char **tmp = NULL, **result = NULL;
 	size_t result_capacity = 0;
 	size_t result_count = 0;
 	int r, saved_errno;
-	size_t len;
 
 	if (!string)
 		return calloc(1, sizeof(char *));
 
-	len = strlen(string);
-	str = alloca(len + 1);
-	(void)strlcpy(str, string, len + 1);
-
+	str = must_copy_string(string);
 	lxc_iterate_parts(token, str, sep) {
 		r = lxc_grow_array((void ***)&result, &result_capacity, result_count + 1, 16);
 		if (r < 0)
@@ -461,22 +456,19 @@ char **lxc_string_split_quoted(char *string)
 
 char **lxc_string_split_and_trim(const char *string, char _sep)
 {
-	char *token, *str;
+	__do_free char *str = NULL;
+	char *token;
 	char sep[2] = { _sep, '\0' };
 	char **result = NULL;
 	size_t result_capacity = 0;
 	size_t result_count = 0;
 	int r, saved_errno;
 	size_t i = 0;
-	size_t len;
 
 	if (!string)
 		return calloc(1, sizeof(char *));
 
-	len = strlen(string);
-	str = alloca(len + 1);
-	(void)strlcpy(str, string, len + 1);
-
+	str = must_copy_string(string);
 	lxc_iterate_parts(token, str, sep) {
 		while (token[0] == ' ' || token[0] == '\t')
 			token++;

--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -44,6 +44,7 @@
 #include "log.h"
 #include "lxclock.h"
 #include "mainloop.h"
+#include "memory_utils.h"
 #include "start.h"
 #include "syscall_wrappers.h"
 #include "terminal.h"
@@ -199,9 +200,9 @@ static int lxc_terminal_truncate_log_file(struct lxc_terminal *terminal)
 
 static int lxc_terminal_rotate_log_file(struct lxc_terminal *terminal)
 {
+	__do_free char *tmp = NULL;
 	int ret;
 	size_t len;
-	char *tmp;
 
 	if (!terminal->log_path || terminal->log_rotate == 0)
 		return -EOPNOTSUPP;
@@ -211,7 +212,7 @@ static int lxc_terminal_rotate_log_file(struct lxc_terminal *terminal)
 		return -EBADF;
 
 	len = strlen(terminal->log_path) + sizeof(".1");
-	tmp = alloca(len);
+	tmp = must_realloc(NULL, len);
 
 	ret = snprintf(tmp, len, "%s.1", terminal->log_path);
 	if (ret < 0 || (size_t)ret >= len)

--- a/src/lxc/tools/lxc_unshare.c
+++ b/src/lxc/tools/lxc_unshare.c
@@ -398,7 +398,7 @@ int main(int argc, char *argv[])
 	if (my_args.setuid) {
 		uint64_t wait_val = 1;
 		/* enough space to accommodate uids */
-		char *umap = (char *)alloca(100);
+		char umap[100];
 
 		/* create new uid mapping using current UID and the one
 		 * specified as parameter


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>