### PR TITLE
cgroup.c: fix memory leak at cgroup init failed

### DIFF
--- a/src/lxc/cgroups/cgroup.c
+++ b/src/lxc/cgroups/cgroup.c
@@ -31,9 +31,11 @@ struct cgroup_ops *cgroup_init(struct lxc_conf *conf)
 	if (!cgroup_ops)
 		return log_error_errno(NULL, errno, "Failed to initialize cgroup driver");
 
-	if (cgroup_ops->data_init(cgroup_ops))
+	if (cgroup_ops->data_init(cgroup_ops)) {
+		cgroup_exit(cgroup_ops);
 		return log_error_errno(NULL, errno,
 				       "Failed to initialize cgroup data");
+	}
 
 	TRACE("Initialized cgroup driver %s", cgroup_ops->driver);
 


### PR DESCRIPTION
Signed-off-by: LiFeng <lifeng68@huawei.com>