### PR TITLE
templates/lxc-download.in: use GPG option "--receive-keys"

### DIFF
--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -135,7 +135,7 @@ gpg_setup() {
   success=
   for _ in $(seq 3); do
     if gpg --keyserver "${DOWNLOAD_KEYSERVER}" ${DOWNLOAD_GPG_PROXY:-} \
-      --recv-keys "${DOWNLOAD_KEYID}" >/dev/null 2>&1; then
+      --receive-keys "${DOWNLOAD_KEYID}" >/dev/null 2>&1; then
       success=1
       break
     fi


### PR DESCRIPTION
Using the option --recv-keys I get an error on openSUSE Tumbleweed which has `gpg2-2.2.20-1.2.x86_64`.

Not sure if this needs to be set differently for older systems, that do not have a recent gpg2 and thus might require the old  behaviour.