### PR TITLE
Add config parameter for /dev tmpfs size

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -1064,7 +1064,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         <filename>/dev</filename> to be set up as needed in the container
         rootfs.  If lxc.autodev is set to 1, then after mounting the container's
         rootfs LXC will mount a fresh tmpfs under <filename>/dev</filename>
-        (limited to 500k) and fill in a minimal set of initial devices.
+        (limited to 500K by default, unless defined in lxc.autodev.tmpfs.size)
+        and fill in a minimal set of initial devices.
         This is generally required when starting a container containing
         a "systemd" based "init" but may be optional at other times.  Additional
         devices in the containers /dev directory may be created through the
@@ -1079,6 +1080,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
             <para>
               Set this to 0 to stop LXC from mounting and populating a minimal
               <filename>/dev</filename> when starting the container.
+            </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>
+            <option>lxc.autodev.tmpfs.size</option>
+          </term>
+          <listitem>
+            <para>
+              Set this to define the size of the /dev tmpfs.
+              The default value is 500000 (500K). If the parameter is used
+              but without value, the default value is used.
             </para>
           </listitem>
         </varlistentry>

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -299,6 +299,7 @@ struct lxc_conf {
 	struct lxc_seccomp seccomp;
 	int maincmd_fd;
 	unsigned int autodev;  /* if 1, mount and fill a /dev at start */
+	int autodevtmpfssize; /* size of the /dev tmpfs */
 	int haltsignal; /* signal used to halt container */
 	int rebootsignal; /* signal used to reboot container */
 	int stopsignal; /* signal used to hard stop container */
@@ -423,6 +424,7 @@ extern int lxc_clear_groups(struct lxc_conf *c);
 extern int lxc_clear_environment(struct lxc_conf *c);
 extern int lxc_clear_limits(struct lxc_conf *c, const char *key);
 extern int lxc_delete_autodev(struct lxc_handler *handler);
+extern int lxc_clear_autodev_tmpfs_size(struct lxc_conf *c);
 extern void lxc_clear_includes(struct lxc_conf *conf);
 extern int lxc_setup_rootfs_prepare_root(struct lxc_conf *conf,
 					 const char *name, const char *lxcpath);

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -83,6 +83,7 @@ lxc_log_define(confile, lxc);
 					   void *);
 
 lxc_config_define(autodev);
+lxc_config_define(autodev_tmpfs_size);
 lxc_config_define(apparmor_allow_incomplete);
 lxc_config_define(apparmor_allow_nesting);
 lxc_config_define(apparmor_profile);
