### PR TITLE
criu: Use -v4 instead of -vvvvvv

### DIFF
--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -375,7 +375,7 @@ static void exec_criu(struct cgroup_ops *cgroup_ops, struct lxc_conf *conf,
 	}
 
 	if (opts->user->verbose)
-		DECLARE_ARG("-vvvvvv");
+		DECLARE_ARG("-v4");
 
 	if (opts->user->action_script) {
 		DECLARE_ARG("--action-script");


### PR DESCRIPTION
CRIU has only 4 [levels of verbosity](https://criu.org/Logging) (errors, warnings, info, debug). Thus, using `-v4` is more appropriate.