### PR TITLE
netns_getifaddrs: adapt to kernel changes

### DIFF
--- a/src/include/netns_ifaddrs.c
+++ b/src/include/netns_ifaddrs.c
@@ -468,7 +468,7 @@ static int __rtnl_enumerate(int link_af, int addr_af, __s32 netns_id,
 	if (fd < 0)
 		return -1;
 
-	r = setsockopt(fd, SOL_NETLINK, NETLINK_DUMP_STRICT_CHK, &(int){1},
+	r = setsockopt(fd, SOL_NETLINK, NETLINK_GET_STRICT_CHK, &(int){1},
 		       sizeof(int));
 	if (r < 0 && netns_id >= 0) {
 		close(fd);

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -240,8 +240,8 @@ extern int __build_bug_on_failed;
 #define prctl_arg(x) ((unsigned long)x)
 
 /* networking */
-#ifndef NETLINK_DUMP_STRICT_CHK
-#define NETLINK_DUMP_STRICT_CHK 12
+#ifndef NETLINK_GET_STRICT_CHK
+#define NETLINK_GET_STRICT_CHK 12
 #endif
 
 #ifndef SOL_NETLINK


### PR DESCRIPTION
s/NETLINK_DUMP_STRICT_CHK/NETLINK_GET_STRICT_CHK/g

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>