### PR TITLE
Fix lxc.cgroup2.<controller> on cgroup2-only systems

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -2684,6 +2684,7 @@ static int cg_unified_init(struct cgroup_ops *ops, bool relative,
 		cg_unified_delegate(&new->cgroup2_chown);
 
 	ops->cgroup_layout = CGROUP_LAYOUT_UNIFIED;
+	ops->unified = new;
 	return CGROUP2_SUPER_MAGIC;
 }
 


### PR DESCRIPTION
In the pure-unified cgroup case (`cg_unified_init` instead of `cg_hybrid_init`), `ops->unified` was left uninitialized, making any attempts to set cgroup controllers using `lxc.cgroup2.<controller>` fail on systems with only cgroup2 mounted.