### PR TITLE
[RFC\ Switch from gnutls to openssl for sha1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -257,6 +257,8 @@ fi
 
 AM_CONDITIONAL([ENABLE_API_DOCS], [test "x$HAVE_DOXYGEN" != "x"])
 
+AC_CONFIG_MACRO_DIRS([config])
+
 # Apparmor
 AC_ARG_ENABLE([apparmor],
 	[AC_HELP_STRING([--enable-apparmor], [enable apparmor support [default=auto]])],
@@ -267,20 +269,21 @@ if test "$enable_apparmor" = "auto" ; then
 fi
 AM_CONDITIONAL([ENABLE_APPARMOR], [test "x$enable_apparmor" = "xyes"])
 
-# GnuTLS
-AC_ARG_ENABLE([gnutls],
-	[AC_HELP_STRING([--enable-gnutls], [enable GnuTLS support [default=auto]])],
-	[], [enable_gnutls=auto])
+# OpenSSL
+# libssl-dev
+AC_ARG_ENABLE([openssl],
+	[AC_HELP_STRING([--enable-openssl], [enable OpenSSL support [default=auto]])],
+	[], [enable_openssl=auto])
 
-if test "$enable_gnutls" = "auto" ; then
-	AC_CHECK_LIB([gnutls], [gnutls_hash_fast], [enable_gnutls=yes], [enable_gnutls=no])
+if test "$enable_openssl" = "auto" ; then
+	AC_CHECK_LIB([ssl], [OPENSSL_init_ssl], [enable_openssl=yes], [enable_openssl=no])
+
 fi
-AM_CONDITIONAL([ENABLE_GNUTLS], [test "x$enable_gnutls" = "xyes"])
+AM_CONDITIONAL([ENABLE_OPENSSL], [test "x$enable_openssl" = "xyes"])
 
-AM_COND_IF([ENABLE_GNUTLS],
-	[AC_CHECK_HEADER([gnutls/gnutls.h],[],[AC_MSG_ERROR([You must install the GnuTLS development package in order to compile lxc])])
-	AC_CHECK_LIB([gnutls], [gnutls_hash_fast],[true],[AC_MSG_ERROR([You must install the GnuTLS development package in order to compile lxc])])
-	AC_SUBST([GNUTLS_LIBS], [-lgnutls])])
+AM_COND_IF([ENABLE_OPENSSL],
+	[AC_CHECK_HEADER([openssl/engine.h],[],[AC_MSG_ERROR([You must install the OpenSSL development package in order to compile lxc])])
+	AC_SUBST([OPENSSL_LIBS], '-lssl -lcrypto')])
 
 # SELinux
 AC_ARG_ENABLE([selinux],
@@ -1014,7 +1017,7 @@ Environment:
  - distribution: $with_distro
  - init script type(s): $init_script
  - rpath: $enable_rpath
- - GnuTLS: $enable_gnutls
+ - OpenSSL: $enable_openssl
  - Bash integration: $enable_bash
 
 Security features:

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -210,8 +210,8 @@ if ENABLE_APPARMOR
 AM_CFLAGS += -DHAVE_APPARMOR
 endif
 
-if ENABLE_GNUTLS
-AM_CFLAGS += -DHAVE_LIBGNUTLS
+if ENABLE_OPENSSL
+AM_CFLAGS += -DHAVE_OPENSSL
 endif
 
 if ENABLE_SECCOMP
@@ -248,7 +248,7 @@ liblxc_la_LDFLAGS = -pthread \
 		    -version-info @LXC_ABI_MAJOR@
 
 liblxc_la_LIBADD = $(CAP_LIBS) \
-		   $(GNUTLS_LIBS) \
+		   $(OPENSSL_LIBS) \
 		   $(SELINUX_LIBS) \
 		   $(SECCOMP_LIBS) \
 		   $(DLOG_LIBS)
@@ -307,7 +307,7 @@ endif
 
 LDADD = liblxc.la \
 	@CAP_LIBS@ \
-	@GNUTLS_LIBS@ \
+	@OPENSSL_LIBS@ \
 	@SECCOMP_LIBS@ \
 	@SELINUX_LIBS@ \
 	@DLOG_LIBS@

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -98,9 +98,8 @@ extern int lxc_pclose(struct lxc_popen_FILE *fp);
 extern int wait_for_pid(pid_t pid);
 extern int lxc_wait_for_pid_status(pid_t pid);
 
-#if HAVE_LIBGNUTLS
-#define SHA_DIGEST_LENGTH 20
-extern int sha1sum_file(char *fnam, unsigned char *md_value);
+#if HAVE_OPENSSL
+extern int sha1sum_file(char *fnam, unsigned char *md_value, int *md_len);
 #endif
 
 /* initialize rand with urandom */


### PR DESCRIPTION
The reason for this is because openssl can be statically linked
against, gnutls cannot.

[ commit msg addendum ] I don't know that openssl is what we want.  Maybe we just want to hardcode our own.  But at least openssl is widely avaiable, and available as .a's.  Also, I guess lxc.pc will also need to be updated if we do this.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>