### PR TITLE
tree-wide: introduce and use syscall number header

### DIFF
--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -43,6 +43,7 @@ noinst_HEADERS = api_extensions.h \
 		 storage/storage_utils.h \
 		 storage/zfs.h \
 		 string_utils.h \
+		 syscall_numbers.h \
 		 syscall_wrappers.h \
 		 terminal.h \
 		 ../tests/lxctest.h \
@@ -145,6 +146,7 @@ liblxc_la_SOURCES = af_unix.c af_unix.h \
 		    storage/zfs.c storage/zfs.h \
 		    string_utils.c string_utils.h \
 		    sync.c sync.h \
+		    syscall_numbers.h \
 		    syscall_wrappers.h \
 		    terminal.c \
 		    utils.c utils.h \
@@ -360,6 +362,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h
 lxc_unshare_SOURCES = tools/lxc_unshare.c \
+		      syscall_numbers.h \
 		      tools/arguments.c tools/arguments.h
 lxc_wait_SOURCES = tools/lxc_wait.c \
 		   tools/arguments.c tools/arguments.h
@@ -381,6 +384,7 @@ init_lxc_SOURCES = cmd/lxc_init.c \
 		   memory_utils.h \
 		   parse.c parse.h \
 		   raw_syscalls.c raw_syscalls.h \
+		   syscall_numbers.h \
 		   string_utils.c string_utils.h
 
 init_lxc_LDFLAGS = -pthread
@@ -391,6 +395,7 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       mainloop.c mainloop.h \
 		       monitor.c monitor.h \
 		       raw_syscalls.c raw_syscalls.h \
+		       syscall_numbers.h \
 		       utils.c utils.h
 lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
@@ -399,6 +404,7 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       network.c network.h \
 		       parse.c parse.h \
 		       raw_syscalls.c raw_syscalls.h \
+		       syscall_numbers.h \
 		       file_utils.c file_utils.h \
 		       string_utils.c string_utils.h \
 		       syscall_wrappers.h

--- a/src/lxc/cgroups/cgroup2_devices.h
+++ b/src/lxc/cgroups/cgroup2_devices.h
@@ -17,50 +17,24 @@
 
 #include "conf.h"
 #include "config.h"
+#include "syscall_numbers.h"
 
 #ifdef HAVE_STRUCT_BPF_CGROUP_DEV_CTX
 #include <linux/bpf.h>
 #include <linux/filter.h>
 #endif
 
-#if !HAVE_BPF
-#if !(defined __NR_bpf && __NR_bpf > 0)
-#if defined __NR_bpf
-#undef __NR_bpf
-#endif
-#if defined __i386__
-#define __NR_bpf 357
-#elif defined __x86_64__
-#define __NR_bpf 321
-#elif defined __aarch64__
-#define __NR_bpf 280
-#elif defined __arm__
-#define __NR_bpf 386
-#elif defined __sparc__
-#define __NR_bpf 349
-#elif defined __s390__
-#define __NR_bpf 351
-#elif defined __tilegx__
-#define __NR_bpf 280
-#else
-#warning "__NR_bpf not defined for your architecture"
-#endif
-#endif
+#ifndef HAVE_BPF
 
 union bpf_attr;
 
 static inline int missing_bpf(int cmd, union bpf_attr *attr, size_t size)
 {
-#ifdef __NR_bpf
-	return (int)syscall(__NR_bpf, cmd, attr, size);
-#else
-	errno = ENOSYS;
-	return -1;
-#endif
+	return syscall(__NR_bpf, cmd, attr, size);
 }
 
 #define bpf missing_bpf
-#endif
+#endif /* HAVE_BPF */
 
 struct bpf_program {
 	int device_list_type;
@@ -70,7 +44,7 @@ struct bpf_program {
 	size_t n_instructions;
 #ifdef HAVE_STRUCT_BPF_CGROUP_DEV_CTX
 	struct bpf_insn *instructions;
-#endif
+#endif /* HAVE_STRUCT_BPF_CGROUP_DEV_CTX */
 
 	char *attached_path;
 	int attached_type;
@@ -97,7 +71,7 @@ static inline void __auto_bpf_program_free__(struct bpf_program **prog)
 	}
 }
 int bpf_list_add_device(struct lxc_conf *conf, struct device_item *device);
