### PR TITLE
network: Makes some routing functions static

### DIFF
--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -222,10 +222,6 @@ extern int lxc_ipv4_addr_add(int ifindex, struct in_addr *addr,
 extern int lxc_ipv4_addr_get(int ifindex, struct in_addr **res);
 extern int lxc_ipv6_addr_get(int ifindex, struct in6_addr **res);
 
-/* Set a destination route to an interface. */
-extern int lxc_ipv4_dest_add(int ifindex, struct in_addr *dest, unsigned int netmask);
-extern int lxc_ipv6_dest_add(int ifindex, struct in6_addr *dest, unsigned int netmask);
-
 /* Set default route. */
 extern int lxc_ipv4_gateway_add(int ifindex, struct in_addr *gw);
 extern int lxc_ipv6_gateway_add(int ifindex, struct in6_addr *gw);


### PR DESCRIPTION
The following functions can be made static for consistency:

	lxc_ipv4_dest_add
	lxc_ipv6_dest_add
	lxc_ip_route_dest_add (renamed)

Signed-off-by: tomponline <thomas.parrott@canonical.com>