### PR TITLE
fix lxcbasename in lxc/lxccontainer.c

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -1322,7 +1322,7 @@ static char *lxcbasename(char *path)
 	while (*p != '/' && p > path)
 		p--;
 
-	return (p == path) ? p : ++p;
+	return (p == path && *p != '/') ? p : ++p;
 }
 
 static bool create_run_template(struct lxc_container *c, char *tpath,

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -1322,7 +1322,7 @@ static char *lxcbasename(char *path)
 	while (*p != '/' && p > path)
 		p--;
 
-	return p;
+	return (p == path) ? p : ++p;
 }
 
 static bool create_run_template(struct lxc_container *c, char *tpath,


### PR DESCRIPTION
After the change, `lxcbasename()` would avoid slash character at the head of the string.
The return value of the `lxcbasename()` is put in the `newargv` variable, and this variable is used in `execvp`.

https://github.com/lxc/lxc/blob/9fc7a50f8a7f1066f658bcb5bab5f3d724318827/src/lxc/lxccontainer.c#L1448

https://github.com/lxc/lxc/blob/9fc7a50f8a7f1066f658bcb5bab5f3d724318827/src/lxc/lxccontainer.c#L1629.

Signed-off-by: knknkn1162 <knknkn1162@gmail.com>