### PR TITLE
attach: don't close stdout of getent

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -459,7 +459,7 @@ static char *lxc_attach_getpwshell(uid_t uid)
 			close(STDERR_FILENO);
 		} else {
 			(void)dup3(fd, STDIN_FILENO, O_CLOEXEC);
-			(void)dup3(fd, STDOUT_FILENO, O_CLOEXEC);
+			(void)dup3(fd, STDERR_FILENO, O_CLOEXEC);
 			close(fd);
 		}
 


### PR DESCRIPTION
See the first context line, we want to replace stderr, as stdout is the pipe from which we want to read the result.