### PR TITLE
cgroups/devices: use dedicated enums

### DIFF
--- a/src/lxc/cgroups/cgroup2_devices.c
+++ b/src/lxc/cgroups/cgroup2_devices.c
@@ -447,7 +447,8 @@ int bpf_list_add_device(struct lxc_conf *conf, struct device_item *device)
 	lxc_list_for_each(it, &conf->devices) {
 		struct device_item *cur = it->elem;
 
-		if (cur->global_rule != -1 && device->global_rule != -1) {
+		if (cur->global_rule > LXC_BPF_DEVICE_CGROUP_LOCAL_RULE &&
+		    device->global_rule > LXC_BPF_DEVICE_CGROUP_LOCAL_RULE) {
 			TRACE("Switched from %s to %s",
 			      cur->global_rule == LXC_BPF_DEVICE_CGROUP_WHITELIST
 				  ? "whitelist"

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -231,9 +231,9 @@ struct lxc_state_client {
 };
 
 enum {
+	LXC_BPF_DEVICE_CGROUP_LOCAL_RULE = -1,
 	LXC_BPF_DEVICE_CGROUP_WHITELIST  =  0,
 	LXC_BPF_DEVICE_CGROUP_BLACKLIST  =  1,
-	LXC_BPF_DEVICE_CGROUP_LOCAL_RULE = -1,
 };
 
 struct device_item {


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>