### PR TITLE
network: Make it possible to set the mode of IPVLAN to L2

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -582,24 +582,21 @@ static int lxc_ipvlan_create(const char *master, const char *name, int mode, int
 	if (nla_put_string(nlmsg, IFLA_INFO_KIND, "ipvlan"))
 		return ret_errno(EPROTO);
 
-	if (mode) {
-		nest2 = nla_begin_nested(nlmsg, IFLA_INFO_DATA);
-		if (!nest2)
-			return ret_errno(EPROTO);
+	nest2 = nla_begin_nested(nlmsg, IFLA_INFO_DATA);
+	if (!nest2)
+		return ret_errno(EPROTO);
 
-		if (nla_put_u32(nlmsg, IFLA_IPVLAN_MODE, mode))
-			return ret_errno(EPROTO);
+	if (nla_put_u32(nlmsg, IFLA_IPVLAN_MODE, mode))
+		return ret_errno(EPROTO);
 
-		/* if_link.h does not define the isolation flag value for bridge mode so we define it as 0
-		 * and only send mode if mode >0 as default mode is bridge anyway according to ipvlan docs.
-		 */
-		if (isolation > 0 &&
-		    nla_put_u16(nlmsg, IFLA_IPVLAN_ISOLATION, isolation))
-			return ret_errno(EPROTO);
+	/* if_link.h does not define the isolation flag value for bridge mode so we define it as 0
+	 * and only send mode if mode >0 as default mode is bridge anyway according to ipvlan docs.
+	 */
+	if (isolation > 0 &&
+	    nla_put_u16(nlmsg, IFLA_IPVLAN_ISOLATION, isolation))
+		return ret_errno(EPROTO);
 
-		nla_end_nested(nlmsg, nest2);
-	}
-
+	nla_end_nested(nlmsg, nest2);
 	nla_end_nested(nlmsg, nest);
 
 	if (nla_put_u32(nlmsg, IFLA_LINK, index))


### PR DESCRIPTION
I want to create a lxc container with IPVLAN in L2 mode.

```
# grep lxc.net /var/lib/lxc/test/config
lxc.net.0.type = ipvlan
lxc.net.0.link = ens192
lxc.net.0.ipvlan.mode = l2
lxc.net.0.ipvlan.isolation = bridge
lxc.net.0.flags = up

# lxc-start -n test -l TRACE

# grep "ipkeGP4J" /var/log/lxc/test.log
lxc-start test 20200409065446.102 DEBUG    network - network.c:instantiate_ipvlan:681 - Instantiated ipvlan "ipkeGP4J" with ifindex is 21 and mode 0
lxc-start test 20200409065446.125 DEBUG    network - network.c:lxc_network_move_created_netdev_priv:3132 - Moved network device "ipkeGP4J" with ifindex 21 to network namespace of 9925
lxc-start test 20200409065446.125 TRACE    network - network.c:lxc_network_send_to_child:3583 - Sent network device name "ipkeGP4J" to child
lxc-start test 20200409065446.125 TRACE    network - network.c:lxc_network_recv_from_parent:3610 - Received network device name "ipkeGP4J" from parent
lxc-start test 20200409065446.127 DEBUG    network - network.c:lxc_network_setup_in_child_namespaces_common:3535 - Network device "ipkeGP4J" has been setup
lxc-start test 20200409065446.136 TRACE    confile_utils - confile_utils.c:lxc_log_configured_netdevs:330 - name: ipkeGP4J

# lxc-attach -n test -- ip -d l show dev ipkeGP4J
21: ipkeGP4J@if2: <BROADCAST,MULTICAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 00:0c:29:ee:5d:32 brd ff:ff:ff:ff:ff:ff promiscuity 0
    ipvlan  mode l3 bridge addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535

```

The log message says `mode 0 (IPVLAN_MODE_L2)`, but it is actually L3 mode.