### PR TITLE
terminal: remove unneeded if condition

### DIFF
--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -1167,10 +1167,7 @@ int lxc_terminal_map_ids(struct lxc_conf *c, struct lxc_terminal *terminal)
 	if (strcmp(terminal->name, "") == 0)
 		return 0;
 
-	if (terminal->slave >= 0)
-		ret = userns_exec_mapped_root(terminal->name, terminal->slave, c);
-	else
-		ret = userns_exec_mapped_root(terminal->name, terminal->slave, c);
+	ret = userns_exec_mapped_root(terminal->name, terminal->slave, c);
 	if (ret < 0) {
 		return log_error(-1, "Failed to chown terminal %d(%s)",
 				 terminal->slave, terminal->name);


### PR DESCRIPTION
Fixes: Coverity 1461742.
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>