### PR TITLE
Read list until process exits

### DIFF
--- a/src/lxc/storage/zfs.c
+++ b/src/lxc/storage/zfs.c
@@ -100,7 +100,6 @@ static bool zfs_list_entry(const char *path, char *output, size_t inlen)
 	while (fgets(output, inlen, f->f)) {
 		if (strstr(output, path)) {
 			found = true;
-			break;
 		}
 	}
 	(void)lxc_pclose(f);


### PR DESCRIPTION
zfs list blocks forever for longer lists of filesystems (as pclose will wait for termination of zfs list). Therefore just reading the output until end.