### PR TITLE
string_utils.h: fix wrong licensing

### DIFF
--- a/src/lxc/string_utils.h
+++ b/src/lxc/string_utils.h
@@ -3,18 +3,19 @@
  * Copyright © 2018 Christian Brauner <christian.brauner@ubuntu.com>.
  * Copyright © 2018 Canonical Ltd.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 2, as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #ifndef __LXC_STRING_UTILS_H


### PR DESCRIPTION
Correcting license for string_utils.h from GPLv2+ to LGPLv2.1+ to be in line with the rest of the codebase and our licensing guidelines (CONTRIBUTING).

This license header was accidentally copy/paste from the wrong source file, this commit fixes the situation.

Individual copyright holders were tracked down and have confirmed their agreement with correcting the licensing information for this file.

Master issue: #2842

/* Affected People */
Christian Brauner <christian.brauner@ubuntu.com>
Fabrice Fontaine <fontaine.fabrice@gmail.com>
Josh Soref <jsoref@gmail.com>

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
Acked-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
Acked-by: Josh Soref <jsoref@gmail.com>