### PR TITLE
network: Adds short sleep between veth setup and neighbour proxy add

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -382,6 +382,13 @@ static int instantiate_veth(struct lxc_handler *handler, struct lxc_netdev *netd
 	}
 
 	if (netdev->priv.veth_attr.mode == VETH_MODE_ROUTER) {
+		/* sleep for a short period of time to work around a bug that intermittently prevents IP neighbour
+		   proxy entries from being added using lxc_ip_neigh_proxy below. When the issue occurs the entries
+		   appear to be added successfully but then do not appear in the proxy list. The length of time
+		   slept doesn't appear to be important, only that the process sleeps for a short period of time.
+		*/
+		nanosleep((const struct timespec[]){{0, 1000}}, NULL);
+
 		if (netdev->ipv4_gateway) {
 			char bufinet4[INET_ADDRSTRLEN];
 			if (!inet_ntop(AF_INET, netdev->ipv4_gateway, bufinet4, sizeof(bufinet4))) {


### PR DESCRIPTION
There is an intermittent issue, experienced on at least Ubuntu 18.04 (5.3.0-40-generic) and Alpine 3.11 (5.4.12-1-virt) when using the router network interface type that causes the IP proxy neighbour entries on the host side of the veth pair to not be created (or to disappear very shortly after being added).

The `ip neigh add proxy` command returns without an error, however by the time the network up hook has started a short time later, the IP neighbour proxy entries are no longer there (if they ever were).

I've also tested this using netlink rather than the ip command to add and both are equally affected.

Adding a short sleep between setting up the veth pair and adding the proxy entries appears to fix it.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>