### PR TITLE
Auto-create /dev/shm and /dev/mqueue

### DIFF
--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -76,7 +76,6 @@ ${rootfs}/tmp \
 ${rootfs}/var/log \
 ${rootfs}/var/run \
 ${rootfs}/dev/pts \
-${rootfs}/dev/shm \
 ${rootfs}/lib \
 ${rootfs}/usr/lib \
 ${rootfs}/lib64 \
@@ -237,6 +236,7 @@ lxc.cap.drop = sys_module mac_admin mac_override sys_time
 
 lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed
 lxc.mount.entry = shm dev/shm tmpfs defaults,create=dir 0 0
+lxc.mount.entry = mqueue dev/mqueue mqueue defaults,create=dir 0 0
 EOF
 
   libdirs="\


### PR DESCRIPTION
Mount fs on /dev/shm and /dev/mqueue to experiment IPC in namespaces

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>