### PR TITLE
lxc/tools/lxc/destroy: Restores error message on container destroy

### DIFF
--- a/src/lxc/tools/lxc_destroy.c
+++ b/src/lxc/tools/lxc_destroy.c
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (!c->is_defined(c)) {
-		INFO("Container %s not found.", my_args.name);
+		ERROR("Container is not defined");
 		lxc_container_put(c);
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
Partially reverts 65b92ea5fcab559fd21be2685bd2f15ef6d33532 so that trying to destroy a non-existent container gives an error message.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>