### PR TITLE
Fix PID namespace pdeathsig handling

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1112,7 +1112,7 @@ static int do_start(void *data)
 	 * exit before we set the pdeath signal leading to a unsupervized
 	 * container.
 	 */
-	ret = lxc_set_death_signal(SIGKILL, 0);
+	ret = lxc_set_death_signal(SIGKILL, handler->monitor_pid);
 	if (ret < 0) {
 		SYSERROR("Failed to set PR_SET_PDEATHSIG to SIGKILL");
 		goto out_warn_father;

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1705,9 +1705,9 @@ int lxc_set_death_signal(int signal, pid_t parent)
 	ret = prctl(PR_SET_PDEATHSIG, prctl_arg(signal), prctl_arg(0),
 		    prctl_arg(0), prctl_arg(0));
 
-	/* Check whether we have been orphaned. */
+	/* If not in a PID namespace, check whether we have been orphaned. */
 	ppid = (pid_t)syscall(SYS_getppid);
-	if (ppid != parent) {
+	if (ppid && ppid != parent) {
 		ret = raise(SIGKILL);
 		if (ret < 0)
 			return -1;


### PR DESCRIPTION
@brauner given what you said in #2902, I believe we can unconditionally pass `monitor_pid` to `lxc_set_death_signal` if we fix the parent check in `lxc_set_death_signal`.