### PR TITLE
gpg: use proxy, if http_proxy is set

### DIFF
--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -60,6 +60,7 @@ if [ -z "${DOWNLOAD_KEYSERVER:-}" ]; then
   # Deal with GPG over http proxy
   if [ -n "${http_proxy:-}" ]; then
     DOWNLOAD_KEYSERVER="hkp://p80.pool.sks-keyservers.net:80"
+    DOWNLOAD_GPG_PROXY="--keyserver-options http-proxy=\"${http_proxy}\""
   fi
 fi
 
@@ -133,8 +134,8 @@ gpg_setup() {
 
   success=
   for _ in $(seq 3); do
-    if gpg --keyserver "${DOWNLOAD_KEYSERVER}" \
-      --recv-keys "${DOWNLOAD_KEYID}" >/dev/null 2>&1; then
+    if $(gpg --keyserver "${DOWNLOAD_KEYSERVER}" ${DOWNLOAD_GPG_PROXY:-} \
+      --recv-keys "${DOWNLOAD_KEYID}" >/dev/null 2>&1); then
       success=1
       break
     fi


### PR DESCRIPTION
Hi everyone,

I found that `gpg` ignores the `http_proxy` environment variable. As the lxc-download script already adjusts the keyserver when `http_proxy` is set, it also should set the necessary `gpg` option. Currently there is no way to use lxc-download behind a proxy, because of this problem.

I had to put the `gpg` command in a subshell, because if not, `gpg` would not work properly, as it does not treat `${DOWNLOAD_GPG_PROXY}` as a valid argument.

If there is a better solution, let me know about it. This is my first pull request for this project, I hope I got everything right.

Cheers,
Marco