-#else
+#else /* !HAVE_STRUCT_BPF_CGROUP_DEV_CTX */
 static inline struct bpf_program *bpf_program_new(uint32_t prog_type)
 {
 	errno = ENOSYS;
@@ -160,7 +134,7 @@ static inline int bpf_list_add_device(struct lxc_conf *conf,
 	errno = ENOSYS;
 	return -1;
 }
-#endif
+#endif /* !HAVE_STRUCT_BPF_CGROUP_DEV_CTX */
 
 #define __do_bpf_program_free \
 	__attribute__((__cleanup__(__auto_bpf_program_free__)))

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -81,19 +81,6 @@
 #include "include/strlcpy.h"
 #endif
 
-/* Define faccessat() if missing from the C library */
-#ifndef HAVE_FACCESSAT
-static int faccessat(int __fd, const char *__file, int __type, int __flag)
-{
-#ifdef __NR_faccessat
-	return syscall(__NR_faccessat, __fd, __file, __type, __flag);
-#else
-	errno = ENOSYS;
-	return -1;
-#endif
-}
-#endif
-
 lxc_log_define(lxccontainer, lxc);
 
 static bool do_lxcapi_destroy(struct lxc_container *c);

--- a/src/lxc/raw_syscalls.c
+++ b/src/lxc/raw_syscalls.c
@@ -15,16 +15,12 @@
 #include "config.h"
 #include "macro.h"
 #include "raw_syscalls.h"
+#include "syscall_numbers.h"
 
 int lxc_raw_execveat(int dirfd, const char *pathname, char *const argv[],
 		     char *const envp[], int flags)
 {
-#ifdef __NR_execveat
-	syscall(__NR_execveat, dirfd, pathname, argv, envp, flags);
-#else
-	errno = ENOSYS;
-#endif
-	return -1;
+	return syscall(__NR_execveat, dirfd, pathname, argv, envp, flags);
 }
 
 /*
@@ -122,11 +118,6 @@ pid_t lxc_raw_clone_cb(int (*fn)(void *), void *args, unsigned long flags,
 
 	return pid;
 }
-
-/* For all the architectures we care about it's the same syscall number. */
-#ifndef __NR_pidfd_send_signal
-#define __NR_pidfd_send_signal 424
-#endif
 
 int lxc_raw_pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
 			      unsigned int flags)

