### PR TITLE
memory_utils: remove unneeded inclusion of mntent.h

### DIFF
--- a/src/lxc/memory_utils.h
+++ b/src/lxc/memory_utils.h
@@ -5,7 +5,6 @@
 
 #include <dirent.h>
 #include <errno.h>
-#include <mntent.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>


### PR DESCRIPTION
Fixes: Android
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>