### PR TITLE
network: Adds IPVLAN support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -51,3 +51,17 @@ The caller can read this message, inspect the syscalls including its arguments. 
 This introduces the `lxc.net.[i].veth.ipv4.route` and `lxc.net.[i].veth.ipv6.route` properties
 on `veth` type network interfaces. This allows adding static routes on host to the container's
 network interface.
+
+## network\_ipvlan
+
+This introduces the `ipvlan` network type.
+
+Example usage:
+
+```
+lxc.net[i].type=ipvlan
+lxc.net[i].ipvlan.mode=[l3|l3s|l2] (defaults to l3)
+lxc.net[i].ipvlan.isolation=[bridge|private|vepa] (defaults to bridge)
+lxc.net[i].link=eth0
+lxc.net[i].flags=up
+```

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -485,7 +485,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               different macvlan on the same upper device. The accepted
               modes are <option>private</option>, <option>vepa</option>,
               <option>bridge</option> and <option>passthru</option>.
-	      In <option>private</option> mode, the device never
+              In <option>private</option> mode, the device never
               communicates with any other device on the same upper_dev (default).
               In <option>vepa</option> mode, the new Virtual Ethernet Port
               Aggregator (VEPA) mode, it assumes that the adjacent
@@ -508,6 +508,41 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               the physical interface are forwarded to the macvlan
               interface. Only one macvlan interface in <option>passthru</option>
               mode is possible for one physical interface.
+            </para>
+
+            <para>
+              <option>ipvlan:</option> an ipvlan interface is linked
+              with the interface specified by
+              the <option>lxc.net.[i].link</option> and assigned to
+              the container.
+              <option>lxc.net.[i].ipvlan.mode</option> specifies the
+              mode the ipvlan will use to communicate between
+              different ipvlan on the same upper device. The accepted
+              modes are <option>l3</option>, <option>l3s</option> and
+              <option>l2</option>. It defaults to <option>l3</option> mode.
+              In <option>l3</option> mode TX processing up to L3 happens on the stack instance
+              attached to the slave device and packets are switched to the stack instance of the
+              master device for the L2 processing and routing from that instance will be
+              used before packets are queued on the outbound device. In this mode the slaves
+              will not receive nor can send multicast / broadcast traffic.
+              In <option>l3s</option> mode TX processing is very similar to the L3 mode except that
+              iptables (conn-tracking) works in this mode and hence it is L3-symmetric (L3s).
+              This will have slightly less performance but that shouldn't matter since you are
+              choosing this mode over plain-L3 mode to make conn-tracking work.
+              In <option>l2</option> mode TX processing happens on the stack instance attached to
+              the slave device and packets are switched and queued to the master device to send
+              out. In this mode the slaves will RX/TX multicast and broadcast (if applicable) as well.
+              <option>lxc.net.[i].ipvlan.isolation</option> specifies the isolation mode.
+              The accepted isolation values are <option>bridge</option>,
+              <option>private</option> and <option>vepa</option>.
+              It defaults to <option>bridge</option>.
+              In <option>bridge</option> isolation mode slaves can cross-talk among themselves
+              apart from talking through the master device.
+              In <option>private</option> isolation mode the port is set in private mode.
+              i.e. port won't allow cross communication between slaves.
+              In <option>vepa</option> isolation mode the port is set in VEPA mode.
+              i.e. port will offload switching functionality to the external entity as
+              described in 802.1Qbg.
             </para>
 
             <para>
@@ -610,8 +645,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               interface (as specified by the
               <option>lxc.net.[i].link</option> option) and use that as
               the gateway. <option>auto</option> is only available when
-              using the <option>veth</option> and
-              <option>macvlan</option> network types.
+              using the <option>veth</option>, 
+              <option>macvlan</option> and <option>ipvlan</option> network types.
             </para>
           </listitem>
         </varlistentry>
@@ -644,8 +679,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               interface (as specified by the
               <option>lxc.net.[i].link</option> option) and use that as
               the gateway. <option>auto</option> is only available when
-              using the <option>veth</option> and
-              <option>macvlan</option> network types.
+              using the <option>veth</option>,
+              <option>macvlan</option> and <option>ipvlan</option> network types.
             </para>
           </listitem>
         </varlistentry>
@@ -680,7 +715,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
                 <listitem>
                  <para>
                  LXC_NET_TYPE: the network type. This is one of the valid
-                 network types listed here (e.g. 'macvlan', 'veth').
+                 network types listed here (e.g. 'vlan', 'macvlan', 'ipvlan', 'veth').
                   </para>
                 </listitem>
 
@@ -746,7 +781,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
                 <listitem>
                  <para>
                  LXC_NET_TYPE: the network type. This is one of the valid
