### PR TITLE
Config: check for %m availability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -637,6 +637,33 @@ AC_CHECK_FUNCS([setns pivot_root sethostname unshare rand_r confstr faccessat ge
 # - STRERROR_R_CHAR_P if it returns char *
 AC_FUNC_STRERROR_R
 
+# Check if "%m" is supported by printf and Co
+AC_MSG_CHECKING([%m format])
+AC_TRY_RUN([
+#include <stdio.h>
+int main(void)
+{
+  char msg[256];
+  int rc;
+
+  rc = snprintf(msg, sizeof(msg), "%m\n");
+  if ((rc > 1) && (msg[0] != '%'))
+  {
+    return 0;
+  }
+  else
+  {
+    return 1;
+  }
+}],
+[fmt_m=yes], [fmt_m=no])
+if test "x$fmt_m" = "xyes"; then
+	AC_DEFINE([HAVE_M_FORMAT], 1, [Have %m format])
+	AC_MSG_RESULT([yes])
+else
+	AC_MSG_RESULT([no])
+fi
+
 # Check for some functions
 AC_CHECK_LIB(pthread, main)
 AC_CHECK_FUNCS(statvfs)


### PR DESCRIPTION
GLIBC supports %m to avoid calling strerror(). Using it saves some code space.
==> This check will define HAVE_M_FORMAT to be use wherever possible (e.g. log.h)

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>