### PR TITLE
lvm: Updates lvcreate to wipe signatures if supported

### DIFF
--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -201,6 +201,21 @@ extern int lxc_unstack_mountpoint(const char *path, bool lazy);
 extern int run_command(char *buf, size_t buf_size, int (*child_fn)(void *),
 		       void *args);
 
+/*
+ * run_command runs a command and collect it's std{err,out} output in buf, returns exit status.
+ *
+ * @param[out] buf     The buffer where the commands std{err,out] output will be
+ *                     read into. If no output was produced, buf will be memset
+ *                     to 0.
+ * @param[in] buf_size The size of buf. This function will reserve one byte for
+ *                     \0-termination.
+ * @param[in] child_fn The function to be run in the child process. This
+ *                     function must exec.
+ * @param[in] args     Arguments to be passed to child_fn.
+ */
+extern int run_command_status(char *buf, size_t buf_size, int (*child_fn)(void *),
+		       void *args);
+
 /* Concatenate all passed-in strings into one path. Do not fail. If any piece
  * is not prefixed with '/', add a '/'.
  */


### PR DESCRIPTION
lvm: Updates lvcreate to wipe signatures if supported, fallbacks to old command if not.

Signed-off-by: tomponline <tomp@tomp.uk>

Related to https://github.com/lxc/lxd/issues/5482#issuecomment-464810627

I found it quite tricky to test an older version of lvcreate, as LXC won't compile on CentOS 5, which has an older version of lvcreate without the `-Wy` flag.

Instead I created a dummy lvcreate command in `/usr/local/sbin/lvcreate` as follows, which outputs the same error as the old version of lvcreate does when passed the `-Wy` flag.

```
ARGS=$@
logger "lvcreate $ARGS"

# Parse command flags
while [ ! $# -eq 0 ]
do
  	case "$1" in
                -Wy )
echo "lvcreate: invalid option -- W
  Error during parsing of command line."
                        exit 3
                        ;;
        esac
	shift
done

/usr/sbin/lvcreate $ARGS
```

Here is the syslog output from it, showing the detection of the error and falling back to old command:

```
Mar 19 18:10:29 centos7 root: lvcreate -Wy --yes -L 1073741824b VolGroup00 -n test
Mar 19 18:10:29 centos7 root: lvcreate -qq -L 1073741824b VolGroup00 -n test
```

Additionally, because `run_command` doesn't provide the exit code, I instead inspected the error output to detect the unsupported lvcreate command.