### PR TITLE
Seccomp notify api update

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -367,6 +367,7 @@ OLD_CFLAGS="$CFLAGS"
 CFLAGS="$CFLAGS $SECCOMP_CFLAGS"
 AC_CHECK_TYPES([scmp_filter_ctx], [], [], [[#include <seccomp.h>]])
 AC_CHECK_DECLS([seccomp_notify_fd], [], [], [[#include <seccomp.h>]])
+AC_CHECK_TYPES([struct seccomp_notif_sizes], [], [], [[#include <seccomp.h>]])
 AC_CHECK_DECLS([seccomp_syscall_resolve_name_arch], [], [], [[#include <seccomp.h>]])
 CFLAGS="$OLD_CFLAGS"
 

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -1997,11 +1997,22 @@ dev/null proc/kcore none bind,relative 0 0
           <listitem>
             <para>
 	      Specify a unix socket to which LXC will connect and forward
-	      seccomp events to. The path must by in the form
+	      seccomp events to. The path must be in the form
 	      unix:/path/to/socket or unix:@socket. The former specifies a
 	      path-bound unix domain socket while the latter specifies an
 	      abstract unix domain socket.
-             </para>
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <option>lxc.seccomp.notify.cookie</option>
+          </term>
+          <listitem>
+            <para>
+	      An additional string sent along with proxied seccomp notification
+	      requests.
+            </para>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/src/lxc/af_unix.c
+++ b/src/lxc/af_unix.c
@@ -219,7 +219,6 @@ static int lxc_abstract_unix_recv_fds_iov(int fd, int *recvfds, int num_recvfds,
 	int ret;
 	struct msghdr msg;
 	struct cmsghdr *cmsg = NULL;
-	char buf[1] = {0};
 	size_t cmsgbufsize = CMSG_SPACE(sizeof(struct ucred)) +
 			     CMSG_SPACE(num_recvfds * sizeof(int));
 

--- a/src/lxc/af_unix.c
+++ b/src/lxc/af_unix.c
@@ -379,13 +379,13 @@ int lxc_unix_sockaddr(struct sockaddr_un *ret, const char *path)
 	return (int)(offsetof(struct sockaddr_un, sun_path) + len + 1);
 }
 
-int lxc_unix_connect(struct sockaddr_un *addr)
+int lxc_unix_connect_type(struct sockaddr_un *addr, int type)
 {
 	__do_close_prot_errno int fd = -EBADF;
 	int ret;
 	ssize_t len;
 
-	fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+	fd = socket(AF_UNIX, type | SOCK_CLOEXEC, 0);
 	if (fd < 0) {
 		SYSERROR("Failed to open new AF_UNIX socket");
 		return -1;
@@ -404,6 +404,11 @@ int lxc_unix_connect(struct sockaddr_un *addr)
 	}
 
 	return move_fd(fd);
+}
+
+int lxc_unix_connect(struct sockaddr_un *addr, int type)
+{
+	return lxc_unix_connect_type(addr, SOCK_STREAM);
 }
 
 int lxc_socket_set_timeout(int fd, int rcv_timeout, int snd_timeout)

--- a/src/lxc/af_unix.h
+++ b/src/lxc/af_unix.h
@@ -35,6 +35,9 @@ extern void lxc_abstract_unix_close(int fd);
 extern int lxc_abstract_unix_connect(const char *path);
 extern int lxc_abstract_unix_send_fds(int fd, int *sendfds, int num_sendfds,
 				      void *data, size_t size);
+extern int lxc_abstract_unix_send_fds_iov(int fd, int *sendfds,
+					  int num_sendfds, struct iovec *iov,
+					  size_t iovlen);
 extern int lxc_unix_send_fds(int fd, int *sendfds, int num_sendfds, void *data,
 			     size_t size);
 extern int lxc_abstract_unix_recv_fds(int fd, int *recvfds, int num_recvfds,

--- a/src/lxc/af_unix.h
+++ b/src/lxc/af_unix.h
@@ -46,6 +46,7 @@ extern int lxc_abstract_unix_send_credential(int fd, void *data, size_t size);
 extern int lxc_abstract_unix_rcv_credential(int fd, void *data, size_t size);
 extern int lxc_unix_sockaddr(struct sockaddr_un *ret, const char *path);
 extern int lxc_unix_connect(struct sockaddr_un *addr);
+extern int lxc_unix_connect_type(struct sockaddr_un *addr, int type);
 extern int lxc_socket_set_timeout(int fd, int rcv_timeout, int snd_timeout);
 
 #endif /* __LXC_AF_UNIX_H */

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -153,6 +153,7 @@ lxc_config_define(rootfs_options);
 lxc_config_define(rootfs_path);
 lxc_config_define(seccomp_profile);
 lxc_config_define(seccomp_allow_nesting);
+lxc_config_define(seccomp_notify_cookie);
 lxc_config_define(seccomp_notify_proxy);
 lxc_config_define(selinux_context);
 lxc_config_define(signal_halt);
@@ -246,6 +247,7 @@ static struct lxc_config_t config_jump_table[] = {
 	{ "lxc.rootfs.options",            set_config_rootfs_options,              get_config_rootfs_options,              clr_config_rootfs_options,            },
 	{ "lxc.rootfs.path",               set_config_rootfs_path,                 get_config_rootfs_path,                 clr_config_rootfs_path,               },
 	{ "lxc.seccomp.allow_nesting",     set_config_seccomp_allow_nesting,       get_config_seccomp_allow_nesting,       clr_config_seccomp_allow_nesting,     },
+	{ "lxc.seccomp.notify.cookie",     set_config_seccomp_notify_cookie,       get_config_seccomp_notify_cookie,       clr_config_seccomp_notify_cookie,     },
 	{ "lxc.seccomp.notify.proxy",      set_config_seccomp_notify_proxy,        get_config_seccomp_notify_proxy,        clr_config_seccomp_notify_proxy,      },
 	{ "lxc.seccomp.profile",           set_config_seccomp_profile,             get_config_seccomp_profile,             clr_config_seccomp_profile,           },
 	{ "lxc.selinux.context",           set_config_selinux_context,             get_config_selinux_context,             clr_config_selinux_context,           },
@@ -1010,6 +1012,16 @@ static int set_config_seccomp_allow_nesting(const char *key, const char *value,
 #else
 	errno = ENOSYS;
 	return -1;
+#endif
+}
+
+static int set_config_seccomp_notify_cookie(const char *key, const char *value,
+					    struct lxc_conf *lxc_conf, void *data)
+{
+#ifdef HAVE_SECCOMP_NOTIFY
+	return set_config_string_item(&lxc_conf->seccomp.notifier.cookie, value);
+#else
+	return minus_one_set_errno(ENOSYS);
 #endif
 }
 
@@ -3955,6 +3967,16 @@ static int get_config_seccomp_allow_nesting(const char *key, char *retv,
 #endif
 }
 
+static int get_config_seccomp_notify_cookie(const char *key, char *retv, int inlen,
+					    struct lxc_conf *c, void *data)
+{
+#ifdef HAVE_SECCOMP_NOTIFY
+	return lxc_get_conf_str(retv, inlen, c->seccomp.notifier.cookie);
+#else
+	return minus_one_set_errno(ENOSYS);
+#endif
+}
+
 static int get_config_seccomp_notify_proxy(const char *key, char *retv, int inlen,
 					   struct lxc_conf *c, void *data)
 {
@@ -4560,6 +4582,18 @@ static inline int clr_config_seccomp_allow_nesting(const char *key,
 #else
 	errno = ENOSYS;
 	return -1;
+#endif
+}
+
+static inline int clr_config_seccomp_notify_cookie(const char *key,
+						   struct lxc_conf *c, void *data)
+{
+#ifdef HAVE_SECCOMP_NOTIFY
+	free(c->seccomp.notifier.cookie);
+	c->seccomp.notifier.cookie = NULL;
+	return 0;
+#else
+	return minus_one_set_errno(ENOSYS);
 #endif
 }
 

--- a/src/lxc/file_utils.c
+++ b/src/lxc/file_utils.c
@@ -142,6 +142,24 @@ again:
 	return ret;
 }
 
+ssize_t lxc_recvmsg_nointr_iov(int sockfd, struct iovec *iov, size_t iovlen,
+			       int flags)
+{
+	ssize_t ret;
+	struct msghdr msg;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = iov;
+	msg.msg_iovlen = iovlen;
+
+again:
+	ret = recvmsg(sockfd, &msg, flags);
+	if (ret < 0 && errno == EINTR)
+		goto again;
+
+	return ret;
+}
+
 ssize_t lxc_read_nointr_expect(int fd, void *buf, size_t count, const void *expected_buf)
 {
 	ssize_t ret;

--- a/src/lxc/file_utils.h
+++ b/src/lxc/file_utils.h
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 #include <sys/vfs.h>
 #include <unistd.h>
 
@@ -43,6 +44,8 @@ extern ssize_t lxc_read_nointr_expect(int fd, void *buf, size_t count,
 extern ssize_t lxc_read_file_expect(const char *path, void *buf, size_t count,
 				      const void *expected_buf);
 extern ssize_t lxc_recv_nointr(int sockfd, void *buf, size_t len, int flags);
+ssize_t lxc_recvmsg_nointr_iov(int sockfd, struct iovec *iov, size_t iovlen,
+			       int flags);
 
 extern bool file_exists(const char *f);
 extern int print_to_file(const char *file, const char *content);

--- a/src/lxc/lxcseccomp.h
+++ b/src/lxc/lxcseccomp.h
@@ -69,6 +69,7 @@ struct seccomp_notify {
 	struct sockaddr_un proxy_addr;
 	struct seccomp_notif *req_buf;
 	struct seccomp_notif_resp *rsp_buf;
+	char *cookie;
 };
 
 #define HAVE_SECCOMP_NOTIFY 1

--- a/src/lxc/lxcseccomp.h
+++ b/src/lxc/lxcseccomp.h
@@ -54,12 +54,21 @@ struct lxc_handler;
 
 #if HAVE_DECL_SECCOMP_NOTIFY_FD
 
+#if !HAVE_STRUCT_SECCOMP_NOTIF_SIZES
+struct seccomp_notif_sizes {
+	__u16 seccomp_notif;
+	__u16 seccomp_notif_resp;
+	__u16 seccomp_data;
+};
+#endif
+
 struct seccomp_notify_proxy_msg {
-	uint32_t version;
-	struct seccomp_notif req;
-	struct seccomp_notif_resp resp;
+	uint64_t __reserved;
 	pid_t monitor_pid;
 	pid_t init_pid;
+	struct seccomp_notif_sizes sizes;
+	uint64_t cookie_len;
+	/* followed by: seccomp_notif, seccomp_notif_resp, cookie */
 };
 
 struct seccomp_notify {
@@ -67,6 +76,7 @@ struct seccomp_notify {
 	int notify_fd;
 	int proxy_fd;
 	struct sockaddr_un proxy_addr;
+	struct seccomp_notif_sizes sizes;
 	struct seccomp_notif *req_buf;
 	struct seccomp_notif_resp *rsp_buf;
 	char *cookie;

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1366,15 +1366,15 @@ int seccomp_notify_handler(int fd, uint32_t events, void *data,
 	char *cookie = conf->seccomp.notifier.cookie;
 	uint64_t req_id;
 
-	if (listener_proxy_fd < 0) {
-		ERROR("No seccomp proxy registered");
-		return minus_one_set_errno(EINVAL);
-	}
-
 	ret = seccomp_notify_receive(fd, req);
 	if (ret) {
 		SYSERROR("Failed to read seccomp notification");
 		goto out;
+	}
+
+	if (listener_proxy_fd < 0) {
+		ERROR("No seccomp proxy registered");
+		return minus_one_set_errno(EINVAL);
 	}
 
 	/* remember the ID in case we receive garbage from the proxy */

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1438,6 +1438,12 @@ int seccomp_notify_handler(int fd, uint32_t events, void *data,
 
 	close_prot_errno_disarm(fd_mem);
 
+	if (msg.__reserved != 0) {
+		ERROR("Proxy filled reserved data in response");
+		seccomp_notify_default_answer(fd, req, resp, hdlr);
+		goto out;
+	}
+
 	if (resp->id != req_id) {
 		resp->id = req_id;
 		ERROR("Proxy returned response with illegal id");

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1466,7 +1466,8 @@ retry:
 		goto out;
 	}
 
-	bytes = lxc_recvmsg_nointr_iov(listener_proxy_fd, iov,iov_len, 0);
+	bytes = lxc_recvmsg_nointr_iov(listener_proxy_fd, iov,iov_len,
+				       MSG_TRUNC);
 	if (bytes != (ssize_t)msg_base_size) {
 		SYSERROR("Failed to receive message from seccomp proxy");
 		seccomp_notify_default_answer(fd, req, resp, hdlr);

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1375,7 +1375,7 @@ int seccomp_notify_handler(int fd, uint32_t events, void *data,
 
 	if (listener_proxy_fd < 0) {
 		ERROR("No seccomp proxy registered");
-		return minus_one_set_errno(EINVAL);
+		return seccomp_notify_default_answer(fd, req, resp, hdlr);
 	}
 
 	/* remember the ID in case we receive garbage from the proxy */

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1311,7 +1311,8 @@ static int seccomp_notify_reconnect(struct lxc_handler *handler)
 
 	close_prot_errno_disarm(handler->conf->seccomp.notifier.proxy_fd);
 
-	notify_fd = lxc_unix_connect(&handler->conf->seccomp.notifier.proxy_addr);
+	notify_fd = lxc_unix_connect_type(
+		&handler->conf->seccomp.notifier.proxy_addr, SOCK_SEQPACKET);
 	if (notify_fd < 0) {
 		SYSERROR("Failed to reconnect to seccomp proxy");
 		return -1;
@@ -1501,7 +1502,8 @@ int lxc_seccomp_setup_proxy(struct lxc_seccomp *seccomp,
 		__do_close_prot_errno int notify_fd = -EBADF;
 		int ret;
 
-		notify_fd = lxc_unix_connect(&seccomp->notifier.proxy_addr);
+		notify_fd = lxc_unix_connect_type(&seccomp->notifier.proxy_addr,
+					     SOCK_SEQPACKET);
 		if (notify_fd < 0) {
 			SYSERROR("Failed to connect to seccomp proxy");
 			return -1;


### PR DESCRIPTION
General description (from the `seccomp: update notify api` commit:)
```
The previous API doesn't reflect the fact that
`seccomp_notif` and `seccomp_notif_resp` are allocatd
dynamically with sizes figured out at runtime.

We now query the sizes via the seccomp(2) syscall and change
`struct seccomp_notify_proxy_msg` to contain the sizes
instead of the data, with the data following afterwards.

Additionally it did not provide a convenient way to identify
the container the message originated from, for which we now
include a cookie configured via `lxc.seccomp.notify.cookie`.

Also verify the `id` in the client's response.
```

Another big change is the switch from `SOCK_STREAM` to `SOCK_SEQPACKET`. I think it makes sense: the seccomp notify kernel api is basically packet based as well.