### PR TITLE
conf: fix memory leak for set config rootfs options

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4096,6 +4096,7 @@ void lxc_conf_free(struct lxc_conf *conf)
 	free(conf->rootfs.bdev_type);
 	free(conf->rootfs.options);
 	free(conf->rootfs.path);
+	free(conf->rootfs.data);
 	free(conf->logfile);
 	if (conf->logfd != -1)
 		close(conf->logfd);


### PR DESCRIPTION
fix memory leak for  lxc_grow_array