### PR TITLE
hooks: Adds LXC_NET_ID enviroment variable

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -699,6 +699,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
                  to 1.
                   </para>
                 </listitem>
+
+                <listitem>
+                 <para>
+                 LXC_NET_ID: the network device index ID in the config file.
+                 Note that this information is only available when
+                 <option>lxc.hook.version</option> is set to 1.
+                  </para>
+                </listitem>
               </itemizedlist>
 
               Whether this information is provided in the form of environment

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -452,7 +452,7 @@ extern int run_script(const char *name, const char *section, const char *script,
 		      ...);
 extern int run_script_argv(const char *name, unsigned int hook_version,
 			   const char *section, const char *script,
-			   const char *hookname, char **argsin);
+			   const char *hookname, char **argsin, int netdev_idx);
 extern int in_caplist(int cap, struct lxc_list *caps);
 extern int setup_sysctl_parameters(struct lxc_list *sysctls);
 extern int lxc_clear_sysctls(struct lxc_conf *c, const char *key);

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -303,7 +303,7 @@ static int instantiate_veth(struct lxc_handler *handler, struct lxc_netdev *netd
 
 		err = run_script_argv(handler->name,
 				handler->conf->hooks_version, "net",
-				netdev->upscript, "up", argv);
+				netdev->upscript, "up", argv, netdev->idx);
 		if (err < 0)
 			goto out_delete;
 	}
@@ -361,7 +361,7 @@ static int instantiate_macvlan(struct lxc_handler *handler, struct lxc_netdev *n
 
 		err = run_script_argv(handler->name,
 				handler->conf->hooks_version, "net",
-				netdev->upscript, "up", argv);
+				netdev->upscript, "up", argv, netdev->idx);
 		if (err < 0)
 			goto on_error;
 	}
@@ -416,7 +416,7 @@ static int instantiate_vlan(struct lxc_handler *handler, struct lxc_netdev *netd
 
 		err = run_script_argv(handler->name,
 				handler->conf->hooks_version, "net",
-				netdev->upscript, "up", argv);
+				netdev->upscript, "up", argv, netdev->idx);
 		if (err < 0) {
 			lxc_netdev_delete_by_name(peer);
 			return -1;
@@ -482,7 +482,7 @@ static int instantiate_phys(struct lxc_handler *handler, struct lxc_netdev *netd
 		return 0;
 
 	ret = run_script_argv(handler->name, handler->conf->hooks_version,
-			      "net", netdev->upscript, "up", argv);
+			      "net", netdev->upscript, "up", argv, netdev->idx);
 	if (ret < 0)
 		return -1;
 
@@ -502,7 +502,7 @@ static int instantiate_empty(struct lxc_handler *handler, struct lxc_netdev *net
 		return 0;
 
 	ret = run_script_argv(handler->name, handler->conf->hooks_version,
-			      "net", netdev->upscript, "up", argv);
+			      "net", netdev->upscript, "up", argv, netdev->idx);
 	if (ret < 0)
 		return -1;
 
@@ -544,7 +544,7 @@ static int shutdown_veth(struct lxc_handler *handler, struct lxc_netdev *netdev)
 
 	ret = run_script_argv(handler->name,
 			handler->conf->hooks_version, "net",
-			netdev->downscript, "down", argv);
+			netdev->downscript, "down", argv, netdev->idx);
 	if (ret < 0)
 		return -1;
 
@@ -564,7 +564,7 @@ static int shutdown_macvlan(struct lxc_handler *handler, struct lxc_netdev *netd
 		return 0;
 
 	ret = run_script_argv(handler->name, handler->conf->hooks_version,
-			      "net", netdev->downscript, "down", argv);
+			      "net", netdev->downscript, "down", argv, netdev->idx);
 	if (ret < 0)
 		return -1;
 
@@ -584,7 +584,7 @@ static int shutdown_vlan(struct lxc_handler *handler, struct lxc_netdev *netdev)
 		return 0;
 
 	ret = run_script_argv(handler->name, handler->conf->hooks_version,
-			      "net", netdev->downscript, "down", argv);
+			      "net", netdev->downscript, "down", argv, netdev->idx);
 	if (ret < 0)
 		return -1;
 
@@ -604,7 +604,7 @@ static int shutdown_phys(struct lxc_handler *handler, struct lxc_netdev *netdev)
 		return 0;
 
 	ret = run_script_argv(handler->name, handler->conf->hooks_version,
-			      "net", netdev->downscript, "down", argv);
+			      "net", netdev->downscript, "down", argv, netdev->idx);
 	if (ret < 0)
 		return -1;
 
@@ -623,7 +623,7 @@ static int shutdown_empty(struct lxc_handler *handler, struct lxc_netdev *netdev
 		return 0;
 
 	ret = run_script_argv(handler->name, handler->conf->hooks_version,
-			      "net", netdev->downscript, "down", argv);
+			      "net", netdev->downscript, "down", argv, netdev->idx);
 	if (ret < 0)
 		return -1;
 
@@ -2321,7 +2321,7 @@ static int lxc_create_network_unpriv_exec(const char *lxcpath, const char *lxcna
 
 		ret = run_script_argv(lxcname,
 				hooks_version, "net",
-				netdev->upscript, "up", argv);
+				netdev->upscript, "up", argv, netdev->idx);
 		if (ret < 0)
 			return -1;
     }


### PR DESCRIPTION
Adds LXC_NET_ID environment variable to network up and down hooks.

This represents the netdev index ID of the network device in the config file.

E.g. lxc.net.6.type=ipvlan would result in LXC_NET_ID = 6

This allows hooks to parse the relevant config file section related to the network being processed.

Signed-off-by: tomponline <thomas.parrott@canonical.com>