### PR TITLE
lxc-user-net: Failed to convert string " Failed to get group name" to integer

### DIFF
--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -26,6 +26,10 @@
 /* Properly support loop devices on 32bit systems. */
 #define _FILE_OFFSET_BITS 64
 
+#ifndef MAX_GRBUF_SIZE
+#define MAX_GRBUF_SIZE 65536
+#endif
+
 #include <errno.h>
 #include <linux/loop.h>
 #include <linux/types.h>


### PR DESCRIPTION
Hello.
If group has a lot of members getgrgid_r fails with ERANGE if buffer is too small. 
I added retry with a larger buffer and buffer limit.

Please backport this to lxc-2.0.11 release.
Thanks.

Signed-off-by: Alexander Kriventsov <akriventsov@nic.ru>