### PR TITLE
seccomp: remove alignment requirements

### DIFF
--- a/src/lxc/lxcseccomp.h
+++ b/src/lxc/lxcseccomp.h
@@ -56,7 +56,7 @@ struct seccomp_notify_proxy_msg {
 	struct seccomp_notif_resp resp;
 	pid_t monitor_pid;
 	pid_t init_pid;
-} __attribute__((packed, aligned(8)));
+};
 
 struct seccomp_notify {
 	bool wants_supervision;


### PR DESCRIPTION
since apparently there are insane programming languages out there that just
silently remove packed members in structs.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>