### PR TITLE
api_extensions: add "pidfd"

### DIFF
--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -38,6 +38,7 @@ static char *api_extensions[] = {
 	"cgroup2_devices",
 #endif
 	"cgroup2",
+	"pidfd",
 	"cgroup_advanced_isolation",
 };
 


### PR DESCRIPTION
Somehow it's documented but wasn't ever added.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>