### PR TITLE
tests: use /dev/null instead of /dev/network_latency

### DIFF
--- a/src/tests/device_add_remove.c
+++ b/src/tests/device_add_remove.c
@@ -21,7 +21,7 @@
 #include <lxc/lxccontainer.h>
 
 #define NAME "device_add_remove_test"
-#define DEVICE "/dev/network_latency"
+#define DEVICE "/dev/loop-control"
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
BugLink: https://bugs.launchpad.net/bugs/1848587

The latter device has been removed apparently.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>