### PR TITLE
cgroups: remove unused method and cleanup cgroup_exit()

### DIFF
--- a/src/lxc/cgroups/cgroup.c
+++ b/src/lxc/cgroups/cgroup.c
@@ -53,13 +53,10 @@ struct cgroup_ops *cgroup_init(struct lxc_conf *conf)
 
 void cgroup_exit(struct cgroup_ops *ops)
 {
-	char **cur;
-	struct hierarchy **it;
-
 	if (!ops)
 		return;
 
-	for (cur = ops->cgroup_use; cur && *cur; cur++)
+	for (char **cur = ops->cgroup_use; cur && *cur; cur++)
 		free(*cur);
 
 	free(ops->cgroup_pattern);
@@ -69,14 +66,12 @@ void cgroup_exit(struct cgroup_ops *ops)
 	if (ops->cgroup2_devices)
 		bpf_program_free(ops->cgroup2_devices);
 
-	for (it = ops->hierarchies; it && *it; it++) {
-		char **p;
-
-		for (p = (*it)->controllers; p && *p; p++)
+	for (struct hierarchy **it = ops->hierarchies; it && *it; it++) {
+		for (char **p = (*it)->controllers; p && *p; p++)
 			free(*p);
 		free((*it)->controllers);
 
-		for (p = (*it)->cgroup2_chown; p && *p; p++)
+		for (char **p = (*it)->cgroup2_chown; p && *p; p++)
 			free(*p);
 		free((*it)->cgroup2_chown);
 

--- a/src/lxc/cgroups/cgroup.h
+++ b/src/lxc/cgroups/cgroup.h
@@ -161,7 +161,6 @@ struct cgroup_ops {
 		       const char *lxcpath, pid_t pid);
 	bool (*mount)(struct cgroup_ops *ops, struct lxc_handler *handler,
 		      const char *root, int type);
-	int (*nrtasks)(struct cgroup_ops *ops);
 	bool (*devices_activate)(struct cgroup_ops *ops,
 				 struct lxc_handler *handler);
 	bool (*monitor_delegate_controllers)(struct cgroup_ops *ops);


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>