### PR TITLE
cgroups: fix "uninitialized transient_len" warning

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1388,7 +1388,7 @@ __cgfsng_ops static bool cgfsng_monitor_enter(struct cgroup_ops *ops,
 		if (ret)
 			return log_error_errno(false, errno, "Failed to enter cgroup \"%s\"", h->monitor_full_path);
 
-                if (handler->transient_pid < 0)
+		if (handler->transient_pid <= 0)
 			return true;
 
 		ret = lxc_writeat(h->cgfd_mon, "cgroup.procs", transient, transient_len);


### PR DESCRIPTION
Without this change, a build error is triggered if you compile with
`-Werror=maybe-uninitialized`.

```
cgroups/cgfsng.c: In function 'cgfsng_monitor_enter':
groups/cgfsng.c:1387:9: error: 'transient_len' may be used uninitialized in this function
   ret = lxc_writeat(h->cgfd_mon, "cgroup.procs", transient, transient_len);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The issue is that if `handler->transient_pid` is 0, then `transient_len` is
uninitialised but `lxc_writeat(..., transient_len)` still gets called.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>