### PR TITLE
Makefile: Adds compile flags -Wall -Werror

### DIFF
--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -202,7 +202,10 @@ AM_CFLAGS = -DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	    -I $(top_srcdir)/src \
 	    -I $(top_srcdir)/src/lxc \
 	    -I $(top_srcdir)/src/lxc/storage \
-	    -I $(top_srcdir)/src/lxc/cgroups
+	    -I $(top_srcdir)/src/lxc/cgroups \
+	    -Wall \
+	    -Werror
+
 
 if ENABLE_APPARMOR
 AM_CFLAGS += -DHAVE_APPARMOR

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -51,7 +51,9 @@ AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	  -I $(top_srcdir)/src/lxc \
 	  -I $(top_srcdir)/src/lxc/cgroups \
 	  -I $(top_srcdir)/src/lxc/tools \
-	  -pthread
+	  -pthread \
+	  -Wall \
+	  -Werror
 
 if ENABLE_APPARMOR
 AM_CFLAGS += -DHAVE_APPARMOR


### PR DESCRIPTION
Makefile: Adds compile flags -Wall -Werror which were not applying.
These are defined already here https://github.com/lxc/lxc/blob/6400238d08cdf1ca20d49bafb85f4e224348bf9d/configure.ac#L43 but are not applying as CFLAGS are overridden in the Makefile.am files

Closes #2885.

Signed-off-by: tomponline <tomp@tomp.uk>