### PR TITLE
Update Makefiles to uninstall paths owned by LXC on installation. 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,12 +19,9 @@ pcdata_DATA = lxc.pc
 libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status libtool
 
-install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(LXCPATH)
-	$(MKDIR_P) $(DESTDIR)$(localstatedir)/cache/lxc
-
 ChangeLog::
 	@touch ChangeLog
 
 rpm: dist
 	rpmbuild --clean -ta ${distdir}.tar.gz $(RPMARGS)
+

--- a/config/apparmor/Makefile.am
+++ b/config/apparmor/Makefile.am
@@ -36,9 +36,8 @@ uninstall-apparmor:
 	rm -f $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/lxc-default
 	rm -f $(DESTDIR)$(sysconfdir)/apparmor.d/abstractions/lxc/start-container
 	rm -f $(DESTDIR)$(sysconfdir)/apparmor.d/abstractions/lxc/container-base
-	rmdir $(DESTDIR)$(sysconfdir)/apparmor.d/lxc/ || :
-	rmdir $(DESTDIR)$(sysconfdir)/apparmor.d/abstractions/lxc/ || :
-	rmdir $(DESTDIR)$(sysconfdir)/apparmor.d/ || :
+	if test -d $(DESTDIR)$(sysconfdir)/apparmor.d/lxc; then rmdir $(DESTDIR)$(sysconfdir)/apparmor.d/lxc; fi
+	if test -d $(DESTDIR)$(sysconfdir)/apparmor.d/abstractions/lxc; then rmdir $(DESTDIR)$(sysconfdir)/apparmor.d/abstractions/lxc; fi
 
 install-data-local: install-apparmor
 uninstall-local: uninstall-apparmor

--- a/config/etc/Makefile.am
+++ b/config/etc/Makefile.am
@@ -3,6 +3,9 @@ config_DATA = default.conf
 
 EXTRA_DIST = default.conf.lxcbr default.conf.libvirt default.conf.unknown
 
+uninstall-local:
+	if test -d $(DESTDIR)$(configdir); then rmdir $(DESTDIR)$(configdir); fi
+
 distclean-local:
 	@$(RM) -f default.conf
 	@$(RM) -f compile config.guess config.sub depcomp install-sh ltmain.sh missing Makefile.in Makefile

--- a/config/init/systemd/Makefile.am
+++ b/config/init/systemd/Makefile.am
@@ -15,7 +15,6 @@ uninstall-systemd:
 	rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/lxc.service
 	rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/lxc@.service
 	rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/lxc-net.service
-	rmdir $(DESTDIR)$(SYSTEMD_UNIT_DIR) || :
 
 pkglibexec_SCRIPTS = lxc-apparmor-load
 

--- a/config/init/sysvinit/Makefile.am
+++ b/config/init/sysvinit/Makefile.am
@@ -18,7 +18,6 @@ install-sysvinit: lxc-containers lxc-net
 uninstall-sysvinit:
 	rm -f $(DESTDIR)$(sysconfdir)/$(initdir)/lxc
 	rm -f $(DESTDIR)$(sysconfdir)/$(initdir)/lxc-net
-	rmdir $(DESTDIR)$(sysconfdir)/$(initdir) || :
 
 install-data-local: install-sysvinit
 uninstall-local: uninstall-sysvinit

--- a/config/init/upstart/Makefile.am
+++ b/config/init/upstart/Makefile.am
@@ -11,7 +11,6 @@ uninstall-upstart:
 	rm -f $(DESTDIR)$(sysconfdir)/init/lxc.conf
 	rm -f $(DESTDIR)$(sysconfdir)/init/lxc-instance.conf
 	rm -f $(DESTDIR)$(sysconfdir)/init/lxc-net.conf
-	rmdir $(DESTDIR)$(sysconfdir)/init || :
 
 install-data-local: install-upstart
 uninstall-local: uninstall-upstart

--- a/config/selinux/Makefile.am
+++ b/config/selinux/Makefile.am
@@ -1,4 +1,4 @@
-selinuxdir=@DATADIR@/lxc/selinux
+selinuxdir=$(pkgdatadir)/selinux
 
 EXTRA_DIST = \
 	lxc.if lxc.te
@@ -6,3 +6,6 @@ EXTRA_DIST = \
 selinux_DATA = \
 	lxc.if \
 	lxc.te
+
+uninstall-hook:
+	if test -d $(DESTDIR)$(selinuxdir); then rmdir $(DESTDIR)$(selinuxdir); fi

