### PR TITLE
parse.c: fix fd leak from memfd_create

### DIFF
--- a/src/lxc/parse.c
+++ b/src/lxc/parse.c
@@ -98,7 +98,7 @@ int lxc_file_for_each_line_mmap(const char *file, lxc_file_cb callback, void *da
 	fd = open(file, O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
 		SYSERROR("Failed to open file \"%s\"", file);
-		return -1;
+		goto on_error;
 	}
 
 	/* sendfile() handles up to 2GB. No config file should be that big. */


### PR DESCRIPTION
Signed-off-by: t00416110 <tanyifeng1@huawei.com>