### PR TITLE
start: ensure all file descriptors are closed during exec

### DIFF
--- a/src/lxc/af_unix.c
+++ b/src/lxc/af_unix.c
@@ -189,7 +189,7 @@ static int lxc_abstract_unix_recv_fds_iov(int fd, int *recvfds, int num_recvfds,
 	msg.msg_iovlen = iovlen;
 
 	do {
-		ret = recvmsg(fd, &msg, 0);
+		ret = recvmsg(fd, &msg, MSG_CMSG_CLOEXEC);
 	} while (ret < 0 && errno == EINTR);
 	if (ret < 0 || ret == 0)
 		return ret;

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1039,14 +1039,13 @@ static int do_start(void *data)
 	struct lxc_handler *handler = data;
 	__lxc_unused __do_close int data_sock0 = handler->data_sock[0],
 					   data_sock1 = handler->data_sock[1];
-	__do_close int status_fd = -EBADF;
+	__do_close int devnull_fd = -EBADF, status_fd = -EBADF;
 	int ret;
 	uid_t new_uid;
 	gid_t new_gid;
 	struct lxc_list *iterator;
 	uid_t nsuid = 0;
 	gid_t nsgid = 0;
-	int devnull_fd = -1;
 
 	lxc_sync_fini_parent(handler);
 
@@ -1401,20 +1400,20 @@ static int do_start(void *data)
 		}
 	}
 
-	/* After this call, we are in error because this ops should not return
+	/*
+	 * After this call, we are in error because this ops should not return
 	 * as it execs.
 	 */
 	handler->ops->start(handler, handler->data);
 
 out_warn_father:
-	/* We want the parent to know something went wrong, so we return a
+	/*
+	 * We want the parent to know something went wrong, so we return a
 	 * special error code.
 	 */
 	lxc_sync_wake_parent(handler, LXC_SYNC_ERROR);
 
 out_error:
-	close_prot_errno_disarm(devnull_fd);
-
 	return -1;
 }
 

--- a/src/lxc/syscall_numbers.h
+++ b/src/lxc/syscall_numbers.h
@@ -35,6 +35,8 @@
 		#define __NR_keyctl 280
 	#elif defined __powerpc__
 		#define __NR_keyctl 271
+	#elif defined __riscv
+		#define __NR_keyctl 219
 	#elif defined __sparc__
 		#define __NR_keyctl 283
 	#elif defined __ia64__
@@ -68,6 +70,8 @@
 		#define __NR_memfd_create 350
 	#elif defined __powerpc__
 		#define __NR_memfd_create 360
+	#elif defined __riscv
+		#define __NR_memfd_create 279
 	#elif defined __sparc__
 		#define __NR_memfd_create 348
 	#elif defined __blackfin__
@@ -103,6 +107,8 @@
 		#define __NR_pivot_root 217
 	#elif defined __powerpc__
 		#define __NR_pivot_root 203
+	#elif defined __riscv
+		#define __NR_pivot_root 41
 	#elif defined __sparc__
 		#define __NR_pivot_root 146
 	#elif defined __ia64__
@@ -136,6 +142,8 @@
 		#define __NR_setns 339
 	#elif defined __powerpc__
 		#define __NR_setns 350
+	#elif defined __riscv
+		#define __NR_setns 268
 	#elif defined __sparc__
 		#define __NR_setns 337
 	#elif defined __ia64__
@@ -169,6 +177,8 @@
 		#define __NR_sethostname 74
 	#elif defined __powerpc__
 		#define __NR_sethostname 74
+	#elif defined __riscv
+		#define __NR_sethostname 161
 	#elif defined __sparc__
 		#define __NR_sethostname 88
 	#elif defined __ia64__
@@ -202,6 +212,8 @@
 		#define __NR_signalfd 316
 	#elif defined __powerpc__
 		#define __NR_signalfd 305
+	#elif defined __riscv
+		#define __NR_signalfd 74
 	#elif defined __sparc__
 		#define __NR_signalfd 311
 	#elif defined __ia64__
@@ -235,6 +247,8 @@
 		#define __NR_signalfd4 322
 	#elif defined __powerpc__
 		#define __NR_signalfd4 313
+	#elif defined __riscv
+		#define __NR_signalfd4 74
 	#elif defined __sparc__
 		#define __NR_signalfd4 317
 	#elif defined __ia64__
@@ -268,6 +282,8 @@
 		#define __NR_unshare 303
 	#elif defined __powerpc__
 		#define __NR_unshare 282
+	#elif defined __riscv
+		#define __NR_unshare 97
 	#elif defined __sparc__
 		#define __NR_unshare 299
 	#elif defined __ia64__
@@ -301,6 +317,8 @@
 		#define __NR_bpf 351
 	#elif defined __powerpc__
 		#define __NR_bpf 361
+	#elif defined __riscv
+		#define __NR_bpf 280
 	#elif defined __sparc__
 		#define __NR_bpf 349
 	#elif defined __ia64__
@@ -334,6 +352,8 @@
 		#define __NR_faccessat 300
 	#elif defined __powerpc__
 		#define __NR_faccessat 298
+	#elif defined __riscv
+		#define __NR_faccessat 48
 	#elif defined __sparc__
 		#define __NR_faccessat 296
 	#elif defined __ia64__
@@ -385,6 +405,8 @@
 		#define __NR_seccomp 348
 	#elif defined __powerpc__
 		#define __NR_seccomp 358
+	#elif defined __riscv
+		#define __NR_seccomp 277
 	#elif defined __sparc__
 		#define __NR_seccomp 346
 	#elif defined __ia64__
@@ -418,6 +440,8 @@
 		#define __NR_gettid 236
 	#elif defined __powerpc__
 		#define __NR_gettid 207
+	#elif defined __riscv
+		#define __NR_gettid 178
 	#elif defined __sparc__
 		#define __NR_gettid 143
 	#elif defined __ia64__
@@ -455,6 +479,8 @@
 		#define __NR_execveat 354
 	#elif defined __powerpc__
 		#define __NR_execveat 362
+	#elif defined __riscv
+		#define __NR_execveat 281
 	#elif defined __sparc__
 		#define __NR_execveat 350
 	#elif defined __ia64__


### PR DESCRIPTION
Closes https://github.com/checkpoint-restore/criu/issues/1011.
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>