--- a/src/lxc/raw_syscalls.h
+++ b/src/lxc/raw_syscalls.h
@@ -81,7 +81,7 @@ static inline pid_t lxc_raw_getpid(void)
 
 static inline pid_t lxc_raw_gettid(void)
 {
-#ifdef __NR_gettid
+#if __NR_gettid > 0
 	return syscall(__NR_gettid);
 #else
 	return lxc_raw_getpid();

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -38,12 +38,7 @@ lxc_log_define(seccomp, lxc);
 static inline int __seccomp(unsigned int operation, unsigned int flags,
 			  void *args)
 {
-#ifdef __NR_seccomp
 	return syscall(__NR_seccomp, operation, flags, args);
-#else
-	errno = ENOSYS;
-	return -1;
-#endif
 }
 #endif
 

--- a/src/lxc/syscall_numbers.h
+++ b/src/lxc/syscall_numbers.h
@@ -1,0 +1,478 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+#ifndef __LXC_SYSCALL_NUMBERS_H
+#define __LXC_SYSCALL_NUMBERS_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+#include <asm/unistd.h>
+#include <errno.h>
+#include <linux/keyctl.h>
+#include <sched.h>
+#include <stdint.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifdef HAVE_LINUX_MEMFD_H
+#include <linux/memfd.h>
+#endif
+
+#ifdef HAVE_SYS_SIGNALFD_H
+#include <sys/signalfd.h>
+#endif
+
+#ifndef __NR_keyctl
+	#if defined __i386__
+		#define __NR_keyctl 288
+	#elif defined __x86_64__
+		#define __NR_keyctl 250
+	#elif defined __arm__
+		#define __NR_keyctl 311
+	#elif defined __aarch64__
+		#define __NR_keyctl 311
+	#elif defined __s390__
+		#define __NR_keyctl 280
+	#elif defined __powerpc__
+		#define __NR_keyctl 271
+	#elif defined __sparc__
+		#define __NR_keyctl 283
+	#elif defined __ia64__
+		#define __NR_keyctl 249
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_keyctl 4282
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_keyctl 6245
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_keyctl 5241
+		#endif
+	#else
+		#define -1
+		#warning "__NR_keyctl not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_memfd_create
+	#if defined __i386__
+		#define __NR_memfd_create 356
+	#elif defined __x86_64__
+		#define __NR_memfd_create 319
+	#elif defined __arm__
+		#define __NR_memfd_create 385
+	#elif defined __aarch64__
+		#define __NR_memfd_create 279
+	#elif defined __s390__
+		#define __NR_memfd_create 350
+	#elif defined __powerpc__
+		#define __NR_memfd_create 360
+	#elif defined __sparc__
+		#define __NR_memfd_create 348
+	#elif defined __blackfin__
+		#define __NR_memfd_create 390
+	#elif defined __ia64__
+		#define __NR_memfd_create 1340
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32
+			#define __NR_memfd_create 4354
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32
+			#define __NR_memfd_create 6318
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64
+			#define __NR_memfd_create 5314
+		#endif
+	#else
+		#define -1
+		#warning "__NR_memfd_create not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_pivot_root
+	#if defined __i386__
+		#define __NR_pivot_root 217
+	#elif defined __x86_64__
+		#define __NR_pivot_root	155
+	#elif defined __arm__
+		#define __NR_pivot_root 218
+	#elif defined __aarch64__
+		#define __NR_pivot_root 218
+	#elif defined __s390__
+		#define __NR_pivot_root 217
+	#elif defined __powerpc__
+		#define __NR_pivot_root 203
+	#elif defined __sparc__
+		#define __NR_pivot_root 146
+	#elif defined __ia64__
+		#define __NR_pivot_root 183
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_pivot_root 4216
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_pivot_root 6151
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_pivot_root 5151
+		#endif
+	#else
+		#define -1
+		#warning "__NR_pivot_root not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_setns
+	#if defined __i386__
+		#define __NR_setns 346
+	#elif defined __x86_64__
+		#define __NR_setns 308
+	#elif defined __arm__
+		#define __NR_setns 375
+	#elif defined __aarch64__
+		#define __NR_setns 375
+	#elif defined __s390__
+		#define __NR_setns 339
+	#elif defined __powerpc__
+		#define __NR_setns 350
+	#elif defined __sparc__
+		#define __NR_setns 337
+	#elif defined __ia64__
+		#define __NR_setns 306
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_setns 4344
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_setns 6308
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_setns 5303
+		#endif
+	#else
+		#define -1
+		#warning "__NR_setns not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_sethostname
+	#if defined __i386__
+		#define __NR_sethostname 74
+	#elif defined __x86_64__
+		#define __NR_sethostname 170
+	#elif defined __arm__
+		#define __NR_sethostname 74
+	#elif defined __aarch64__
+		#define __NR_sethostname 74
+	#elif defined __s390__
+		#define __NR_sethostname 74
+	#elif defined __powerpc__
+		#define __NR_sethostname 74
+	#elif defined __sparc__
+		#define __NR_sethostname 88
+	#elif defined __ia64__
+		#define __NR_sethostname 59
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_sethostname 474
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_sethostname 6165
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_sethostname 5165
+		#endif
+	#else
+		#define -1
+		#warning "__NR_sethostname not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_signalfd
+	#if defined __i386__
+		#define __NR_signalfd 321
+	#elif defined __x86_64__
+		#define __NR_signalfd 282
+	#elif defined __arm__
+		#define __NR_signalfd 349
+	#elif defined __aarch64__
+		#define __NR_signalfd 349
+	#elif defined __s390__
+		#define __NR_signalfd 316
+	#elif defined __powerpc__
+		#define __NR_signalfd 305
+	#elif defined __sparc__
+		#define __NR_signalfd 311
+	#elif defined __ia64__
+		#define __NR_signalfd 283
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_signalfd 4317
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_signalfd 6280
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_signalfd 5276
+		#endif
+	#else
+		#define -1
+		#warning "__NR_signalfd not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_signalfd4
+	#if defined __i386__
+		#define __NR_signalfd4 327
+	#elif defined __x86_64__
+		#define __NR_signalfd4 289
+	#elif defined __arm__
+		#define __NR_signalfd4 355
+	#elif defined __aarch64__
+		#define __NR_signalfd4 355
+	#elif defined __s390__
+		#define __NR_signalfd4 322
+	#elif defined __powerpc__
+		#define __NR_signalfd4 313
+	#elif defined __sparc__
+		#define __NR_signalfd4 317
+	#elif defined __ia64__
+		#define __NR_signalfd4 289
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_signalfd4 4324
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_signalfd4 6287
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_signalfd4 5283
+		#endif
+	#else
+		#define -1
+		#warning "__NR_signalfd4 not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_unshare
+	#if defined __i386__
+		#define __NR_unshare 310
+	#elif defined __x86_64__
+		#define __NR_unshare 272
+	#elif defined __arm__
+		#define __NR_unshare 337
+	#elif defined __aarch64__
+		#define __NR_unshare 337
+	#elif defined __s390__
+		#define __NR_unshare 303
+	#elif defined __powerpc__
+		#define __NR_unshare 282
+	#elif defined __sparc__
+		#define __NR_unshare 299
+	#elif defined __ia64__
+		#define __NR_unshare 272
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_unshare 4303
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_unshare 6266
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_unshare 5262
+		#endif
+	#else
+		#define -1
+		#warning "__NR_unshare not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_bpf
+	#if defined __i386__
+		#define __NR_bpf 357
+	#elif defined __x86_64__
+		#define __NR_bpf 321
+	#elif defined __arm__
+		#define __NR_bpf 386
+	#elif defined __aarch64__
+		#define __NR_bpf 386
+	#elif defined __s390__
+		#define __NR_bpf 351
+	#elif defined __powerpc__
+		#define __NR_bpf 361
+	#elif defined __sparc__
+		#define __NR_bpf 349
+	#elif defined __ia64__
+		#define __NR_bpf 317
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_bpf 4355
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_bpf 6319
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_bpf 5315
+		#endif
+	#else
+		#define -1
+		#warning "__NR_bpf not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_faccessat
+	#if defined __i386__
+		#define __NR_faccessat 307
+	#elif defined __x86_64__
+		#define __NR_faccessat 269
+	#elif defined __arm__
+		#define __NR_faccessat 334
+	#elif defined __aarch64__
+		#define __NR_faccessat 334
+	#elif defined __s390__
+		#define __NR_faccessat 300
+	#elif defined __powerpc__
+		#define __NR_faccessat 298
+	#elif defined __sparc__
+		#define __NR_faccessat 296
+	#elif defined __ia64__
+		#define __NR_faccessat 269
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_faccessat 4300
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_faccessat 6263
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_faccessat 5259
+		#endif
+	#else
+		#define -1
+		#warning "__NR_faccessat not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_pidfd_send_signal
+	#if defined __alpha__
+		#define __NR_pidfd_send_signal 534
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_pidfd_send_signal 4424
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_pidfd_send_signal 6424
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_pidfd_send_signal 5424
+		#endif
+	#else
+		#define __NR_pidfd_send_signal 424
+	#endif
+#endif
+
+#ifndef __NR_seccomp
+	#if defined __i386__
+		#define __NR_seccomp 354
+	#elif defined __x86_64__
+		#define __NR_seccomp 317
+	#elif defined __arm__
+		#define __NR_seccomp 383
+	#elif defined __aarch64__
+		#define __NR_seccomp 383
+	#elif defined __s390__
+		#define __NR_seccomp 348
+	#elif defined __powerpc__
+		#define __NR_seccomp 358
+	#elif defined __sparc__
+		#define __NR_seccomp 346
+	#elif defined __ia64__
+		#define __NR_seccomp 329
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_seccomp 4352
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_seccomp 6316
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_seccomp 5312
+		#endif
+	#else
+		#define -1
+		#warning "__NR_seccomp not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_gettid
+	#if defined __i386__
+		#define __NR_gettid 224
+	#elif defined __x86_64__
+		#define __NR_gettid 186
+	#elif defined __arm__
+		#define __NR_gettid 224
+	#elif defined __aarch64__
+		#define __NR_gettid 224
+	#elif defined __s390__
+		#define __NR_gettid 236
+	#elif defined __powerpc__
+		#define __NR_gettid 207
+	#elif defined __sparc__
+		#define __NR_gettid 143
+	#elif defined __ia64__
+		#define __NR_gettid 81
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_gettid 4222
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_gettid 6178
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_gettid 5178
+		#endif
+	#else
+		#define -1
+		#warning "__NR_gettid not defined for your architecture"
+	#endif
+#endif
+
+#ifndef __NR_execveat
+	#if defined __i386__
+		#define __NR_execveat 358
+	#elif defined __x86_64__
+		#ifdef __ILP32__	/* x32 */
+			#define __NR_execveat 545
+		#else
+			#define __NR_execveat 322
+		#endif
+	#elif defined __arm__
+		#define __NR_execveat 387
+	#elif defined __aarch64__
+		#define __NR_execveat 387
+	#elif defined __s390__
+		#define __NR_execveat 354
+	#elif defined __powerpc__
+		#define __NR_execveat 362
+	#elif defined __sparc__
+		#define __NR_execveat 350
+	#elif defined __ia64__
+		#define __NR_execveat 318
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_execveat 4356
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_execveat 6320
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_execveat 5316
+		#endif
+	#else
+		#define -1
+		#warning "__NR_execveat not defined for your architecture"
+	#endif
+#endif
+
+#endif /* __LXC_SYSCALL_NUMBERS_H */

--- a/src/lxc/tools/lxc_unshare.c
+++ b/src/lxc/tools/lxc_unshare.c
@@ -41,7 +41,6 @@ struct start_arg {
 };
 
 static int my_parser(struct lxc_arguments *args, int c, char *arg);
-static inline int sethostname_including_android(const char *name, size_t len);
 static int get_namespace_flags(char *namespaces);
 static bool lookup_user(const char *oparg, uid_t *uid);
 static int mount_fs(const char *source, const char *target, const char *type);
@@ -127,23 +126,6 @@ static int my_parser(struct lxc_arguments *args, int c, char *arg)
 		break;
 	}
 	return 0;
-}
-
-/* Define sethostname() if missing from the C library also workaround some
- * quirky with having this defined in multiple places.
- */
-static inline int sethostname_including_android(const char *name, size_t len)
-{
-#ifndef HAVE_SETHOSTNAME
-#ifdef __NR_sethostname
-	return syscall(__NR_sethostname, name, len);
-#else
-	errno = ENOSYS;
-	return -1;
-#endif
-#else
-	return sethostname(name, len);
-#endif
 }
 
 static int get_namespace_flags(char *namespaces)
@@ -266,7 +248,7 @@ static int do_start(void *arg)
 		lxc_setup_fs();
 
 	if ((start_arg->flags & CLONE_NEWUTS) && want_hostname)
-		if (sethostname_including_android(want_hostname, strlen(want_hostname)) < 0) {
+		if (sethostname(want_hostname, strlen(want_hostname)) < 0) {
 			SYSERROR("Failed to set hostname %s", want_hostname);
 			_exit(EXIT_FAILURE);
 		}


### PR DESCRIPTION
This allows us:
- to compile on kernels with outdated headers
- compile on older kernels but shipping on newer kernels

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>