### PR TITLE
cgroups: ignore legacy limits on pure cgroup2 systems

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -2847,6 +2847,9 @@ __cgfsng_ops static bool cgfsng_setup_limits_legacy(struct cgroup_ops *ops,
 	if (!ops->hierarchies)
 		return ret_set_errno(false, EINVAL);
 
+	if (!pure_unified_layout(ops))
+		return log_warn_errno(true, EINVAL, "Ignoring legacy cgroup limits on pure cgroup2 system");
+
 	sorted_cgroup_settings = sort_cgroup_settings(cgroup_settings);
 	if (!sorted_cgroup_settings)
 		return false;


### PR DESCRIPTION
Link: https://github.com/lxc/lxc/issues/3183#issuecomment-612462322
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>