### PR TITLE
network: fix lxc_netdev_rename_by_index()

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -1160,8 +1160,10 @@ int lxc_netdev_rename_by_index(int ifindex, const char *newname)
 		return err;
 
 	len = strlen(newname);
-	if (len == 1 || len >= IFNAMSIZ)
+	if (len == 1 || len >= IFNAMSIZ) {
+		err = -EINVAL;
 		goto out;
+	}
 
 	err = -ENOMEM;
 	nlmsg = nlmsg_alloc(NLMSG_GOOD_SIZE);


### PR DESCRIPTION
Return an error code when the name is invalid instead of pretending that things
are fine.

Closes #3044.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>