### PR TITLE
compiler: add __returns_twice attribute

### DIFF
--- a/src/lxc/compiler.h
+++ b/src/lxc/compiler.h
@@ -59,6 +59,10 @@
 #	define __hot __attribute__((hot))
 #endif
 
+#ifndef __returns_twice
+#define __returns_twice __attribute__((returns_twice))
+#endif
+
 #define __cgfsng_ops
 
 #endif /* __LXC_COMPILER_H */

--- a/src/lxc/raw_syscalls.c
+++ b/src/lxc/raw_syscalls.c
@@ -9,6 +9,7 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+#include "compiler.h"
 #include "config.h"
 #include "macro.h"
 #include "raw_syscalls.h"
@@ -32,7 +33,7 @@ int lxc_raw_execveat(int dirfd, const char *pathname, char *const argv[],
  * The nice thing about this is that we get fork() behavior. That is
  * lxc_raw_clone() returns 0 in the child and the child pid in the parent.
  */
-pid_t lxc_raw_clone(unsigned long flags)
+__returns_twice pid_t lxc_raw_clone(unsigned long flags)
 {
 	/*
 	 * These flags don't interest at all so we don't jump through any hoops


### PR DESCRIPTION
The returns_twice attribute tells the compiler that a function may return more
than one time. The compiler will ensure that all registers are dead before
calling such a function and will emit a warning about the variables that may be
clobbered after the second return from the function. Examples of such functions
are setjmp and vfork. The longjmp-like counterpart of such function, if any,
might need to be marked with the noreturn attribute.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>