### PR TITLE
Typo in a comment

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1321,7 +1321,7 @@ static int do_start(void *data)
 
 	/* Add the requested environment variables to the current environment to
 	 * allow them to be used by the various hooks, such as the start hook
-	 * above.
+	 * below.
 	 */
 	lxc_list_for_each(iterator, &handler->conf->environment) {
 		ret = putenv((char *)iterator->elem);


### PR DESCRIPTION
"above" was used instead of "below"

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>