### PR TITLE
cgroups: fix cgroup limit braino

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -2848,7 +2848,7 @@ __cgfsng_ops static bool cgfsng_setup_limits_legacy(struct cgroup_ops *ops,
 	if (!ops->hierarchies)
 		return ret_set_errno(false, EINVAL);
 
-	if (!pure_unified_layout(ops))
+	if (pure_unified_layout(ops))
 		return log_warn_errno(true, EINVAL, "Ignoring legacy cgroup limits on pure cgroup2 system");
 
 	sorted_cgroup_settings = sort_cgroup_settings(cgroup_settings);


### PR DESCRIPTION
Fixes: https://discuss.linuxcontainers.org/t/memory-limits-no-longer-being-applied/7429/7
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>