### PR TITLE
network: improve veth device creation

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -2999,9 +2999,10 @@ bool lxc_delete_network_unpriv(struct lxc_handler *handler)
 		     netdev->link);
 
 clear_ifindices:
-		/* We need to clear any ifindices we recorded so liblxc won't
-		 * have cached stale data which would cause it to fail on reboot
-		 * we're we don't re-read the on-disk config file.
+		/*
+		 * We need to clear any ifindices we recorded so liblxc won't
+		 * have cached stale data which would cause it to fail on
+		 * reboot where we don't re-read the on-disk config file.
 		 */
 		netdev->ifindex = 0;
 		if (netdev->type == LXC_NET_PHYS) {

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -203,7 +203,8 @@ extern int lxc_netdev_down(const char *name);
 extern int lxc_netdev_set_mtu(const char *name, int mtu);
 
 /* Create a virtual network devices. */
-extern int lxc_veth_create(const char *name1, const char *name2);
+extern int lxc_veth_create(const char *name1, const char *name2, pid_t pid,
+			   unsigned int mtu);
 extern int lxc_macvlan_create(const char *master, const char *name, int mode);
 extern int lxc_vlan_create(const char *master, const char *name,
 			   unsigned short vid);

--- a/src/tests/api_reboot.c
+++ b/src/tests/api_reboot.c
@@ -29,17 +29,46 @@
 
 #include "lxc/lxccontainer.h"
 #include "lxctest.h"
+#include "utils.h"
+
+#ifndef HAVE_STRLCPY
+#include "include/strlcpy.h"
+#endif
+
+#define TSTNAME "lxc-api-reboot"
 
 int main(int argc, char *argv[])
 {
 	int i;
 	struct lxc_container *c;
 	int ret = EXIT_FAILURE;
+	struct lxc_log log;
+	char template[sizeof(P_tmpdir"/reboot_XXXXXX")];
+
+	(void)strlcpy(template, P_tmpdir"/reboot_XXXXXX", sizeof(template));
+
+	i = lxc_make_tmpfile(template, false);
+	if (i < 0) {
+		lxc_error("Failed to create temporary log file for container %s\n", TSTNAME);
+		exit(EXIT_FAILURE);
+	} else {
+		lxc_debug("Using \"%s\" as temporary log file for container %s\n", template, TSTNAME);
+		close(i);
+	}
+
+	log.name = TSTNAME;
+	log.file = template;
+	log.level = "TRACE";
+	log.prefix = "reboot";
+	log.quiet = false;
+	log.lxcpath = NULL;
+	if (lxc_log_init(&log))
+		exit(ret);
 
 	/* Test that the reboot() API function properly waits for containers to
 	 * restart.
 	 */
-	c = lxc_container_new("reboot", NULL);
+	c = lxc_container_new(TSTNAME, NULL);
 	if (!c) {
 		lxc_error("%s", "Failed to create container \"reboot\"");
 		exit(ret);
@@ -120,8 +149,24 @@ on_error_stop:
 on_error_put:
 	lxc_container_put(c);
 
-	if (ret == EXIT_SUCCESS)
+	if (ret == EXIT_SUCCESS) {
 		lxc_debug("%s\n", "All reboot tests passed");
+	} else {
+		int fd;
+
+		fd = open(template, O_RDONLY);
+		if (fd >= 0) {
+			char buf[4096];
+			ssize_t buflen;
+			while ((buflen = read(fd, buf, 1024)) > 0) {
+				buflen = write(STDERR_FILENO, buf, buflen);
+				if (buflen <= 0)
+					break;
+			}
+			close(fd);
+		}
+	}
+	(void)unlink(template);
 
 	exit(ret);
 }


### PR DESCRIPTION
This allows us to avoid having to move the network device. It also allows us to
work around a kernel bug that in combination with a recent change in systemd
244 causes uses of systemd-networkd to not get an ip address.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>