### PR TITLE
Deactivate autodev in busybox template

### DIFF
--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -235,6 +235,7 @@ lxc.cap.drop = sys_module mac_admin mac_override sys_time
 # When using LXC with apparmor, uncomment the next line to run unconfined:
 #lxc.apparmor.profile = unconfined
 
+lxc.autodev = 0
 lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed
 lxc.mount.entry = shm /dev/shm tmpfs defaults 0 0
 EOF


### PR DESCRIPTION
Add lxc.autodev = 0 to use the dev directory built by the busybox template

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>