### PR TITLE
syscall_wrappers: rename internal memfd_create to memfd_create_lxc

### DIFF
--- a/src/lxc/syscall_wrappers.h
+++ b/src/lxc/syscall_wrappers.h
@@ -74,7 +74,7 @@ static inline long __keyctl(int cmd, unsigned long arg2, unsigned long arg3,
 #endif
 
 #ifndef HAVE_MEMFD_CREATE
-static inline int memfd_create(const char *name, unsigned int flags) {
+static inline int memfd_create_lxc(const char *name, unsigned int flags) {
 	#ifndef __NR_memfd_create
 		#if defined __i386__
 			#define __NR_memfd_create 356
@@ -113,6 +113,7 @@ static inline int memfd_create(const char *name, unsigned int flags) {
 	return -1;
 	#endif
 }
+#define memfd_create memfd_create_lxc
 #else
 extern int memfd_create(const char *name, unsigned int flags);
 #endif


### PR DESCRIPTION
In case the internal memfd_create has to be used, make sure we don't
clash with the already existing memfd_create function from glibc.

This can happen if this glibc function is a stub. In this case, at
./configure time, the test for this function will return false, however
the declaration of that function is still available. This leads to
compilation errors.

Signed-off-by: Patrick Havelange <patrick.havelange@essensium.com>