### PR TITLE
fix rpm packaging for bash completion directory.

### DIFF
--- a/lxc.spec.in
+++ b/lxc.spec.in
@@ -125,6 +125,10 @@ development of the Linux containers.
 %prep
 %setup -q -n %{name}-%{version}%{?beta_dot}
 %build
+
+#Dont use pkgconfig to get bash completion dir and use backwards compatible location.
+export bashcompdir=%{_sysconfdir}/bash_completion.d
+
 PATH=$PATH:/usr/sbin:/sbin %configure $args \
 %if "x%{_unitdir}" != "x"
   --with-systemdsystemunitdir=%{_unitdir} \


### PR DESCRIPTION
Closes #1825

Signed-off-by: tomponline <tomp@tomp.uk>