### PR TITLE
fix: #2927 api doc generation fails under out of source build.

### DIFF
--- a/doc/api/Makefile.am
+++ b/doc/api/Makefile.am
@@ -2,7 +2,7 @@ EXTRA_DIST = Doxyfile
 
 if ENABLE_API_DOCS
 html: Doxyfile
-	doxygen
+	doxygen $<
 endif
 
 .PHONY: html


### PR DESCRIPTION
Signed-off-by: yosukesan <y.otsuki30@gmail.com>

# Description of the patch

This patch fix api doc generation failure by doxgen.

# Trigger of the problem

Absence of argument when doxygen is called was the cause.
If no argument is specified, doxygen searches a Doxyfile in current dir. Hence, in source build worked.
However, in out of source build this did not.

# Test

I tested both out of source and in source build both successfully terminated.

* In source build was just simple.
```
bash autogen.sh && ./configure && make
```

* out of source build
Identical to "Step to reproduce" in #2972

Do I need test more ? If so let me know.

# Note

For CMake users, out of source build is standard procedure :).