### PR TITLE
hooks: drop namespace references before post-stop

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1026,6 +1026,9 @@ void lxc_fini(const char *name, struct lxc_handler *handler)
 		lxc_set_state(name, handler, STOPPED);
 	}
 
+	/* Avoid lingering namespace references. */
+	lxc_put_nsfds(handler);
+
 	ret = run_lxc_hooks(name, "post-stop", handler->conf, NULL);
 	if (ret < 0) {
 		ERROR("Failed to run lxc.hook.post-stop for container \"%s\"", name);


### PR DESCRIPTION
Callers such as LXD run post-stop hooks to perform cleanup operations on
shutdown. This can involve umount and other things. To avoid surprises with
lingering namespace references we should close all our namespace-preserving
file descriptors. We don't need them at this point anymore anyway.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>