### PR TITLE
NIC: Veth native bridge VLAN support

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -474,6 +474,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               <option>lxc.net.[i].veth.ipv6.route</option> options.
               Several lines specify several routes.
               The route is in format x.y.z.t/m, eg. 192.168.1.0/24.
+
+              In <option>bridge</option> mode untagged VLAN membership can be set with the
+              <option>lxc.net.[i].veth.vlan.id</option> option. It accepts a special value of 'none' indicating
+              that the container port should be removed from the bridge's default untagged VLAN.
+              The <option>lxc.net.[i].veth.vlan.tagged.id</option> option can be specified multiple times to set
+              the container's bridge port membership to one or more tagged VLANs.
             </para>
 
             <para>

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -40,6 +40,7 @@ static char *api_extensions[] = {
 	"cgroup2",
 	"pidfd",
 	"cgroup_advanced_isolation",
+	"network_bridge_vlan",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -128,6 +128,7 @@ lxc_config_define(net_veth_pair);
 lxc_config_define(net_veth_ipv4_route);
 lxc_config_define(net_veth_ipv6_route);
 lxc_config_define(net_veth_vlan_id);
+lxc_config_define(net_veth_vlan_tagged_id);
 lxc_config_define(net_vlan_id);
 lxc_config_define(no_new_privs);
 lxc_config_define(personality);
@@ -242,6 +243,7 @@ static struct lxc_config_t config_jump_table[] = {
 	{ "lxc.net.veth.ipv4.route",       set_config_net_veth_ipv4_route,         get_config_net_veth_ipv4_route,         clr_config_net_veth_ipv4_route,       },
 	{ "lxc.net.veth.ipv6.route",       set_config_net_veth_ipv6_route,         get_config_net_veth_ipv6_route,         clr_config_net_veth_ipv6_route,       },
 	{ "lxc.net.veth.vlan.id",          set_config_net_veth_vlan_id,            get_config_net_veth_vlan_id,            clr_config_net_veth_vlan_id,          },
+	{ "lxc.net.veth.vlan.tagged.id",   set_config_net_veth_vlan_tagged_id,     get_config_net_veth_vlan_tagged_id,     clr_config_net_veth_vlan_tagged_id,   },
 	{ "lxc.net.",                      set_config_net_nic,                     get_config_net_nic,                     clr_config_net_nic,                   },
 	{ "lxc.net",                       set_config_net,                         get_config_net,                         clr_config_net,                       },
 	{ "lxc.no_new_privs",	           set_config_no_new_privs,                get_config_no_new_privs,                clr_config_no_new_privs,              },
@@ -309,6 +311,7 @@ static int set_config_net_type(const char *key, const char *value,
 		netdev->type = LXC_NET_VETH;
 		lxc_list_init(&netdev->priv.veth_attr.ipv4_routes);
 		lxc_list_init(&netdev->priv.veth_attr.ipv6_routes);
+		lxc_list_init(&netdev->priv.veth_attr.vlan_tagged_ids);
 		if (!lxc_veth_flag_to_mode(netdev->priv.veth_attr.mode))
 			lxc_veth_mode_to_flag(&netdev->priv.veth_attr.mode, "bridge");
 	} else if (strcmp(value, "macvlan") == 0) {
@@ -517,6 +520,39 @@ static int set_config_net_veth_vlan_id(const char *key, const char *value,
 	}
 
 	netdev->priv.veth_attr.vlan_id_set = true;
+	return 0;
+}
+
+static int set_config_net_veth_vlan_tagged_id(const char *key, const char *value,
+				       struct lxc_conf *lxc_conf, void *data)
+{
+	__do_free struct lxc_list *list = NULL;
+	int ret;
+	unsigned short vlan_id;
+	struct lxc_netdev *netdev = data;
+
+	if (!netdev)
+		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_veth_vlan_tagged_id(key, lxc_conf, data);
+
+	ret = get_u16(&vlan_id, value, 0);
+	if (ret < 0)
+		ret_errno(EINVAL);
+
+	if (vlan_id > BRIDGE_VLAN_ID_MAX)
+		ret_errno(EINVAL);
+
+	list = malloc(sizeof(*list));
+	if (!list)
+		return ret_errno(ENOMEM);
+
+	lxc_list_init(list);
+	list->elem = UINT_TO_PTR(vlan_id);
+
+	lxc_list_add_tail(&netdev->priv.veth_attr.vlan_tagged_ids, move_ptr(list));
+
 	return 0;
 }
 
@@ -5348,6 +5384,24 @@ static int clr_config_net_veth_vlan_id(const char *key, struct lxc_conf *lxc_con
 	return 0;
 }
 
+static int clr_config_net_veth_vlan_tagged_id(const char *key,
+				       struct lxc_conf *lxc_conf, void *data)
+{
+	struct lxc_netdev *netdev = data;
+	struct lxc_list *cur, *next;
+
+	if (!netdev)
+		return ret_errno(EINVAL);
+
+	lxc_list_for_each_safe(cur, &netdev->priv.veth_attr.vlan_tagged_ids, next) {
+		lxc_list_del(cur);
+		free(cur);
+	}
+
+	return 0;
+}
+
+
 static int clr_config_net_script_up(const char *key, struct lxc_conf *lxc_conf,
 				    void *data)
 {
@@ -5838,6 +5892,37 @@ static int get_config_net_veth_vlan_id(const char *key, char *retv, int inlen,
 		memset(retv, 0, inlen);
 
 	strprint(retv, inlen, "%d", netdev->priv.veth_attr.vlan_id);
+
+	return fulllen;
+}
+
+static int get_config_net_veth_vlan_tagged_id(const char *key, char *retv, int inlen,
+				       struct lxc_conf *c, void *data)
+{
+	int len;
+	size_t listlen;
+	struct lxc_list *it;
+	int fulllen = 0;
+	struct lxc_netdev *netdev = data;
+
+	if (!netdev)
+		ret_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VETH)
+		return 0;
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	listlen = lxc_list_len(&netdev->priv.veth_attr.vlan_tagged_ids);
+
+	lxc_list_for_each(it, &netdev->priv.veth_attr.vlan_tagged_ids) {
+		unsigned short i = PTR_TO_USHORT(it->elem);
+		strprint(retv, inlen, "%u%s", i,
+			 (listlen-- > 1) ? "\n" : "");
+	}
 
 	return fulllen;
 }

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -32,6 +32,7 @@
 #include "../include/netns_ifaddrs.h"
 #include "log.h"
 #include "lxcseccomp.h"
+#include "macro.h"
 #include "memory_utils.h"
 #include "network.h"
 #include "parse.h"
@@ -126,6 +127,7 @@ lxc_config_define(net_veth_mode);
 lxc_config_define(net_veth_pair);
 lxc_config_define(net_veth_ipv4_route);
 lxc_config_define(net_veth_ipv6_route);
+lxc_config_define(net_veth_vlan_id);
 lxc_config_define(net_vlan_id);
 lxc_config_define(no_new_privs);
 lxc_config_define(personality);
@@ -239,6 +241,7 @@ static struct lxc_config_t config_jump_table[] = {
 	{ "lxc.net.veth.pair",             set_config_net_veth_pair,               get_config_net_veth_pair,               clr_config_net_veth_pair,             },
 	{ "lxc.net.veth.ipv4.route",       set_config_net_veth_ipv4_route,         get_config_net_veth_ipv4_route,         clr_config_net_veth_ipv4_route,       },
 	{ "lxc.net.veth.ipv6.route",       set_config_net_veth_ipv6_route,         get_config_net_veth_ipv6_route,         clr_config_net_veth_ipv6_route,       },
+	{ "lxc.net.veth.vlan.id",          set_config_net_veth_vlan_id,            get_config_net_veth_vlan_id,            clr_config_net_veth_vlan_id,          },
 	{ "lxc.net.",                      set_config_net_nic,                     get_config_net_nic,                     clr_config_net_nic,                   },
 	{ "lxc.net",                       set_config_net,                         get_config_net,                         clr_config_net,                       },
 	{ "lxc.no_new_privs",	           set_config_no_new_privs,                get_config_no_new_privs,                clr_config_no_new_privs,              },
@@ -485,6 +488,36 @@ static int set_config_net_veth_pair(const char *key, const char *value,
 		return -1;
 
 	return network_ifname(netdev->priv.veth_attr.pair, value, sizeof(netdev->priv.veth_attr.pair));
+}
+
+static int set_config_net_veth_vlan_id(const char *key, const char *value,
+				  struct lxc_conf *lxc_conf, void *data)
+{
+	int ret;
+	struct lxc_netdev *netdev = data;
+
+	if (!netdev)
+		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_veth_vlan_id(key, lxc_conf, data);
+
+	if (strcmp(value, "none") == 0) {
+		netdev->priv.veth_attr.vlan_id = BRIDGE_VLAN_NONE;
+	} else {
+		unsigned short vlan_id;
+		ret = get_u16(&vlan_id, value, 0);
+		if (ret < 0)
+			return ret_errno(EINVAL);
+
+		if (vlan_id > BRIDGE_VLAN_ID_MAX)
+			return ret_errno(EINVAL);
+
+		netdev->priv.veth_attr.vlan_id = vlan_id;
+	}
+
+	netdev->priv.veth_attr.vlan_id_set = true;
+	return 0;
 }
 
 static int set_config_net_macvlan_mode(const char *key, const char *value,
@@ -5301,6 +5334,20 @@ static int clr_config_net_veth_pair(const char *key, struct lxc_conf *lxc_conf,
 	return 0;
 }
 
+static int clr_config_net_veth_vlan_id(const char *key, struct lxc_conf *lxc_conf,
+				  void *data)
+{
+	struct lxc_netdev *netdev = data;
+
+	if (!netdev)
+		return ret_errno(EINVAL);
+
+	netdev->priv.veth_attr.vlan_id = 0;
+	netdev->priv.veth_attr.vlan_id_set = false;
+
+	return 0;
+}
+
 static int clr_config_net_script_up(const char *key, struct lxc_conf *lxc_conf,
 				    void *data)
 {
@@ -5772,6 +5819,29 @@ static int get_config_net_veth_pair(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
+static int get_config_net_veth_vlan_id(const char *key, char *retv, int inlen,
+				  struct lxc_conf *c, void *data)
+{
+	int len;
+	int fulllen = 0;
+	struct lxc_netdev *netdev = data;
+
+	if (!netdev)
+		return ret_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VETH)
+		return 0;
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	strprint(retv, inlen, "%d", netdev->priv.veth_attr.vlan_id);
+
+	return fulllen;
+}
+
 static int get_config_net_script_up(const char *key, char *retv, int inlen,
 				    struct lxc_conf *c, void *data)
 {
@@ -6200,6 +6270,7 @@ int lxc_list_net(struct lxc_conf *c, const char *key, char *retv, int inlen)
 		strprint(retv, inlen, "veth.pair\n");
 		strprint(retv, inlen, "veth.ipv4.route\n");
 		strprint(retv, inlen, "veth.ipv6.route\n");
+		strprint(retv, inlen, "veth.vlan.id\n");
 		break;
 	case LXC_NET_MACVLAN:
 		strprint(retv, inlen, "macvlan.mode\n");

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -274,6 +274,11 @@ void lxc_log_configured_netdevs(const struct lxc_conf *conf)
 			if (netdev->priv.veth_attr.vlan_id_set)
 				TRACE("veth vlan id: %d", netdev->priv.veth_attr.vlan_id);
 
+			lxc_list_for_each_safe(cur, &netdev->priv.veth_attr.vlan_tagged_ids, next) {
+				unsigned short vlan_tagged_id = PTR_TO_USHORT(cur->elem);
+				TRACE("veth vlan tagged id: %u", vlan_tagged_id);
+			}
+
 			break;
 		case LXC_NET_MACVLAN:
 			TRACE("type: macvlan");

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -257,6 +257,7 @@ void lxc_log_configured_netdevs(const struct lxc_conf *conf)
 		switch (netdev->type) {
 		case LXC_NET_VETH:
 			TRACE("type: veth");
+			TRACE("veth mode: %d", netdev->priv.veth_attr.mode);
 
 			if (netdev->priv.veth_attr.pair[0] != '\0')
 				TRACE("veth pair: %s",
@@ -269,6 +270,10 @@ void lxc_log_configured_netdevs(const struct lxc_conf *conf)
 			if (netdev->priv.veth_attr.ifindex > 0)
 				TRACE("host side ifindex for veth device: %d",
 				      netdev->priv.veth_attr.ifindex);
+
+			if (netdev->priv.veth_attr.vlan_id_set)
+				TRACE("veth vlan id: %d", netdev->priv.veth_attr.vlan_id);
+
 			break;
 		case LXC_NET_MACVLAN:
 			TRACE("type: macvlan");

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -449,6 +449,11 @@ static void lxc_free_netdev(struct lxc_netdev *netdev)
 			free(cur->elem);
 			free(cur);
 		}
+
+		lxc_list_for_each_safe(cur, &netdev->priv.veth_attr.vlan_tagged_ids, next) {
+			lxc_list_del(cur);
+			free(cur);
+		}
 	}
 
 	free(netdev);

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -380,6 +380,26 @@ extern int __build_bug_on_failed;
 #define IPVLAN_ISOLATION_VEPA 2
 #endif
 
+#ifndef BRIDGE_FLAGS_MASTER
+#define BRIDGE_FLAGS_MASTER 1 /* Bridge command to/from master */
+#endif
+
+#ifndef BRIDGE_VLAN_INFO_PVID
+#define BRIDGE_VLAN_INFO_PVID (1<<1) /* VLAN is PVID, ingress untagged */
+#endif
+
+#ifndef BRIDGE_VLAN_INFO_UNTAGGED
+#define BRIDGE_VLAN_INFO_UNTAGGED (1<<2) /* VLAN egresses untagged */
+#endif
+
+#ifndef IFLA_BRIDGE_FLAGS
+#define IFLA_BRIDGE_FLAGS 0
+#endif
+
+#ifndef IFLA_BRIDGE_VLAN_INFO
+#define IFLA_BRIDGE_VLAN_INFO 2
+#endif
+
 /* Attributes of RTM_NEWNSID/RTM_GETNSID messages */
 enum {
 	__LXC_NETNSA_NONE,

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -380,6 +380,10 @@ extern int __build_bug_on_failed;
 #define IPVLAN_ISOLATION_VEPA 2
 #endif
 
+#ifndef BRIDGE_VLAN_NONE
+#define BRIDGE_VLAN_NONE -1 /* Bridge VLAN option set to "none". */
+#endif
+
 #ifndef BRIDGE_FLAGS_MASTER
 #define BRIDGE_FLAGS_MASTER 1 /* Bridge command to/from master */
 #endif

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -384,6 +384,10 @@ extern int __build_bug_on_failed;
 #define BRIDGE_VLAN_NONE -1 /* Bridge VLAN option set to "none". */
 #endif
 
+#ifndef BRIDGE_VLAN_ID_MAX
+#define BRIDGE_VLAN_ID_MAX 4094 /* Bridge VLAN MAX VLAN ID. */
+#endif
+
 #ifndef BRIDGE_FLAGS_MASTER
 #define BRIDGE_FLAGS_MASTER 1 /* Bridge command to/from master */
 #endif

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -433,6 +433,9 @@ enum {
 
 #define PTR_TO_UINT64(p) ((uint64_t)((intptr_t)(p)))
 
+#define UINT_TO_PTR(u) ((void *) ((uintptr_t) (u)))
+#define PTR_TO_USHORT(p) ((unsigned short)((uintptr_t)(p)))
+
 #define LXC_INVALID_UID ((uid_t)-1)
 #define LXC_INVALID_GID ((gid_t)-1)
 

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -324,11 +324,15 @@ static int instantiate_veth(struct lxc_handler *handler, struct lxc_netdev *netd
 	}
 
 	if (!is_empty_string(netdev->link) && netdev->priv.veth_attr.mode == VETH_MODE_BRIDGE) {
+		if (!lxc_nic_exists(netdev->link)) {
+			SYSERROR("Failed to attach \"%s\" to bridge \"%s\", bridge interface doesn't exist", veth1, netdev->link);
+			goto out_delete;
+		}
+
 		err = lxc_bridge_attach(netdev->link, veth1);
 		if (err) {
 			errno = -err;
-			SYSERROR("Failed to attach \"%s\" to bridge \"%s\"",
-			         veth1, netdev->link);
+			SYSERROR("Failed to attach \"%s\" to bridge \"%s\"", veth1, netdev->link);
 			goto out_delete;
 		}
 		INFO("Attached \"%s\" to bridge \"%s\"", veth1, netdev->link);

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -748,7 +748,7 @@ static int lxc_ipvlan_create(const char *master, const char *name, int mode, int
 
 	err = netlink_open(nlh_ptr, NETLINK_ROUTE);
 	if (err)
-		return ret_errno(-err);
+		return err;
 
 	nlmsg = nlmsg_alloc(NLMSG_GOOD_SIZE);
 	if (!nlmsg)

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -79,6 +79,9 @@ struct ifla_veth {
 	struct lxc_list ipv4_routes;
 	struct lxc_list ipv6_routes;
 	int mode; /* bridge, router */
+	short vlan_id;
+	bool vlan_id_set;
+	struct lxc_list vlan_tagged_ids;
 };
 
 struct ifla_vlan {

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -776,6 +776,11 @@ int main(int argc, char *argv[])
 		return -1;
 	}
 
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.veth.vlan.id", "2", tmpf, true, "veth")) {
+		lxc_error("%s\n", "lxc.net.0.veth.vlan.id");
+		return -1;
+	}
+
 	if (set_get_compare_clear_save_load(c, "lxc.net.0.script.up", "/some/up/path", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.script.up");
 		goto non_test_error;

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -786,6 +786,11 @@ int main(int argc, char *argv[])
 		return -1;
 	}
 
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.veth.vlan.tagged.id", "2", tmpf, true, "veth")) {
+		lxc_error("%s\n", "lxc.net.0.veth.vlan.tagged.id");
+		return -1;
+	}
+
 	if (set_get_compare_clear_save_load(c, "lxc.net.0.script.up", "/some/up/path", tmpf, true)) {
 		lxc_error("%s\n", "lxc.net.0.script.up");
 		goto non_test_error;

--- a/src/tests/parse_config_file.c
+++ b/src/tests/parse_config_file.c
@@ -776,6 +776,11 @@ int main(int argc, char *argv[])
 		return -1;
 	}
 
+	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.veth.vlan.id", "none", tmpf, false, "veth")) {
+		lxc_error("%s\n", "lxc.net.0.veth.vlan.id");
+		return -1;
+	}
+
 	if (set_get_compare_clear_save_load_network(c, "lxc.net.0.veth.vlan.id", "2", tmpf, true, "veth")) {
 		lxc_error("%s\n", "lxc.net.0.veth.vlan.id");
 		return -1;


### PR DESCRIPTION
Adds support for native bridge vlans.

Adds the following config keys:

- `lxc.net.0.veth.vlan.id` - singular VLAN ID for untagged membership (PVID). It accepts a special value of "none" to indicate that it should not be a member of any untagged VLAN (including the default one for the bridge).
- `lxc.net.0.veth.vlan.tagged.id` - multi-line option for specifying additional tagged VLAN ID memberships.

E.g.

```
lxc.net.0.flags = up
lxc.net.0.type = veth
lxc.net.0.veth.mode = bridge
lxc.net.0.veth.vlan.id = 2
lxc.net.0.veth.vlan.tagged.id = 3
lxc.net.0.veth.vlan.tagged.id = 4
lxc.net.0.link = br0
```