### PR TITLE
Fix lxc-oci template with loop backingstore

### DIFF
--- a/templates/lxc-oci.in
+++ b/templates/lxc-oci.in
@@ -348,8 +348,7 @@ fi
 # shellcheck disable=SC2039
 # shellcheck disable=SC2068
 umoci --log=error unpack ${umoci_args[@]} --image "${DOWNLOAD_TEMP}:latest" "${LXC_ROOTFS}.tmp"
-rmdir "${LXC_ROOTFS}"
-mv "${LXC_ROOTFS}.tmp/rootfs" "${LXC_ROOTFS}"
+find "${LXC_ROOTFS}.tmp/rootfs" -mindepth 1 -maxdepth 1 -exec mv '{}' "${LXC_ROOTFS}/" \;
 
 OCI_CONF_FILE=$(getconfigpath "${DOWNLOAD_TEMP}" latest)
 LXC_CONF_FILE="${LXC_PATH}/config"


### PR DESCRIPTION
Move the content of rootfs inside OCI package to rootfs instead of replacing it, as the directory is used as the mountpoint.

Tested with directory and loop backingstore.

Noticed this on Debian, where the error message was `rmdir: failed to remove '/usr/lib/x86_64-linux-gnu/lxc/rootfs': Device or resource busy` when running 

    lxc-create -n test -t oci -B loop -- -u docker://centos:latest