### PR TITLE
conf: correctly cleanup memory in get_minimal_idmap()

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3985,45 +3985,35 @@ static struct lxc_list *get_minimal_idmap(const struct lxc_conf *conf,
 	tmplist = malloc(sizeof(*tmplist));
 	if (!tmplist)
 		return NULL;
-	lxc_list_add_elem(tmplist, container_root_uid);
+	/* idmap will now keep track of that memory. */
+	lxc_list_add_elem(tmplist, move_ptr(host_uid_map));
 	lxc_list_add_tail(idmap, tmplist);
 
 	if (container_root_uid) {
-		/* idmap will now keep track of that memory. */
-		move_ptr(container_root_uid);
-
 		/* Add container root to the map. */
 		tmplist = malloc(sizeof(*tmplist));
 		if (!tmplist)
 			return NULL;
-		lxc_list_add_elem(tmplist, host_uid_map);
+		/* idmap will now keep track of that memory. */
+		lxc_list_add_elem(tmplist, move_ptr(container_root_uid));
 		lxc_list_add_tail(idmap, tmplist);
 	}
-	/* idmap will now keep track of that memory. */
-	move_ptr(container_root_uid);
-	/* idmap will now keep track of that memory. */
-	move_ptr(host_uid_map);
 
 	tmplist = malloc(sizeof(*tmplist));
 	if (!tmplist)
 		return NULL;
-	lxc_list_add_elem(tmplist, container_root_gid);
+	/* idmap will now keep track of that memory. */
+	lxc_list_add_elem(tmplist, move_ptr(host_gid_map));
 	lxc_list_add_tail(idmap, tmplist);
 
 	if (container_root_gid) {
-		/* idmap will now keep track of that memory. */
-		move_ptr(container_root_gid);
-
 		tmplist = malloc(sizeof(*tmplist));
 		if (!tmplist)
 			return NULL;
-		lxc_list_add_elem(tmplist, host_gid_map);
+		/* idmap will now keep track of that memory. */
+		lxc_list_add_elem(tmplist, move_ptr(container_root_gid));
 		lxc_list_add_tail(idmap, tmplist);
 	}
-	/* idmap will now keep track of that memory. */
-	move_ptr(container_root_gid);
-	/* idmap will now keep track of that memory. */
-	move_ptr(host_gid_map);
 
 	TRACE("Allocated minimal idmapping for ns uid %d and ns gid %d", nsuid, nsgid);
 


### PR DESCRIPTION
Fixes: Coverity 1461760.
Fixes: Coverity 1461762.
Fixes: Coverity 1461763.
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>