### PR TITLE
src/lxc/raw_syscalls.c: fix sparc assembly

### DIFF
--- a/src/lxc/raw_syscalls.c
+++ b/src/lxc/raw_syscalls.c
@@ -76,7 +76,7 @@ __returns_twice pid_t lxc_raw_clone(unsigned long flags, int *pidfd)
 		     * processor status register (psr) is used instead of a
 		     * full register.
 		     */
-		    "addx %%g0, 0, %g1"
+		    "addx %%g0, 0, %%g1"
 		    : "=r"(g1), "=r"(o0), "=r"(o1), "=r"(o2) /* outputs */
 		    : "r"(g1), "r"(o0), "r"(o1), "r"(o2)     /* inputs */
 		    : "%cc");				     /* clobbers */


### PR DESCRIPTION
Build of lxc 3.2.1 fails with ultrasparc on:

```
raw_syscalls.c: In function ‘lxc_raw_clone’:
raw_syscalls.c:66:3: error: invalid 'asm': invalid operand output code
   asm volatile(
   ^~~
```

Issue has been added with commit b52e8e68a61866da2af86e85905ec850f8a8b7fc which added `%g1` instead of `%%g1`

Fixes:
 - http://autobuild.buildroot.org/results/17c2319850f02f24da6fbef9656c07f86fdc5a3a

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>