### PR TITLE
utils: Copying source filename to avoid missing info.

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1557,6 +1557,8 @@ int lxc_prepare_loop_dev(const char *source, char *loop_dev, int flags)
 	memset(&lo64, 0, sizeof(lo64));
 	lo64.lo_flags = flags;
 
+	strlcpy(lo64.lo_file_name, source, LO_NAME_SIZE);
+
 	ret = ioctl(fd_loop, LOOP_SET_STATUS64, &lo64);
 	if (ret < 0) {
 		SYSERROR("Failed to set loop status64");


### PR DESCRIPTION
Some applications use information from `LOOP_GET_STATUS64`. The 
file associated with loop device is pointed inside structure field
`lo_file_name`. The current code is setting up a loop device without
this information. A legacy example of code checking this is cryptsetup:

    static char *_ioctl_backing_file(const char *loop)
    {
        struct loop_info64 lo64 = {0};
        int loop_fd;

        loop_fd = open(loop, O_RDONLY);
        if (loop_fd < 0)
            return NULL;

        if (ioctl(loop_fd, LOOP_GET_STATUS64, &lo64) < 0) {
            close(loop_fd);
            return NULL;
        }

        lo64.lo_file_name[LO_NAME_SIZE-2] = '*';
        lo64.lo_file_name[LO_NAME_SIZE-1] = 0;

        close(loop_fd);
        return strdup((char*)lo64.lo_file_name);
    }

It will return an empty string because lo_file_name was not set.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>