### PR TITLE
config: Fix parsing of mount options

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1853,16 +1853,21 @@ static void parse_mntopt(char *opt, unsigned long *flags, char **data, size_t si
 {
 	struct mount_opt *mo;
 
-	/* If opt is found in mount_opt, set or clear flags.
-	 * Otherwise append it to data. */
+	/* If '=' is contained in opt, the option must go into data. */
+	if (!strchr(opt, '=')) {
 
-	for (mo = &mount_opt[0]; mo->name != NULL; mo++) {
-		if (strncmp(opt, mo->name, strlen(mo->name)) == 0) {
-			if (mo->clear)
-				*flags &= ~mo->flag;
-			else
-				*flags |= mo->flag;
-			return;
+		/* If opt is found in mount_opt, set or clear flags.
+		 * Otherwise append it to data. */
+		size_t opt_len = strlen(opt);
+		for (mo = &mount_opt[0]; mo->name != NULL; mo++) {
+			size_t mo_name_len = strlen(mo->name);
+			if (opt_len == mo_name_len && strncmp(opt, mo->name, mo_name_len) == 0) {
+				if (mo->clear)
+					*flags &= ~mo->flag;
+				else
+					*flags |= mo->flag;
+				return;
+			}
 		}
 	}
 


### PR DESCRIPTION
When parsing mount options e.g. from lxc.mount.entry the specified options are mapped to the flags constants. To do so, the strings are compared to the options contained in mount_opt. However, when comparing the strings, the length of the string is not checked. That entails that the option "rootcontext=selinux-context" is mapped to the mount option read-only (ro). This commit fixes
this issue by checking if a '=' is contained in the specified option and additionally comparing the length of the strings.