### PR TITLE
lxclock: fix a small memory leak

### DIFF
--- a/src/lxc/lxclock.c
+++ b/src/lxc/lxclock.c
@@ -169,6 +169,8 @@ struct lxc_lock *lxc_newlock(const char *lxcpath, const char *name)
 	l->type = LXC_LOCK_FLOCK;
 	l->u.f.fname = lxclock_name(lxcpath, name);
 	if (!l->u.f.fname) {
+		if (!name)
+			free(l->u.sem);
 		free(l);
 		l = NULL;
 		goto on_error;


### PR DESCRIPTION
if (!name), we allocate an unnamed semaphore, but if we then fail to
allocate/create the lock, we don't free this semaphore, and we just leak
it.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>