### PR TITLE
Revert "start: remove unnecessary check for valid cgroup_ops"

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -933,8 +933,10 @@ void lxc_end(struct lxc_handler *handler)
 
 	lsm_process_cleanup(handler->conf, handler->lxcpath);
 
-	cgroup_ops->payload_destroy(cgroup_ops, handler);
-	cgroup_ops->monitor_destroy(cgroup_ops, handler);
+	if (cgroup_ops) {
+		cgroup_ops->payload_destroy(cgroup_ops, handler);
+		cgroup_ops->monitor_destroy(cgroup_ops, handler);
+	}
 
 	if (handler->conf->reboot == REBOOT_NONE) {
 		/* For all new state clients simply close the command socket.


### PR DESCRIPTION
This reverts commit 52520e4f793f73e5956c2d9de9c83f074622ce1d.

This can be NULL when there's a pre-start hook which fails.