### PR TITLE
Autoconf 2.69 conformance

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,4 @@
-#                                               -*- Autoconf -*-
-# Process this file with autoconf to produce a configure script.
+AC_PREREQ([2.69])
 
 m4_define([lxc_devel], 1)
 m4_define([lxc_version_major], 3)
@@ -123,7 +122,7 @@ AC_CONFIG_LINKS([config/etc/default.conf:config/etc/${distroconf}])
 # Check for init system type
 AC_MSG_CHECKING([for init system type])
 AC_ARG_WITH([init-script],
-	    [AC_HELP_STRING([--with-init-script@<:@=TYPE@<:@,TYPE,...@:>@@:>@],
+	    [AS_HELP_STRING([--with-init-script@<:@=TYPE@<:@,TYPE,...@:>@@:>@],
 			    [Type(s) of init script to install: sysvinit, systemd, upstart,
 			     distro @<:@default=distro@:>@])],[],[with_init_script=distro])
 case "$with_init_script" in
@@ -185,19 +184,19 @@ if test "x$with_systemdsystemunitdir" != "xno"; then
 fi
 
 AC_ARG_ENABLE([werror],
-	[AC_HELP_STRING([--disable-werror],
+	[AS_HELP_STRING([--disable-werror],
 	[do not treat warnings as errors])],
 	[], [enable_werror=yes])
 
 # Allow disabling rpath
 AC_ARG_ENABLE([rpath],
-	[AC_HELP_STRING([--enable-rpath], [set rpath in executables [default=no]])],
+	[AS_HELP_STRING([--enable-rpath], [set rpath in executables [default=no]])],
 	[], [enable_rpath=no])
 AM_CONDITIONAL([ENABLE_RPATH], [test "x$enable_rpath" = "xyes"])
 
 # Documentation (manpages)
 AC_ARG_ENABLE([doc],
-	[AC_HELP_STRING([--enable-doc], [make man pages [default=auto]])],
+	[AS_HELP_STRING([--enable-doc], [make man pages [default=auto]])],
 	[], [enable_doc=auto])
 
 if test "x$enable_doc" = "xyes" -o "x$enable_doc" = "xauto"; then
@@ -237,7 +236,7 @@ AC_SUBST(docdtd)
 
 # Documentation (API)
 AC_ARG_ENABLE([api-docs],
-	[AC_HELP_STRING([--enable-api-docs],
+	[AS_HELP_STRING([--enable-api-docs],
 	[make API documentation [default=auto]])],
 	[], [enable_api_docs=auto])
 
@@ -261,7 +260,7 @@ AC_CONFIG_MACRO_DIRS([config])
 
 # Apparmor
 AC_ARG_ENABLE([apparmor],
-	[AC_HELP_STRING([--enable-apparmor], [enable apparmor support [default=auto]])],
+	[AS_HELP_STRING([--enable-apparmor], [enable apparmor support [default=auto]])],
 	[], [enable_apparmor=auto])
 
 if test "$enable_apparmor" = "auto" ; then
@@ -272,7 +271,7 @@ AM_CONDITIONAL([ENABLE_APPARMOR], [test "x$enable_apparmor" = "xyes"])
 # OpenSSL
 # libssl-dev
 AC_ARG_ENABLE([openssl],
-	[AC_HELP_STRING([--enable-openssl], [enable OpenSSL support [default=auto]])],
+	[AS_HELP_STRING([--enable-openssl], [enable OpenSSL support [default=auto]])],
 	[], [enable_openssl=auto])
 
 if test "$enable_openssl" = "auto" ; then
@@ -287,7 +286,7 @@ AM_COND_IF([ENABLE_OPENSSL],
 
 # SELinux
 AC_ARG_ENABLE([selinux],
-	[AC_HELP_STRING([--enable-selinux], [enable SELinux support [default=auto]])],
+	[AS_HELP_STRING([--enable-selinux], [enable SELinux support [default=auto]])],
 	[], [enable_selinux=auto])
 
 if test "x$enable_selinux" = xauto; then
@@ -301,7 +300,7 @@ AM_COND_IF([ENABLE_SELINUX],
 
 # Seccomp syscall filter
 AC_ARG_ENABLE([seccomp],
-	[AC_HELP_STRING([--enable-seccomp], [enable seccomp support [default=auto]])],
+	[AS_HELP_STRING([--enable-seccomp], [enable seccomp support [default=auto]])],
 	[], [enable_seccomp=auto])
 
 if test "x$enable_seccomp" = "xauto" ; then
@@ -347,7 +346,7 @@ LIBS="$OLD_LIBS"
 
 # Linux capabilities
 AC_ARG_ENABLE([capabilities],
-	[AC_HELP_STRING([--enable-capabilities], [enable kernel capabilities support [default=auto]])],
+	[AS_HELP_STRING([--enable-capabilities], [enable kernel capabilities support [default=auto]])],
 	[], [enable_capabilities=auto])
 
 if test "x$enable_capabilities" = "xauto"; then
@@ -373,13 +372,13 @@ CFLAGS="$OLD_CFLAGS"
 
 # Configuration examples
 AC_ARG_ENABLE([examples],
-	[AC_HELP_STRING([--enable-examples], [install examples [default=yes]])],
+	[AS_HELP_STRING([--enable-examples], [install examples [default=yes]])],
 	[], [enable_examples=yes])
 AM_CONDITIONAL([ENABLE_EXAMPLES], [test "x$enable_examples" = "xyes"])
 
 # Enable dumping stack traces
 AC_ARG_ENABLE([mutex-debugging],
-	[AC_HELP_STRING([--enable-mutex-debugging], [Makes mutexes to report error and provide stack trace [default=no]])],
+	[AS_HELP_STRING([--enable-mutex-debugging], [Makes mutexes to report error and provide stack trace [default=no]])],
 	[], [enable_mutex_debugging=no])
 AM_CONDITIONAL([MUTEX_DEBUGGING], [test "x$enable_mutex_debugging" = "xyes"])
 
@@ -409,7 +408,7 @@ m4_ifdef([PKG_CHECK_VAR], [],
 
 # Optional bash integration
 AC_ARG_ENABLE([bash],
-	[AC_HELP_STRING([--enable-bash], [build bash integration [default=yes]])],
+	[AS_HELP_STRING([--enable-bash], [build bash integration [default=yes]])],
 	[], [enable_bash=yes])
 AM_CONDITIONAL([ENABLE_BASH], [test "x$enable_bash" = "xyes"])
 
@@ -423,31 +422,31 @@ AM_COND_IF([ENABLE_BASH],
 
 # Build the command line tools
 AC_ARG_ENABLE([tools],
-	[AC_HELP_STRING([--enable-tools], [build the command line tools [default=yes]])],
+	[AS_HELP_STRING([--enable-tools], [build the command line tools [default=yes]])],
 	[], [enable_tools=yes])
 AM_CONDITIONAL([ENABLE_TOOLS], [test "x$enable_tools" = "xyes"])
 
 # Build the liblxc commands
 AC_ARG_ENABLE([commands],
-	[AC_HELP_STRING([--enable-commands], [build the liblxc commands [default=yes]])],
+	[AS_HELP_STRING([--enable-commands], [build the liblxc commands [default=yes]])],
 	[], [enable_commands=yes])
 AM_CONDITIONAL([ENABLE_COMMANDS], [test "x$enable_commands" = "xyes"])
 
 # Build with ASAN commands
 AC_ARG_ENABLE([asan],
-	[AC_HELP_STRING([--enable-asan], [build with address sanitizer enabled [default=no]])],
+	[AS_HELP_STRING([--enable-asan], [build with address sanitizer enabled [default=no]])],
 	[], [enable_asan=no])
 AM_CONDITIONAL([ENABLE_ASAN], [test "x$enable_asan" = "xyes"])
 
 # Optional test binaries
 AC_ARG_ENABLE([tests],
-	[AC_HELP_STRING([--enable-tests], [build test/example binaries [default=no]])],
+	[AS_HELP_STRING([--enable-tests], [build test/example binaries [default=no]])],
 	[], [enable_tests=no])
 AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" = "xyes"])
 
 # Allow overriding the default runtime dir (/run)
 AC_ARG_WITH([runtime-path],
-	[AC_HELP_STRING(
+	[AS_HELP_STRING(
 		[--with-runtime-path=dir],
 		[runtime directory (default: /run)]
 	)], [], [with_runtime_path=['/run']])
@@ -456,49 +455,49 @@ AC_ARG_WITH([runtime-path],
 # This is overridden by an entry in the file called LXCCONF
 # (i.e. /etc/lxc/lxc.conf)
 AC_ARG_WITH([config-path],
-	[AC_HELP_STRING(
+	[AS_HELP_STRING(
 		[--with-config-path=dir],
 		[lxc configuration repository path]
 	)], [], [with_config_path=['${localstatedir}/lib/lxc']])
 
 # The path of the global lxc configuration file.
 AC_ARG_WITH([global-conf],
-	[AC_HELP_STRING(
+	[AS_HELP_STRING(
 		[--with-global-conf=dir],
 		[global lxc configuration file]
 	)], [], [with_global_conf=['${sysconfdir}/lxc/lxc.conf']])
 
 # The path of the userns network configuration file
 AC_ARG_WITH([usernic-conf],
-	[AC_HELP_STRING(
+	[AS_HELP_STRING(
 		[--with-usernic-conf],
 		[user network interface configuration file]
 	)], [], [with_usernic_conf=['${sysconfdir}/lxc/lxc-usernet']])
 
 # The path of the runtime usernic database
 AC_ARG_WITH([usernic-db],
-	[AC_HELP_STRING(
+	[AS_HELP_STRING(
 		[--with-usernic-db],
 		[lxc user nic database]
 	)], [], [with_usernic_db=['${with_runtime_path}/lxc/nics']])
 
 # Rootfs path, where the container mount structure is assembled
 AC_ARG_WITH([rootfs-path],
-	[AC_HELP_STRING(
+	[AS_HELP_STRING(
 		[--with-rootfs-path=dir],
 		[lxc rootfs mount point]
 	)], [], [with_rootfs_path=['${libdir}/lxc/rootfs']])
 
 # cgroup pattern specification
 AC_ARG_WITH([cgroup-pattern],
-	[AC_HELP_STRING(
+	[AS_HELP_STRING(
 		[--with-cgroup-pattern=pattern],
 		[pattern for container cgroups]
 	)], [], [with_cgroup_pattern=['lxc.payload/%n']])
 
 # The path for the apparmor_parser's cache for generated apparmor profiles
 AC_ARG_WITH([apparmor-cache-dir],
-	[AC_HELP_STRING(
+	[AS_HELP_STRING(
 		[--with-apparmor-cache-dir=dir],
 		[path for apparmor_parser cache]
 	)], [], [with_apparmor_cache_dir=['${localstatedir}/cache/lxc/apparmor']])
@@ -506,7 +505,7 @@ AC_ARG_WITH([apparmor-cache-dir],
 # Container log path.  By default, use $lxcpath.
 AC_MSG_CHECKING([Whether to place logfiles in container config path])
 AC_ARG_ENABLE([configpath-log],
-	[AC_HELP_STRING([--enable-configpath-log], [use logfiles in config path [default=no]])],
+	[AS_HELP_STRING([--enable-configpath-log], [use logfiles in config path [default=no]])],
 	[], [enable_configpath_log=no])
 AC_MSG_RESULT([$enable_configpath_log])
 AM_CONDITIONAL([USE_CONFIGPATH_LOGS], [test "$enable_configpath_log" = "yes"])
@@ -518,7 +517,7 @@ else
 fi
 
 AC_ARG_WITH([log-path],
-	[AC_HELP_STRING(
+	[AS_HELP_STRING(
 		[--with-log-path=dir],
 		[per container log path]
 	)], [], [with_log_path=['${default_log_path}']])
@@ -579,7 +578,7 @@ AM_CONDITIONAL([IS_BIONIC], [test "x$is_bionic" = "xyes"])
 
 # Configuration examples
 AC_ARG_ENABLE([pam],
-	[AC_HELP_STRING([--enable-pam], [enable pam module [default=no]])],
+	[AS_HELP_STRING([--enable-pam], [enable pam module [default=no]])],
 	[], [enable_pam=no])
 AM_CONDITIONAL([ENABLE_PAM], [test "x$enable_pam" = "xyes"])
 
@@ -770,12 +769,12 @@ if test "x$enable_werror" = "xyes"; then
 fi
 
 AC_ARG_ENABLE([thread-safety],
-	[AC_HELP_STRING([--enable-thread-safety], [enforce thread-safety otherwise fail the build [default=yes]])],
+	[AS_HELP_STRING([--enable-thread-safety], [enforce thread-safety otherwise fail the build [default=yes]])],
 	[], [enable_thread_safety=yes])
 AM_CONDITIONAL([ENFORCE_THREAD_SAFETY], [test "x$enable_thread_safety" = "xyes"])
 
 AC_ARG_ENABLE([dlog],
-	[AC_HELP_STRING([--enable-dlog], [enable dlog support [default=no]])],
+	[AS_HELP_STRING([--enable-dlog], [enable dlog support [default=no]])],
 	[], [enable_dlog=no])
 AM_CONDITIONAL([ENABLE_DLOG], [test "x$enable_dlog" = "xyes"])
 
@@ -788,7 +787,7 @@ AM_COND_IF([ENABLE_DLOG],
 	])
 
 AC_ARG_ENABLE([memfd-rexec],
-	[AC_HELP_STRING([--enable-memfd-rexec], [enforce liblxc as a memfd to protect against certain symlink attacks [default=yes]])],
+	[AS_HELP_STRING([--enable-memfd-rexec], [enforce liblxc as a memfd to protect against certain symlink attacks [default=yes]])],
 	[], [enable_memfd_rexec=yes])
 AM_CONDITIONAL([ENFORCE_MEMFD_REXEC], [test "x$enable_memfd_rexec" = "xyes"])
 if test "x$enable_memfd_rexec" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -173,9 +173,9 @@ AC_MSG_RESULT($init_script)
 
 # systemd unit dir
 AC_ARG_WITH([systemdsystemunitdir],
-            AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
-            [],
-            [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+	AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
+	[with_systemdsystemunitdir=$withval],
+	[with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
 if test -z "$with_systemdsystemunitdir"; then
   with_systemdsystemunitdir=/lib/systemd/system
 fi
@@ -184,20 +184,19 @@ if test "x$with_systemdsystemunitdir" != "xno"; then
 fi
 
 AC_ARG_ENABLE([werror],
-	[AS_HELP_STRING([--disable-werror],
-	[do not treat warnings as errors])],
-	[], [enable_werror=yes])
+	[AS_HELP_STRING([--disable-werror], [do not treat warnings as errors])],
+	[enable_werror=$enableval], [enable_werror=yes])
 
 # Allow disabling rpath
 AC_ARG_ENABLE([rpath],
 	[AS_HELP_STRING([--enable-rpath], [set rpath in executables [default=no]])],
-	[], [enable_rpath=no])
+	[enable_rpath=$enableval], [enable_rpath=no])
 AM_CONDITIONAL([ENABLE_RPATH], [test "x$enable_rpath" = "xyes"])
 
 # Documentation (manpages)
 AC_ARG_ENABLE([doc],
 	[AS_HELP_STRING([--enable-doc], [make man pages [default=auto]])],
-	[], [enable_doc=auto])
+	[enable_doc=$enableval], [enable_doc=auto])
 
 if test "x$enable_doc" = "xyes" -o "x$enable_doc" = "xauto"; then
 	db2xman=""
@@ -236,9 +235,8 @@ AC_SUBST(docdtd)
 
 # Documentation (API)
 AC_ARG_ENABLE([api-docs],
-	[AS_HELP_STRING([--enable-api-docs],
-	[make API documentation [default=auto]])],
-	[], [enable_api_docs=auto])
+	[AS_HELP_STRING([--enable-api-docs], [make API documentation [default=auto]])],
+	[enable_api_docs=$enableval], [enable_api_docs=auto])
 
 if test "x$enable_api_docs" = "xyes" -o "x$enable_api_docs" = "xauto"; then
 	AC_CHECK_PROGS([HAVE_DOXYGEN],[doxygen])
@@ -261,7 +259,7 @@ AC_CONFIG_MACRO_DIRS([config])
 # Apparmor
 AC_ARG_ENABLE([apparmor],
 	[AS_HELP_STRING([--enable-apparmor], [enable apparmor support [default=auto]])],
-	[], [enable_apparmor=auto])
+	[enable_apparmor=$enableval], [enable_apparmor=auto])
 
 if test "$enable_apparmor" = "auto" ; then
 	AC_CHECK_LIB([apparmor],[aa_change_profile],[enable_apparmor=yes], [enable_apparmor=no])
@@ -272,7 +270,7 @@ AM_CONDITIONAL([ENABLE_APPARMOR], [test "x$enable_apparmor" = "xyes"])
 # libssl-dev
 AC_ARG_ENABLE([openssl],
 	[AS_HELP_STRING([--enable-openssl], [enable OpenSSL support [default=auto]])],
-	[], [enable_openssl=auto])
+	[enable_openssl=$enableval], [enable_openssl=auto])
 
 if test "$enable_openssl" = "auto" ; then
 	AC_CHECK_LIB([ssl], [OPENSSL_init_ssl], [enable_openssl=yes], [enable_openssl=no])
@@ -287,7 +285,7 @@ AM_COND_IF([ENABLE_OPENSSL],
 # SELinux
 AC_ARG_ENABLE([selinux],
 	[AS_HELP_STRING([--enable-selinux], [enable SELinux support [default=auto]])],
-	[], [enable_selinux=auto])
+	[enable_selinux=$enableval], [enable_selinux=auto])
 
 if test "x$enable_selinux" = xauto; then
 	AC_CHECK_LIB([selinux],[setexeccon_raw],[enable_selinux=yes],[enable_selinux=no])
@@ -301,7 +299,7 @@ AM_COND_IF([ENABLE_SELINUX],
 # Seccomp syscall filter
 AC_ARG_ENABLE([seccomp],
 	[AS_HELP_STRING([--enable-seccomp], [enable seccomp support [default=auto]])],
-	[], [enable_seccomp=auto])
+	[enable_seccomp=$enableval], [enable_seccomp=auto])
 
 if test "x$enable_seccomp" = "xauto" ; then
 	AC_CHECK_LIB([seccomp],[seccomp_init],[enable_seccomp=yes],[enable_seccomp=no])
@@ -347,7 +345,7 @@ LIBS="$OLD_LIBS"
 # Linux capabilities
 AC_ARG_ENABLE([capabilities],
 	[AS_HELP_STRING([--enable-capabilities], [enable kernel capabilities support [default=auto]])],
-	[], [enable_capabilities=auto])
+	[enable_capabilities=$enableval], [enable_capabilities=auto])
 
 if test "x$enable_capabilities" = "xauto"; then
 	AC_CHECK_LIB([cap],[cap_set_proc],[enable_capabilities=yes],[enable_capabilities=no])
@@ -373,13 +371,13 @@ CFLAGS="$OLD_CFLAGS"
 # Configuration examples
 AC_ARG_ENABLE([examples],
 	[AS_HELP_STRING([--enable-examples], [install examples [default=yes]])],
-	[], [enable_examples=yes])
+	[enable_examples=$enableval], [enable_examples=yes])
 AM_CONDITIONAL([ENABLE_EXAMPLES], [test "x$enable_examples" = "xyes"])
 
 # Enable dumping stack traces
 AC_ARG_ENABLE([mutex-debugging],
 	[AS_HELP_STRING([--enable-mutex-debugging], [Makes mutexes to report error and provide stack trace [default=no]])],
-	[], [enable_mutex_debugging=no])
+	[enable_mutex_debugging=$enableval], [enable_mutex_debugging=no])
 AM_CONDITIONAL([MUTEX_DEBUGGING], [test "x$enable_mutex_debugging" = "xyes"])
 
 AM_COND_IF([MUTEX_DEBUGGING],
@@ -409,7 +407,7 @@ m4_ifdef([PKG_CHECK_VAR], [],
 # Optional bash integration
 AC_ARG_ENABLE([bash],
 	[AS_HELP_STRING([--enable-bash], [build bash integration [default=yes]])],
-	[], [enable_bash=yes])
+	[enable_bash=$enableval], [enable_bash=yes])
 AM_CONDITIONAL([ENABLE_BASH], [test "x$enable_bash" = "xyes"])
 
 AM_COND_IF([ENABLE_BASH],
@@ -423,90 +421,74 @@ AM_COND_IF([ENABLE_BASH],
 # Build the command line tools
 AC_ARG_ENABLE([tools],
 	[AS_HELP_STRING([--enable-tools], [build the command line tools [default=yes]])],
-	[], [enable_tools=yes])
+	[enable_tools=$enableval], [enable_tools=yes])
 AM_CONDITIONAL([ENABLE_TOOLS], [test "x$enable_tools" = "xyes"])
 
 # Build the liblxc commands
 AC_ARG_ENABLE([commands],
 	[AS_HELP_STRING([--enable-commands], [build the liblxc commands [default=yes]])],
-	[], [enable_commands=yes])
+	[enable_commands=$enableval], [enable_commands=yes])
 AM_CONDITIONAL([ENABLE_COMMANDS], [test "x$enable_commands" = "xyes"])
 
 # Build with ASAN commands
 AC_ARG_ENABLE([asan],
 	[AS_HELP_STRING([--enable-asan], [build with address sanitizer enabled [default=no]])],
-	[], [enable_asan=no])
+	[enable_asan=$enableval], [enable_asan=no])
 AM_CONDITIONAL([ENABLE_ASAN], [test "x$enable_asan" = "xyes"])
 
 # Optional test binaries
 AC_ARG_ENABLE([tests],
 	[AS_HELP_STRING([--enable-tests], [build test/example binaries [default=no]])],
-	[], [enable_tests=no])
+	[enable_tests=$enableval], [enable_tests=no])
 AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" = "xyes"])
 
 # Allow overriding the default runtime dir (/run)
 AC_ARG_WITH([runtime-path],
-	[AS_HELP_STRING(
-		[--with-runtime-path=dir],
-		[runtime directory (default: /run)]
-	)], [], [with_runtime_path=['/run']])
+	[AS_HELP_STRING([--with-runtime-path=dir], [runtime directory (default: /run)])],
+	[with_runtime_path=$withval], [with_runtime_path=['/run']])
 
 # LXC container path, where the containers are actually stored
 # This is overridden by an entry in the file called LXCCONF
 # (i.e. /etc/lxc/lxc.conf)
 AC_ARG_WITH([config-path],
-	[AS_HELP_STRING(
-		[--with-config-path=dir],
-		[lxc configuration repository path]
-	)], [], [with_config_path=['${localstatedir}/lib/lxc']])
+	[AS_HELP_STRING([--with-config-path=dir], [lxc configuration repository path])],
+	[with_config_path=$withval], [with_config_path=['${localstatedir}/lib/lxc']])
 
 # The path of the global lxc configuration file.
 AC_ARG_WITH([global-conf],
-	[AS_HELP_STRING(
-		[--with-global-conf=dir],
-		[global lxc configuration file]
-	)], [], [with_global_conf=['${sysconfdir}/lxc/lxc.conf']])
+	[AS_HELP_STRING([--with-global-conf=dir], [global lxc configuration file])],
+	[with_global_conf=$withval], [with_global_conf=['${sysconfdir}/lxc/lxc.conf']])
 
 # The path of the userns network configuration file
 AC_ARG_WITH([usernic-conf],
-	[AS_HELP_STRING(
-		[--with-usernic-conf],
-		[user network interface configuration file]
-	)], [], [with_usernic_conf=['${sysconfdir}/lxc/lxc-usernet']])
+	[AS_HELP_STRING([--with-usernic-conf], [user network interface configuration file])],
+	[with_usernic_conf=$withval], [with_usernic_conf=['${sysconfdir}/lxc/lxc-usernet']])
 
 # The path of the runtime usernic database
 AC_ARG_WITH([usernic-db],
-	[AS_HELP_STRING(
-		[--with-usernic-db],
-		[lxc user nic database]
-	)], [], [with_usernic_db=['${with_runtime_path}/lxc/nics']])
+	[AS_HELP_STRING([--with-usernic-db], [lxc user nic database])],
+	[with_usernic_db=$withval], [with_usernic_db=['${with_runtime_path}/lxc/nics']])
 
 # Rootfs path, where the container mount structure is assembled
 AC_ARG_WITH([rootfs-path],
-	[AS_HELP_STRING(
-		[--with-rootfs-path=dir],
-		[lxc rootfs mount point]
-	)], [], [with_rootfs_path=['${libdir}/lxc/rootfs']])
+	[AS_HELP_STRING([--with-rootfs-path=dir], [lxc rootfs mount point])],
+	[with_rootfs_path=$withval], [with_rootfs_path=['${libdir}/lxc/rootfs']])
 
 # cgroup pattern specification
 AC_ARG_WITH([cgroup-pattern],
-	[AS_HELP_STRING(
-		[--with-cgroup-pattern=pattern],
-		[pattern for container cgroups]
-	)], [], [with_cgroup_pattern=['lxc.payload/%n']])
+	[AS_HELP_STRING([--with-cgroup-pattern=pattern], [pattern for container cgroups])],
+	[with_cgroup_pattern=$withval], [with_cgroup_pattern=['lxc.payload/%n']])
 
 # The path for the apparmor_parser's cache for generated apparmor profiles
 AC_ARG_WITH([apparmor-cache-dir],
-	[AS_HELP_STRING(
-		[--with-apparmor-cache-dir=dir],
-		[path for apparmor_parser cache]
-	)], [], [with_apparmor_cache_dir=['${localstatedir}/cache/lxc/apparmor']])
+	[AS_HELP_STRING([--with-apparmor-cache-dir=dir],[path for apparmor_parser cache])],
+	[with_apparmor_cache_dir=$withval], [with_apparmor_cache_dir=['${localstatedir}/cache/lxc/apparmor']])
 
 # Container log path.  By default, use $lxcpath.
 AC_MSG_CHECKING([Whether to place logfiles in container config path])
 AC_ARG_ENABLE([configpath-log],
 	[AS_HELP_STRING([--enable-configpath-log], [use logfiles in config path [default=no]])],
-	[], [enable_configpath_log=no])
+	[enable_configpath_log=$enableval], [enable_configpath_log=no])
 AC_MSG_RESULT([$enable_configpath_log])
 AM_CONDITIONAL([USE_CONFIGPATH_LOGS], [test "$enable_configpath_log" = "yes"])
 
@@ -517,10 +499,8 @@ else
 fi
 
 AC_ARG_WITH([log-path],
-	[AS_HELP_STRING(
-		[--with-log-path=dir],
-		[per container log path]
-	)], [], [with_log_path=['${default_log_path}']])
+	[AS_HELP_STRING([--with-log-path=dir],[per container log path])],
+	[with_log_path=$withval], [with_log_path=['${default_log_path}']])
 
 # Expand some useful variables
 AS_AC_EXPAND(PREFIX, "$prefix")
@@ -579,7 +559,7 @@ AM_CONDITIONAL([IS_BIONIC], [test "x$is_bionic" = "xyes"])
 # Configuration examples
 AC_ARG_ENABLE([pam],
 	[AS_HELP_STRING([--enable-pam], [enable pam module [default=no]])],
-	[], [enable_pam=no])
+	[enable_pam=$enableval], [enable_pam=no])
 AM_CONDITIONAL([ENABLE_PAM], [test "x$enable_pam" = "xyes"])
 
 AM_COND_IF([ENABLE_PAM],
@@ -587,7 +567,7 @@ AM_COND_IF([ENABLE_PAM],
 		[pamdir],
 		[AS_HELP_STRING([--with-pamdir=PATH],[Specify the directory where PAM modules are stored,
 							or "none" if PAM modules are not to be built])],
-		[pamdir="${withval}"],
+		[pamdir=$withval],
 		[
 			if test "${prefix}" = "/usr"; then
 				pamdir="/lib${libdir##*/lib}/security"
@@ -770,12 +750,12 @@ fi
 
 AC_ARG_ENABLE([thread-safety],
 	[AS_HELP_STRING([--enable-thread-safety], [enforce thread-safety otherwise fail the build [default=yes]])],
-	[], [enable_thread_safety=yes])
+	[enable_thread_safety=$enableval], [enable_thread_safety=yes])
 AM_CONDITIONAL([ENFORCE_THREAD_SAFETY], [test "x$enable_thread_safety" = "xyes"])
 
 AC_ARG_ENABLE([dlog],
 	[AS_HELP_STRING([--enable-dlog], [enable dlog support [default=no]])],
-	[], [enable_dlog=no])
+	[enable_dlog=$enableval], [enable_dlog=no])
 AM_CONDITIONAL([ENABLE_DLOG], [test "x$enable_dlog" = "xyes"])
 
 AM_COND_IF([ENABLE_DLOG],
@@ -788,7 +768,7 @@ AM_COND_IF([ENABLE_DLOG],
 
 AC_ARG_ENABLE([memfd-rexec],
 	[AS_HELP_STRING([--enable-memfd-rexec], [enforce liblxc as a memfd to protect against certain symlink attacks [default=yes]])],
-	[], [enable_memfd_rexec=yes])
+	[enable_memfd_rexec=$enableval], [enable_memfd_rexec=yes])
 AM_CONDITIONAL([ENFORCE_MEMFD_REXEC], [test "x$enable_memfd_rexec" = "xyes"])
 if test "x$enable_memfd_rexec" = "xyes"; then
 	AC_DEFINE([ENFORCE_MEMFD_REXEC], 1, [Rexec liblxc as memfd])


### PR DESCRIPTION
This PR adds to configure.ac the AC_PREREQ(2.69) to ensure that a recent enough version of Autoconf is being used. It also changes AC_HELP_STRING renamed to AS_HELP_STRING in Autoconf 2.69 and allows users to give to ./configure the option '--enable-feature' or  '--with-package' by setting the action-if-given values. I'd like to send more patches to configure.ac but will open small PR to easy the review process. Please let me know if there is something else that you guys would like to do in configure.ac.
