### PR TITLE
Suppress useless udhcpc directory

### DIFF
--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -75,7 +75,6 @@ ${rootfs}/mnt \
 ${rootfs}/tmp \
 ${rootfs}/var/log \
 ${rootfs}/var/run \
-${rootfs}/usr/share/udhcpc \
 ${rootfs}/dev/pts \
 ${rootfs}/dev/shm \
 ${rootfs}/lib \


### PR DESCRIPTION
The udhcpc directory is created with "mkdir -p" at the place dynamically specified by "busybox udhcpc --help".

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>