### PR TITLE
Bad SGML/man manual translation

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -1172,9 +1172,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               <option>relative</option> source path is taken to be relative to
               the mounted container root. For instance,
              </para>
-<screen>
-dev/null proc/kcore none bind,relative 0 0
-</screen>
+             <programlisting>
+             dev/null proc/kcore none bind,relative 0 0
+             </programlisting>
              <para>
               Will expand dev/null to ${<option>LXC_ROOTFS_MOUNT</option>}/dev/null,
               and mount it to proc/kcore inside the container.


### PR DESCRIPTION
When calling "man lxc.container.conf", an internal "man" keyword is displayed :

$ man lxc.container.conf
[...]
lxc.mount.entry
              Specify a mount point corresponding to a line in the fstab format.  Moreover lxc supports mount  propagation,  such  as
              rslave  or  rprivate, and adds three additional mount options.  optional don't fail if mount does not work.  create=dir
              or create=file to create dir (or file) when the point will be mounted.  relative source path is taken to be relative to
              the mounted container root. For instance,

dev/null proc/kcore none bind,relative 0 0
              .fi     <-----------------------------------UNEXPECTED KEYWORD !!!!

The problem seems to come from the missing blanks before "dev/null proc/kcore none bind,relative 0 0"

Moreover, for homogeneity purposes, it is better to use the <programlisting> tag used in the rest of the text instead of <screen>.

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>

