### PR TITLE
lxc/log: Adds error_log_errno macro

### DIFF
--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -505,6 +505,13 @@ ATTR_UNUSED static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 	} while (0)
 #endif
 
+#define error_log_errno(__errno__, format, ...) 	\
+	({						\
+		errno = __errno__;			\
+		SYSERROR(format, ##__VA_ARGS__);	\
+		-1;					\
+	})
+
 extern int lxc_log_fd;
 
 extern int lxc_log_syslog(int facility);


### PR DESCRIPTION
Suggested usage:

	return error_log_errno(err, "Failed: %s", "some error");

It sets errno to the value of err, then calls SYSERROR with the format and remaining args.

It always returns -1.

Suggested-by: Christian Brauner <christian.brauner@ubuntu.com>
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>