### PR TITLE
cgroups: fix build warning on GCC 7

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1360,7 +1360,7 @@ __cgfsng_ops static inline bool cgfsng_payload_create(struct cgroup_ops *ops,
 __cgfsng_ops static bool cgfsng_monitor_enter(struct cgroup_ops *ops,
 					      struct lxc_handler *handler)
 {
-	int monitor_len, transient_len;
+	int monitor_len, transient_len = 0;
 	char monitor[INTTYPE_TO_STRLEN(pid_t)],
 	    transient[INTTYPE_TO_STRLEN(pid_t)];
 


### PR DESCRIPTION
GCC 7 appears to be clever enough to detect that transient_len is
uninitialised but not that it won't be used despite [1]. Just initialise
it to zero to stop the complaining, and allow LXC to build on openSUSE
Leap.

[1]: 346830421a96 ("cgroups: fix "uninitialized transient_len" warning")

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>