### PR TITLE
lxc-unshare: add syscall_wrappers.h to build requirements

### DIFF
--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -363,6 +363,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h
 lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      syscall_numbers.h \
+		      syscall_wrapper.h \
 		      tools/arguments.c tools/arguments.h
 lxc_wait_SOURCES = tools/lxc_wait.c \
 		   tools/arguments.c tools/arguments.h

--- a/src/lxc/tools/lxc_unshare.c
+++ b/src/lxc/tools/lxc_unshare.c
@@ -26,6 +26,8 @@
 #include "list.h"
 #include "log.h"
 #include "namespace.h"
+#include "syscall_numbers.h"
+#include "syscall_wrappers.h"
 #include "utils.h"
 
 lxc_log_define(lxc_unshare, lxc);


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>