### PR TITLE
start: pidfds obviously start - like any fd - at 0

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1112,9 +1112,9 @@ void lxc_abort(const char *name, struct lxc_handler *handler)
 
 	lxc_set_state(name, handler, ABORTING);
 
-	if (handler->pidfd > 0)
+	if (handler->pidfd >= 0)
 		ret = lxc_raw_pidfd_send_signal(handler->pidfd, SIGKILL, NULL, 0);
-	else if (handler->proc_pidfd > 0)
+	else if (handler->proc_pidfd >= 0)
 		ret = lxc_raw_pidfd_send_signal(handler->proc_pidfd, SIGKILL, NULL, 0);
 	else if (handler->pid > 0)
 		ret = kill(handler->pid, SIGKILL);


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>