### PR TITLE
terminal: return NULL on error in terminal_signal_init

### DIFF
--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -174,7 +174,7 @@ on_error:
 		ts->sigfd = -1;
 	}
 
-	return ts;
+	return NULL;
 }
 
 void lxc_terminal_signal_fini(struct lxc_terminal *terminal)


### PR DESCRIPTION
Callers expect a NULL on error, and with PR #3171 marking
the pointer as `__do_free`, we now return a pointer to freed
memory here otherwise.

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>