### PR TITLE
Adds veth router mode

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -96,3 +96,12 @@ This is primarily intended for use with layer 3 networking devices, such as IPVL
 
 This introduces the ability to specify a custom MTU for `phys` and `macvlan` devices using the
 `lxc.net.[i].mtu` property.
+
+# network\_veth\_router
+
+This introduces the ability to specify a `lxc.net.[i].veth.mode` setting, which takes a value of
+"bridge" or "router". This defaults to "bridge".
+
+In "router" mode static routes are created on the host for the container's IP addresses pointing to
+the host side veth interface. In addition to the routes, a static IP neighbour proxy is added to
+the host side veth interface for the IPv4 and IPv6 gateway IPs.

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -443,14 +443,23 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             <para>
               <option>veth:</option> a virtual ethernet pair
               device is created with one side assigned to the container
-              and the other side attached to a bridge specified by
+              and the other side on the host.
+              <option>lxc.net.[i].veth.mode</option> specifies the
+              mode the veth parent will use on the host.
+              The accepted  modes are <option>bridge</option> and <option>router</option>.
+              The mode defaults to bridge if not specified.
+              In <option>bridge</option> mode the host side is attached to a bridge specified by
               the <option>lxc.net.[i].link</option> option.
-              If the bridge is not specified, then the veth pair device
+              If the bridge link is not specified, then the veth pair device
               will be created but not attached to any bridge.
               Otherwise, the bridge has to be created on the system
               before starting the container.
               <command>lxc</command> won't handle any
               configuration outside of the container.
