### PR TITLE
tools: fix -g and -u parameters for lxc-execute and lxc-attach and fix pidfd detection logic

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -689,7 +689,7 @@ static int lxc_cmd_stop_callback(int fd, struct lxc_cmd_req *req,
 		stopsignal = handler->conf->stopsignal;
 	memset(&rsp, 0, sizeof(rsp));
 
-	if (handler-> pidfd >= 0)
+	if (handler->pidfd >= 0)
 		rsp.ret = lxc_raw_pidfd_send_signal(handler->pidfd, stopsignal, NULL, 0);
 	else
 		rsp.ret = kill(handler->pid, stopsignal);

--- a/src/lxc/raw_syscalls.c
+++ b/src/lxc/raw_syscalls.c
@@ -123,13 +123,13 @@ pid_t lxc_raw_clone_cb(int (*fn)(void *), void *args, unsigned long flags,
 	return pid;
 }
 
+/* For all the architectures we care about it's the same syscall number. */
+#ifndef __NR_pidfd_send_signal
+#define __NR_pidfd_send_signal 424
+#endif
+
 int lxc_raw_pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
 			      unsigned int flags)
 {
-#ifdef __NR_pidfd_send_signal
 	return syscall(__NR_pidfd_send_signal, pidfd, sig, info, flags);
-#else
-	errno = ENOSYS;
-	return -1;
-#endif
 }

--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -132,6 +132,8 @@ Options :\n\
 	.checker      = NULL,
 	.log_priority = "ERROR",
 	.log_file     = "none",
+	.uid          = LXC_INVALID_UID,
+	.gid          = LXC_INVALID_GID,
 };
 
 static int my_parser(struct lxc_arguments *args, int c, char *arg)
@@ -345,10 +347,10 @@ int main(int argc, char *argv[])
 			goto out;
 	}
 
-	if (my_args.uid)
+	if (my_args.uid != LXC_INVALID_UID)
 		attach_options.uid = my_args.uid;
 
-	if (my_args.gid)
+	if (my_args.gid != LXC_INVALID_GID)
 		attach_options.gid = my_args.gid;
 
 	if (command.program) {

--- a/src/lxc/tools/lxc_execute.c
+++ b/src/lxc/tools/lxc_execute.c
@@ -63,6 +63,8 @@ Options :\n\
 	.log_priority = "ERROR",
 	.log_file     = "none",
 	.daemonize    = 0,
+	.uid          = LXC_INVALID_UID,
+	.gid          = LXC_INVALID_GID,
 };
 
 static int my_parser(struct lxc_arguments *args, int c, char *arg)
@@ -190,7 +192,7 @@ int main(int argc, char *argv[])
 	if (!bret)
 		goto out;
 
-	if (my_args.uid) {
+	if (my_args.uid != LXC_INVALID_UID) {
 		char buf[256];
 
 		ret = snprintf(buf, 256, "%d", my_args.uid);
@@ -202,7 +204,7 @@ int main(int argc, char *argv[])
 			goto out;
 	}
 
-	if (my_args.gid) {
+	if (my_args.gid != LXC_INVALID_GID) {
 		char buf[256];
 
 		ret = snprintf(buf, 256, "%d", my_args.gid);

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1833,5 +1833,9 @@ bool lxc_can_use_pidfd(int pidfd)
 	if (ret < 0)
 		return log_error_errno(false, errno, "Kernel does not support waiting on processes through pidfds");
 
+	ret = lxc_raw_pidfd_send_signal(pidfd, 0, NULL, 0);
+	if (ret)
+		return log_error_errno(false, errno, "Kernel does not support sending singals through pidfds");
+
 	return log_trace(true, "Kernel supports pidfds");
 }


### PR DESCRIPTION
Closes #3188.
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>