### PR TITLE
Revert "nl: fix memory leak"

### DIFF
--- a/src/lxc/nl.c
+++ b/src/lxc/nl.c
@@ -106,10 +106,8 @@ struct nlmsg *nlmsg_alloc(size_t size)
 		return ret_set_errno(NULL, ENOMEM);
 
 	nlmsg->nlmsghdr = malloc(len);
-	if (!nlmsg->nlmsghdr) {
-		free(nlmsg);
+	if (!nlmsg->nlmsghdr)
 		return ret_set_errno(NULL, ENOMEM);
-	}
 
 	memset(nlmsg->nlmsghdr, 0, len);
 	nlmsg->cap = len;


### PR DESCRIPTION
This was an obvious braino on my part to merge this. Out automatic cleanup
macros will handle this case just fine so this introduces a double-free. Rever
this commit.

This reverts commit 9d05339487f4e9c4e7f700f963c161a4d9977ae4.