### PR TITLE
Adaptation to latest busybox

### DIFF
--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -140,7 +140,7 @@ EOF
   chmod 644 "${rootfs}/etc/inittab" || return 1
 
   # Look for the pathname of "default.script" from the help of udhcpc
-  DEF_SCRIPT=`${BUSYBOX_EXE} udhcpc -h 2>&1 | grep -- '-s,--script PROG' | cut -d'/' -f2- | cut -d')' -f1`
+  DEF_SCRIPT=`${BUSYBOX_EXE} udhcpc --help 2>&1 | egrep -- '-s.*Run PROG' | cut -d'/' -f2- | cut -d')' -f1`
   DEF_SCRIPT_DIR=`dirname /${DEF_SCRIPT}`
   mkdir -p ${rootfs}/${DEF_SCRIPT_DIR}
   chmod 644 ${rootfs}/${DEF_SCRIPT_DIR} || return 1


### PR DESCRIPTION
In busybox 1.30, the help of udhcpc for "-s" option changed:
--> busybox v1.27.2: -s,--script PROG	Run PROG at DHCP events (default /usr/share/udhcpc/default.script)
--> busybox v1.30.1: -s PROG		Run PROG at DHCP events (default /etc/udhcpc/default.script)
So, I changed the command line which extracts the script name to make it work for both versions

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>