### PR TITLE
seccomp: add ifdefine for SECCOMP_FILTER_FLAG_NEW_LISTENER

### DIFF
--- a/src/lxc/lxcseccomp.h
+++ b/src/lxc/lxcseccomp.h
@@ -45,6 +45,10 @@ struct lxc_conf;
 struct lxc_epoll_descr;
 struct lxc_handler;
 
+#ifndef SECCOMP_FILTER_FLAG_NEW_LISTENER
+#define SECCOMP_FILTER_FLAG_NEW_LISTENER (1UL << 3)
+#endif
+
 #ifdef HAVE_SECCOMP
 
 


### PR DESCRIPTION
So that we can deal with older kernels.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>