-                 network types listed here (e.g. 'macvlan', 'veth').
+                 network types listed here (e.g. 'vlan', 'macvlan', 'ipvlan', 'veth').
                   </para>
                 </listitem>
 

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -45,6 +45,7 @@ static char *api_extensions[] = {
 	"seccomp_allow_nesting",
 	"seccomp_notify",
 	"network_veth_routes",
+	"network_ipvlan",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -299,6 +299,17 @@ void lxc_log_configured_netdevs(const struct lxc_conf *conf)
 				      mode ? mode : "(invalid mode)");
 			}
 			break;
+		case LXC_NET_IPVLAN:
+			TRACE("type: ipvlan");
+
+			char *mode;
+			mode = lxc_ipvlan_flag_to_mode(netdev->priv.ipvlan_attr.mode);
+			TRACE("ipvlan mode: %s", mode ? mode : "(invalid mode)");
+
+			char *isolation;
+			isolation = lxc_ipvlan_flag_to_isolation(netdev->priv.ipvlan_attr.isolation);
+			TRACE("ipvlan isolation: %s", isolation ? isolation : "(invalid isolation)");
+			break;
 		case LXC_NET_VLAN:
 			TRACE("type: vlan");
 			TRACE("vlan id: %d", netdev->priv.vlan_attr.vid);
@@ -514,6 +525,74 @@ char *lxc_macvlan_flag_to_mode(int mode)
 			continue;
 
 		return macvlan_mode[i].name;
