### PR TITLE
caps: check uid and euid

### DIFF
--- a/src/lxc/caps.c
+++ b/src/lxc/caps.c
@@ -154,8 +154,7 @@ int lxc_ambient_caps_up(void)
 	int last_cap = CAP_LAST_CAP;
 	char *cap_names = NULL;
 
-	/* When we are run as root, we don't want to play with the capabilities. */
-	if (!getuid())
+	if (!getuid() || geteuid())
 		return 0;
 
 	caps = cap_get_proc();
@@ -222,8 +221,7 @@ int lxc_ambient_caps_down(void)
 	cap_t caps;
 	cap_value_t cap;
 
-	/* When we are run as root, we don't want to play with the capabilities. */
-	if (!getuid())
+	if (!getuid() || geteuid())
 		return 0;
 
 	ret = prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0);


### PR DESCRIPTION
When we are running inside of a user namespace getuid() will return a
non-zero uid. So let's check euid as well to make sure we correctly drop
capabilities

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>