### PR TITLE
proposed fix for #2892 - fix lxcbasename in lxc/lxccontainer.c

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -1320,12 +1320,13 @@ static struct lxc_storage *do_storage_create(struct lxc_container *c,
 	return bdev;
 }
 
-static char *lxcbasename(char *path)
+/* Strip path and return name of file for argv[0] passed to execvp */
+static char *lxctemplatefilename(char *tpath)
 {
 	char *p;
 
-	p = path + strlen(path) - 1;
-	while (*p != '/' && p > path)
+	p = tpath + strlen(tpath) - 1;
+	while ( (p-1) >= tpath && *(p-1) != '/')
 		p--;
 
 	return p;
@@ -1451,7 +1452,7 @@ static bool create_run_template(struct lxc_container *c, char *tpath,
 		newargv = malloc(nargs * sizeof(*newargv));
 		if (!newargv)
 			_exit(EXIT_FAILURE);
-		newargv[0] = lxcbasename(tpath);
+		newargv[0] = lxctemplatefilename(tpath);
 
 		/* --path */
 		len = strlen(c->config_path) + strlen(c->name) + strlen("--path=") + 2;


### PR DESCRIPTION
There is a previous pull request for this: https://github.com/lxc/lxc/pull/2892

Signed-off-by: Paul Romlow <promlow@users.noreply.github.com>

Changed name of function so its purpose is more clear, and added comment. The function will return only the characters to the right of '/', if one exists.