### PR TITLE
pidfds: don't print a scary warning on ENOSYS

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1641,7 +1641,10 @@ static int proc_pidfd_open(pid_t pid)
 
 	/* Test whether we can send signals. */
 	if (lxc_raw_pidfd_send_signal(proc_pidfd, 0, NULL, 0)) {
-		SYSERROR("Failed to send signal through pidfd");
+		if (errno != ENOSYS)
+			SYSERROR("Failed to send signal through pidfd");
+		else
+			INFO("Sending signals through pidfds not supported on this kernel");
 		return -1;
 	}
 


### PR DESCRIPTION
Most kernels don't have this functionality yet, and so the warning is
printed a lot. Our people are scared of warnings, so let's make it INFO
instead in this case.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>