### PR TITLE
tree-wide: initialize all auto-cleanup variables

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1260,7 +1260,7 @@ static int mkdir_eexist_on_last(const char *dir, mode_t mode)
 
 	orig_len = strlen(dir);
 	do {
-		__do_free char *makeme;
+		__do_free char *makeme = NULL;
 		int ret;
 		size_t cur_len;
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -909,9 +909,9 @@ static int set_config_net_ipv6_gateway(const char *key, const char *value,
 static int set_config_net_veth_ipv6_route(const char *key, const char *value,
 				       struct lxc_conf *lxc_conf, void *data)
 {
-	__do_free char *valdup;
-	__do_free struct lxc_inet6dev *inet6dev;
-	__do_free struct lxc_list *list;
+	__do_free char *valdup = NULL;
+	__do_free struct lxc_inet6dev *inet6dev = NULL;
+	__do_free struct lxc_list *list = NULL;
 	int ret;
 	char *netmask, *slash;
 	struct lxc_netdev *netdev = data;


### PR DESCRIPTION
Closes: #3101.
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>