### PR TITLE
Makefile: fix typo

### DIFF
--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -363,7 +363,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h
 lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      syscall_numbers.h \
-		      syscall_wrapper.h \
+		      syscall_wrappers.h \
 		      tools/arguments.c tools/arguments.h
 lxc_wait_SOURCES = tools/lxc_wait.c \
 		   tools/arguments.c tools/arguments.h


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>