### PR TITLE
seccomp: send process memory fd

### DIFF
--- a/src/lxc/af_unix.c
+++ b/src/lxc/af_unix.c
@@ -199,6 +199,12 @@ again:
 	return ret;
 }
 
+int lxc_unix_send_fds(int fd, int *sendfds, int num_sendfds, void *data,
+		      size_t size)
+{
+	return lxc_abstract_unix_send_fds(fd, sendfds, num_sendfds, data, size);
+}
+
 int lxc_abstract_unix_recv_fds(int fd, int *recvfds, int num_recvfds,
 			       void *data, size_t size)
 {

--- a/src/lxc/af_unix.h
+++ b/src/lxc/af_unix.h
@@ -35,6 +35,8 @@ extern void lxc_abstract_unix_close(int fd);
 extern int lxc_abstract_unix_connect(const char *path);
 extern int lxc_abstract_unix_send_fds(int fd, int *sendfds, int num_sendfds,
 				      void *data, size_t size);
+extern int lxc_unix_send_fds(int fd, int *sendfds, int num_sendfds, void *data,
+			     size_t size);
 extern int lxc_abstract_unix_recv_fds(int fd, int *recvfds, int num_recvfds,
 				      void *data, size_t size);
 extern int lxc_abstract_unix_send_credential(int fd, void *data, size_t size);


### PR DESCRIPTION
There's an inherent race when reading a process's memory. The easiest way is to
have liblxc get an fd and check that the race was one, send it to the caller
(They are free to ignore it if they don't use recvmsg()).

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>