### PR TITLE
network: Adds layer 2 (ARP/NDP) proxy mode

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -65,3 +65,22 @@ lxc.net[i].ipvlan.isolation=[bridge|private|vepa] (defaults to bridge)
 lxc.net[i].link=eth0
 lxc.net[i].flags=up
 ```
+
+## network\_l2proxy
+
+This introduces the `lxc.net.[i].l2proxy` that can be either `0` or `1`. Defaults to `0`.
+This, when used with `lxc.net.[i].link`, will add IP neighbour proxy entries on the linked device
+for any IPv4 and IPv6 addresses on the container's network device.
+
+For IPv4 addresses it will check the following sysctl values and fail with an error if not set:
+
+```
+net.ipv4.conf.[link].forwarding=1
+```
+
+For IPv6 addresses it will check the following sysctl values and fail with an error if not set:
+
+```
+net.ipv6.conf.[link].proxy_ndp=1
+net.ipv6.conf.[link].forwarding=1
+```

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -580,6 +580,24 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
+            <option>lxc.net.[i].l2proxy</option>
+          </term>
+          <listitem>
+            <para>
+              Controls whether layer 2 IP neighbour proxy entries will be added to the
+              lxc.net.[i].link interface for the IP addresses of the container.
+              Can be set to 0 or 1. Defaults to 0.
+              When used with IPv4 addresses, the following sysctl values need to be set:
+              net.ipv4.conf.[link].forwarding=1
+              When used with IPv6 addresses, the following sysctl values need to be set:
+              net.ipv6.conf.[link].proxy_ndp=1
+              net.ipv6.conf.[link].forwarding=1
+              </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>
             <option>lxc.net.[i].mtu</option>
           </term>
           <listitem>
@@ -645,7 +663,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               interface (as specified by the
               <option>lxc.net.[i].link</option> option) and use that as
               the gateway. <option>auto</option> is only available when
-              using the <option>veth</option>, 
+              using the <option>veth</option>,
               <option>macvlan</option> and <option>ipvlan</option> network types.
             </para>
           </listitem>

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -46,6 +46,7 @@ static char *api_extensions[] = {
 	"seccomp_notify",
 	"network_veth_routes",
 	"network_ipvlan",
+	"network_l2proxy",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -339,6 +339,10 @@ void lxc_log_configured_netdevs(const struct lxc_conf *conf)
 			if (netdev->link[0] != '\0')
 				TRACE("link: %s", netdev->link);
 
+			/* l2proxy only used when link is specified */
+			if (netdev->link[0] != '\0')
+				TRACE("l2proxy: %s", netdev->l2proxy ? "true" : "false");
+
 			if (netdev->name[0] != '\0')
 				TRACE("name: %s", netdev->name);
 

--- a/src/lxc/file_utils.c
+++ b/src/lxc/file_utils.c
@@ -147,7 +147,7 @@ ssize_t lxc_read_nointr_expect(int fd, void *buf, size_t count, const void *expe
 	ssize_t ret;
 
 	ret = lxc_read_nointr(fd, buf, count);
-	if (ret <= 0)
+	if (ret < 0)
 		return ret;
 
 	if ((size_t)ret != count)
@@ -158,7 +158,18 @@ ssize_t lxc_read_nointr_expect(int fd, void *buf, size_t count, const void *expe
 		return -1;
 	}
 
-	return ret;
+	return 0;
+}
+
+ssize_t lxc_read_file_expect(const char *path, void *buf, size_t count, const void *expected_buf)
+{
+	__do_close_prot_errno int fd = -EBADF;
+
+	fd = open(path, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return -1;
+
+	return lxc_read_nointr_expect(fd, buf, count, expected_buf);
 }
 
 bool file_exists(const char *f)

--- a/src/lxc/file_utils.h
+++ b/src/lxc/file_utils.h
@@ -40,6 +40,8 @@ extern ssize_t lxc_send_nointr(int sockfd, void *buf, size_t len, int flags);
 extern ssize_t lxc_read_nointr(int fd, void *buf, size_t count);
 extern ssize_t lxc_read_nointr_expect(int fd, void *buf, size_t count,
 				      const void *expected_buf);
+extern ssize_t lxc_read_file_expect(const char *path, void *buf, size_t count,
+				      const void *expected_buf);
 extern ssize_t lxc_recv_nointr(int sockfd, void *buf, size_t len, int flags);
 
 extern bool file_exists(const char *f);

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -171,6 +171,7 @@ struct lxc_netdev {
 	int type;
 	int flags;
 	char link[IFNAMSIZ];
+	bool l2proxy;
 	char name[IFNAMSIZ];
 	char *hwaddr;
 	char *mtu;


### PR DESCRIPTION
Adds the `lxc.net.[i].l2proxy` flag that can be either 0 or 1.

Defaults to 0.

This, when used with `lxc.net.[i].link`, will add IP neighbour proxy entries on the linked device
for any IPv4 and IPv6 addresses on the container's network device.

E.g. where enp3s0 is the linked parent interface.

```
ip -4 route add local ${IF_IP4}/32 dev enp3s0
ip neigh add proxy ${IF_IP4} dev enp3s0
ip -6 route add local ${IF_IP6}/128 dev enp3s0
ip neigh add proxy ${IF_IP6} dev enp3s0
```

Additionally, for IPv4 addresses it will check the following sysctls are enabled and fail with an error if not:

```
sysctl net.ipv4.conf.enp3s0.forwarding=1
```

Additionally, for IPv6 addresses it will check the following sysctls are enabled and fail with an error if not:

```
sysctl net.ipv6.conf.enp3s0.proxy_ndp=1
sysctl net.ipv6.conf.enp3s0.forwarding=1
```

Signed-off-by: tomponline <thomas.parrott@canonical.com>