### PR TITLE
seccomp: do not set SECCOMP_FILTER_FLAG_NEW_LISTENER

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -944,11 +944,6 @@ static int parse_config_v2(FILE *f, char *line, size_t *line_bufsz, struct lxc_c
 #if HAVE_DECL_SECCOMP_NOTIFY_FD
 		if ((rule.action == SCMP_ACT_NOTIFY) &&
 		    !conf->seccomp.notifier.wants_supervision) {
-			ret = seccomp_attr_set(conf->seccomp.seccomp_ctx,
-					       SECCOMP_FILTER_FLAG_NEW_LISTENER, 1);
-			if (ret)
-				goto bad_rule;
-
 			conf->seccomp.notifier.wants_supervision = true;
 			TRACE("Set SECCOMP_FILTER_FLAG_NEW_LISTENER attribute");
 		}


### PR DESCRIPTION
Do not set SECCOMP_FILTER_FLAG_NEW_LISTENER as seccomp attribute.
Prior to libseccomp merging support for SECCOMP_RET_USER_NOTIF there was a
libseccomp specific attribute that needed to be set before
SECCOMP_RET_USER_NOTIF could be used. This has been removed.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>