### PR TITLE
Fix returning -1 in functions with return type bool

### DIFF
--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -1273,7 +1273,6 @@ static bool do_dump(struct lxc_container *c, char *mode, struct migrate_opts *op
 		if (!cgroup_ops) {
 			ERROR("failed to cgroup_init()");
 			_exit(EXIT_FAILURE);
-			return -1;
 		}
 
 		os.pipefd = criuout[1];

--- a/src/lxc/storage/lvm.c
+++ b/src/lxc/storage/lvm.c
@@ -535,13 +535,13 @@ bool lvm_create_clone(struct lxc_conf *conf, struct lxc_storage *orig,
 		if (!newsize && blk_getsize(orig, &size) < 0) {
 			ERROR("Failed to detect size of logical volume \"%s\"",
 			      orig->src);
-			return -1;
+			return false;
 		}
 
 		/* detect filesystem */
 		if (detect_fs(orig, fstype, 100) < 0) {
 			INFO("Failed to detect filesystem type for \"%s\"", orig->src);
-			return -1;
+			return false;
 		}
 	} else if (!newsize) {
 			size = DEFAULT_FS_SIZE;
@@ -553,7 +553,7 @@ bool lvm_create_clone(struct lxc_conf *conf, struct lxc_storage *orig,
 	ret = do_lvm_create(src, size, thinpool);
 	if (ret < 0) {
 		ERROR("Failed to create lvm storage volume \"%s\"", src);
-		return -1;
+		return false;
 	}
 
 	cmd_args[0] = fstype;
@@ -563,7 +563,7 @@ bool lvm_create_clone(struct lxc_conf *conf, struct lxc_storage *orig,
 	if (ret < 0) {
 		ERROR("Failed to create new filesystem \"%s\" for lvm storage "
 		      "volume \"%s\": %s", fstype, src, cmd_output);
-		return -1;
+		return false;
 	}
 
 	data.orig = orig;

--- a/src/lxc/storage/zfs.c
+++ b/src/lxc/storage/zfs.c
@@ -427,7 +427,7 @@ bool zfs_snapshot(struct lxc_conf *conf, struct lxc_storage *orig,
 	if (ret < 0 || ret >= PATH_MAX) {
 		ERROR("Failed to create string");
 		free(snapshot);
-		return -1;
+		return false;
 	}
 
 	cmd_args.dataset = lxc_storage_get_path(new->src, new->type);


### PR DESCRIPTION
This fixes a couple of issues in error paths when returning -1 when false was intended. Detected by the help of cppcheck.