### PR TITLE
suppress false-negative error in templates and nvidia hook

### DIFF
--- a/hooks/nvidia
+++ b/hooks/nvidia
@@ -58,8 +58,12 @@ in_userns() {
         echo $fields | grep -q " 0 1$" && { echo userns-root; return; } || true
     done < /proc/self/uid_map
 
-    [ "$(cat /proc/self/uid_map)" = "$(cat /proc/1/uid_map)" ] && \
-        { echo userns-root; return; }
+    if [ -e /proc/1/uid_map ]; then
+        if [ "$(cat /proc/self/uid_map)" = "$(cat /proc/1/uid_map)" ]; then
+            echo userns-root
+            return
+        fi
+    fi
     echo yes
 }
 

--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -42,7 +42,12 @@ in_userns() {
     fi
   done < /proc/self/uid_map
 
-  [ "$(cat /proc/self/uid_map)" = "$(cat /proc/1/uid_map)" ] && { echo userns-root; return; }
+  if [ -e /proc/1/uid_map ]; then
+    if [ "$(cat /proc/self/uid_map)" = "$(cat /proc/1/uid_map)" ]; then
+      echo userns-root
+      return
+    fi
+  fi
   echo yes
 }
 

--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -179,7 +179,12 @@ in_userns() {
     fi
   done < /proc/self/uid_map
 
-  [ "$(cat /proc/self/uid_map)" = "$(cat /proc/1/uid_map)" ] && { echo userns-root; return; }
+  if [ -e /proc/1/uid_map ]; then
+    if [ "$(cat /proc/self/uid_map)" = "$(cat /proc/1/uid_map)" ]; then
+      echo userns-root
+      return
+    fi
+  fi
   echo yes
 }
 

--- a/templates/lxc-local.in
+++ b/templates/lxc-local.in
@@ -51,8 +51,13 @@ in_userns() {
     fi
   done < /proc/self/uid_map
 
-  [ "$(cat /proc/self/uid_map)" = "$(cat /proc/1/uid_map)" ] && { echo userns-root; return; }
-    echo yes
+  if [ -e /proc/1/uid_map ]; then
+    if [ "$(cat /proc/self/uid_map)" = "$(cat /proc/1/uid_map)" ]; then
+      echo userns-root
+      return
+    fi
+  fi
+  echo yes
 }
 
 usage() {

--- a/templates/lxc-oci.in
+++ b/templates/lxc-oci.in
@@ -62,7 +62,12 @@ in_userns() {
     fi
   done < /proc/self/uid_map
 
-  [ "$(cat /proc/self/uid_map)" = "$(cat /proc/1/uid_map)" ] && { echo userns-root; return; }
+  if [ -e /proc/1/uid_map ]; then
+    if [ "$(cat /proc/self/uid_map)" = "$(cat /proc/1/uid_map)" ]; then
+      echo userns-root
+      return
+    fi
+  fi
   echo yes
 }
 


### PR DESCRIPTION
When creating unprivileged containers I came across the following error:

> $ lxc-create … -t download … -- --dist debian …
> /proc/1/uid_map: No such file or directory

The cause seems to be that ``/proc`` is mounted with ``hidepid=2`` which makes ``/proc/1/…`` appear absent for non-root users.

Since the script works correctly despite the error, this error message might be confusing for users.

I am not into LXC, so please check carefully and let me know if I can help further in fixing this.

Thanks for LXC and considering this PR.