### PR TITLE
start: fix container killing logic

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1094,11 +1094,13 @@ void lxc_abort(const char *name, struct lxc_handler *handler)
 	if (handler->pidfd >= 0) {
 		ret = lxc_raw_pidfd_send_signal(handler->pidfd, SIGKILL, NULL, 0);
 		if (ret)
-			SYSWARN("Failed to send SIGKILL via pidfd %d for process %d", handler->pidfd, handler->pid);
+			SYSWARN("Failed to send SIGKILL via pidfd %d for process %d",
+				handler->pidfd, handler->pid);
 	}
 
-	if (ret && (errno != ESRCH) && kill(handler->pid, SIGKILL))
-		SYSERROR("Failed to send SIGKILL to %d", handler->pid);
+	if (!ret || errno != ESRCH)
+		if (kill(handler->pid, SIGKILL))
+			SYSWARN("Failed to send SIGKILL to %d", handler->pid);
 
 	do {
 		ret = waitpid(-1, &status, 0);


### PR DESCRIPTION
We need to account for the case where pidfd's are not supported by the kernel
in question.

Closes: #3254
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>