### PR TITLE
checkconfig: Show LXC version in output.

### DIFF
--- a/src/lxc/cmd/lxc-checkconfig.in
+++ b/src/lxc/cmd/lxc-checkconfig.in
@@ -52,6 +52,8 @@ is_probed() {
     fi
 }
 
+echo "LXC version $(lxc-start --version)"
+
 if [ ! -f $CONFIG ]; then
     echo "Kernel configuration not found at $CONFIG; searching..."
     KVER="`uname -r`"


### PR DESCRIPTION
Please add the LXC version to the output of lxc-checkconfig.  Convenience is King 👑 

Thanks