+	}
+
+	return NULL;
+}
+
+static struct lxc_ipvlan_mode {
+	char *name;
+	int mode;
+} ipvlan_mode[] = {
+    { "l3",  IPVLAN_MODE_L3  },
+    { "l3s", IPVLAN_MODE_L3S },
+    { "l2",  IPVLAN_MODE_L2  },
+};
+
+int lxc_ipvlan_mode_to_flag(int *mode, const char *value)
+{
+	for (size_t i = 0; i < sizeof(ipvlan_mode) / sizeof(ipvlan_mode[0]); i++) {
+		if (strcmp(ipvlan_mode[i].name, value) != 0)
+			continue;
+
+		*mode = ipvlan_mode[i].mode;
+		return 0;
+	}
+
+	return -1;
+}
+
+char *lxc_ipvlan_flag_to_mode(int mode)
+{
+	for (size_t i = 0; i < sizeof(ipvlan_mode) / sizeof(ipvlan_mode[0]); i++) {
+		if (ipvlan_mode[i].mode != mode)
+			continue;
+
+		return ipvlan_mode[i].name;
+	}
+
+	return NULL;
+}
+
+static struct lxc_ipvlan_isolation {
+	char *name;
+	int flag;
+} ipvlan_isolation[] = {
+    { "bridge",  IPVLAN_ISOLATION_BRIDGE  },
+    { "private", IPVLAN_ISOLATION_PRIVATE },
+    { "vepa",    IPVLAN_ISOLATION_VEPA    },
+};
+
+int lxc_ipvlan_isolation_to_flag(int *flag, const char *value)
+{
+	for (size_t i = 0; i < sizeof(ipvlan_isolation) / sizeof(ipvlan_isolation[0]); i++) {
+		if (strcmp(ipvlan_isolation[i].name, value) != 0)
+			continue;
+
+		*flag = ipvlan_isolation[i].flag;
+		return 0;
+	}
+
+	return -1;
+}
+
+char *lxc_ipvlan_flag_to_isolation(int flag)
+{
+	for (size_t i = 0; i < sizeof(ipvlan_isolation) / sizeof(ipvlan_isolation[0]); i++) {
+		if (ipvlan_isolation[i].flag != flag)
+			continue;
+
+		return ipvlan_isolation[i].name;
 	}
 
 	return NULL;

--- a/src/lxc/confile_utils.h
+++ b/src/lxc/confile_utils.h
@@ -58,6 +58,10 @@ extern bool lxc_remove_nic_by_idx(struct lxc_conf *conf, unsigned int idx);
 extern void lxc_free_networks(struct lxc_list *networks);
 extern int lxc_macvlan_mode_to_flag(int *mode, const char *value);
 extern char *lxc_macvlan_flag_to_mode(int mode);
+extern int lxc_ipvlan_mode_to_flag(int *mode, const char *value);
+extern char *lxc_ipvlan_flag_to_mode(int mode);
+extern int lxc_ipvlan_isolation_to_flag(int *mode, const char *value);
+extern char *lxc_ipvlan_flag_to_isolation(int mode);
 
 extern int set_config_string_item(char **conf_item, const char *value);
 extern int set_config_string_item_max(char **conf_item, const char *value,

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -280,6 +280,14 @@ extern int __build_bug_on_failed;
 #define IFLA_MACVLAN_MODE 1
 #endif
 
+#ifndef IFLA_IPVLAN_MODE
+#define IFLA_IPVLAN_MODE 1
+#endif
+
+#ifndef IFLA_IPVLAN_ISOLATION
+#define IFLA_IPVLAN_ISOLATION 2
+#endif
+
 #ifndef IFLA_NEW_NETNSID
 #define IFLA_NEW_NETNSID 45
 #endif
@@ -331,6 +339,30 @@ extern int __build_bug_on_failed;
 
 #ifndef MACVLAN_MODE_PASSTHRU
 #define MACVLAN_MODE_PASSTHRU 8
+#endif
+
+#ifndef IPVLAN_MODE_L2
+#define IPVLAN_MODE_L2 0
+#endif
+
+#ifndef IPVLAN_MODE_L3
+#define IPVLAN_MODE_L3 1
+#endif
+
+#ifndef IPVLAN_MODE_L3S
+#define IPVLAN_MODE_L3S 2
+#endif
+
+#ifndef IPVLAN_ISOLATION_BRIDGE
+#define IPVLAN_ISOLATION_BRIDGE 0
+#endif
+
+#ifndef IPVLAN_ISOLATION_PRIVATE
+#define IPVLAN_ISOLATION_PRIVATE 1
+#endif
+
+#ifndef IPVLAN_ISOLATION_VEPA
+#define IPVLAN_ISOLATION_VEPA 2
 #endif
 
 /* Attributes of RTM_NEWNSID/RTM_GETNSID messages */

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -40,6 +40,7 @@ enum {
 	LXC_NET_EMPTY,
 	LXC_NET_VETH,
 	LXC_NET_MACVLAN,
+	LXC_NET_IPVLAN,
 	LXC_NET_PHYS,
 	LXC_NET_VLAN,
 	LXC_NET_NONE,
@@ -110,6 +111,11 @@ struct ifla_macvlan {
 	int mode; /* private, vepa, bridge, passthru */
 };
 
+struct ifla_ipvlan {
+	int mode; /* l3, l3s, l2 */
+	int isolation; /* bridge, private, vepa */
+};
+
 /* Contains information about the physical network device as seen from the host.
  * @ifindex : The ifindex of the physical network device in the host's network
  *            namespace.
@@ -120,6 +126,7 @@ struct ifla_phys {
 
 union netdev_p {
 	struct ifla_macvlan macvlan_attr;
+	struct ifla_ipvlan ipvlan_attr;
 	struct ifla_phys phys_attr;
 	struct ifla_veth veth_attr;
 	struct ifla_vlan vlan_attr;

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -666,6 +666,11 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.type", "ipvlan", tmpf, true)) {
+		lxc_error("%s\n", "lxc.net.0.type");
+		goto non_test_error;
+	}
+
 	if (set_get_compare_clear_save_load(c, "lxc.net.1000.type", "phys", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.1000.type");
 		goto non_test_error;
@@ -698,6 +703,36 @@ int main(int argc, char *argv[])
 
 	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.macvlan.mode", "bridge", tmpf, true, "macvlan")) {
 		lxc_error("%s\n", "lxc.net.0.macvlan.mode");
+		goto non_test_error;
+	}
+
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.ipvlan.mode", "l3", tmpf, true, "ipvlan")) {
+		lxc_error("%s\n", "lxc.net.0.ipvlan.mode");
+		goto non_test_error;
+	}
+
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.ipvlan.mode", "l3s", tmpf, true, "ipvlan")) {
+		lxc_error("%s\n", "lxc.net.0.ipvlan.mode");
+		goto non_test_error;
+	}
+
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.ipvlan.mode", "l2", tmpf, true, "ipvlan")) {
+		lxc_error("%s\n", "lxc.net.0.ipvlan.mode");
+		goto non_test_error;
+	}
+
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.ipvlan.isolation", "bridge", tmpf, true, "ipvlan")) {
+		lxc_error("%s\n", "lxc.net.0.ipvlan.isolation");
+		goto non_test_error;
+	}
+
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.ipvlan.isolation", "private", tmpf, true, "ipvlan")) {
+		lxc_error("%s\n", "lxc.net.0.ipvlan.isolation");
+		goto non_test_error;
+	}
+
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.ipvlan.isolation", "vepa", tmpf, true, "ipvlan")) {
+		lxc_error("%s\n", "lxc.net.0.ipvlan.isolation");
 		goto non_test_error;
 	}
 


### PR DESCRIPTION
Example usage:

	lxc.net[i].type=ipvlan
	lxc.net[i].ipvlan.mode=[l3|l3s|l2] (defaults to l3)
	lxc.net[i].ipvlan.isolation=[bridge|private|vepa] (defaults to bridge)
	lxc.net[i].link=eth0
	lxc.net[i].flags=up

Signed-off-by: tomponline <thomas.parrott@canonical.com>