+              In <option>router</option> mode static routes are created on the host for the
+              container's IP addresses pointing to the host side veth interface.
+              Additionally Proxy ARP and Proxy NDP entries are added on the host side veth interface
+              for the gateway IPs defined in the container to allow the container to reach the host.
               By default, <command>lxc</command> chooses a name for the
               network device belonging to the outside of the
               container, but if you wish to handle

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -49,6 +49,7 @@ static char *api_extensions[] = {
 	"network_l2proxy",
 	"network_gateway_device_route",
 	"network_phys_macvlan_mtu",
+	"network_veth_router",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -139,6 +139,7 @@ lxc_config_define(net_nic);
 lxc_config_define(net_script_down);
 lxc_config_define(net_script_up);
 lxc_config_define(net_type);
+lxc_config_define(net_veth_mode);
 lxc_config_define(net_veth_pair);
 lxc_config_define(net_veth_ipv4_route);
 lxc_config_define(net_veth_ipv6_route);
@@ -234,6 +235,7 @@ static struct lxc_config_t config_jump_table[] = {
 	{ "lxc.net.script.up",             set_config_net_script_up,               get_config_net_script_up,               clr_config_net_script_up,             },
 	{ "lxc.net.type",                  set_config_net_type,                    get_config_net_type,                    clr_config_net_type,                  },
 	{ "lxc.net.vlan.id",               set_config_net_vlan_id,                 get_config_net_vlan_id,                 clr_config_net_vlan_id,               },
+	{ "lxc.net.veth.mode",             set_config_net_veth_mode,               get_config_net_veth_mode,               clr_config_net_veth_mode,             },
 	{ "lxc.net.veth.pair",             set_config_net_veth_pair,               get_config_net_veth_pair,               clr_config_net_veth_pair,             },
 	{ "lxc.net.veth.ipv4.route",       set_config_net_veth_ipv4_route,         get_config_net_veth_ipv4_route,         clr_config_net_veth_ipv4_route,       },
 	{ "lxc.net.veth.ipv6.route",       set_config_net_veth_ipv6_route,         get_config_net_veth_ipv6_route,         clr_config_net_veth_ipv6_route,       },
@@ -303,6 +305,7 @@ static int set_config_net_type(const char *key, const char *value,
 		netdev->type = LXC_NET_VETH;
 		lxc_list_init(&netdev->priv.veth_attr.ipv4_routes);
 		lxc_list_init(&netdev->priv.veth_attr.ipv6_routes);
+		lxc_veth_mode_to_flag(&netdev->priv.veth_attr.mode, "bridge");
 	} else if (strcmp(value, "macvlan") == 0) {
 		netdev->type = LXC_NET_MACVLAN;
 		lxc_macvlan_mode_to_flag(&netdev->priv.macvlan_attr.mode, "private");
@@ -448,6 +451,21 @@ static int set_config_net_name(const char *key, const char *value,
 		return -1;
 
 	return network_ifname(netdev->name, value, sizeof(netdev->name));
+}
+
+
+static int set_config_net_veth_mode(const char *key, const char *value,
+				       struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev = data;
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_veth_mode(key, lxc_conf, data);
+
+	if (!netdev)
+		return -1;
+
+	return lxc_veth_mode_to_flag(&netdev->priv.veth_attr.mode, value);
 }
 
 static int set_config_net_veth_pair(const char *key, const char *value,
@@ -5094,6 +5112,22 @@ static int clr_config_net_ipvlan_isolation(const char *key,
 	return 0;
 }
 
+static int clr_config_net_veth_mode(const char *key,
+				       struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev = data;
+
+	if (!netdev)
+		return minus_one_set_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VETH)
+		return 0;
+
+	netdev->priv.veth_attr.mode = -1;
+
+	return 0;
+}
+
 static int clr_config_net_veth_pair(const char *key, struct lxc_conf *lxc_conf,
 				    void *data)
 {
@@ -5505,6 +5539,42 @@ static int get_config_net_ipvlan_isolation(const char *key, char *retv, int inle
 		break;
 	case IPVLAN_ISOLATION_VEPA:
 		mode = "vepa";
+		break;
+	default:
+		mode = "(invalid)";
+		break;
+	}
+
+	strprint(retv, inlen, "%s", mode);
+
+	return fulllen;
+}
+
+static int get_config_net_veth_mode(const char *key, char *retv, int inlen,
+				       struct lxc_conf *c, void *data)
+{
+	int len;
+	int fulllen = 0;
+	const char *mode;
+	struct lxc_netdev *netdev = data;
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	if (!netdev)
+		return minus_one_set_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VETH)
+		return 0;
+
+	switch (netdev->priv.veth_attr.mode) {
+	case VETH_MODE_BRIDGE:
+		mode = "bridge";
+		break;
+	case VETH_MODE_ROUTER:
+		mode = "router";
 		break;
 	default:
 		mode = "(invalid)";

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -501,6 +501,28 @@ void lxc_free_networks(struct lxc_list *networks)
 	lxc_list_init(networks);
 }
 
+
+static struct lxc_veth_mode {
+	char *name;
+	int mode;
+} veth_mode[] = {
+    { "bridge", VETH_MODE_BRIDGE },
+    { "router", VETH_MODE_ROUTER },
+};
+
+int lxc_veth_mode_to_flag(int *mode, const char *value)
+{
+	for (size_t i = 0; i < sizeof(veth_mode) / sizeof(veth_mode[0]); i++) {
+		if (strcmp(veth_mode[i].name, value) != 0)
+			continue;
+
+		*mode = veth_mode[i].mode;
+		return 0;
+	}
+
+	return minus_one_set_errno(EINVAL);
+}
+
 static struct lxc_macvlan_mode {
 	char *name;
 	int mode;

--- a/src/lxc/confile_utils.h
+++ b/src/lxc/confile_utils.h
@@ -56,6 +56,7 @@ lxc_get_netdev_by_idx(struct lxc_conf *conf, unsigned int idx, bool allocate);
 extern void lxc_log_configured_netdevs(const struct lxc_conf *conf);
 extern bool lxc_remove_nic_by_idx(struct lxc_conf *conf, unsigned int idx);
 extern void lxc_free_networks(struct lxc_list *networks);
+extern int lxc_veth_mode_to_flag(int *mode, const char *value);
 extern int lxc_macvlan_mode_to_flag(int *mode, const char *value);
 extern char *lxc_macvlan_flag_to_mode(int mode);
 extern int lxc_ipvlan_mode_to_flag(int *mode, const char *value);

--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -505,6 +505,13 @@ ATTR_UNUSED static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 	} while (0)
 #endif
 
+#define error_log_errno(__errno__, format, ...) 	\
+	({						\
+		errno = __errno__;			\
+		SYSERROR(format, ##__VA_ARGS__);	\
+		-1;					\
+	})
+
 extern int lxc_log_fd;
 
 extern int lxc_log_syslog(int facility);

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -281,6 +281,14 @@ extern int __build_bug_on_failed;
 #define VETH_INFO_PEER 1
 #endif
 
+#ifndef VETH_MODE_BRIDGE
+#define VETH_MODE_BRIDGE 1
+#endif
+
+#ifndef VETH_MODE_ROUTER
+#define VETH_MODE_ROUTER 2
+#endif
+
 #ifndef IFLA_MACVLAN_MODE
 #define IFLA_MACVLAN_MODE 1
 #endif

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -264,6 +264,12 @@ extern int lxc_neigh_proxy_on(const char *name, int family);
 /* Disable neighbor proxying. */
 extern int lxc_neigh_proxy_off(const char *name, int family);
 
+/* Activate IP forwarding. */
+extern int lxc_ip_forwarding_on(const char *name, int family);
+
+/* Disable IP forwarding. */
+extern int lxc_ip_forwarding_off(const char *name, int family);
+
 /* Generate a new unique network interface name.
  * Allocated memory must be freed by caller.
  */

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -98,6 +98,7 @@ struct ifla_veth {
 	int ifindex;
 	struct lxc_list ipv4_routes;
 	struct lxc_list ipv6_routes;
+	int mode; /* bridge, router */
 };
 
 struct ifla_vlan {


### PR DESCRIPTION
This PR adds a new "router" mode for veth networking.

The idea behind this is to provide an ipvlan-like networking mode that has the following properties:

- Works on older kernels.
- Uses the host's routing table (and netfilter rules) to route packets (potentially out of different interfaces or between containers), unlike ipvlan.
- Prevents containers from altering their IP.
- Prevents broadcast/multicast traffic to/from containers.
- Provides same MAC externally for all containers.
- No bridge interface to manage.
- Supports layer 3 only mode for setups where BGP (or other routing protocols) are running on the host to distribute container's IPs in the local routing table to the wider network.
- Containers can optionally have IPs published on local LAN at layer 2 using the existing `l2proxy` and `link` settings.

To implementation adds a new `mode` config property for veth type networks, which can support 2 values; "bridge" and "router".

If `mode` is "bridge" then all existing behaviour is maintained.
If `mode` is not defined in the config file, it defaults to "bridge". 

This "router" mode will configure the host machine as a router for the container by adding static routes for the container's IPs on the host pointing to the host-side veth interface. It will also add static IP proxy entries on the host-side veth interface for the container's gateway IPs.

Example usage:

```
lxc.net.0.type = veth
lxc.net.0.link = eth0
lxc.net.0.flags = up
lxc.net.0.veth.mode = router
lxc.net.0.ipv4.address = 192.168.3.3/32
lxc.net.0.ipv6.address = 2a02:xxx:xxx:3::3/128
lxc.net.0.ipv4.gateway = 169.254.0.1
lxc.net.0.ipv6.gateway = auto
lxc.net.0.l2proxy = 1
lxc.net.0.link = eth0
```