### PR TITLE
try to fix search user instead of search substring

### DIFF
--- a/src/lxc/cmd/lxc_user_nic.c
+++ b/src/lxc/cmd/lxc_user_nic.c
@@ -423,7 +423,8 @@ static char *find_line(char *buf_start, char *buf_end, char *name,
 		if (strncmp(buf_start, name, strlen(name)))
 			*found = false;
 		else
-			*owner = true;
+			if (strlen(name) == (size_t)(end_of_word - buf_start))
+				*owner = true;
 
 		buf_start = end_of_word + 1;
 		while ((buf_start < buf_end) && isblank(*buf_start))


### PR DESCRIPTION
Hello.
This patch prevent search username as a substring in another username.
Signed-off-by: Alexander Kriventsov <akriventsov@nic.ru>