### PR TITLE
attach: use move_fd in lxc_proc_close_ns_fd

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -126,7 +126,7 @@ static struct lxc_proc_context_info *lxc_proc_get_context_info(pid_t pid)
 static inline void lxc_proc_close_ns_fd(struct lxc_proc_context_info *ctx)
 {
 	for (int i = 0; i < LXC_NS_MAX; i++) {
-		__do_close_prot_errno int fd = ctx->ns_fd[i];
+		__do_close_prot_errno int fd = move_fd(ctx->ns_fd[i]);
 	}
 }
 


### PR DESCRIPTION
Previously this set `ctx->ns_fd[*]` to `-EBADF` until commit
fd2a88b190eb ("attach: cleanup macros lxc_proc_close_ns_fd",
but there are some code paths where we call this before
later calling `lxc_proc_put_context_info` which would call
this function again with the file descriptors still
unchanged.

Note: Haven't run into an actual issue, just noticed this while
going through my unread notifications...
