### PR TITLE
network: Adds hook handling for vlan network type

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -297,6 +297,21 @@ static int instantiate_vlan(struct lxc_handler *handler, struct lxc_netdev *netd
 		return -1;
 	}
 
+	if (netdev->upscript) {
+		char *argv[] = {
+		    "vlan",
+		    netdev->link,
+		    NULL,
+		};
+
+		err = run_script_argv(handler->name,
+				handler->conf->hooks_version, "net",
+				netdev->upscript, "up", argv);
+		if (err < 0)
+			lxc_netdev_delete_by_name(peer);
+			return -1;
+	}
+
 	DEBUG("Instantiated vlan \"%s\" with ifindex is \"%d\" (vlan1000)",
 	      peer, netdev->ifindex);
 	if (netdev->mtu) {
@@ -447,6 +462,21 @@ static int shutdown_macvlan(struct lxc_handler *handler, struct lxc_netdev *netd
 
 static int shutdown_vlan(struct lxc_handler *handler, struct lxc_netdev *netdev)
 {
+	int ret;
+	char *argv[] = {
+	    "vlan",
+	    netdev->link,
+	    NULL,
+	};
+
+	if (!netdev->downscript)
+		return 0;
+
+	ret = run_script_argv(handler->name, handler->conf->hooks_version,
+			      "net", netdev->downscript, "down", argv);
+	if (ret < 0)
+		return -1;
+
 	return 0;
 }
 


### PR DESCRIPTION
I noticed that the vlan network type doesn't execute network up/down hook scripts.

Signed-off-by: tomponline <thomas.parrott@canonical.com>