### PR TITLE
api-extensions: add seccomp_allow_deny_syntax extension

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -127,3 +127,7 @@ Privileged containers will usually be able to override the cgroup limits given t
 ## time\_namespace
 
 This adds time namespace support to LXC.
+
+## seccomp\_allow\_deny\_syntax
+
+This adds the ability to use "denylist" and "allowlist" in seccomp v2 policies.

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -42,6 +42,7 @@ static char *api_extensions[] = {
 	"cgroup_advanced_isolation",
 	"network_bridge_vlan",
 	"time_namespace",
+	"seccomp_allow_deny_syntax",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>