@@ -173,6 +174,7 @@ static struct lxc_config_t config_jump_table[] = {
 	{ "lxc.apparmor.allow_incomplete", set_config_apparmor_allow_incomplete,   get_config_apparmor_allow_incomplete,   clr_config_apparmor_allow_incomplete, },
 	{ "lxc.apparmor.allow_nesting",    set_config_apparmor_allow_nesting,      get_config_apparmor_allow_nesting,      clr_config_apparmor_allow_nesting,    },
 	{ "lxc.apparmor.raw",              set_config_apparmor_raw,                get_config_apparmor_raw,                clr_config_apparmor_raw,              },
+	{ "lxc.autodev.tmpfs.size",        set_config_autodev_tmpfs_size,          get_config_autodev_tmpfs_size,          clr_config_autodev_tmpfs_size,        },
 	{ "lxc.autodev",                   set_config_autodev,                     get_config_autodev,                     clr_config_autodev,                   },
 	{ "lxc.cap.drop",                  set_config_cap_drop,                    get_config_cap_drop,                    clr_config_cap_drop,                  },
 	{ "lxc.cap.keep",                  set_config_cap_keep,                    get_config_cap_keep,                    clr_config_cap_keep,                  },
@@ -1548,6 +1550,20 @@ static int set_config_autodev(const char *key, const char *value,
 
 	if (lxc_conf->autodev > 1)
 		return -1;
+
+	return 0;
+}
+
+static int set_config_autodev_tmpfs_size(const char *key, const char *value,
+			      struct lxc_conf *lxc_conf, void *data)
+{
+	if (lxc_config_value_empty(value)) {
+		lxc_conf->autodevtmpfssize = 500000;
+		return 0;
+	}
+
+	if (lxc_safe_int(value, &lxc_conf->autodevtmpfssize) < 0)
+		lxc_conf->autodevtmpfssize = 500000;
 
 	return 0;
 }
@@ -4020,6 +4036,12 @@ static int get_config_autodev(const char *key, char *retv, int inlen,
 	return lxc_get_conf_int(c, retv, inlen, c->autodev);
 }
 
+static int get_config_autodev_tmpfs_size(const char *key, char *retv, int inlen,
+			      struct lxc_conf *c, void *data)
+{
+	return lxc_get_conf_int(c, retv, inlen, c->autodevtmpfssize);
+}
+
 static int get_config_signal_halt(const char *key, char *retv, int inlen,
 				  struct lxc_conf *c, void *data)
 {
@@ -4639,6 +4661,13 @@ static inline int clr_config_autodev(const char *key, struct lxc_conf *c,
 				     void *data)
 {
 	c->autodev = 1;
+	return 0;
+}
+
+static inline int clr_config_autodev_tmpfs_size(const char *key, struct lxc_conf *c,
+				     void *data)
+{
+	c->autodevtmpfssize = 500000;
 	return 0;
 }
 
@@ -5956,6 +5985,7 @@ int lxc_list_subkeys(struct lxc_conf *conf, const char *key, char *retv,
 		strprint(retv, inlen, "name\n");
 	} else if (!strcmp(key, "lxc.hook")) {
 		strprint(retv, inlen, "autodev\n");
+		strprint(retv, inlen, "autodevtmpfssize\n");
 		strprint(retv, inlen, "clone\n");
 		strprint(retv, inlen, "destroy\n");
 		strprint(retv, inlen, "mount\n");

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -560,6 +560,11 @@ int main(int argc, char *argv[])
 		goto non_test_error;
 	}
 
+	if (set_get_compare_clear_save_load(c, "lxc.autodev.tmpfs.size", "1", tmpf, true) < 0) {
+		lxc_error("%s\n", "lxc.autodev.tmpfs.size");
+		goto non_test_error;
+	}
+
 	if (set_get_compare_clear_save_load(c, "lxc.autodev", "1", tmpf, true) <
 	    0) {
 		lxc_error("%s\n", "lxc.autodev");


### PR DESCRIPTION
Second try's a charm. Sorry. Closed the other PR in favour for this PR. 

This PR wants to solve an issue with a limited size of the `/dev` tmpfs, which already happened a while ago in https://github.com/lxc/lxc/issues/781. Back then the size of the `/dev` tmpfs was increased but with a fixed size. 
Under some rare but real circumstances, the `/dev` tmpfs can run out of space. Here from a real container in production:

```
root@irnsrvc16 ~ # df -h /dev
Filesystem     Type   Size  Used Avail Use% Mounted on
none           tmpfs  492K  492K     0 100% /dev
```

The reason in this case is that this specific container is used as central syslog server (using syslog-ng) for a couple dozen other LXC containers. syslog-ng uses its console logging to /dev/tty10, which just uses up the whole space

```
root@irnsrvc16 ~ # ll /dev/tt*
crw-rw-rw- 1 root root   5, 0 Aug 21  2018 /dev/tty
crw--w---- 1 root tty  136, 0 Aug 21  2018 /dev/tty1
-rw-r----- 1 root adm  503808 Aug 23 09:21 /dev/tty10
crw--w---- 1 root tty  136, 1 Aug 21  2018 /dev/tty2
crw--w---- 1 root tty  136, 2 Aug 21  2018 /dev/tty3
crw--w---- 1 root tty  136, 3 Aug 21  2018 /dev/tty4
```

This is just one practical example. There may be other uses cases where `/dev` may run out of space.

Important: The current default of 500K as tmpfs size will stay unless `lxc.devfs_size` is used to overwrite that value. This way security to protect against a misbehaving software spamming `/dev` is in place, yet the admin has the freedom to increase (or decrease) the default size for his own reasons.