### PR TITLE
Gather container's specific filenames in one place

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -130,9 +130,9 @@ static bool config_file_exists(const char *lxcpath, const char *cname)
 	size_t len;
 
 	/* $lxcpath + '/' + $cname + '/config' + \0 */
-	len = strlen(lxcpath) + strlen(cname) + 9;
+	len = strlen(lxcpath) + 1 + strlen(cname) + 1 + strlen(LXC_CONFIG_FNAME) + 1;
 	fname = must_realloc(NULL, len);
-	ret = snprintf(fname, len, "%s/%s/config", lxcpath, cname);
+	ret = snprintf(fname, len, "%s/%s/%s", lxcpath, cname, LXC_CONFIG_FNAME);
 	if (ret < 0 || (size_t)ret >= len)
 		return false;
 
@@ -163,9 +163,9 @@ static int ongoing_create(struct lxc_container *c)
 	int ret;
 	size_t len;
 
-	len = strlen(c->config_path) + strlen(c->name) + 10;
+	len = strlen(c->config_path) + 1 + strlen(c->name) + 1 + strlen(LXC_PARTIAL_FNAME) + 1;
 	path = must_realloc(NULL, len);
-	ret = snprintf(path, len, "%s/%s/partial", c->config_path, c->name);
+	ret = snprintf(path, len, "%s/%s/%s", c->config_path, c->name, LXC_PARTIAL_FNAME);
 	if (ret < 0 || (size_t)ret >= len)
 		return LXC_CREATE_FAILED;
 
@@ -209,9 +209,9 @@ static int create_partial(struct lxc_container *c)
 	struct flock lk = {0};
 
 	/* $lxcpath + '/' + $name + '/partial' + \0 */
-	len = strlen(c->config_path) + strlen(c->name) + 10;
+	len = strlen(c->config_path) + 1 + strlen(c->name) + 1 + strlen(LXC_PARTIAL_FNAME) + 1;
 	path = must_realloc(NULL, len);
-	ret = snprintf(path, len, "%s/%s/partial", c->config_path, c->name);
+	ret = snprintf(path, len, "%s/%s/%s", c->config_path, c->name, LXC_PARTIAL_FNAME);
 	if (ret < 0 || (size_t)ret >= len)
 		return -1;
 
@@ -247,9 +247,9 @@ static void remove_partial(struct lxc_container *c, int fd)
 	close(fd);
 
 	/* $lxcpath + '/' + $name + '/partial' + \0 */
-	len = strlen(c->config_path) + strlen(c->name) + 10;
+	len = strlen(c->config_path) + 1 + strlen(c->name) + 1 + strlen(LXC_PARTIAL_FNAME) + 1;
 	path = must_realloc(NULL, len);
-	ret = snprintf(path, len, "%s/%s/partial", c->config_path, c->name);
+	ret = snprintf(path, len, "%s/%s/%s", c->config_path, c->name, LXC_PARTIAL_FNAME);
 	if (ret < 0 || (size_t)ret >= len)
 		return;
 
@@ -1289,9 +1289,9 @@ static struct lxc_storage *do_storage_create(struct lxc_container *c,
 		ret = snprintf(dest, len, "%s", rpath);
 	} else {
 		const char *lxcpath = do_lxcapi_get_config_path(c);
-		len = strlen(c->name) + strlen(lxcpath) + 9;
+		len = strlen(c->name) + 1 + strlen(lxcpath) + 1 + strlen(LXC_ROOTFS_DNAME) + 1;
 		dest = must_realloc(NULL, len);
-		ret = snprintf(dest, len, "%s/%s/rootfs", lxcpath, c->name);
+		ret = snprintf(dest, len, "%s/%s/%s", lxcpath, c->name, LXC_ROOTFS_DNAME);
 	}
 	if (ret < 0 || (size_t)ret >= len)
 		return NULL;
