### PR TITLE
Init "busy" field in "lxc_terminal_info" to -1 (not 0)

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1006,7 +1006,7 @@ int lxc_allocate_ttys(struct lxc_conf *conf)
 			SYSWARN("Failed to set FD_CLOEXEC flag on slave fd %d of "
 			        "tty device \"%s\"", tty->slave, tty->name);
 
-		tty->busy = 0;
+		tty->busy = -1;
 	}
 
 	INFO("Finished creating %zu tty devices", ttys->max);

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1526,7 +1526,7 @@ static int lxc_recv_ttys_from_child(struct lxc_handler *handler)
 			break;
 
 		tty = &ttys->tty[i];
-		tty->busy = 0;
+		tty->busy = -1;
 		tty->master = ttyfds[0];
 		tty->slave = ttyfds[1];
 		TRACE("Received pty with master fd %d and slave fd %d from "

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1530,7 +1530,7 @@ static int lxc_recv_ttys_from_child(struct lxc_handler *handler)
 		tty->master = ttyfds[0];
 		tty->slave = ttyfds[1];
 		TRACE("Received pty with master fd %d and slave fd %d from "
-		      "parent", tty->master, tty->slave);
+		      "child", tty->master, tty->slave);
 	}
 
 	if (ret < 0)

--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -593,7 +593,7 @@ int lxc_terminal_allocate(struct lxc_conf *conf, int sockfd, int *ttyreq)
 		if (*ttyreq > ttys->max)
 			goto out;
 
-		if (ttys->tty[*ttyreq - 1].busy)
+		if (ttys->tty[*ttyreq - 1].busy >= 0)
 			goto out;
 
 		/* The requested tty is available. */
@@ -602,7 +602,7 @@ int lxc_terminal_allocate(struct lxc_conf *conf, int sockfd, int *ttyreq)
 	}
 
 	/* Search for next available tty, fixup index tty1 => [0]. */
-	for (ttynum = 1; ttynum <= ttys->max && ttys->tty[ttynum - 1].busy; ttynum++) {
+	for (ttynum = 1; ttynum <= ttys->max && ttys->tty[ttynum - 1].busy >= 0; ttynum++) {
 		;
 	}
 
@@ -628,7 +628,7 @@ void lxc_terminal_free(struct lxc_conf *conf, int fd)
 
 	for (i = 0; i < ttys->max; i++)
 		if (ttys->tty[i].busy == fd)
-			ttys->tty[i].busy = 0;
+			ttys->tty[i].busy = -1;
 
 	if (terminal->proxy.busy != fd)
 		return;


### PR DESCRIPTION
As the "busy" field of the "struct lxc_terminal_info" is set to a socket descriptor when the embedding structure is marked "in use", it should be initialized to -1 instead of 0 as 0 is also a valid file descriptor.

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>
