### PR TITLE
conf: do lxc.mount.entry mounts right after lxc.mount.fstab

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3546,6 +3546,15 @@ int lxc_setup(struct lxc_handler *handler)
 		return -1;
 	}
 
+	if (!lxc_list_empty(&lxc_conf->mount_list)) {
+		ret = setup_mount_entries(lxc_conf, &lxc_conf->rootfs,
+					  &lxc_conf->mount_list, name, lxcpath);
+		if (ret < 0) {
+			ERROR("Failed to setup mount entries");
+			return -1;
+		}
+	}
+
 	if (lxc_conf->is_execute) {
 		if (execveat_supported()) {
 			int fd;
@@ -3600,15 +3609,6 @@ int lxc_setup(struct lxc_handler *handler)
 		ret = lxc_fill_autodev(&lxc_conf->rootfs);
 		if (ret < 0) {
 			ERROR("Failed to populate \"/dev\"");
-			return -1;
-		}
-	}
-
-	if (!lxc_list_empty(&lxc_conf->mount_list)) {
-		ret = setup_mount_entries(lxc_conf, &lxc_conf->rootfs,
-					  &lxc_conf->mount_list, name, lxcpath);
-		if (ret < 0) {
-			ERROR("Failed to setup mount entries");
 			return -1;
 		}
 	}


### PR DESCRIPTION
These configuration options use the same syntax and therefore it seems
more intuitive to have the same behavior for both of them, which is
not the case today since mount hooks and autodev mounts are called
between the two.

See: https://github.com/lxc/lxc/issues/2932

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>