### PR TITLE
containertests: fix null pointer defereference

### DIFF
--- a/src/tests/containertests.c
+++ b/src/tests/containertests.c
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
 
 	str = c->config_file_name(c);
 #define CONFIGFNAM LXCPATH "/" MYNAME "/config"
-	if (!str || strcmp(str, CONFIGFNAM)) {
+	if (str && strcmp(str, CONFIGFNAM)) {
 		fprintf(stderr, "%d: got wrong config file name (%s, not %s)\n", __LINE__, str, CONFIGFNAM);
 		goto out;
 	}


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

In the if condition : if !str is true i.e. str is NULL, it does further operations on str (fprintf) which can cause segmentation fault. Fix this by by changing the if condition to : 
if (str && strcmp(str, CONFIGFNAM))