### PR TITLE
conf: fix read-only bind mounts

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -1847,15 +1847,14 @@ static int mount_entry(const char *fsname, const char *target,
 	}
 
 	if ((mountflags & MS_REMOUNT) || (mountflags & MS_BIND)) {
-		unsigned long required_flags = 0;
 
 		DEBUG("Remounting \"%s\" on \"%s\" to respect bind or remount options",
 		      srcpath ? srcpath : "(none)", target ? target : "(none)");
 
-		if (mountflags & MS_RDONLY)
-			required_flags |= MS_RDONLY;
 #ifdef HAVE_STATVFS
 		if (srcpath && statvfs(srcpath, &sb) == 0) {
+			unsigned long required_flags = 0;
+
 			if (sb.f_flag & MS_NOSUID)
 				required_flags |= MS_NOSUID;
 
@@ -1875,7 +1874,8 @@ static int mount_entry(const char *fsname, const char *target,
 			 * does not have any flags which are not already in
 			 * mountflags, then skip the remount.
 			 */
-			if (!(mountflags & MS_REMOUNT) && !(required_flags & ~mountflags)) {
+			if (!(mountflags & MS_REMOUNT) &&
+			    (!(required_flags & ~mountflags) && !(mountflags & MS_RDONLY))) {
 				DEBUG("Mountflags already were %lu, skipping remount", mountflags);
 				goto skipremount;
 			}


### PR DESCRIPTION
Here we would always set MS_RDONLY in required_flags if it was set in
mountflags, so the expression:

!(required_flags & ~mountflags)

would always be true, and we would always skip the remount.

Instead, let's treat readonly as special: always do the remount if
MS_RDONLY is present. Unfortunately it doesn't seem to show up in
sb.f_flag, so we can't use the same path as everything else.

This only inadvertently worked before because of a bug fixed in
f75917858023 ("conf: don't accidently double-mount").

Signed-off-by: Tycho Andersen <tycho@tycho.ws>