### PR TITLE
network: Adds gateway device route mode

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -84,3 +84,10 @@ For IPv6 addresses it will check the following sysctl values and fail with an er
 net.ipv6.conf.[link].proxy_ndp=1
 net.ipv6.conf.[link].forwarding=1
 ```
+
+## network\_gateway\_device\_route
+
+This introduces the ability to specify `lxc.net.[i].ipv4.gateway` and/or
+`lxc.net.[i].ipv6.gateway` with a value of `dev` which will cause the default gateway
+inside the container to be created as a device route without destination gateway IP needed.
+This is primarily intended for use with layer 3 networking devices, such as IPVLAN.

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -665,6 +665,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               the gateway. <option>auto</option> is only available when
               using the <option>veth</option>,
               <option>macvlan</option> and <option>ipvlan</option> network types.
+              Can also have the special value of <option>dev</option>,
+              which means to set the default gateway as a device route.
+              This is primarily for use with layer 3 network modes, such as IPVLAN.
             </para>
           </listitem>
         </varlistentry>
@@ -699,6 +702,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               the gateway. <option>auto</option> is only available when
               using the <option>veth</option>,
               <option>macvlan</option> and <option>ipvlan</option> network types.
+              Can also have the special value of <option>dev</option>,
+              which means to set the default gateway as a device route.
+              This is primarily for use with layer 3 network modes, such as IPVLAN.
             </para>
           </listitem>
         </varlistentry>

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -47,6 +47,7 @@ static char *api_extensions[] = {
 	"network_veth_routes",
 	"network_ipvlan",
 	"network_l2proxy",
+	"network_gateway_device_route",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -686,9 +686,13 @@ static int set_config_net_ipv4_gateway(const char *key, const char *value,
 
 	free(netdev->ipv4_gateway);
 
-	if (!strcmp(value, "auto")) {
+	if (strcmp(value, "auto") == 0) {
 		netdev->ipv4_gateway = NULL;
 		netdev->ipv4_gateway_auto = true;
+	} else if (strcmp(value, "dev") == 0) {
+		netdev->ipv4_gateway = NULL;
+		netdev->ipv4_gateway_auto = false;
+		netdev->ipv4_gateway_dev = true;
 	} else {
 		int ret;
 		struct in_addr *gw;
@@ -853,9 +857,13 @@ static int set_config_net_ipv6_gateway(const char *key, const char *value,
 
 	free(netdev->ipv6_gateway);
 
-	if (!strcmp(value, "auto")) {
+	if (strcmp(value, "auto") == 0) {
 		netdev->ipv6_gateway = NULL;
 		netdev->ipv6_gateway_auto = true;
+	} else if (strcmp(value, "dev") == 0) {
+		netdev->ipv6_gateway = NULL;
+		netdev->ipv6_gateway_auto = false;
+		netdev->ipv6_gateway_dev = true;
 	} else {
 		int ret;
 		struct in6_addr *gw;
@@ -5625,6 +5633,8 @@ static int get_config_net_ipv4_gateway(const char *key, char *retv, int inlen,
 
 	if (netdev->ipv4_gateway_auto) {
 		strprint(retv, inlen, "auto");
+	} else if (netdev->ipv4_gateway_dev) {
+		strprint(retv, inlen, "dev");
 	} else if (netdev->ipv4_gateway) {
 		inet_ntop(AF_INET, netdev->ipv4_gateway, buf, sizeof(buf));
 		strprint(retv, inlen, "%s", buf);
@@ -5714,6 +5724,8 @@ static int get_config_net_ipv6_gateway(const char *key, char *retv, int inlen,
 
 	if (netdev->ipv6_gateway_auto) {
 		strprint(retv, inlen, "auto");
+	} else if (netdev->ipv6_gateway_dev) {
+		strprint(retv, inlen, "dev");
 	} else if (netdev->ipv6_gateway) {
 		inet_ntop(AF_INET6, netdev->ipv6_gateway, buf, sizeof(buf));
 		strprint(retv, inlen, "%s", buf);

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -361,6 +361,9 @@ void lxc_log_configured_netdevs(const struct lxc_conf *conf)
 			TRACE("ipv4 gateway auto: %s",
 			      netdev->ipv4_gateway_auto ? "true" : "false");
 
+			TRACE("ipv4 gateway dev: %s",
+			      netdev->ipv4_gateway_dev ? "true" : "false");
+
 			if (netdev->ipv4_gateway) {
 				inet_ntop(AF_INET, netdev->ipv4_gateway,
 					  bufinet4, sizeof(bufinet4));
@@ -376,6 +379,9 @@ void lxc_log_configured_netdevs(const struct lxc_conf *conf)
 
 			TRACE("ipv6 gateway auto: %s",
 			      netdev->ipv6_gateway_auto ? "true" : "false");
+
+			TRACE("ipv6 gateway dev: %s",
+			      netdev->ipv6_gateway_dev ? "true" : "false");
 
 			if (netdev->ipv6_gateway) {
 				inet_ntop(AF_INET6, netdev->ipv6_gateway,

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -156,9 +156,11 @@ union netdev_p {
  * @ipv6              : a list of ipv6 addresses to be set on the network device
  * @ipv4_gateway_auto : whether the ipv4 gateway is to be automatically gathered
  *                      from the associated @link
+ * @ipv4_gateway_dev  : whether the ipv4 gateway is to be set as a device route
  * @ipv4_gateway      : ipv4 gateway
  * @ipv6_gateway_auto : whether the ipv6 gateway is to be automatically gathered
  *                      from the associated @link
+ * @ipv6_gateway_dev  : whether the ipv6 gateway is to be set as a device route
  * @ipv6_gateway      : ipv6 gateway
  * @upscript          : a script filename to be executed during interface
  *                      configuration
@@ -179,8 +181,10 @@ struct lxc_netdev {
 	struct lxc_list ipv4;
 	struct lxc_list ipv6;
 	bool ipv4_gateway_auto;
+	bool ipv4_gateway_dev;
 	struct in_addr *ipv4_gateway;
 	bool ipv6_gateway_auto;
+	bool ipv6_gateway_dev;
 	struct in6_addr *ipv6_gateway;
 	char *upscript;
 	char *downscript;

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -108,6 +108,16 @@ static int set_and_clear_complete_netdev(struct lxc_container *c)
 		return -1;
 	}
 
+	if (!c->set_config_item(c, "lxc.net.1.ipv4.gateway", "auto")) {
+		lxc_error("%s\n", "lxc.net.1.ipv4.gateway");
+		return -1;
+	}
+
+	if (!c->set_config_item(c, "lxc.net.1.ipv4.gateway", "dev")) {
+		lxc_error("%s\n", "lxc.net.1.ipv4.gateway");
+		return -1;
+	}
+
 	if (!c->set_config_item(c, "lxc.net.1.ipv6.address",
 				"2003:db8:1:0:214:1234:fe0b:3596/64")) {
 		lxc_error("%s\n", "lxc.net.1.ipv6.address");
@@ -116,6 +126,16 @@ static int set_and_clear_complete_netdev(struct lxc_container *c)
 
 	if (!c->set_config_item(c, "lxc.net.1.ipv6.gateway",
 				"2003:db8:1:0::1")) {
+		lxc_error("%s\n", "lxc.net.1.ipv6.gateway");
+		return -1;
+	}
+
+	if (!c->set_config_item(c, "lxc.net.1.ipv6.gateway", "auto")) {
+		lxc_error("%s\n", "lxc.net.1.ipv6.gateway");
+		return -1;
+	}
+
+	if (!c->set_config_item(c, "lxc.net.1.ipv6.gateway", "dev")) {
 		lxc_error("%s\n", "lxc.net.1.ipv6.gateway");
 		return -1;
 	}
@@ -781,7 +801,27 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv4.gateway", "auto", tmpf, true)) {
+		lxc_error("%s\n", "lxc.net.0.ipv4.gateway");
+		goto non_test_error;
+	}
+
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv4.gateway", "dev", tmpf, true)) {
+		lxc_error("%s\n", "lxc.net.0.ipv4.gateway");
+		goto non_test_error;
+	}
+
 	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv6.gateway", "2003:db8:1::1", tmpf, true)) {
+		lxc_error("%s\n", "lxc.net.0.ipv6.gateway");
+		goto non_test_error;
+	}
+
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv6.gateway", "auto", tmpf, true)) {
+		lxc_error("%s\n", "lxc.net.0.ipv6.gateway");
+		goto non_test_error;
+	}
+
+	if (set_get_compare_clear_save_load(c, "lxc.net.0.ipv6.gateway", "dev", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.ipv6.gateway");
 		goto non_test_error;
 	}


### PR DESCRIPTION
Adds ability to specify "dev" as the gateway value, which will cause a device route to be set as default gateway.

This is primarily intended for use with IPVLAN where due to the nature of it operating at layer 3, we do not need to specify a gateway IP address.

Signed-off-by: tomponline <thomas.parrott@canonical.com>