### PR TITLE
[lxc.service] Starts after remote-fs.target to allow containers relyi…

### DIFF
--- a/config/init/systemd/lxc.service.in
+++ b/config/init/systemd/lxc.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=LXC Container Initialization and Autoboot Code
-After=network.target lxc-net.service
+After=network.target lxc-net.service remote-fs.target
 Wants=lxc-net.service
 Documentation=man:lxc-autostart man:lxc
 


### PR DESCRIPTION
…ng on remote FS to work

Signed-off-by: Pierre-Elliott Bécue <becue@crans.org>

Fix #3114 