### PR TITLE
fix wrong order of bridge/nic in error message

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -2466,7 +2466,7 @@ int lxc_ovs_delete_port(const char *bridge, const char *nic)
 			  lxc_ovs_delete_port_exec, (void *)&args);
 	if (ret < 0) {
 		ERROR("Failed to delete \"%s\" from openvswitch bridge \"%s\": "
-		      "%s", bridge, nic, cmd_output);
+		      "%s", nic, bridge, cmd_output);
 		return -1;
 	}
 
@@ -2494,7 +2494,7 @@ static int lxc_ovs_attach_bridge(const char *bridge, const char *nic)
 			  lxc_ovs_attach_bridge_exec, (void *)&args);
 	if (ret < 0) {
 		ERROR("Failed to attach \"%s\" to openvswitch bridge \"%s\": %s",
-		      bridge, nic, cmd_output);
+		      nic, bridge, cmd_output);
 		return -1;
 	}
 


### PR DESCRIPTION
Seems to be a simple mixup.
Found in LXC 3.0.3 shipped with Ubuntu 18.04.