### PR TITLE
Update cgroup.h

### DIFF
--- a/src/lxc/cgroups/cgroup.h
+++ b/src/lxc/cgroups/cgroup.h
@@ -77,7 +77,7 @@ typedef enum {
  *   If the hierarchy is a legacy hierarchy this will be set to
  *   CGROUP_SUPER_MAGIC.
  * - unified hierarchy
- *   If the hierarchy is a legacy hierarchy this will be set to
+ *   If the hierarchy is a unified hierarchy this will be set to
  *   CGROUP2_SUPER_MAGIC.
  */
 struct hierarchy {


### PR DESCRIPTION
Fixed the documentation to say that cgroupv2 uses a unified hierarchy
Signed-off-by: Aaditya Murthy <amurthy123@utexas.edu>