### PR TITLE
start: call lxc_find_gateway_addresses early

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -2473,8 +2473,7 @@ int lxc_find_gateway_addresses(struct lxc_handler *handler)
 			continue;
 
 		if (netdev->type != LXC_NET_VETH && netdev->type != LXC_NET_MACVLAN) {
-			ERROR("Automatic gateway detection is only supported "
-			      "for veth and macvlan");
+			ERROR("Automatic gateway detection is only supported for veth and macvlan");
 			return -1;
 		}
 
@@ -2489,16 +2488,16 @@ int lxc_find_gateway_addresses(struct lxc_handler *handler)
 
 		if (netdev->ipv4_gateway_auto) {
 			if (lxc_ipv4_addr_get(link_index, &netdev->ipv4_gateway)) {
-				ERROR("Failed to automatically find ipv4 gateway "
-				      "address from link interface \"%s\"", netdev->link);
+				ERROR("Failed to automatically find ipv4 gateway address from link interface \"%s\"",
+				      netdev->link);
 				return -1;
 			}
 		}
 
 		if (netdev->ipv6_gateway_auto) {
 			if (lxc_ipv6_addr_get(link_index, &netdev->ipv6_gateway)) {
-				ERROR("Failed to automatically find ipv6 gateway "
-				      "address from link interface \"%s\"", netdev->link);
+				ERROR("Failed to automatically find ipv6 gateway address from link interface \"%s\"",
+				      netdev->link);
 				return -1;
 			}
 		}
@@ -4035,18 +4034,6 @@ int lxc_netns_get_nsid(int fd)
 int lxc_create_network(struct lxc_handler *handler)
 {
 	int ret;
-
-	/*
-	 * Find gateway addresses from the link device, which is no longer
-	 * accessible inside the container. Do this before creating network
-	 * interfaces, since goto out_delete_net does not work before
-	 * lxc_clone.
-	 */
-	ret = lxc_find_gateway_addresses(handler);
-	if (ret) {
-		ERROR("Failed to find gateway addresses");
-		return -1;
-	}
 
 	if (handler->am_root) {
 		ret = lxc_create_network_priv(handler);

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1697,6 +1697,14 @@ static int lxc_spawn(struct lxc_handler *handler)
 	if (ret < 0)
 		goto out_sync_fini;
 
+	if (handler->ns_clone_flags & CLONE_NEWNET) {
+		ret = lxc_find_gateway_addresses(handler);
+		if (ret) {
+			ERROR("Failed to find gateway addresses");
+			goto out_sync_fini;
+		}
+	}
+
 	if (!cgroup_ops->payload_create(cgroup_ops, handler)) {
 		ERROR("Failed creating cgroups");
 		goto out_delete_net;


### PR DESCRIPTION
This restores the lxc.net.x.ipv4.gateway = auto and
lxc.net.x.ipv6.gateway = auto functionality.

When the child is created the parent and child have different views of
struct lxc_handler since - obviously - virtual memory is duplicated. So any
changes to done by the parent that the child should see need to be IPCed to it.
For any non-actual device creation stuff this does not make much sense. This
includes finding gateway addresses. Move it back prior to clone().

Fixes #3078

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
[christian.brauner@ubuntu.com: non-functional changes and update commit message]
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>