### PR TITLE
start: Moves lxc_find_gateway_addresses back to before clone

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -4036,18 +4036,6 @@ int lxc_create_network(struct lxc_handler *handler)
 {
 	int ret;
 
-	/*
-	 * Find gateway addresses from the link device, which is no longer
-	 * accessible inside the container. Do this before creating network
-	 * interfaces, since goto out_delete_net does not work before
-	 * lxc_clone.
-	 */
-	ret = lxc_find_gateway_addresses(handler);
-	if (ret) {
-		ERROR("Failed to find gateway addresses");
-		return -1;
-	}
-
 	if (handler->am_root) {
 		ret = lxc_create_network_priv(handler);
 		if (ret)

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1697,6 +1697,20 @@ static int lxc_spawn(struct lxc_handler *handler)
 	if (ret < 0)
 		goto out_sync_fini;
 
+	if (handler->ns_clone_flags & CLONE_NEWNET) {
+		/*
+		* Find gateway addresses from the link device, which is no longer
+		* accessible inside the container. Do this before creating network
+		* interfaces, since goto out_delete_net does not work before
+		* lxc_clone.
+		*/
+		ret = lxc_find_gateway_addresses(handler);
+		if (ret) {
+			ERROR("Failed to find gateway addresses");
+			goto out_sync_fini;
+		}
+	}
+
 	if (!cgroup_ops->payload_create(cgroup_ops, handler)) {
 		ERROR("Failed creating cgroups");
 		goto out_delete_net;


### PR DESCRIPTION
This restores the lxc.net.x.ipv4.gateway = auto and lxc.net.x.ipv6.gateway = auto functionality.

Fixes #3078

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>