### PR TITLE
utils: Fix wrong integer of a function parameter.

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -1660,7 +1660,8 @@ static bool prepend_lxc_header(char *path, const char *t, char *const argv[])
 	FILE *f;
 	int ret = -1;
 #if HAVE_OPENSSL
-	int i, md_len = 0;
+	int i;
+	unsigned int md_len = 0;
 	unsigned char md_value[EVP_MAX_MD_SIZE];
 	char *tpath;
 #endif

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -333,7 +333,7 @@ again:
 #ifdef HAVE_OPENSSL
 #include <openssl/evp.h>
 
-static int do_sha1_hash(const char *buf, int buflen, unsigned char *md_value, int *md_len)
+static int do_sha1_hash(const char *buf, int buflen, unsigned char *md_value, unsigned int *md_len)
 {
 	EVP_MD_CTX *mdctx;
 	const EVP_MD *md;
@@ -353,7 +353,7 @@ static int do_sha1_hash(const char *buf, int buflen, unsigned char *md_value, in
 	return 0;
 }
 
-int sha1sum_file(char *fnam, unsigned char *digest, int *md_len)
+int sha1sum_file(char *fnam, unsigned char *digest, unsigned int *md_len)
 {
 	char *buf;
 	int ret;

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -99,7 +99,7 @@ extern int wait_for_pid(pid_t pid);
 extern int lxc_wait_for_pid_status(pid_t pid);
 
 #if HAVE_OPENSSL
-extern int sha1sum_file(char *fnam, unsigned char *md_value, int *md_len);
+extern int sha1sum_file(char *fnam, unsigned char *md_value, unsigned int *md_len);
 #endif
 
 /* initialize rand with urandom */


### PR DESCRIPTION
If SSL is enabled, utils will include function `do_sha1_hash()` to
generate a sha1 encrypted buffer. Last function argument of
`EVP_DigestFinal_ex()` requires a `unsigned int` but the current
parameter is an `integer` type.

See error:
utils.c:350:38: error: passing 'int *' to parameter of type 'unsigned int *' converts between pointers to integer types with different sign
      [-Werror,-Wpointer-sign]
        EVP_DigestFinal_ex(mdctx, md_value, md_len);
                                            ^~~~~~
/usr/include/openssl/evp.h:549:49: note: passing argument to parameter 's' here
                                  unsigned int *s);

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>