### PR TITLE
cgroups: handle older kernels (e.g. v4.9)

### DIFF
--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -467,6 +467,8 @@ extern int setup_proc_filesystem(struct lxc_list *procs, pid_t pid);
 extern int lxc_clear_procs(struct lxc_conf *c, const char *key);
 extern int lxc_clear_apparmor_raw(struct lxc_conf *c);
 extern int lxc_clear_namespace(struct lxc_conf *c);
-extern int userns_exec_minimal(const struct lxc_conf *conf, int (*fn)(void *), void *data);
+extern int userns_exec_minimal(const struct lxc_conf *conf,
+			       int (*fn_parent)(void *), void *fn_parent_data,
+			       int (*fn_child)(void *), void *fn_child_data);
 
 #endif /* __LXC_CONF_H */

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1703,6 +1703,7 @@ static int lxc_spawn(struct lxc_handler *handler)
 	}
 
 	if (!cgroup_ops->payload_enter(cgroup_ops, handler)) {
+		ERROR("Failed to enter cgroups");
 		goto out_delete_net;
 	}
 


### PR DESCRIPTION
On olders kernels the restrictions to move processes between cgroups are
different than they are on newer kernels. Specifically, we're running into the
following check:
```c
if (!uid_eq(cred->euid, GLOBAL_ROOT_UID) &&
    !uid_eq(cred->euid, tcred->uid) &&
    !uid_eq(cred->euid, tcred->suid))
        ret = -EACCES;
```
which dictates that in order to move a process into a cgroup one either needs
to be global root (no restrictions apply) or the effective uid of the process
trying to move the process and the {saved}uid of the process that is supposed
to be mvoed need to be identical. The new attaching logic we did didn't
fulfill this criterion for because it's not present on new kernels.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>