### PR TITLE
attach: do not reload container

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1008,9 +1008,9 @@ static inline void lxc_attach_terminal_close_log(struct lxc_terminal *terminal)
 	close_prot_errno_disarm(terminal->log_fd);
 }
 
-int lxc_attach(const char *name, const char *lxcpath,
-	       lxc_attach_exec_t exec_function, void *exec_payload,
-	       lxc_attach_options_t *options, pid_t *attached_process)
+int lxc_attach(struct lxc_container *container, lxc_attach_exec_t exec_function,
+	       void *exec_payload, lxc_attach_options_t *options,
+	       pid_t *attached_process)
 {
 	int i, ret, status;
 	int ipc_sockets[2];
@@ -1020,6 +1020,7 @@ int lxc_attach(const char *name, const char *lxcpath,
 	struct lxc_proc_context_info *init_ctx;
 	struct lxc_terminal terminal;
 	struct lxc_conf *conf;
+	char *name, *lxcpath;
 	struct attach_clone_payload payload = {0};
 
 	ret = access("/proc/self/ns", X_OK);
@@ -1028,20 +1029,33 @@ int lxc_attach(const char *name, const char *lxcpath,
 		return -1;
 	}
 
+	if (!container)
+		return minus_one_set_errno(EINVAL);
+
+	if (!lxc_container_get(container))
+		return minus_one_set_errno(EINVAL);
+
+	name = container->name;
+	lxcpath = container->config_path;
+
 	if (!options)
 		options = &attach_static_default_options;
 
 	init_pid = lxc_cmd_get_init_pid(name, lxcpath);
 	if (init_pid < 0) {
 		ERROR("Failed to get init pid");
+		lxc_container_put(container);
 		return -1;
 	}
 
 	init_ctx = lxc_proc_get_context_info(init_pid);
 	if (!init_ctx) {
 		ERROR("Failed to get context of init process: %ld", (long)init_pid);
+		lxc_container_put(container);
 		return -1;
 	}
+
+	init_ctx->container = container;
 
 	personality = get_personality(name, lxcpath);
 	if (init_ctx->personality < 0) {
@@ -1050,12 +1064,6 @@ int lxc_attach(const char *name, const char *lxcpath,
 		return -1;
 	}
 	init_ctx->personality = personality;
-
-	init_ctx->container = lxc_container_new(name, lxcpath);
-	if (!init_ctx->container) {
-		lxc_proc_put_context_info(init_ctx);
-		return -1;
-	}
 
 	if (!init_ctx->container->lxc_conf) {
 		init_ctx->container->lxc_conf = lxc_conf_init();

--- a/src/lxc/attach.h
+++ b/src/lxc/attach.h
@@ -41,7 +41,7 @@ struct lxc_proc_context_info {
 	int ns_fd[LXC_NS_MAX];
 };
 
-extern int lxc_attach(const char *name, const char *lxcpath,
+extern int lxc_attach(struct lxc_container *container,
 		      lxc_attach_exec_t exec_function, void *exec_payload,
 		      lxc_attach_options_t *options, pid_t *attached_process);
 

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4064,7 +4064,7 @@ static int lxcapi_attach(struct lxc_container *c, lxc_attach_exec_t exec_functio
 
 	current_config = c->lxc_conf;
 
-	ret = lxc_attach(c->name, c->config_path, exec_function, exec_payload, options, attached_process);
+	ret = lxc_attach(c, exec_function, exec_payload, options, attached_process);
 	current_config = NULL;
 	return ret;
 }
@@ -4081,7 +4081,7 @@ static int do_lxcapi_attach_run_wait(struct lxc_container *c, lxc_attach_options
 	command.program = (char*)program;
 	command.argv = (char**)argv;
 
-	r = lxc_attach(c->name, c->config_path, lxc_attach_run_command, &command, options, &pid);
+	r = lxc_attach(c, lxc_attach_run_command, &command, options, &pid);
 	if (r < 0) {
 		ERROR("ups");
 		return r;


### PR DESCRIPTION
Let lxc_attach() reuse the already initialized container.

Closes https://github.com/lxc/lxd/issues/5755.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>