### PR TITLE
commands_utils: fix socket leak when adding state client

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -863,7 +863,7 @@ int lxc_cmd_add_state_client(const char *name, const char *lxcpath,
 	return MAX_STATE;
 }
 
-static int lxc_cmd_add_state_client_callback(int fd, struct lxc_cmd_req *req,
+static int lxc_cmd_add_state_client_callback(__owns int fd, struct lxc_cmd_req *req,
 					     struct lxc_handler *handler,
 					     struct lxc_epoll_descr *descr)
 {
@@ -888,6 +888,10 @@ static int lxc_cmd_add_state_client_callback(int fd, struct lxc_cmd_req *req,
 	ret = lxc_cmd_rsp_send(fd, &rsp);
 	if (ret < 0)
 		goto reap_client_fd;
+
+	/* close fd if state is already achieved to avoid leakage */
+	if (rsp.ret != MAX_STATE)
+		close(fd);
 
 	return 0;
 

--- a/src/lxc/commands_utils.c
+++ b/src/lxc/commands_utils.c
@@ -171,7 +171,7 @@ int lxc_cmd_connect(const char *name, const char *lxcpath,
 	return client_fd;
 }
 
-int lxc_add_state_client(int state_client_fd, struct lxc_handler *handler,
+int lxc_add_state_client(__owns int state_client_fd, struct lxc_handler *handler,
 			 lxc_state_t states[MAX_STATE])
 {
 	__do_free struct lxc_state_client *newclient = NULL;

--- a/src/lxc/commands_utils.c
+++ b/src/lxc/commands_utils.c
@@ -195,7 +195,6 @@ int lxc_add_state_client(int state_client_fd, struct lxc_handler *handler,
 		lxc_list_add_elem(tmplist, newclient);
 		lxc_list_add_tail(&handler->conf->state_clients, tmplist);
 	} else {
-		close(state_client_fd);
 		return state;
 	}
 

--- a/src/lxc/commands_utils.c
+++ b/src/lxc/commands_utils.c
@@ -171,7 +171,7 @@ int lxc_cmd_connect(const char *name, const char *lxcpath,
 	return client_fd;
 }
 
-int lxc_add_state_client(__owns int state_client_fd, struct lxc_handler *handler,
+int lxc_add_state_client(int state_client_fd, struct lxc_handler *handler,
 			 lxc_state_t states[MAX_STATE])
 {
 	__do_free struct lxc_state_client *newclient = NULL;

--- a/src/lxc/commands_utils.c
+++ b/src/lxc/commands_utils.c
@@ -195,6 +195,7 @@ int lxc_add_state_client(int state_client_fd, struct lxc_handler *handler,
 		lxc_list_add_elem(tmplist, newclient);
 		lxc_list_add_tail(&handler->conf->state_clients, tmplist);
 	} else {
+		close(state_client_fd);
 		return state;
 	}
 

--- a/src/lxc/compiler.h
+++ b/src/lxc/compiler.h
@@ -52,6 +52,9 @@
 #define __lxc_unused
 #endif
 
+/* Indicates taking ownership */
+#define __owns
+
 #define __cgfsng_ops
 
 #endif /* __LXC_COMPILER_H */

--- a/src/lxc/compiler.h
+++ b/src/lxc/compiler.h
@@ -52,9 +52,6 @@
 #define __lxc_unused
 #endif
 
-/* Indicates taking ownership */
-#define __owns
-
 #define __cgfsng_ops
 
 #endif /* __LXC_COMPILER_H */


### PR DESCRIPTION
If lxc_add_state_client() is called with the container already being in
the desired state the client fd will never be closed and is leaking.
This due to setting stay_connected in lxc_cmd for
LXC_CMD_ADD_STATE_CLIENT. If the desired state isn't already achieved
the client fd will later be closed by calling lxc_cmd_fd_cleanup() but
in the other case the client configuration isn't added to the handlers
state clients. So the client fd has to be closed explicitely.

This is simply tested by starting container A and calling lxc-wait -n A
-s RUNNING.