### PR TITLE
attach: set no_new_privs flag after LSM label

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -770,17 +770,6 @@ static int attach_child_main(struct attach_clone_payload *payload)
 	else
 		new_gid = ns_root_gid;
 
-	if ((init_ctx->container && init_ctx->container->lxc_conf &&
-	     init_ctx->container->lxc_conf->no_new_privs) ||
-	    (options->attach_flags & LXC_ATTACH_NO_NEW_PRIVS)) {
-		ret = prctl(PR_SET_NO_NEW_PRIVS, prctl_arg(1), prctl_arg(0),
-			    prctl_arg(0), prctl_arg(0));
-		if (ret < 0)
-			goto on_error;
-
-		TRACE("Set PR_SET_NO_NEW_PRIVS");
-	}
-
 	if (needs_lsm) {
 		bool on_exec;
 
@@ -793,6 +782,17 @@ static int attach_child_main(struct attach_clone_payload *payload)
 			goto on_error;
 
 		TRACE("Set %s LSM label to \"%s\"", lsm_name(), init_ctx->lsm_label);
+	}
+
+	if ((init_ctx->container && init_ctx->container->lxc_conf &&
+	     init_ctx->container->lxc_conf->no_new_privs) ||
+	    (options->attach_flags & LXC_ATTACH_NO_NEW_PRIVS)) {
+		ret = prctl(PR_SET_NO_NEW_PRIVS, prctl_arg(1), prctl_arg(0),
+			    prctl_arg(0), prctl_arg(0));
+		if (ret < 0)
+			goto on_error;
+
+		TRACE("Set PR_SET_NO_NEW_PRIVS");
 	}
 
 	if (init_ctx->container && init_ctx->container->lxc_conf &&


### PR DESCRIPTION
In `start.c:1284`, no_new_privs flag is set after LSM label is set.
Also, in `lxc.container.conf` documentation it is written that:
```
Note that PR_SET_NO_NEW_PRIVS is applied after the container has
changed into its intended AppArmor profile or SElinux context.
```
This commit fixes the behavior of `lxc_attach` by moving
`PR_SET_NO_NEW_PRIVS` set logic after LSM for the process is configured;

Closes #3393

Signed-off-by: Alexander Livenets <a.livenets@gmail.com>