--- a/config/sysconfig/Makefile.am
+++ b/config/sysconfig/Makefile.am
@@ -1,6 +1,5 @@
-sysconfigdir="@LXC_DISTRO_SYSCONF@"
+sysconfigdir=@LXC_DISTRO_SYSCONF@
 
-sysconfig_DATA = \
-	lxc
+sysconfig_DATA = lxc
 
 EXTRA_DIST = $(sysconfig_DATA)

--- a/config/templates/Makefile.am
+++ b/config/templates/Makefile.am
@@ -9,3 +9,6 @@ templatesconfig_DATA = common.conf \
 		       nesting.conf \
 		       oci.common.conf \
 		       userns.conf
+
+uninstall-hook:
+	if test -d $(DESTDIR)$(templatesconfigdir); then rmdir $(DESTDIR)$(templatesconfigdir); fi

--- a/config/templates/common.conf.d/Makefile.am
+++ b/config/templates/common.conf.d/Makefile.am
@@ -1,6 +1,9 @@
-templatesconfigdir=@LXCTEMPLATECONFIG@/common.conf.d/
+commonconfddir=@LXCTEMPLATECONFIG@/common.conf.d/
 
 EXTRA_DIST = README
 
-templatesconfig_DATA = \
+commonconfd_DATA = \
 	README
+
+uninstall-hook:
+	if test -d $(DESTDIR)$(commonconfddir); then rmdir $(DESTDIR)$(commonconfddir); fi

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -77,3 +77,6 @@ lxc-%.sgml : common_options.sgml see_also.sgml
 clean-local:
 	$(RM) manpage.* *.7 *.5 *.1 *.8 $(man_MANS)
 endif
+
+uninstall-local:
+	if test -d $(DESTDIR)$(docdir); then rmdir $(DESTDIR)$(docdir); fi

--- a/doc/examples/Makefile.am
+++ b/doc/examples/Makefile.am
@@ -12,6 +12,10 @@ pkgexamples_DATA = \
 	seccomp-v1.conf \
 	seccomp-v2-blacklist.conf \
 	seccomp-v2.conf
+
+uninstall-hook:
+	if test -d $(DESTDIR)$(pkgexamplesdir); then rmdir $(DESTDIR)$(pkgexamplesdir); fi
+
 endif
 
 noinst_DATA = \
@@ -30,3 +34,5 @@ EXTRA_DIST = \
 	seccomp-v1.conf \
 	seccomp-v2-blacklist.conf \
 	seccomp-v2.conf
+
+

--- a/hooks/Makefile.am
+++ b/hooks/Makefile.am
@@ -22,3 +22,7 @@ unmount_namespace_SOURCES += \
 endif
 
 EXTRA_DIST=$(hooks_SCRIPTS)
+
+uninstall-hook:
+	if test -d $(DESTDIR)$(hooksdir); then rmdir $(DESTDIR)$(hooksdir); fi
+	if test -d $(DESTDIR)$(datadir)/lxc; then rmdir $(DESTDIR)$(datadir)/lxc; fi

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -490,9 +490,13 @@ install-exec-hook:
 	chmod u+s $(DESTDIR)$(libexecdir)/lxc/lxc-user-nic
 endif
 
+uninstall-hook:
+	if test -d $(DESTDIR)$(pkgincludedir); then rmdir $(DESTDIR)$(pkgincludedir); fi
+
 uninstall-local:
 	$(RM) $(DESTDIR)$(libdir)/liblxc.so*
 	$(RM) $(DESTDIR)$(libdir)/liblxc.a
+	rm -f $(DESTDIR)$(datadir)/lxc/lxc.functions
 if ENABLE_PAM
 if HAVE_PAM
 	$(RM) $(DESTDIR)$(pamdir)/pam_cgfs.so*

--- a/templates/Makefile.am
+++ b/templates/Makefile.am
@@ -4,3 +4,6 @@ templates_SCRIPTS = lxc-busybox \
 		    lxc-download \
 		    lxc-local \
 		    lxc-oci
+
+uninstall-hook:
+	if test -d $(DESTDIR)$(templatesdir); then rmdir $(DESTDIR)$(templatesdir); fi


### PR DESCRIPTION
This PR updates Makefiles.am to remove directories owned by LXC that are created on 'make install'. It also removes some paths that LXC does not own and are being removed on 'make uninstall'. Although it could not remove the ${libexecdir}/lxc/hooks or ${libdir}/lxc/rootfs (the former could be specified by the user when running the ./configure script).