### PR TITLE
lxc-start: remove bad doc

### DIFF
--- a/src/lxc/tools/lxc_start.c
+++ b/src/lxc/tools/lxc_start.c
@@ -88,7 +88,6 @@ Options :\n\
   -c, --console=FILE     Use specified FILE for the container console\n\
   -L, --console-log=FILE Log container console output to FILE\n\
   -C, --close-all-fds    If any fds are inherited, close them\n\
-                         If not specified, exit with failure instead\n\
                          Note: --daemon implies --close-all-fds\n\
   -s, --define KEY=VAL   Assign VAL to configuration variable KEY\n\
       --share-[net|ipc|uts|pid]=NAME Share a namespace with another container or pid\n\


### PR DESCRIPTION
We don't in fact exit(1) if this is not specified, and it wouldn't make
sense to, since most people probably don't specify this.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>