### PR TITLE
cgroups/cgfsng: do not prematurely close file descriptors

### DIFF
--- a/src/lxc/cgroups/cgroup.h
+++ b/src/lxc/cgroups/cgroup.h
@@ -166,6 +166,7 @@ struct cgroup_ops {
 				 struct lxc_handler *handler);
 	bool (*monitor_delegate_controllers)(struct cgroup_ops *ops);
 	bool (*payload_delegate_controllers)(struct cgroup_ops *ops);
+	void (*payload_finalize)(struct cgroup_ops *ops);
 };
 
 extern struct cgroup_ops *cgroup_init(struct lxc_conf *conf);

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1922,6 +1922,9 @@ static int lxc_spawn(struct lxc_handler *handler)
 		}
 	}
 
+	cgroup_ops->payload_finalize(cgroup_ops);
+	TRACE("Finished setting up cgroups");
+
 	/* Run any host-side start hooks */
 	ret = run_lxc_hooks(name, "start-host", conf, NULL);
 	if (ret < 0) {


### PR DESCRIPTION
When adding the new improved cgroup setup logic I didn't account for the fact
that we need the hierarchy fds up until chown. Add a dedicated cleanup method
to fix this:
```
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, , 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, tasks, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
lxc b1 20191212205052.712 WARN     cgfsng - cgroups/cgfsng.c:fchowmodat:1481 - Bad file descriptor - Failed to fchownat(-9, cgroup.procs, 1000000000, 0, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW )
```
Closes #3228.
Fixes: 1973b62aab41 ("cgroups/cgfsng: improve cgroup creation and removal")
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>