### PR TITLE
commands: don't flood logs

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -1508,7 +1508,7 @@ static int lxc_cmd_process(int fd, struct lxc_cmd_req *req,
 	};
 
 	if (req->cmd >= LXC_CMD_MAX)
-		return log_error_errno(-1, ENOENT, "Undefined command id %d", req->cmd);
+		return log_trace_errno(-1, EINVAL, "Invalid command id %d", req->cmd);
 
 	return cb[req->cmd](fd, req, handler, descr);
 }


### PR DESCRIPTION
We're ignoring commands that we don't know about. They used to be fatal. Not
anymore.

Closes: #3459.
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>