### PR TITLE
init: add ExecReload to lxc.service to only reload profiles

### DIFF
--- a/config/init/systemd/lxc.service.in
+++ b/config/init/systemd/lxc.service.in
@@ -10,6 +10,7 @@ RemainAfterExit=yes
 ExecStartPre=@LIBEXECDIR@/lxc/lxc-apparmor-load
 ExecStart=@LIBEXECDIR@/lxc/lxc-containers start
 ExecStop=@LIBEXECDIR@/lxc/lxc-containers stop
+ExecReload=@LIBEXECDIR@/lxc/lxc-apparmor-load
 # Environment=BOOTUP=serial
 # Environment=CONSOLETYPE=serial
 Delegate=yes


### PR DESCRIPTION
I wanna say it seems nicer for packaging, but then again debhelpers cannot reload anyway ;-)
Still, I think it makes sense.