### PR TITLE
lxc.pc.in: add libs.private for static linking

### DIFF
--- a/lxc.pc.in
+++ b/lxc.pc.in
@@ -9,4 +9,5 @@ Description: linux container tools
 Version: @PACKAGE_VERSION@
 URL: http://linuxcontainers.org
 Libs: -L${libdir} -llxc -lutil
+Libs.private: @CAP_LIBS@ @SECCOMP_LIBS@ @OPENSSL_LIBS@ @SELINUX_LIBS@ @PAM_LIBS@ @DLOG_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
None of them seem to support pkg-config themselves, else we could add
them to Requires.private.