### PR TITLE
More pdeathsig fixes

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1438,7 +1438,7 @@ static int do_start(void *data)
 	}
 
 	if (handler->conf->monitor_signal_pdeath != SIGKILL) {
-		ret = lxc_set_death_signal(handler->conf->monitor_signal_pdeath, 0);
+		ret = lxc_set_death_signal(handler->conf->monitor_signal_pdeath, handler->monitor_pid);
 		if (ret < 0) {
 			SYSERROR("Failed to set PR_SET_PDEATHSIG to %d",
 				 handler->conf->monitor_signal_pdeath);

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1190,7 +1190,7 @@ static int do_start(void *data)
 			goto out_warn_father;
 
 		/* set{g,u}id() clears deathsignal */
-		ret = lxc_set_death_signal(SIGKILL, 0);
+		ret = lxc_set_death_signal(SIGKILL, handler->monitor_pid);
 		if (ret < 0) {
 			SYSERROR("Failed to set PR_SET_PDEATHSIG to SIGKILL");
 			goto out_warn_father;


### PR DESCRIPTION
Completes #2903 for user namespaces and `lxc.monitor.signal.pdeath`
