### PR TITLE
[wip] namespaces: allow a pathname to a nsfd for namespace to share

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1367,20 +1367,26 @@ int lxc_preserve_ns(const int pid, const char *ns)
 /* 5 /proc + 21 /int_as_str + 3 /ns + 20 /NS_NAME + 1 \0 */
 #define __NS_PATH_LEN 50
 	char path[__NS_PATH_LEN];
+	const char *p;
 
 	/* This way we can use this function to also check whether namespaces
 	 * are supported by the kernel by passing in the NULL or the empty
 	 * string.
 	 */
-	ret = snprintf(path, __NS_PATH_LEN, "/proc/%d/ns%s%s", pid,
-		       !ns || strcmp(ns, "") == 0 ? "" : "/",
-		       !ns || strcmp(ns, "") == 0 ? "" : ns);
-	if (ret < 0 || (size_t)ret >= __NS_PATH_LEN) {
-		errno = EFBIG;
-		return -1;
+	if (ns[0] == '/') {
+		p = ns;
+	} else {
+		ret = snprintf(path, __NS_PATH_LEN, "/proc/%d/ns%s%s", pid,
+			       !ns || strcmp(ns, "") == 0 ? "" : "/",
+			       !ns || strcmp(ns, "") == 0 ? "" : ns);
+		if (ret < 0 || (size_t)ret >= __NS_PATH_LEN) {
+			errno = EFBIG;
+			return -1;
+		}
+		p = path;
 	}
 
-	return open(path, O_RDONLY | O_CLOEXEC);
+	return open(p, O_RDONLY | O_CLOEXEC);
 }
 
 bool lxc_switch_uid_gid(uid_t uid, gid_t gid)


### PR DESCRIPTION
This is something that might be needed per the crio/runc bundle spec documentation, i.e.

https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#namespaces

Signed-off-by: Serge Hallyn <shallyn@cisco.com>