### PR TITLE
doc: Add more info about 'lxc.start.order'

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -2578,7 +2578,8 @@ dev/null proc/kcore none bind,relative 0 0
           <listitem>
             <para>
               An integer used to sort the containers when auto-starting
-              a series of containers at once.
+              a series of containers at once. A lower value means an
+              earlier start.
             </para>
           </listitem>
         </varlistentry>


### PR DESCRIPTION
This trivial patch adds more information about 'lxc.start.order'. Currently there is nothing about how the "order" is treated (whether a lower value means an earlier start or opposite). This patch adds a sentence which explains it.