### PR TITLE
network: Adds veth static routes feature

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -32,3 +32,9 @@ until a reboot succeeded. It takes a timeout argument. When set to `> 0`
 This adds support for injecting and removing mounts into/from a running
 containers. Two new API functions `mount()` and `umount()` are added. They
 mirror the current mount and umount API of the kernel.
+
+## network\_veth\_routes
+
+This introduces the `lxc.net.[i].veth.ipv4.route` and `lxc.net.[i].veth.ipv6.route` properties
+on `veth` type network interfaces. This allows adding static routes on host to the container's
+network interface.

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -375,7 +375,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
           <listitem>
             <para>
               The only allowed values are 0 and 1. Set this to 1 to destroy a
-              container on shutdown. 
+              container on shutdown.
             </para>
           </listitem>
         </varlistentry>
@@ -459,6 +459,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               the <option>lxc.net.[i].veth.pair</option> option (except for
               unprivileged containers where this option is ignored for security
               reasons).
+
+              Static routes can be added on the host pointing to the container using the
+              <option>lxc.net.[i].veth.ipv4.route</option> and
+              <option>lxc.net.[i].veth.ipv6.route</option> options.
+              Several lines specify several routes.
+              The route is in format x.y.z.t/m, eg. 192.168.1.0/24.
             </para>
 
             <para>
@@ -855,7 +861,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             When manually specifying a size for the log file the value should
             be a power of 2 when converted to bytes. Valid size prefixes are
             'KB', 'MB', 'GB'. (Note that all conversions are based on multiples
-            of 1024. That means 'KB' == 'KiB', 'MB' == 'MiB', 'GB' == 'GiB'. 
+            of 1024. That means 'KB' == 'KiB', 'MB' == 'MiB', 'GB' == 'GiB'.
             Additionally, the case of the suffix is ignored, i.e. 'kB', 'KB' and
             'Kb' are treated equally.)
 
@@ -1629,7 +1635,7 @@ dev/null proc/kcore none bind,relative 0 0
             </para>
 
             <para>
-            To inherit the namespace from another container set the 
+            To inherit the namespace from another container set the
             <option>lxc.namespace.share.[namespace identifier]</option> to the name of
             the container, e.g. <option>lxc.namespace.share.pid=c3</option>.
             </para>
@@ -1708,7 +1714,7 @@ dev/null proc/kcore none bind,relative 0 0
           </term>
           <listitem>
             <para>
-              Specify the kernel parameters to be set. The parameters available 
+              Specify the kernel parameters to be set. The parameters available
               are those listed under /proc/sys/.
               Note that not all sysctls are namespaced. Changing Non-namespaced
               sysctls will cause the system-wide setting to be modified.
@@ -1716,7 +1722,7 @@ dev/null proc/kcore none bind,relative 0 0
                 <refentrytitle><command>sysctl</command></refentrytitle>
                 <manvolnum>8</manvolnum>
               </citerefentry>.
-              If used with no value, lxc will clear the parameters specified up 
+              If used with no value, lxc will clear the parameters specified up
               to this point.
             </para>
           </listitem>

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -44,6 +44,7 @@ static char *api_extensions[] = {
 	"mount_injection_file",
 	"seccomp_allow_nesting",
 	"seccomp_notify",
+	"network_veth_routes",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -95,6 +95,8 @@ struct ifla_veth {
 	char pair[IFNAMSIZ];
 	char veth1[IFNAMSIZ];
 	int ifindex;
+	struct lxc_list ipv4_routes;
+	struct lxc_list ipv6_routes;
 };
 
 struct ifla_vlan {
@@ -221,8 +223,8 @@ extern int lxc_ipv4_addr_get(int ifindex, struct in_addr **res);
 extern int lxc_ipv6_addr_get(int ifindex, struct in6_addr **res);
 
 /* Set a destination route to an interface. */
-extern int lxc_ipv4_dest_add(int ifindex, struct in_addr *dest);
-extern int lxc_ipv6_dest_add(int ifindex, struct in6_addr *dest);
+extern int lxc_ipv4_dest_add(int ifindex, struct in_addr *dest, unsigned int netmask);
+extern int lxc_ipv6_dest_add(int ifindex, struct in6_addr *dest, unsigned int netmask);
 
 /* Set default route. */
 extern int lxc_ipv4_gateway_add(int ifindex, struct in_addr *gw);

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -134,6 +134,16 @@ static int set_and_clear_complete_netdev(struct lxc_container *c)
 		return -1;
 	}
 
+	if (!c->set_config_item(c, "lxc.net.1.veth.ipv4.route", "192.0.2.1/32")) {
+		lxc_error("%s\n", "lxc.net.1.veth.ipv4.route");
+		return -1;
+	}
+
+	if (!c->set_config_item(c, "lxc.net.1.veth.ipv6.route", "2001:db8::1/128")) {
+		lxc_error("%s\n", "lxc.net.1.veth.ipv6.route");
+		return -1;
+	}
+
 	if (!c->set_config_item(c, "lxc.net.1.hwaddr",
 				"52:54:00:80:7a:5d")) {
 		lxc_error("%s\n", "lxc.net.1.hwaddr");
@@ -693,6 +703,16 @@ int main(int argc, char *argv[])
 	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.veth.pair", "clusterfuck", tmpf, true, "veth")) {
 		lxc_error("%s\n", "lxc.net.0.veth.pair");
 		goto non_test_error;
+	}
+
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.veth.ipv4.route", "192.0.2.1/32", tmpf, true, "veth")) {
+		lxc_error("%s\n", "lxc.net.0.veth.ipv4.route");
+		return -1;
+	}
+
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.veth.ipv6.route", "2001:db8::1/128", tmpf, true, "veth")) {
+		lxc_error("%s\n", "lxc.net.0.veth.ipv6.route");
+		return -1;
 	}
 
 	if (set_get_compare_clear_save_load(c, "lxc.net.0.script.up", "/some/up/path", tmpf, true)) {


### PR DESCRIPTION
Adds support for specifying static routes for veth network devices what will be created on the host.

e.g.

```
lxc.net.0.veth.ipv4.route = 192.0.2.1/32
lxc.net.0.veth.ipv4.route = 192.0.3.0/24
lxc.net.0.veth.ipv6.route = 2001:db8::1/128
lxc.net.0.veth.ipv6.route = 2001:db8:2::/64
```