### PR TITLE
network: move phys netdevs back to monitor's net ns rather than pid 1's

### DIFF
--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -261,6 +261,10 @@ extern int __build_bug_on_failed;
 #define IFLA_NET_NS_PID 19
 #endif
 
+#ifndef IFLA_NET_NS_FD
+#define IFLA_NET_NS_FD 28
+#endif
+
 #ifndef IFLA_INFO_KIND
 #define IFLA_INFO_KIND 1
 #endif


### PR DESCRIPTION
Updates lxc_restore_phys_nics_to_netns() to move phys netdevs back to the monitor's network namespace rather than the previously hardcoded PID 1 net ns.

This is to fix instances where LXC is started inside a net ns different from PID 1 and physical devices are moved back to a different net ns when the container is shutdown than the net ns than where the container was started from.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>