@@ -3041,7 +3041,7 @@ static bool container_destroy(struct lxc_container *c,
 	 * +
 	 * \0
 	 */
-	len = strlen(p1) + 1 + strlen(c->name) + 1 + 6 + 1;
+	len = strlen(p1) + 1 + strlen(c->name) + 1 + strlen(LXC_CONFIG_FNAME) + 1;
 	path = malloc(len);
 	if (!path) {
 		ERROR("Failed to allocate memory");
@@ -3054,7 +3054,7 @@ static bool container_destroy(struct lxc_container *c,
 	if (storage && (!strcmp(storage->type, "overlay") ||
 			!strcmp(storage->type, "overlayfs")) &&
 	    (storage->flags & LXC_STORAGE_INTERNAL_OVERLAY_RESTORE)) {
-		ret = snprintf(path, len, "%s/%s/config", p1, c->name);
+		ret = snprintf(path, len, "%s/%s/%s", p1, c->name, LXC_CONFIG_FNAME);
 		if (ret < 0 || (size_t)ret >= len)
 			goto out;
 
@@ -3230,12 +3230,12 @@ static bool set_config_filename(struct lxc_container *c)
 		return false;
 
 	/* $lxc_path + "/" + c->name + "/" + "config" + '\0' */
-	len = strlen(c->config_path) + strlen(c->name) + strlen("config") + 3;
+	len = strlen(c->config_path) + 1 + strlen(c->name) + 1 + strlen(LXC_CONFIG_FNAME) + 1;
 	newpath = malloc(len);
 	if (!newpath)
 		return false;
 
-	ret = snprintf(newpath, len, "%s/%s/config", c->config_path, c->name);
+	ret = snprintf(newpath, len, "%s/%s/%s", c->config_path, c->name, LXC_CONFIG_FNAME);
 	if (ret < 0 || ret >= len) {
 		fprintf(stderr, "Error printing out config file name\n");
 		free(newpath);
@@ -3834,7 +3834,7 @@ static struct lxc_container *do_lxcapi_clone(struct lxc_container *c, const char
 	if (!lxcpath)
 		lxcpath = do_lxcapi_get_config_path(c);
 
-	ret = snprintf(newpath, PATH_MAX, "%s/%s/config", lxcpath, newname);
+	ret = snprintf(newpath, PATH_MAX, "%s/%s/%s", lxcpath, newname, LXC_CONFIG_FNAME);
 	if (ret < 0 || ret >= PATH_MAX) {
 		SYSERROR("clone: failed making config pathname");
 		goto out;
@@ -3883,7 +3883,7 @@ static struct lxc_container *do_lxcapi_clone(struct lxc_container *c, const char
 	saved_unexp_conf = NULL;
 	c->lxc_conf->unexpanded_len = saved_unexp_len;
 
-	ret = snprintf(newpath, PATH_MAX, "%s/%s/rootfs", lxcpath, newname);
+	ret = snprintf(newpath, PATH_MAX, "%s/%s/%s", lxcpath, newname, LXC_ROOTFS_DNAME);
 	if (ret < 0 || ret >= PATH_MAX) {
 		SYSERROR("clone: failed making rootfs pathname");
 		goto out;
@@ -4228,8 +4228,8 @@ static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
 
 	strftime(buffer, 25, "%Y:%m:%d %H:%M:%S", &tm_info);
 
-	dfnam = must_realloc(NULL, strlen(snappath) + strlen(newname) + 5);
-	sprintf(dfnam, "%s/%s/ts", snappath, newname);
+	char *dfnam = alloca(strlen(snappath) + 1 + strlen(newname) + 1 + strlen(LXC_TIMESTAMP_FNAME) + 1);
+	sprintf(dfnam, "%s/%s/%s", snappath, newname, LXC_TIMESTAMP_FNAME);
 	f = fopen(dfnam, "w");
 	if (!f) {
 		ERROR("Failed to open %s", dfnam);
@@ -4251,10 +4251,10 @@ static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
 	if (commentfile) {
 		__do_free char *path = NULL;
 		/* $p / $name / comment \0 */
-		int len = strlen(snappath) + strlen(newname) + 10;
+		int len = strlen(snappath) + 1 + strlen(newname) + 1 + strlen(LXC_COMMENT_FNAME) + 1;
 
 		path = must_realloc(NULL, len);
-		sprintf(path, "%s/%s/comment", snappath, newname);
+		snprintf(path, len, "%s/%s/%s", snappath, newname, LXC_COMMENT_FNAME);
 		return copy_file(commentfile, path) < 0 ? -1 : i;
 	}
 
@@ -4350,7 +4350,7 @@ static int do_lxcapi_snapshot_list(struct lxc_container *c, struct lxc_snapshot 
 		if (!strcmp(direntp->d_name, ".."))
 			continue;
 
-		ret = snprintf(path2, PATH_MAX, "%s/%s/config", snappath, direntp->d_name);
+		ret = snprintf(path2, PATH_MAX, "%s/%s/%s", snappath, direntp->d_name, LXC_CONFIG_FNAME);
 		if (ret < 0 || ret >= PATH_MAX) {
 			ERROR("pathname too long");
 			goto out_free;

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4228,7 +4228,7 @@ static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
 
 	strftime(buffer, 25, "%Y:%m:%d %H:%M:%S", &tm_info);
 
-	char *dfnam = alloca(strlen(snappath) + 1 + strlen(newname) + 1 + strlen(LXC_TIMESTAMP_FNAME) + 1);
+	dfnam = alloca(strlen(snappath) + 1 + strlen(newname) + 1 + strlen(LXC_TIMESTAMP_FNAME) + 1);
 	sprintf(dfnam, "%s/%s/%s", snappath, newname, LXC_TIMESTAMP_FNAME);
 	f = fopen(dfnam, "w");
 	if (!f) {

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -66,11 +66,11 @@ enum {
 };
 
 /* Container's specific file names */
-#define LXC_CONFIG_FNAME       "config"
-#define LXC_PARTIAL_FNAME      "partial"
-#define LXC_ROOTFS_DNAME       "rootfs"
-#define LXC_TIMESTAMP_FNAME    "ts"
-#define LXC_COMMENT_FNAME      "comment"
+#define LXC_CONFIG_FNAME      "config"
+#define LXC_PARTIAL_FNAME     "partial"
+#define LXC_ROOTFS_DNAME      "rootfs"
+#define LXC_TIMESTAMP_FNAME   "ts"
+#define LXC_COMMENT_FNAME     "comment"
 
 /*!
  * An LXC container.

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -65,6 +65,13 @@ enum {
 	LXC_SECCOMP_NOTIFY_MAX,
 };
 
+/* Container's specific file names */
+#define LXC_CONFIG_FNAME       "config"
+#define LXC_PARTIAL_FNAME      "partial"
+#define LXC_ROOTFS_DNAME       "rootfs"
+#define LXC_TIMESTAMP_FNAME    "ts"
+#define LXC_COMMENT_FNAME      "comment"
+
 /*!
  * An LXC container.
  *


### PR DESCRIPTION
The names of the container's specific file/directory are hard coded in one place (lxccontainer.h) instead of repeating the strings everywhere in lxccontainer.c

 Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>
