### PR TITLE
conf: introduce userns_exec_mapped_root()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -622,7 +622,7 @@ AC_CHECK_HEADER([ifaddrs.h],
 AC_HEADER_MAJOR
 
 # Check for some syscalls functions
-AC_CHECK_FUNCS([setns pivot_root sethostname unshare rand_r confstr faccessat gettid memfd_create])
+AC_CHECK_FUNCS([setns pivot_root sethostname unshare rand_r confstr faccessat gettid memfd_create move_mount open_tree])
 
 # Check for strerror_r() support. Defines:
 # - HAVE_STRERROR_R if available

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -473,5 +473,7 @@ extern int lxc_clear_namespace(struct lxc_conf *c);
 extern int userns_exec_minimal(const struct lxc_conf *conf,
 			       int (*fn_parent)(void *), void *fn_parent_data,
 			       int (*fn_child)(void *), void *fn_child_data);
+extern int userns_exec_mapped_root(const char *path, int path_fd,
+				   const struct lxc_conf *conf);
 
 #endif /* __LXC_CONF_H */

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -57,6 +57,20 @@
 #define CAP_SETGID 6
 #endif
 
+/* move_mount */
+#ifndef MOVE_MOUNT_F_EMPTY_PATH
+#define MOVE_MOUNT_F_EMPTY_PATH 0x00000004 /* Empty from path permitted */
+#endif
+
+/* open_tree */
+#ifndef OPEN_TREE_CLONE
+#define OPEN_TREE_CLONE 1 /* Clone the target tree and attach the clone */
+#endif
+
+#ifndef OPEN_TREE_CLOEXEC
+#define OPEN_TREE_CLOEXEC O_CLOEXEC /* Close the file on execve() */
+#endif
+
 /* prctl */
 #ifndef PR_CAPBSET_READ
 #define PR_CAPBSET_READ 23

--- a/src/lxc/syscall_numbers.h
+++ b/src/lxc/syscall_numbers.h
@@ -501,4 +501,40 @@
 	#endif
 #endif
 
+#ifndef __NR_move_mount
+	#if defined __alpha__
+		#define __NR_move_mount 539
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_move_mount 4429
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_move_mount 6429
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_move_mount 5429
+		#endif
+	#else
+		#define __NR_move_mount 429
+	#endif
+#endif
+
+#ifndef __NR_open_tree
+	#if defined __alpha__
+		#define __NR_open_tree 538
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_open_tree 4428
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_open_tree 6428
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_open_tree 5428
+		#endif
+	#else
+		#define __NR_open_tree 428
+	#endif
+#endif
+
 #endif /* __LXC_SYSCALL_NUMBERS_H */

--- a/src/lxc/syscall_wrappers.h
+++ b/src/lxc/syscall_wrappers.h
@@ -137,4 +137,28 @@ static int faccessat(int __fd, const char *__file, int __type, int __flag)
 }
 #endif
 
+#ifndef HAVE_MOVE_MOUNT
+static inline int move_mount_lxc(int from_dfd, const char *from_pathname,
+				 int to_dfd, const char *to_pathname,
+				 unsigned int flags)
+{
+	return syscall(__NR_move_mount, from_dfd, from_pathname, to_dfd,
+		       to_pathname, flags);
+}
+#define move_mount move_mount_lxc
+#else
+extern int move_mount(int from_dfd, const char *from_pathname, int to_dfd,
+		      const char *to_pathname, unsigned int flags);
+#endif
+
+#ifndef HAVE_OPEN_TREE
+static inline int open_tree_lxc(int dfd, const char *filename, unsigned int flags)
+{
+	return syscall(__NR_open_tree, dfd, filename, flags);
+}
+#define open_tree open_tree_lxc
+#else
+extern int open_tree(int dfd, const char *filename, unsigned int flags);
+#endif
+
 #endif /* __LXC_SYSCALL_WRAPPER_H */

--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -1167,13 +1167,16 @@ int lxc_terminal_map_ids(struct lxc_conf *c, struct lxc_terminal *terminal)
 	if (strcmp(terminal->name, "") == 0)
 		return 0;
 
-	ret = chown_mapped_root(terminal->name, c);
+	if (terminal->slave >= 0)
+		ret = userns_exec_mapped_root(terminal->name, terminal->slave, c);
+	else
+		ret = userns_exec_mapped_root(terminal->name, terminal->slave, c);
 	if (ret < 0) {
-		ERROR("Failed to chown terminal \"%s\"", terminal->name);
-		return -1;
+		return log_error(-1, "Failed to chown terminal %d(%s)",
+				 terminal->slave, terminal->name);
 	}
 
-	TRACE("Chowned terminal \"%s\"", terminal->name);
+	TRACE("Chowned terminal %d(%s)", terminal->slave, terminal->name);
 
 	return 0;
 }

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -241,4 +241,14 @@ extern bool lxc_can_use_pidfd(int pidfd);
 
 extern int fix_stdio_permissions(uid_t uid);
 
+static inline bool uid_valid(uid_t uid)
+{
+	return uid != LXC_INVALID_UID;
+}
+
+static inline bool gid_valid(gid_t gid)
+{
+	return gid != LXC_INVALID_GID;
+}
+
 #endif /* __LXC_UTILS_H */


### PR DESCRIPTION
to avoid the overhead of calling to lxc-usernsexec whenever we can.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>