### PR TITLE
cmd: fix shebang

### DIFF
--- a/src/lxc/cmd/lxc-checkconfig.in
+++ b/src/lxc/cmd/lxc-checkconfig.in
@@ -1,6 +1,5 @@
-# SPDX-License-Identifier: LGPL-2.1+
-
 #!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1+
 
 # Allow environment variables to override config
 : ${CONFIG:=/proc/config.gz}

--- a/src/lxc/cmd/lxc-update-config.in
+++ b/src/lxc/cmd/lxc-update-config.in
@@ -1,6 +1,5 @@
-# SPDX-License-Identifier: LGPL-2.1+
-
 #!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1+
 
 # Make sure the usual locations are in PATH
 export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
Signed-off-by: vikaig <vikaig99@gmail.com>

Fixes these errors
```
$ lxc-checkconfig
Failed to execute process '/usr/bin/lxc-checkconfig'. Reason:
exec: Exec format error
The file '/usr/bin/lxc-checkconfig' is marked as an executable but could not be run by the operating system.

$ lxc-update-config
Failed to execute process '/usr/bin/lxc-update-config'. Reason:
exec: Exec format error
The file '/usr/bin/lxc-update-config' is marked as an executable but could not be run by the operating system.
```