### PR TITLE
Fix lxc-update-config in network.address

### DIFF
--- a/src/lxc/cmd/lxc-update-config.in
+++ b/src/lxc/cmd/lxc-update-config.in
@@ -69,7 +69,7 @@ sed -i \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.init_uid\)\([[:blank:]*]\|=\)/\1lxc\.init\.uid\3/g' \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.init_gid\)\([[:blank:]*]\|=\)/\1lxc\.init\.gid\3/g' \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.limit\)\([[:blank:]*]\|=\)/\1lxc\.prlimit\3/g' \
--e 's/\([[:blank:]*]\|#*\)\(lxc\.network\)\(\.[[:digit:]*]\)\(\.ipv4\)/\1lxc\.net\3\4\.address/g' \
+-e 's/\([[:blank:]*]\|#*\)\(lxc\.network\)\(\.[[:digit:]*]\)\(\.ipv4\)/\1lxc\.net\3\4/g' \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.network\)\(\.[[:digit:]*]\)/\1lxc\.net\3/g' \
 -e 's/\([[:blank:]*]\|#*\)\(lxc\.network\)\([[:blank:]*]\|=\)/\1lxc\.net\3/g' \
 -e '/\([[:blank:]*]\|#*\)\(lxc\.rootfs\.backend\)\([[:blank:]*]\|=\)/d' \


### PR DESCRIPTION
Dear developpers,

When we use lxc-update-config to translate a LXCv2 to LXCv3 configuration file, we have a issue with the parameters `lxc.network.X.ipv4.address`.

The output of the translate is: 
`lxc.net.0.ipv4.address.address`

Instead of:
`lxc.net.0.ipv4.address`

This introduce a bug: the container want to use the gateway address as a secondary network address.