### PR TITLE
tree-wide: hide unnecessary symbols

### DIFF
--- a/src/include/netns_ifaddrs.h
+++ b/src/include/netns_ifaddrs.h
@@ -12,6 +12,7 @@ extern "C" {
 #include <stdbool.h>
 #include <sys/socket.h>
 
+#include "compiler.h"
 #include "netns_ifaddrs.h"
 
 struct netns_ifaddrs {
@@ -50,9 +51,9 @@ struct netns_ifaddrs {
 #define __ifa_broadaddr ifa_ifu.ifu_broadaddr
 #define __ifa_dstaddr ifa_ifu.ifu_dstaddr
 
-extern void netns_freeifaddrs(struct netns_ifaddrs *);
-extern int netns_getifaddrs(struct netns_ifaddrs **ifap, __s32 netns_id,
-			    bool *netnsid_aware);
+__hidden extern void netns_freeifaddrs(struct netns_ifaddrs *);
+__hidden extern int netns_getifaddrs(struct netns_ifaddrs **ifap, __s32 netns_id,
+				     bool *netnsid_aware);
 
 #ifdef __cplusplus
 }

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -338,6 +338,7 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
+		     log.c log.h \
 		     rexec.c rexec.h \
 		     string_utils.c string_utils.h
 lxc_autostart_SOURCES = tools/lxc_autostart.c \
@@ -349,6 +350,7 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			confile_utils.c confile_utils.h \
 			file_utils.c file_utils.h \
 			initutils.c initutils.h \
+			log.c log.h \
 			string_utils.c string_utils.h
 lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     tools/arguments.c tools/arguments.h \
@@ -359,6 +361,7 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
+		     log.c log.h \
 		     string_utils.c string_utils.h
 lxc_config_SOURCES = tools/lxc_config.c \
 		     tools/arguments.c tools/arguments.h \
@@ -369,6 +372,7 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
+		     log.c log.h \
 		     string_utils.c string_utils.h
 lxc_console_SOURCES = tools/lxc_console.c \
 		      tools/arguments.c tools/arguments.h \
@@ -379,6 +383,7 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      confile_utils.c confile_utils.h \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
+		      log.c log.h \
 		      string_utils.c string_utils.h
 lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      tools/arguments.c tools/arguments.h \
@@ -389,6 +394,7 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      confile_utils.c confile_utils.h \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
+		      log.c log.h \
 		      string_utils.c string_utils.h
 lxc_device_SOURCES = tools/lxc_device.c \
 		     tools/arguments.c tools/arguments.h \
@@ -399,6 +405,7 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
+		     log.c log.h \
 		     string_utils.c string_utils.h
 lxc_execute_SOURCES = tools/lxc_execute.c \
 		      tools/arguments.c tools/arguments.h \
@@ -409,6 +416,7 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      confile_utils.c confile_utils.h \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
+		      log.c log.h \
 		      string_utils.c string_utils.h
 lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     tools/arguments.c tools/arguments.h \
@@ -419,6 +427,7 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
+		     log.c log.h \
 		     string_utils.c string_utils.h
 lxc_info_SOURCES = tools/lxc_info.c \
 		   tools/arguments.c tools/arguments.h \
@@ -429,6 +438,7 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   confile_utils.c confile_utils.h \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
+		   log.c log.h \
 		   string_utils.c string_utils.h
 lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      tools/arguments.c tools/arguments.h \
@@ -439,6 +449,7 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      confile_utils.c confile_utils.h \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
+		      log.c log.h \
 		      macro.h \
 		      string_utils.c string_utils.h
 lxc_ls_SOURCES = tools/lxc_ls.c \
@@ -450,6 +461,7 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 confile_utils.c confile_utils.h \
 		 file_utils.c file_utils.h \
 		 initutils.c initutils.h \
+		 log.c log.h \
 		 memory_utils.h \
 		 string_utils.c string_utils.h
 lxc_copy_SOURCES = tools/lxc_copy.c \
@@ -461,6 +473,7 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   confile_utils.c confile_utils.h \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
+		   log.c log.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
 lxc_start_SOURCES = tools/lxc_start.c \
@@ -472,6 +485,7 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    confile_utils.c confile_utils.h \
 		    file_utils.c file_utils.h \
 		    initutils.c initutils.h \
+		    log.c log.h \
 		    string_utils.c string_utils.h
 lxc_stop_SOURCES = tools/lxc_stop.c \
 		   tools/arguments.c tools/arguments.h \
@@ -482,6 +496,7 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   confile_utils.c confile_utils.h \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
+		   log.c log.h \
 		   string_utils.c string_utils.h
 lxc_top_SOURCES = tools/lxc_top.c \
 		  tools/arguments.c tools/arguments.h \
@@ -492,6 +507,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  confile_utils.c confile_utils.h \
 		  file_utils.c file_utils.h \
 		  initutils.c initutils.h \
+		  log.c log.h \
 		  string_utils.c string_utils.h
 lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h \
@@ -502,6 +518,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       confile_utils.c confile_utils.h \
 		       file_utils.c file_utils.h \
 		       initutils.c initutils.h \
+		       log.c log.h \
 		       string_utils.c string_utils.h
 lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      tools/arguments.c tools/arguments.h \
@@ -512,6 +529,7 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      confile_utils.c confile_utils.h \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
+		      log.c log.h \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
@@ -524,6 +542,7 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   confile_utils.c confile_utils.h \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
+		   log.c log.h \
 		   string_utils.c string_utils.h
 lxc_create_SOURCES = tools/lxc_create.c \
 		     tools/arguments.c tools/arguments.h \
@@ -534,6 +553,7 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
+		     log.c log.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
 lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
@@ -545,6 +565,7 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       confile_utils.c confile_utils.h \
 		       file_utils.c file_utils.h \
 		       initutils.c initutils.h \
+		       log.c log.h \
 		       string_utils.c string_utils.h
 lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 tools/arguments.c tools/arguments.h \
@@ -555,16 +576,19 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 confile_utils.c confile_utils.h \
 			 file_utils.c file_utils.h \
 			 initutils.c initutils.h \
+			 log.c log.h \
 			 string_utils.c string_utils.h
 endif
 
 if ENABLE_COMMANDS
 # Binaries shipping with liblxc
 init_lxc_SOURCES = cmd/lxc_init.c \
+		   caps.c caps.h \
 		   compiler.h \
 		   error.c error.h \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
+		   log.c log.h \
 		   memory_utils.h \
 		   parse.c parse.h \
 		   process_utils.c process_utils.h \

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -361,7 +361,8 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
 		     utils.c utils.h \
-		     uuid.c uuid.h
+		     uuid.c uuid.h \
+		     $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_attach_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -397,7 +398,8 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			sync.c sync.h \
 			terminal.c terminal.h \
 			utils.c utils.h \
-			uuid.c uuid.h
+			uuid.c uuid.h \
+			$(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -433,7 +435,8 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
 		     utils.c utils.h \
-		     uuid.c uuid.h
+		     uuid.c uuid.h \
+		     $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -469,7 +472,8 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
 		     utils.c utils.h \
-		     uuid.c uuid.h
+		     uuid.c uuid.h \
+		     $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_config_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -505,7 +509,8 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
 		      utils.c utils.h \
-		      uuid.c uuid.h
+		      uuid.c uuid.h \
+		      $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_console_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -541,7 +546,8 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
 		      utils.c utils.h \
-		      uuid.c uuid.h
+		      uuid.c uuid.h \
+		      $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -577,7 +583,8 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
 		     utils.c utils.h \
-		     uuid.c uuid.h
+		     uuid.c uuid.h \
+		     $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_device_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -613,7 +620,8 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
 		      utils.c utils.h \
-		      uuid.c uuid.h
+		      uuid.c uuid.h \
+		      $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_execute_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -649,7 +657,8 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
 		     utils.c utils.h \
-		     uuid.c uuid.h
+		     uuid.c uuid.h \
+		     $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -685,7 +694,8 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
 		   utils.c utils.h \
-		   uuid.c uuid.h
+		   uuid.c uuid.h \
+		   $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_info_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -722,7 +732,8 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
 		      utils.c utils.h \
-		      uuid.c uuid.h
+		      uuid.c uuid.h \
+		      $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -759,7 +770,8 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 sync.c sync.h \
 		 terminal.c terminal.h \
 		 utils.c utils.h \
-		 uuid.c uuid.h
+		 uuid.c uuid.h \
+		 $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_ls_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -796,7 +808,8 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
 		   utils.c utils.h \
-		   uuid.c uuid.h
+		   uuid.c uuid.h \
+		   $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_copy_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -832,7 +845,8 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    sync.c sync.h \
 		    terminal.c terminal.h \
 		    utils.c utils.h \
-		    uuid.c uuid.h
+		    uuid.c uuid.h \
+		    $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_start_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -868,7 +882,8 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
 		   utils.c utils.h \
-		   uuid.c uuid.h
+		   uuid.c uuid.h \
+		   $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -904,7 +919,8 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  sync.c sync.h \
 		  terminal.c terminal.h \
 		  utils.c utils.h \
-		  uuid.c uuid.h
+		  uuid.c uuid.h \
+		  $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -940,7 +956,8 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       sync.c sync.h \
 		       terminal.c terminal.h \
 		       utils.c utils.h \
-		       uuid.c uuid.h
+		       uuid.c uuid.h \
+		       $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -978,7 +995,8 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      syscall_wrappers.h \
 		      terminal.c terminal.h \
 		      utils.c utils.h \
-		      uuid.c uuid.h
+		      uuid.c uuid.h \
+		      $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_unshare_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1014,7 +1032,8 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
 		   utils.c utils.h \
-		   uuid.c uuid.h
+		   uuid.c uuid.h \
+		   $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_wait_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1051,7 +1070,8 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
 		     utils.c utils.h \
-		     uuid.c uuid.h
+		     uuid.c uuid.h \
+		     $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_create_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1087,7 +1107,8 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       sync.c sync.h \
 		       terminal.c terminal.h \
 		       utils.c utils.h \
-		       uuid.c uuid.h
+		       uuid.c uuid.h \
+		       $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1123,7 +1144,8 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 sync.c sync.h \
 			 terminal.c terminal.h \
 			 utils.c utils.h \
-			 uuid.c uuid.h
+			 uuid.c uuid.h \
+			 $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1182,7 +1204,8 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       syscall_numbers.h \
 		       terminal.c terminal.h \
 		       utils.c utils.h \
-		       uuid.c uuid.h
+		       uuid.c uuid.h \
+		       $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_monitord_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1221,7 +1244,8 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       syscall_wrappers.h \
 		       terminal.c terminal.h \
 		       utils.c utils.h \
-		       uuid.c uuid.h
+		       uuid.c uuid.h \
+		       $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_user_nic_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1260,7 +1284,8 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 syscall_wrappers.h \
 			 terminal.c terminal.h \
 			 utils.c utils.h \
-			 uuid.c uuid.h
+			 uuid.c uuid.h \
+			 $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_usernsexec_SOURCES += seccomp.c lxcseccomp.h
 endif

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -342,6 +342,7 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
+		     parse.c parse.h \
 		     rexec.c rexec.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -361,6 +362,7 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			namespace.c namespace.h \
 			network.c network.h \
 			nl.c nl.h \
+			parse.c parse.h \
 			string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
@@ -379,6 +381,7 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
+		     parse.c parse.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
@@ -397,6 +400,7 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
+		     parse.c parse.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_config_SOURCES += seccomp.c lxcseccomp.h
@@ -415,6 +419,7 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      namespace.c namespace.h \
 		      network.c network.h \
 		      nl.c nl.h \
+		      parse.c parse.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_console_SOURCES += seccomp.c lxcseccomp.h
@@ -433,6 +438,7 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      namespace.c namespace.h \
 		      network.c network.h \
 		      nl.c nl.h \
+		      parse.c parse.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
@@ -451,6 +457,7 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
+		     parse.c parse.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_device_SOURCES += seccomp.c lxcseccomp.h
@@ -469,6 +476,7 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      namespace.c namespace.h \
 		      network.c network.h \
 		      nl.c nl.h \
+		      parse.c parse.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_execute_SOURCES += seccomp.c lxcseccomp.h
@@ -487,6 +495,7 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
+		     parse.c parse.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
@@ -505,6 +514,7 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   namespace.c namespace.h \
 		   network.c network.h \
 		   nl.c nl.h \
+		   parse.c parse.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_info_SOURCES += seccomp.c lxcseccomp.h
@@ -525,6 +535,7 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      namespace.c namespace.h \
 		      network.c network.h \
 		      nl.c nl.h \
+		      parse.c parse.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
@@ -544,6 +555,7 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 namespace.c namespace.h \
 		 network.c network.h \
 		 nl.c nl.h \
+		 parse.c parse.h \
 		 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_ls_SOURCES += seccomp.c lxcseccomp.h
@@ -562,6 +574,7 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   namespace.c namespace.h \
 		   network.c network.h \
 		   nl.c nl.h \
+		   parse.c parse.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -581,6 +594,7 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    namespace.c namespace.h \
 		    network.c network.h \
 		    nl.c nl.h \
+		    parse.c parse.h \
 		    string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_start_SOURCES += seccomp.c lxcseccomp.h
@@ -600,6 +614,7 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   namespace.c namespace.h \
 		   network.c network.h \
 		   nl.c nl.h \
+		   parse.c parse.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
@@ -619,6 +634,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  namespace.c namespace.h \
 		  network.c network.h \
 		  nl.c nl.h \
+		  parse.c parse.h \
 		  string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h
@@ -637,6 +653,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       namespace.c namespace.h \
 		       network.c network.h \
 		       nl.c nl.h \
+		       parse.c parse.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
@@ -655,6 +672,7 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      namespace.c namespace.h \
 		      network.c network.h \
 		      nl.c nl.h \
+		      parse.c parse.h \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
@@ -675,6 +693,7 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   namespace.c namespace.h \
 		   network.c network.h \
 		   nl.c nl.h \
+		   parse.c parse.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_wait_SOURCES += seccomp.c lxcseccomp.h
@@ -693,6 +712,7 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
+		     parse.c parse.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -712,6 +732,7 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       namespace.c namespace.h \
 		       network.c network.h \
 		       nl.c nl.h \
+		       parse.c parse.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
@@ -730,6 +751,7 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 namespace.c namespace.h \
 			 network.c network.h \
 			 nl.c nl.h \
+			 parse.c parse.h \
 			 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
@@ -771,6 +793,7 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       namespace.c namespace.h \
 		       network.c network.h \
 		       nl.c nl.h \
+		       parse.c parse.h \
 		       process_utils.c process_utils.h \
 		       string_utils.c string_utils.h \
 		       syscall_numbers.h \
@@ -817,6 +840,7 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 namespace.c namespace.h \
 			 network.c network.h \
 			 nl.c nl.h \
+			 parse.c parse.h \
 			 string_utils.c string_utils.h \
 			 syscall_wrappers.h \
 			 utils.c utils.h

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -353,6 +353,7 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     rexec.c rexec.h \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
+		     state.c state.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_attach_SOURCES += seccomp.c lxcseccomp.h
@@ -381,6 +382,7 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			process_utils.c process_utils.h \
 			ringbuf.c ringbuf.h \
 			start.c start.h \
+			state.c state.h \
 			string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
@@ -409,6 +411,7 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     process_utils.c process_utils.h \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
+		     state.c state.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
@@ -437,6 +440,7 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     process_utils.c process_utils.h \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
+		     state.c state.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_config_SOURCES += seccomp.c lxcseccomp.h
@@ -465,6 +469,7 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      process_utils.c process_utils.h \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
+		      state.c state.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_console_SOURCES += seccomp.c lxcseccomp.h
@@ -493,6 +498,7 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      process_utils.c process_utils.h \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
+		      state.c state.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
@@ -521,6 +527,7 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     process_utils.c process_utils.h \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
+		     state.c state.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_device_SOURCES += seccomp.c lxcseccomp.h
@@ -549,6 +556,7 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      process_utils.c process_utils.h \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
+		      state.c state.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_execute_SOURCES += seccomp.c lxcseccomp.h
@@ -577,6 +585,7 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     process_utils.c process_utils.h \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
+		     state.c state.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
@@ -605,6 +614,7 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   process_utils.c process_utils.h \
 		   ringbuf.c ringbuf.h \
 		   start.c start.h \
+		   state.c state.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_info_SOURCES += seccomp.c lxcseccomp.h
@@ -634,6 +644,7 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      process_utils.c process_utils.h \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
+		      state.c state.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
@@ -663,6 +674,7 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 process_utils.c process_utils.h \
 		 ringbuf.c ringbuf.h \
 		 start.c start.h \
+		 state.c state.h \
 		 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_ls_SOURCES += seccomp.c lxcseccomp.h
@@ -691,6 +703,7 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   process_utils.c process_utils.h \
 		   ringbuf.c ringbuf.h \
 		   start.c start.h \
+		   state.c state.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -720,6 +733,7 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    process_utils.c process_utils.h \
 		    ringbuf.c ringbuf.h \
 		    start.c start.h \
+		    state.c state.h \
 		    string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_start_SOURCES += seccomp.c lxcseccomp.h
@@ -748,6 +762,7 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   process_utils.c process_utils.h \
 		   ringbuf.c ringbuf.h \
 		   start.c start.h \
+		   state.c state.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
@@ -776,6 +791,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  process_utils.c process_utils.h \
 		  ringbuf.c ringbuf.h \
 		  start.c start.h \
+		  state.c state.h \
 		  string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h
@@ -804,6 +820,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       process_utils.c process_utils.h \
 		       ringbuf.c ringbuf.h \
 		       start.c start.h \
+		       state.c state.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
@@ -832,6 +849,7 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      process_utils.c process_utils.h \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
+		      state.c state.h \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
@@ -862,6 +880,7 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   process_utils.c process_utils.h \
 		   ringbuf.c ringbuf.h \
 		   start.c start.h \
+		   state.c state.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_wait_SOURCES += seccomp.c lxcseccomp.h
@@ -890,6 +909,7 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     process_utils.c process_utils.h \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
+		     state.c state.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -919,6 +939,7 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       process_utils.c process_utils.h \
 		       ringbuf.c ringbuf.h \
 		       start.c start.h \
+		       state.c state.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
@@ -947,6 +968,7 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 process_utils.c process_utils.h \
 			 ringbuf.c ringbuf.h \
 			 start.c start.h \
+			 state.c state.h \
 			 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
@@ -997,6 +1019,7 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       process_utils.c process_utils.h \
 		       ringbuf.c ringbuf.h \
 		       start.c start.h \
+		       state.c state.h \
 		       string_utils.c string_utils.h \
 		       syscall_numbers.h \
 		       utils.c utils.h
@@ -1028,6 +1051,7 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       process_utils.c process_utils.h \
 		       ringbuf.c ringbuf.h \
 		       start.c start.h \
+		       state.c state.h \
 		       string_utils.c string_utils.h \
 		       syscall_numbers.h \
 		       syscall_wrappers.h
@@ -1060,6 +1084,7 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 process_utils.c process_utils.h \
 			 ringbuf.c ringbuf.h \
 			 start.c start.h \
+			 state.c state.h \
 			 string_utils.c string_utils.h \
 			 syscall_wrappers.h \
 			 utils.c utils.h

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -127,8 +127,8 @@ liblxc_la_SOURCES = af_unix.c af_unix.h \
 		    memory_utils.h \
 		    mainloop.c mainloop.h \
 		    namespace.c namespace.h \
-		    nl.c nl.h \
 		    network.c network.h \
+		    nl.c nl.h \
 		    monitor.c monitor.h \
 		    parse.c parse.h \
 		    process_utils.c process_utils.h \
@@ -340,6 +340,8 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     namespace.c namespace.h \
+		     network.c network.h \
+		     nl.c nl.h \
 		     rexec.c rexec.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -357,6 +359,8 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			initutils.c initutils.h \
 			log.c log.h \
 			namespace.c namespace.h \
+			network.c network.h \
+			nl.c nl.h \
 			string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
@@ -373,6 +377,8 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     namespace.c namespace.h \
+		     network.c network.h \
+		     nl.c nl.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
@@ -389,6 +395,8 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     namespace.c namespace.h \
+		     network.c network.h \
+		     nl.c nl.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_config_SOURCES += seccomp.c lxcseccomp.h
@@ -405,6 +413,8 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      namespace.c namespace.h \
+		      network.c network.h \
+		      nl.c nl.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_console_SOURCES += seccomp.c lxcseccomp.h
@@ -421,6 +431,8 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      namespace.c namespace.h \
+		      network.c network.h \
+		      nl.c nl.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
@@ -437,6 +449,8 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     namespace.c namespace.h \
+		     network.c network.h \
+		     nl.c nl.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_device_SOURCES += seccomp.c lxcseccomp.h
@@ -453,6 +467,8 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      namespace.c namespace.h \
+		      network.c network.h \
+		      nl.c nl.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_execute_SOURCES += seccomp.c lxcseccomp.h
@@ -469,6 +485,8 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     namespace.c namespace.h \
+		     network.c network.h \
+		     nl.c nl.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
@@ -485,6 +503,8 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   initutils.c initutils.h \
 		   log.c log.h \
 		   namespace.c namespace.h \
+		   network.c network.h \
+		   nl.c nl.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_info_SOURCES += seccomp.c lxcseccomp.h
@@ -503,6 +523,8 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      macro.h \
 		      monitor.c monitor.h \
 		      namespace.c namespace.h \
+		      network.c network.h \
+		      nl.c nl.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
@@ -520,6 +542,8 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 log.c log.h \
 		 memory_utils.h \
 		 namespace.c namespace.h \
+		 network.c network.h \
+		 nl.c nl.h \
 		 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_ls_SOURCES += seccomp.c lxcseccomp.h
@@ -536,6 +560,8 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   initutils.c initutils.h \
 		   log.c log.h \
 		   namespace.c namespace.h \
+		   network.c network.h \
+		   nl.c nl.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -553,6 +579,8 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    initutils.c initutils.h \
 		    log.c log.h \
 		    namespace.c namespace.h \
+		    network.c network.h \
+		    nl.c nl.h \
 		    string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_start_SOURCES += seccomp.c lxcseccomp.h
@@ -570,6 +598,8 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   log.c log.h \
 		   mainloop.c mainloop.h \
 		   namespace.c namespace.h \
+		   network.c network.h \
+		   nl.c nl.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
@@ -587,6 +617,8 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  log.c log.h \
 		  mainloop.c mainloop.h \
 		  namespace.c namespace.h \
+		  network.c network.h \
+		  nl.c nl.h \
 		  string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h
@@ -603,6 +635,8 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       initutils.c initutils.h \
 		       log.c log.h \
 		       namespace.c namespace.h \
+		       network.c network.h \
+		       nl.c nl.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
@@ -619,6 +653,8 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      namespace.c namespace.h \
+		      network.c network.h \
+		      nl.c nl.h \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
@@ -637,6 +673,8 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   initutils.c initutils.h \
 		   log.c log.h \
 		   namespace.c namespace.h \
+		   network.c network.h \
+		   nl.c nl.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_wait_SOURCES += seccomp.c lxcseccomp.h
@@ -653,6 +691,8 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     namespace.c namespace.h \
+		     network.c network.h \
+		     nl.c nl.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -670,6 +710,8 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       initutils.c initutils.h \
 		       log.c log.h \
 		       namespace.c namespace.h \
+		       network.c network.h \
+		       nl.c nl.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
@@ -686,6 +728,8 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 initutils.c initutils.h \
 			 log.c log.h \
 			 namespace.c namespace.h \
+			 network.c network.h \
+			 nl.c nl.h \
 			 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
@@ -725,6 +769,8 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       mainloop.c mainloop.h \
 		       monitor.c monitor.h \
 		       namespace.c namespace.h \
+		       network.c network.h \
+		       nl.c nl.h \
 		       process_utils.c process_utils.h \
 		       string_utils.c string_utils.h \
 		       syscall_numbers.h \
@@ -769,6 +815,8 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 macro.h \
 			 memory_utils.h \
 			 namespace.c namespace.h \
+			 network.c network.h \
+			 nl.c nl.h \
 			 string_utils.c string_utils.h \
 			 syscall_wrappers.h \
 			 utils.c utils.h

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -334,6 +334,7 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
 		     conf.c conf.h \
+		     confile.c confile.h \
 		     rexec.c rexec.h \
 		     string_utils.c string_utils.h
 lxc_autostart_SOURCES = tools/lxc_autostart.c \
@@ -341,60 +342,70 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			af_unix.c af_unix.h \
 			caps.c caps.h \
 			conf.c conf.h \
+			confile.c confile.h \
 			string_utils.c string_utils.h
 lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
 		     conf.c conf.h \
+		     confile.c confile.h \
 		     string_utils.c string_utils.h
 lxc_config_SOURCES = tools/lxc_config.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
 		     conf.c conf.h \
+		     confile.c confile.h \
 		     string_utils.c string_utils.h
 lxc_console_SOURCES = tools/lxc_console.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
 		      conf.c conf.h \
+		      confile.c confile.h \
 		      string_utils.c string_utils.h
 lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
 		      conf.c conf.h \
+		      confile.c confile.h \
 		      string_utils.c string_utils.h
 lxc_device_SOURCES = tools/lxc_device.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
 		     conf.c conf.h \
+		     confile.c confile.h \
 		     string_utils.c string_utils.h
 lxc_execute_SOURCES = tools/lxc_execute.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
 		      conf.c conf.h \
+		      confile.c confile.h \
 		      string_utils.c string_utils.h
 lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
 		     conf.c conf.h \
+		     confile.c confile.h \
 		     string_utils.c string_utils.h
 lxc_info_SOURCES = tools/lxc_info.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
 		   conf.c conf.h \
+		   confile.c confile.h \
 		   string_utils.c string_utils.h
 lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
 		      conf.c conf.h \
+		      confile.c confile.h \
 		      macro.h \
 		      string_utils.c string_utils.h
 lxc_ls_SOURCES = tools/lxc_ls.c \
@@ -402,6 +413,7 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 af_unix.c af_unix.h \
 		 caps.c caps.h \
 		 conf.c conf.h \
+		 confile.c confile.h \
 		 memory_utils.h \
 		 string_utils.c string_utils.h
 lxc_copy_SOURCES = tools/lxc_copy.c \
@@ -409,6 +421,7 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
 		   conf.c conf.h \
+		   confile.c confile.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
 lxc_start_SOURCES = tools/lxc_start.c \
@@ -416,30 +429,35 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    af_unix.c af_unix.h \
 		    caps.c caps.h \
 		    conf.c conf.h \
+		    confile.c confile.h \
 		    string_utils.c string_utils.h
 lxc_stop_SOURCES = tools/lxc_stop.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
 		   conf.c conf.h \
+		   confile.c confile.h \
 		   string_utils.c string_utils.h
 lxc_top_SOURCES = tools/lxc_top.c \
 		  tools/arguments.c tools/arguments.h \
 		  af_unix.c af_unix.h \
 		  caps.c caps.h \
 		  conf.c conf.h \
+		  confile.c confile.h \
 		  string_utils.c string_utils.h
 lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
 		       conf.c conf.h \
+		       confile.c confile.h \
 		       string_utils.c string_utils.h
 lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
 		      conf.c conf.h \
+		      confile.c confile.h \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
@@ -448,12 +466,14 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
 		   conf.c conf.h \
+		   confile.c confile.h \
 		   string_utils.c string_utils.h
 lxc_create_SOURCES = tools/lxc_create.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
 		     conf.c conf.h \
+		     confile.c confile.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
 lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
@@ -461,12 +481,14 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
 		       conf.c conf.h \
+		       confile.c confile.h \
 		       string_utils.c string_utils.h
 lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 tools/arguments.c tools/arguments.h \
 			 af_unix.c af_unix.h \
 			 caps.c caps.h \
 			 conf.c conf.h \
+			 confile.c confile.h \
 			 string_utils.c string_utils.h
 endif
 
@@ -488,6 +510,7 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
 		       conf.c conf.h \
+		       confile.c confile.h \
 		       log.c log.h \
 		       mainloop.c mainloop.h \
 		       monitor.c monitor.h \
@@ -500,6 +523,7 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
 		       conf.c conf.h \
+		       confile.c confile.h \
 		       log.c log.h \
 		       memory_utils.h \
 		       network.c network.h \
@@ -514,6 +538,7 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 af_unix.c af_unix.h \
 			 caps.c caps.h \
 			 conf.c conf.h \
+			 confile.c confile.h \
 			 file_utils.c file_utils.h \
 			 list.h \
 			 log.c log.h \

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -354,7 +354,8 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
 		     state.c state.h \
-		     string_utils.c string_utils.h
+		     string_utils.c string_utils.h \
+		     sync.c sync.h
 if ENABLE_SECCOMP
 lxc_attach_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -383,7 +384,8 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			ringbuf.c ringbuf.h \
 			start.c start.h \
 			state.c state.h \
-			string_utils.c string_utils.h
+			string_utils.c string_utils.h \
+			sync.c sync.h
 if ENABLE_SECCOMP
 lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -412,7 +414,8 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
 		     state.c state.h \
-		     string_utils.c string_utils.h
+		     string_utils.c string_utils.h \
+		     sync.c sync.h
 if ENABLE_SECCOMP
 lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -441,7 +444,8 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
 		     state.c state.h \
-		     string_utils.c string_utils.h
+		     string_utils.c string_utils.h \
+		     sync.c sync.h
 if ENABLE_SECCOMP
 lxc_config_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -470,7 +474,8 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
 		      state.c state.h \
-		      string_utils.c string_utils.h
+		      string_utils.c string_utils.h \
+		      sync.c sync.h
 if ENABLE_SECCOMP
 lxc_console_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -499,7 +504,8 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
 		      state.c state.h \
-		      string_utils.c string_utils.h
+		      string_utils.c string_utils.h \
+		      sync.c sync.h
 if ENABLE_SECCOMP
 lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -528,7 +534,8 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
 		     state.c state.h \
-		     string_utils.c string_utils.h
+		     string_utils.c string_utils.h \
+		     sync.c sync.h
 if ENABLE_SECCOMP
 lxc_device_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -557,7 +564,8 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
 		      state.c state.h \
-		      string_utils.c string_utils.h
+		      string_utils.c string_utils.h \
+		      sync.c sync.h
 if ENABLE_SECCOMP
 lxc_execute_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -586,7 +594,8 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
 		     state.c state.h \
-		     string_utils.c string_utils.h
+		     string_utils.c string_utils.h \
+		     sync.c sync.h
 if ENABLE_SECCOMP
 lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -615,7 +624,8 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   ringbuf.c ringbuf.h \
 		   start.c start.h \
 		   state.c state.h \
-		   string_utils.c string_utils.h
+		   string_utils.c string_utils.h \
+		   sync.c sync.h
 if ENABLE_SECCOMP
 lxc_info_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -645,7 +655,8 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
 		      state.c state.h \
-		      string_utils.c string_utils.h
+		      string_utils.c string_utils.h \
+		      sync.c sync.h
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -675,7 +686,8 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 ringbuf.c ringbuf.h \
 		 start.c start.h \
 		 state.c state.h \
-		 string_utils.c string_utils.h
+		 string_utils.c string_utils.h \
+		 sync.c sync.h
 if ENABLE_SECCOMP
 lxc_ls_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -705,7 +717,8 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   start.c start.h \
 		   state.c state.h \
 		   storage/storage_utils.c storage/storage_utils.h \
-		   string_utils.c string_utils.h
+		   string_utils.c string_utils.h \
+		   sync.c sync.h
 if ENABLE_SECCOMP
 lxc_copy_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -734,7 +747,8 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    ringbuf.c ringbuf.h \
 		    start.c start.h \
 		    state.c state.h \
-		    string_utils.c string_utils.h
+		    string_utils.c string_utils.h \
+		    sync.c sync.h
 if ENABLE_SECCOMP
 lxc_start_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -763,7 +777,8 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   ringbuf.c ringbuf.h \
 		   start.c start.h \
 		   state.c state.h \
-		   string_utils.c string_utils.h
+		   string_utils.c string_utils.h \
+		   sync.c sync.h
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -792,7 +807,8 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  ringbuf.c ringbuf.h \
 		  start.c start.h \
 		  state.c state.h \
-		  string_utils.c string_utils.h
+		  string_utils.c string_utils.h \
+		  sync.c sync.h
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -821,7 +837,8 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       ringbuf.c ringbuf.h \
 		       start.c start.h \
 		       state.c state.h \
-		       string_utils.c string_utils.h
+		       string_utils.c string_utils.h \
+		       sync.c sync.h
 if ENABLE_SECCOMP
 lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -851,6 +868,7 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      start.c start.h \
 		      state.c state.h \
 		      string_utils.c string_utils.h \
+		      sync.c sync.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
 if ENABLE_SECCOMP
@@ -881,7 +899,8 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   ringbuf.c ringbuf.h \
 		   start.c start.h \
 		   state.c state.h \
-		   string_utils.c string_utils.h
+		   string_utils.c string_utils.h \
+		   sync.c sync.h
 if ENABLE_SECCOMP
 lxc_wait_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -911,7 +930,8 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     start.c start.h \
 		     state.c state.h \
 		     storage/storage_utils.c storage/storage_utils.h \
-		     string_utils.c string_utils.h
+		     string_utils.c string_utils.h \
+		     sync.c sync.h
 if ENABLE_SECCOMP
 lxc_create_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -940,7 +960,8 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       ringbuf.c ringbuf.h \
 		       start.c start.h \
 		       state.c state.h \
-		       string_utils.c string_utils.h
+		       string_utils.c string_utils.h \
+		       sync.c sync.h
 if ENABLE_SECCOMP
 lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -969,7 +990,8 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 ringbuf.c ringbuf.h \
 			 start.c start.h \
 			 state.c state.h \
-			 string_utils.c string_utils.h
+			 string_utils.c string_utils.h \
+			 sync.c sync.h
 if ENABLE_SECCOMP
 lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1021,6 +1043,7 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       start.c start.h \
 		       state.c state.h \
 		       string_utils.c string_utils.h \
+		       sync.c sync.h \
 		       syscall_numbers.h \
 		       utils.c utils.h
 if ENABLE_SECCOMP
@@ -1053,6 +1076,7 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       start.c start.h \
 		       state.c state.h \
 		       string_utils.c string_utils.h \
+		       sync.c sync.h \
 		       syscall_numbers.h \
 		       syscall_wrappers.h
 if ENABLE_SECCOMP
@@ -1086,6 +1110,7 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 start.c start.h \
 			 state.c state.h \
 			 string_utils.c string_utils.h \
+			 sync.c sync.h \
 			 syscall_wrappers.h \
 			 utils.c utils.h
 if ENABLE_SECCOMP

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -553,6 +553,7 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
+		   mainloop.c mainloop.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
@@ -568,6 +569,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  file_utils.c file_utils.h \
 		  initutils.c initutils.h \
 		  log.c log.h \
+		  mainloop.c mainloop.h \
 		  string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -48,7 +48,6 @@ noinst_HEADERS = api_extensions.h \
 		 terminal.h \
 		 ../tests/lxctest.h \
 		 tools/arguments.h \
-		 storage/storage_utils.h \
 		 utils.h \
 		 uuid.h
 
@@ -357,6 +356,17 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
 		     state.c state.h \
+		     storage/btrfs.c storage/btrfs.h \
+		     storage/dir.c storage/dir.h \
+		     storage/loop.c storage/loop.h \
+		     storage/lvm.c storage/lvm.h \
+		     storage/nbd.c storage/nbd.h \
+		     storage/overlay.c storage/overlay.h \
+		     storage/rbd.c storage/rbd.h \
+		     storage/rsync.c storage/rsync.h \
+		     storage/storage.c storage/storage.h \
+		     storage/storage_utils.c storage/storage_utils.h \
+		     storage/zfs.c storage/zfs.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
@@ -394,6 +404,17 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			ringbuf.c ringbuf.h \
 			start.c start.h \
 			state.c state.h \
+			storage/btrfs.c storage/btrfs.h \
+			storage/dir.c storage/dir.h \
+			storage/loop.c storage/loop.h \
+			storage/lvm.c storage/lvm.h \
+			storage/nbd.c storage/nbd.h \
+			storage/overlay.c storage/overlay.h \
+			storage/rbd.c storage/rbd.h \
+			storage/rsync.c storage/rsync.h \
+			storage/storage.c storage/storage.h \
+			storage/storage_utils.c storage/storage_utils.h \
+			storage/zfs.c storage/zfs.h \
 			string_utils.c string_utils.h \
 			sync.c sync.h \
 			terminal.c terminal.h \
@@ -431,6 +452,17 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
 		     state.c state.h \
+		     storage/btrfs.c storage/btrfs.h \
+		     storage/dir.c storage/dir.h \
+		     storage/loop.c storage/loop.h \
+		     storage/lvm.c storage/lvm.h \
+		     storage/nbd.c storage/nbd.h \
+		     storage/overlay.c storage/overlay.h \
+		     storage/rbd.c storage/rbd.h \
+		     storage/rsync.c storage/rsync.h \
+		     storage/storage.c storage/storage.h \
+		     storage/storage_utils.c storage/storage_utils.h \
+		     storage/zfs.c storage/zfs.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
@@ -468,6 +500,17 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
 		     state.c state.h \
+		     storage/btrfs.c storage/btrfs.h \
+		     storage/dir.c storage/dir.h \
+		     storage/loop.c storage/loop.h \
+		     storage/lvm.c storage/lvm.h \
+		     storage/nbd.c storage/nbd.h \
+		     storage/overlay.c storage/overlay.h \
+		     storage/rbd.c storage/rbd.h \
+		     storage/rsync.c storage/rsync.h \
+		     storage/storage.c storage/storage.h \
+		     storage/storage_utils.c storage/storage_utils.h \
+		     storage/zfs.c storage/zfs.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
@@ -505,6 +548,17 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
 		      state.c state.h \
+		      storage/btrfs.c storage/btrfs.h \
+		      storage/dir.c storage/dir.h \
+		      storage/loop.c storage/loop.h \
+		      storage/lvm.c storage/lvm.h \
+		      storage/nbd.c storage/nbd.h \
+		      storage/overlay.c storage/overlay.h \
+		      storage/rbd.c storage/rbd.h \
+		      storage/rsync.c storage/rsync.h \
+		      storage/storage.c storage/storage.h \
+		      storage/storage_utils.c storage/storage_utils.h \
+		      storage/zfs.c storage/zfs.h \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
@@ -542,6 +596,17 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
 		      state.c state.h \
+		      storage/btrfs.c storage/btrfs.h \
+		      storage/dir.c storage/dir.h \
+		      storage/loop.c storage/loop.h \
+		      storage/lvm.c storage/lvm.h \
+		      storage/nbd.c storage/nbd.h \
+		      storage/overlay.c storage/overlay.h \
+		      storage/rbd.c storage/rbd.h \
+		      storage/rsync.c storage/rsync.h \
+		      storage/storage.c storage/storage.h \
+		      storage/storage_utils.c storage/storage_utils.h \
+		      storage/zfs.c storage/zfs.h \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
@@ -579,6 +644,17 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
 		     state.c state.h \
+		     storage/btrfs.c storage/btrfs.h \
+		     storage/dir.c storage/dir.h \
+		     storage/loop.c storage/loop.h \
+		     storage/lvm.c storage/lvm.h \
+		     storage/nbd.c storage/nbd.h \
+		     storage/overlay.c storage/overlay.h \
+		     storage/rbd.c storage/rbd.h \
+		     storage/rsync.c storage/rsync.h \
+		     storage/storage.c storage/storage.h \
+		     storage/storage_utils.c storage/storage_utils.h \
+		     storage/zfs.c storage/zfs.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
@@ -616,6 +692,17 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
 		      state.c state.h \
+		      storage/btrfs.c storage/btrfs.h \
+		      storage/dir.c storage/dir.h \
+		      storage/loop.c storage/loop.h \
+		      storage/lvm.c storage/lvm.h \
+		      storage/nbd.c storage/nbd.h \
+		      storage/overlay.c storage/overlay.h \
+		      storage/rbd.c storage/rbd.h \
+		      storage/rsync.c storage/rsync.h \
+		      storage/storage.c storage/storage.h \
+		      storage/storage_utils.c storage/storage_utils.h \
+		      storage/zfs.c storage/zfs.h \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
@@ -653,6 +740,17 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
 		     state.c state.h \
+		     storage/btrfs.c storage/btrfs.h \
+		     storage/dir.c storage/dir.h \
+		     storage/loop.c storage/loop.h \
+		     storage/lvm.c storage/lvm.h \
+		     storage/nbd.c storage/nbd.h \
+		     storage/overlay.c storage/overlay.h \
+		     storage/rbd.c storage/rbd.h \
+		     storage/rsync.c storage/rsync.h \
+		     storage/storage.c storage/storage.h \
+		     storage/storage_utils.c storage/storage_utils.h \
+		     storage/zfs.c storage/zfs.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
@@ -690,6 +788,17 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   ringbuf.c ringbuf.h \
 		   start.c start.h \
 		   state.c state.h \
+		   storage/btrfs.c storage/btrfs.h \
+		   storage/dir.c storage/dir.h \
+		   storage/loop.c storage/loop.h \
+		   storage/lvm.c storage/lvm.h \
+		   storage/nbd.c storage/nbd.h \
+		   storage/overlay.c storage/overlay.h \
+		   storage/rbd.c storage/rbd.h \
+		   storage/rsync.c storage/rsync.h \
+		   storage/storage.c storage/storage.h \
+		   storage/storage_utils.c storage/storage_utils.h \
+		   storage/zfs.c storage/zfs.h \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
@@ -728,6 +837,17 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
 		      state.c state.h \
+		      storage/btrfs.c storage/btrfs.h \
+		      storage/dir.c storage/dir.h \
+		      storage/loop.c storage/loop.h \
+		      storage/lvm.c storage/lvm.h \
+		      storage/nbd.c storage/nbd.h \
+		      storage/overlay.c storage/overlay.h \
+		      storage/rbd.c storage/rbd.h \
+		      storage/rsync.c storage/rsync.h \
+		      storage/storage.c storage/storage.h \
+		      storage/storage_utils.c storage/storage_utils.h \
+		      storage/zfs.c storage/zfs.h \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
@@ -766,6 +886,17 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 ringbuf.c ringbuf.h \
 		 start.c start.h \
 		 state.c state.h \
+		 storage/btrfs.c storage/btrfs.h \
+		 storage/dir.c storage/dir.h \
+		 storage/loop.c storage/loop.h \
+		 storage/lvm.c storage/lvm.h \
+		 storage/nbd.c storage/nbd.h \
+		 storage/overlay.c storage/overlay.h \
+		 storage/rbd.c storage/rbd.h \
+		 storage/rsync.c storage/rsync.h \
+		 storage/storage.c storage/storage.h \
+		 storage/storage_utils.c storage/storage_utils.h \
+		 storage/zfs.c storage/zfs.h \
 		 string_utils.c string_utils.h \
 		 sync.c sync.h \
 		 terminal.c terminal.h \
@@ -803,7 +934,17 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   ringbuf.c ringbuf.h \
 		   start.c start.h \
 		   state.c state.h \
+		   storage/btrfs.c storage/btrfs.h \
+		   storage/dir.c storage/dir.h \
+		   storage/loop.c storage/loop.h \
+		   storage/lvm.c storage/lvm.h \
+		   storage/nbd.c storage/nbd.h \
+		   storage/overlay.c storage/overlay.h \
+		   storage/rbd.c storage/rbd.h \
+		   storage/rsync.c storage/rsync.h \
+		   storage/storage.c storage/storage.h \
 		   storage/storage_utils.c storage/storage_utils.h \
+		   storage/zfs.c storage/zfs.h \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
@@ -841,6 +982,17 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    ringbuf.c ringbuf.h \
 		    start.c start.h \
 		    state.c state.h \
+		    storage/btrfs.c storage/btrfs.h \
+		    storage/dir.c storage/dir.h \
+		    storage/loop.c storage/loop.h \
+		    storage/lvm.c storage/lvm.h \
+		    storage/nbd.c storage/nbd.h \
+		    storage/overlay.c storage/overlay.h \
+		    storage/rbd.c storage/rbd.h \
+		    storage/rsync.c storage/rsync.h \
+		    storage/storage.c storage/storage.h \
+		    storage/storage_utils.c storage/storage_utils.h \
+		    storage/zfs.c storage/zfs.h \
 		    string_utils.c string_utils.h \
 		    sync.c sync.h \
 		    terminal.c terminal.h \
@@ -878,6 +1030,17 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   ringbuf.c ringbuf.h \
 		   start.c start.h \
 		   state.c state.h \
+		   storage/btrfs.c storage/btrfs.h \
+		   storage/dir.c storage/dir.h \
+		   storage/loop.c storage/loop.h \
+		   storage/lvm.c storage/lvm.h \
+		   storage/nbd.c storage/nbd.h \
+		   storage/overlay.c storage/overlay.h \
+		   storage/rbd.c storage/rbd.h \
+		   storage/rsync.c storage/rsync.h \
+		   storage/storage.c storage/storage.h \
+		   storage/storage_utils.c storage/storage_utils.h \
+		   storage/zfs.c storage/zfs.h \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
@@ -915,6 +1078,17 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  ringbuf.c ringbuf.h \
 		  start.c start.h \
 		  state.c state.h \
+		  storage/btrfs.c storage/btrfs.h \
+		  storage/dir.c storage/dir.h \
+		  storage/loop.c storage/loop.h \
+		  storage/lvm.c storage/lvm.h \
+		  storage/nbd.c storage/nbd.h \
+		  storage/overlay.c storage/overlay.h \
+		  storage/rbd.c storage/rbd.h \
+		  storage/rsync.c storage/rsync.h \
+		  storage/storage.c storage/storage.h \
+		  storage/storage_utils.c storage/storage_utils.h \
+		  storage/zfs.c storage/zfs.h \
 		  string_utils.c string_utils.h \
 		  sync.c sync.h \
 		  terminal.c terminal.h \
@@ -952,6 +1126,17 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       ringbuf.c ringbuf.h \
 		       start.c start.h \
 		       state.c state.h \
+		       storage/btrfs.c storage/btrfs.h \
+		       storage/dir.c storage/dir.h \
+		       storage/loop.c storage/loop.h \
+		       storage/lvm.c storage/lvm.h \
+		       storage/nbd.c storage/nbd.h \
+		       storage/overlay.c storage/overlay.h \
+		       storage/rbd.c storage/rbd.h \
+		       storage/rsync.c storage/rsync.h \
+		       storage/storage.c storage/storage.h \
+		       storage/storage_utils.c storage/storage_utils.h \
+		       storage/zfs.c storage/zfs.h \
 		       string_utils.c string_utils.h \
 		       sync.c sync.h \
 		       terminal.c terminal.h \
@@ -989,6 +1174,17 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      ringbuf.c ringbuf.h \
 		      start.c start.h \
 		      state.c state.h \
+		      storage/btrfs.c storage/btrfs.h \
+		      storage/dir.c storage/dir.h \
+		      storage/loop.c storage/loop.h \
+		      storage/lvm.c storage/lvm.h \
+		      storage/nbd.c storage/nbd.h \
+		      storage/overlay.c storage/overlay.h \
+		      storage/rbd.c storage/rbd.h \
+		      storage/rsync.c storage/rsync.h \
+		      storage/storage.c storage/storage.h \
+		      storage/storage_utils.c storage/storage_utils.h \
+		      storage/zfs.c storage/zfs.h \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
 		      syscall_numbers.h \
@@ -1028,6 +1224,17 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   ringbuf.c ringbuf.h \
 		   start.c start.h \
 		   state.c state.h \
+		   storage/btrfs.c storage/btrfs.h \
+		   storage/dir.c storage/dir.h \
+		   storage/loop.c storage/loop.h \
+		   storage/lvm.c storage/lvm.h \
+		   storage/nbd.c storage/nbd.h \
+		   storage/overlay.c storage/overlay.h \
+		   storage/rbd.c storage/rbd.h \
+		   storage/rsync.c storage/rsync.h \
+		   storage/storage.c storage/storage.h \
+		   storage/storage_utils.c storage/storage_utils.h \
+		   storage/zfs.c storage/zfs.h \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
@@ -1065,7 +1272,17 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     ringbuf.c ringbuf.h \
 		     start.c start.h \
 		     state.c state.h \
+		     storage/btrfs.c storage/btrfs.h \
+		     storage/dir.c storage/dir.h \
+		     storage/loop.c storage/loop.h \
+		     storage/lvm.c storage/lvm.h \
+		     storage/nbd.c storage/nbd.h \
+		     storage/overlay.c storage/overlay.h \
+		     storage/rbd.c storage/rbd.h \
+		     storage/rsync.c storage/rsync.h \
+		     storage/storage.c storage/storage.h \
 		     storage/storage_utils.c storage/storage_utils.h \
+		     storage/zfs.c storage/zfs.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
@@ -1103,6 +1320,17 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       ringbuf.c ringbuf.h \
 		       start.c start.h \
 		       state.c state.h \
+		       storage/btrfs.c storage/btrfs.h \
+		       storage/dir.c storage/dir.h \
+		       storage/loop.c storage/loop.h \
+		       storage/lvm.c storage/lvm.h \
+		       storage/nbd.c storage/nbd.h \
+		       storage/overlay.c storage/overlay.h \
+		       storage/rbd.c storage/rbd.h \
+		       storage/rsync.c storage/rsync.h \
+		       storage/storage.c storage/storage.h \
+		       storage/storage_utils.c storage/storage_utils.h \
+		       storage/zfs.c storage/zfs.h \
 		       string_utils.c string_utils.h \
 		       sync.c sync.h \
 		       terminal.c terminal.h \
@@ -1140,6 +1368,17 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 ringbuf.c ringbuf.h \
 			 start.c start.h \
 			 state.c state.h \
+			 storage/btrfs.c storage/btrfs.h \
+			 storage/dir.c storage/dir.h \
+			 storage/loop.c storage/loop.h \
+			 storage/lvm.c storage/lvm.h \
+			 storage/nbd.c storage/nbd.h \
+			 storage/overlay.c storage/overlay.h \
+			 storage/rbd.c storage/rbd.h \
+			 storage/rsync.c storage/rsync.h \
+			 storage/storage.c storage/storage.h \
+			 storage/storage_utils.c storage/storage_utils.h \
+			 storage/zfs.c storage/zfs.h \
 			 string_utils.c string_utils.h \
 			 sync.c sync.h \
 			 terminal.c terminal.h \
@@ -1199,6 +1438,17 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       ringbuf.c ringbuf.h \
 		       start.c start.h \
 		       state.c state.h \
+		       storage/btrfs.c storage/btrfs.h \
+		       storage/dir.c storage/dir.h \
+		       storage/loop.c storage/loop.h \
+		       storage/lvm.c storage/lvm.h \
+		       storage/nbd.c storage/nbd.h \
+		       storage/overlay.c storage/overlay.h \
+		       storage/rbd.c storage/rbd.h \
+		       storage/rsync.c storage/rsync.h \
+		       storage/storage.c storage/storage.h \
+		       storage/storage_utils.c storage/storage_utils.h \
+		       storage/zfs.c storage/zfs.h \
 		       string_utils.c string_utils.h \
 		       sync.c sync.h \
 		       syscall_numbers.h \
@@ -1238,6 +1488,17 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       ringbuf.c ringbuf.h \
 		       start.c start.h \
 		       state.c state.h \
+		       storage/btrfs.c storage/btrfs.h \
+		       storage/dir.c storage/dir.h \
+		       storage/loop.c storage/loop.h \
+		       storage/lvm.c storage/lvm.h \
+		       storage/nbd.c storage/nbd.h \
+		       storage/overlay.c storage/overlay.h \
+		       storage/rbd.c storage/rbd.h \
+		       storage/rsync.c storage/rsync.h \
+		       storage/storage.c storage/storage.h \
+		       storage/storage_utils.c storage/storage_utils.h \
+		       storage/zfs.c storage/zfs.h \
 		       string_utils.c string_utils.h \
 		       sync.c sync.h \
 		       syscall_numbers.h \
@@ -1279,6 +1540,17 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 ringbuf.c ringbuf.h \
 			 start.c start.h \
 			 state.c state.h \
+			 storage/btrfs.c storage/btrfs.h \
+			 storage/dir.c storage/dir.h \
+			 storage/loop.c storage/loop.h \
+			 storage/lvm.c storage/lvm.h \
+			 storage/nbd.c storage/nbd.h \
+			 storage/overlay.c storage/overlay.h \
+			 storage/rbd.c storage/rbd.h \
+			 storage/rsync.c storage/rsync.h \
+			 storage/storage.c storage/storage.h \
+			 storage/storage_utils.c storage/storage_utils.h \
+			 storage/zfs.c storage/zfs.h \
 			 string_utils.c string_utils.h \
 			 sync.c sync.h \
 			 syscall_wrappers.h \

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -343,6 +343,7 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
+		     process_utils.c process_utils.h \
 		     rexec.c rexec.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -363,6 +364,7 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			network.c network.h \
 			nl.c nl.h \
 			parse.c parse.h \
+			process_utils.c process_utils.h \
 			string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
@@ -382,6 +384,7 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
+		     process_utils.c process_utils.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
@@ -401,6 +404,7 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
+		     process_utils.c process_utils.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_config_SOURCES += seccomp.c lxcseccomp.h
@@ -420,6 +424,7 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      network.c network.h \
 		      nl.c nl.h \
 		      parse.c parse.h \
+		      process_utils.c process_utils.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_console_SOURCES += seccomp.c lxcseccomp.h
@@ -439,6 +444,7 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      network.c network.h \
 		      nl.c nl.h \
 		      parse.c parse.h \
+		      process_utils.c process_utils.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
@@ -458,6 +464,7 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
+		     process_utils.c process_utils.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_device_SOURCES += seccomp.c lxcseccomp.h
@@ -477,6 +484,7 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      network.c network.h \
 		      nl.c nl.h \
 		      parse.c parse.h \
+		      process_utils.c process_utils.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_execute_SOURCES += seccomp.c lxcseccomp.h
@@ -496,6 +504,7 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
+		     process_utils.c process_utils.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
@@ -515,6 +524,7 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   network.c network.h \
 		   nl.c nl.h \
 		   parse.c parse.h \
+		   process_utils.c process_utils.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_info_SOURCES += seccomp.c lxcseccomp.h
@@ -536,6 +546,7 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      network.c network.h \
 		      nl.c nl.h \
 		      parse.c parse.h \
+		      process_utils.c process_utils.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
@@ -556,6 +567,7 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 network.c network.h \
 		 nl.c nl.h \
 		 parse.c parse.h \
+		 process_utils.c process_utils.h \
 		 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_ls_SOURCES += seccomp.c lxcseccomp.h
@@ -575,6 +587,7 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   network.c network.h \
 		   nl.c nl.h \
 		   parse.c parse.h \
+		   process_utils.c process_utils.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -595,6 +608,7 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    network.c network.h \
 		    nl.c nl.h \
 		    parse.c parse.h \
+		    process_utils.c process_utils.h \
 		    string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_start_SOURCES += seccomp.c lxcseccomp.h
@@ -615,6 +629,7 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   network.c network.h \
 		   nl.c nl.h \
 		   parse.c parse.h \
+		   process_utils.c process_utils.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
@@ -635,6 +650,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  network.c network.h \
 		  nl.c nl.h \
 		  parse.c parse.h \
+		  process_utils.c process_utils.h \
 		  string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h
@@ -654,6 +670,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       network.c network.h \
 		       nl.c nl.h \
 		       parse.c parse.h \
+		       process_utils.c process_utils.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
@@ -673,6 +690,7 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      network.c network.h \
 		      nl.c nl.h \
 		      parse.c parse.h \
+		      process_utils.c process_utils.h \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
@@ -694,6 +712,7 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   network.c network.h \
 		   nl.c nl.h \
 		   parse.c parse.h \
+		   process_utils.c process_utils.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_wait_SOURCES += seccomp.c lxcseccomp.h
@@ -713,6 +732,7 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
+		     process_utils.c process_utils.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -733,6 +753,7 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       network.c network.h \
 		       nl.c nl.h \
 		       parse.c parse.h \
+		       process_utils.c process_utils.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
@@ -752,6 +773,7 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 network.c network.h \
 			 nl.c nl.h \
 			 parse.c parse.h \
+			 process_utils.c process_utils.h \
 			 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
@@ -841,6 +863,7 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 network.c network.h \
 			 nl.c nl.h \
 			 parse.c parse.h \
+			 process_utils.c process_utils.h \
 			 string_utils.c string_utils.h \
 			 syscall_wrappers.h \
 			 utils.c utils.h

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -357,7 +357,8 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
-		     utils.c utils.h
+		     utils.c utils.h \
+		     uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_attach_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -389,7 +390,8 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			string_utils.c string_utils.h \
 			sync.c sync.h \
 			terminal.c terminal.h \
-			utils.c utils.h
+			utils.c utils.h \
+			uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -421,7 +423,8 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
-		     utils.c utils.h
+		     utils.c utils.h \
+		     uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -453,7 +456,8 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
-		     utils.c utils.h
+		     utils.c utils.h \
+		     uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_config_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -485,7 +489,8 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
-		      utils.c utils.h
+		      utils.c utils.h \
+		      uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_console_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -517,7 +522,8 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
-		      utils.c utils.h
+		      utils.c utils.h \
+		      uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -549,7 +555,8 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
-		     utils.c utils.h
+		     utils.c utils.h \
+		     uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_device_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -581,7 +588,8 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
-		      utils.c utils.h
+		      utils.c utils.h \
+		      uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_execute_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -613,7 +621,8 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
-		     utils.c utils.h
+		     utils.c utils.h \
+		     uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -645,7 +654,8 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
-		   utils.c utils.h
+		   utils.c utils.h \
+		   uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_info_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -678,7 +688,8 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
 		      terminal.c terminal.h \
-		      utils.c utils.h
+		      utils.c utils.h \
+		      uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -711,7 +722,8 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 string_utils.c string_utils.h \
 		 sync.c sync.h \
 		 terminal.c terminal.h \
-		 utils.c utils.h
+		 utils.c utils.h \
+		 uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_ls_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -744,7 +756,8 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
-		   utils.c utils.h
+		   utils.c utils.h \
+		   uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_copy_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -776,7 +789,8 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    string_utils.c string_utils.h \
 		    sync.c sync.h \
 		    terminal.c terminal.h \
-		    utils.c utils.h
+		    utils.c utils.h \
+		    uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_start_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -808,7 +822,8 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
-		   utils.c utils.h
+		   utils.c utils.h \
+		   uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -840,7 +855,8 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  string_utils.c string_utils.h \
 		  sync.c sync.h \
 		  terminal.c terminal.h \
-		  utils.c utils.h
+		  utils.c utils.h \
+		  uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -872,7 +888,8 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       string_utils.c string_utils.h \
 		       sync.c sync.h \
 		       terminal.c terminal.h \
-		       utils.c utils.h
+		       utils.c utils.h \
+		       uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -906,7 +923,8 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      syscall_numbers.h \
 		      syscall_wrappers.h \
 		      terminal.c terminal.h \
-		      utils.c utils.h
+		      utils.c utils.h \
+		      uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_unshare_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -938,7 +956,8 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
 		   terminal.c terminal.h \
-		   utils.c utils.h
+		   utils.c utils.h \
+		   uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_wait_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -971,7 +990,8 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
 		     terminal.c terminal.h \
-		     utils.c utils.h
+		     utils.c utils.h \
+		     uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_create_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1003,7 +1023,8 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       string_utils.c string_utils.h \
 		       sync.c sync.h \
 		       terminal.c terminal.h \
-		       utils.c utils.h
+		       utils.c utils.h \
+		       uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1035,7 +1056,8 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 string_utils.c string_utils.h \
 			 sync.c sync.h \
 			 terminal.c terminal.h \
-			 utils.c utils.h
+			 utils.c utils.h \
+			 uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1090,7 +1112,8 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       sync.c sync.h \
 		       syscall_numbers.h \
 		       terminal.c terminal.h \
-		       utils.c utils.h
+		       utils.c utils.h \
+		       uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_monitord_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1125,7 +1148,8 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       syscall_numbers.h \
 		       syscall_wrappers.h \
 		       terminal.c terminal.h \
-		       utils.c utils.h
+		       utils.c utils.h \
+		       uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_user_nic_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1160,7 +1184,8 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 sync.c sync.h \
 			 syscall_wrappers.h \
 			 terminal.c terminal.h \
-			 utils.c utils.h
+			 utils.c utils.h \
+			 uuid.c uuid.h
 if ENABLE_SECCOMP
 lxc_usernsexec_SOURCES += seccomp.c lxcseccomp.h
 endif

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -339,6 +339,7 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     namespace.c namespace.h \
 		     rexec.c rexec.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -355,6 +356,7 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			file_utils.c file_utils.h \
 			initutils.c initutils.h \
 			log.c log.h \
+			namespace.c namespace.h \
 			string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
@@ -370,6 +372,7 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     namespace.c namespace.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
@@ -385,6 +388,7 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     namespace.c namespace.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_config_SOURCES += seccomp.c lxcseccomp.h
@@ -400,6 +404,7 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
+		      namespace.c namespace.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_console_SOURCES += seccomp.c lxcseccomp.h
@@ -415,6 +420,7 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
+		      namespace.c namespace.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
@@ -430,6 +436,7 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     namespace.c namespace.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_device_SOURCES += seccomp.c lxcseccomp.h
@@ -445,6 +452,7 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
+		      namespace.c namespace.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_execute_SOURCES += seccomp.c lxcseccomp.h
@@ -460,6 +468,7 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     namespace.c namespace.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
@@ -475,6 +484,7 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
+		   namespace.c namespace.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_info_SOURCES += seccomp.c lxcseccomp.h
@@ -492,6 +502,7 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      log.c log.h \
 		      macro.h \
 		      monitor.c monitor.h \
+		      namespace.c namespace.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
@@ -508,6 +519,7 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 initutils.c initutils.h \
 		 log.c log.h \
 		 memory_utils.h \
+		 namespace.c namespace.h \
 		 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_ls_SOURCES += seccomp.c lxcseccomp.h
@@ -523,6 +535,7 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
+		   namespace.c namespace.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -539,6 +552,7 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    file_utils.c file_utils.h \
 		    initutils.c initutils.h \
 		    log.c log.h \
+		    namespace.c namespace.h \
 		    string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_start_SOURCES += seccomp.c lxcseccomp.h
@@ -555,6 +569,7 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   initutils.c initutils.h \
 		   log.c log.h \
 		   mainloop.c mainloop.h \
+		   namespace.c namespace.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
@@ -571,6 +586,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  initutils.c initutils.h \
 		  log.c log.h \
 		  mainloop.c mainloop.h \
+		  namespace.c namespace.h \
 		  string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h
@@ -586,6 +602,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       file_utils.c file_utils.h \
 		       initutils.c initutils.h \
 		       log.c log.h \
+		       namespace.c namespace.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
@@ -601,6 +618,7 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
+		      namespace.c namespace.h \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
@@ -618,6 +636,7 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
+		   namespace.c namespace.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_wait_SOURCES += seccomp.c lxcseccomp.h
@@ -633,6 +652,7 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     namespace.c namespace.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -649,6 +669,7 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       file_utils.c file_utils.h \
 		       initutils.c initutils.h \
 		       log.c log.h \
+		       namespace.c namespace.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
@@ -664,6 +685,7 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 file_utils.c file_utils.h \
 			 initutils.c initutils.h \
 			 log.c log.h \
+			 namespace.c namespace.h \
 			 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
@@ -702,6 +724,7 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       log.c log.h \
 		       mainloop.c mainloop.h \
 		       monitor.c monitor.h \
+		       namespace.c namespace.h \
 		       process_utils.c process_utils.h \
 		       string_utils.c string_utils.h \
 		       syscall_numbers.h \
@@ -721,6 +744,7 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       initutils.c initutils.h \
 		       log.c log.h \
 		       memory_utils.h \
+		       namespace.c namespace.h \
 		       network.c network.h \
 		       nl.c nl.h \
 		       parse.c parse.h \
@@ -744,6 +768,7 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 log.c log.h \
 			 macro.h \
 			 memory_utils.h \
+			 namespace.c namespace.h \
 			 string_utils.c string_utils.h \
 			 syscall_wrappers.h \
 			 utils.c utils.h

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -333,18 +333,26 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     commands.c commands.h \
+		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     error.c error.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     lxclock.c lxclock.h \
+		     mainloop.c mainloop.h \
+		     monitor.c monitor.h \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
 		     process_utils.c process_utils.h \
 		     rexec.c rexec.h \
+		     ringbuf.c ringbuf.h \
+		     start.c start.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_attach_SOURCES += seccomp.c lxcseccomp.h
@@ -354,17 +362,25 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			tools/arguments.c tools/arguments.h \
 			af_unix.c af_unix.h \
 			caps.c caps.h \
+			commands.c commands.h \
+			commands_utils.c commands_utils.h \
 			conf.c conf.h \
 			confile.c confile.h \
 			confile_utils.c confile_utils.h \
+			error.c error.h \
 			file_utils.c file_utils.h \
 			initutils.c initutils.h \
 			log.c log.h \
+			lxclock.c lxclock.h \
+			mainloop.c mainloop.h \
+			monitor.c monitor.h \
 			namespace.c namespace.h \
 			network.c network.h \
 			nl.c nl.h \
 			parse.c parse.h \
 			process_utils.c process_utils.h \
+			ringbuf.c ringbuf.h \
+			start.c start.h \
 			string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
@@ -374,17 +390,25 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     commands.c commands.h \
+		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     error.c error.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     lxclock.c lxclock.h \
+		     mainloop.c mainloop.h \
+		     monitor.c monitor.h \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
 		     process_utils.c process_utils.h \
+		     ringbuf.c ringbuf.h \
+		     start.c start.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
@@ -394,17 +418,25 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     commands.c commands.h \
+		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     error.c error.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     lxclock.c lxclock.h \
+		     mainloop.c mainloop.h \
+		     monitor.c monitor.h \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
 		     process_utils.c process_utils.h \
+		     ringbuf.c ringbuf.h \
+		     start.c start.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_config_SOURCES += seccomp.c lxcseccomp.h
@@ -414,17 +446,25 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      commands.c commands.h \
+		      commands_utils.c commands_utils.h \
 		      conf.c conf.h \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
+		      error.c error.h \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
+		      lxclock.c lxclock.h \
+		      mainloop.c mainloop.h \
+		      monitor.c monitor.h \
 		      namespace.c namespace.h \
 		      network.c network.h \
 		      nl.c nl.h \
 		      parse.c parse.h \
 		      process_utils.c process_utils.h \
+		      ringbuf.c ringbuf.h \
+		      start.c start.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_console_SOURCES += seccomp.c lxcseccomp.h
@@ -434,17 +474,25 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      commands.c commands.h \
+		      commands_utils.c commands_utils.h \
 		      conf.c conf.h \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
+		      error.c error.h \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
+		      lxclock.c lxclock.h \
+		      mainloop.c mainloop.h \
+		      monitor.c monitor.h \
 		      namespace.c namespace.h \
 		      network.c network.h \
 		      nl.c nl.h \
 		      parse.c parse.h \
 		      process_utils.c process_utils.h \
+		      ringbuf.c ringbuf.h \
+		      start.c start.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
@@ -454,17 +502,25 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     commands.c commands.h \
+		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     error.c error.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     lxclock.c lxclock.h \
+		     mainloop.c mainloop.h \
+		     monitor.c monitor.h \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
 		     process_utils.c process_utils.h \
+		     ringbuf.c ringbuf.h \
+		     start.c start.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_device_SOURCES += seccomp.c lxcseccomp.h
@@ -474,17 +530,25 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      commands.c commands.h \
+		      commands_utils.c commands_utils.h \
 		      conf.c conf.h \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
+		      error.c error.h \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
+		      lxclock.c lxclock.h \
+		      mainloop.c mainloop.h \
+		      monitor.c monitor.h \
 		      namespace.c namespace.h \
 		      network.c network.h \
 		      nl.c nl.h \
 		      parse.c parse.h \
 		      process_utils.c process_utils.h \
+		      ringbuf.c ringbuf.h \
+		      start.c start.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_execute_SOURCES += seccomp.c lxcseccomp.h
@@ -494,17 +558,25 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     commands.c commands.h \
+		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     error.c error.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     lxclock.c lxclock.h \
+		     mainloop.c mainloop.h \
+		     monitor.c monitor.h \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
 		     process_utils.c process_utils.h \
+		     ringbuf.c ringbuf.h \
+		     start.c start.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
@@ -514,17 +586,25 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   commands.c commands.h \
+		   commands_utils.c commands_utils.h \
 		   conf.c conf.h \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
+		   error.c error.h \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
+		   lxclock.c lxclock.h \
+		   mainloop.c mainloop.h \
+		   monitor.c monitor.h \
 		   namespace.c namespace.h \
 		   network.c network.h \
 		   nl.c nl.h \
 		   parse.c parse.h \
 		   process_utils.c process_utils.h \
+		   ringbuf.c ringbuf.h \
+		   start.c start.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_info_SOURCES += seccomp.c lxcseccomp.h
@@ -534,19 +614,26 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      commands.c commands.h \
+		      commands_utils.c commands_utils.h \
 		      conf.c conf.h \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
+		      error.c error.h \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
+		      lxclock.c lxclock.h \
 		      macro.h \
+		      mainloop.c mainloop.h \
 		      monitor.c monitor.h \
 		      namespace.c namespace.h \
 		      network.c network.h \
 		      nl.c nl.h \
 		      parse.c parse.h \
 		      process_utils.c process_utils.h \
+		      ringbuf.c ringbuf.h \
+		      start.c start.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
@@ -556,18 +643,26 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 tools/arguments.c tools/arguments.h \
 		 af_unix.c af_unix.h \
 		 caps.c caps.h \
+		 commands.c commands.h \
+		 commands_utils.c commands_utils.h \
 		 conf.c conf.h \
 		 confile.c confile.h \
 		 confile_utils.c confile_utils.h \
+		 error.c error.h \
 		 file_utils.c file_utils.h \
 		 initutils.c initutils.h \
 		 log.c log.h \
+		 lxclock.c lxclock.h \
+		 mainloop.c mainloop.h \
 		 memory_utils.h \
+		 monitor.c monitor.h \
 		 namespace.c namespace.h \
 		 network.c network.h \
 		 nl.c nl.h \
 		 parse.c parse.h \
 		 process_utils.c process_utils.h \
+		 ringbuf.c ringbuf.h \
+		 start.c start.h \
 		 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_ls_SOURCES += seccomp.c lxcseccomp.h
@@ -577,17 +672,25 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   commands.c commands.h \
+		   commands_utils.c commands_utils.h \
 		   conf.c conf.h \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
+		   error.c error.h \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
+		   lxclock.c lxclock.h \
+		   mainloop.c mainloop.h \
+		   monitor.c monitor.h \
 		   namespace.c namespace.h \
 		   network.c network.h \
 		   nl.c nl.h \
 		   parse.c parse.h \
 		   process_utils.c process_utils.h \
+		   ringbuf.c ringbuf.h \
+		   start.c start.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -598,17 +701,25 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    tools/arguments.c tools/arguments.h \
 		    af_unix.c af_unix.h \
 		    caps.c caps.h \
+		    commands.c commands.h \
+		    commands_utils.c commands_utils.h \
 		    conf.c conf.h \
 		    confile.c confile.h \
 		    confile_utils.c confile_utils.h \
+		    error.c error.h \
 		    file_utils.c file_utils.h \
 		    initutils.c initutils.h \
 		    log.c log.h \
+		    lxclock.c lxclock.h \
+		    mainloop.c mainloop.h \
+		    monitor.c monitor.h \
 		    namespace.c namespace.h \
 		    network.c network.h \
 		    nl.c nl.h \
 		    parse.c parse.h \
 		    process_utils.c process_utils.h \
+		    ringbuf.c ringbuf.h \
+		    start.c start.h \
 		    string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_start_SOURCES += seccomp.c lxcseccomp.h
@@ -618,18 +729,25 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   commands.c commands.h \
+		   commands_utils.c commands_utils.h \
 		   conf.c conf.h \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
+		   error.c error.h \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
+		   lxclock.c lxclock.h \
 		   mainloop.c mainloop.h \
+		   monitor.c monitor.h \
 		   namespace.c namespace.h \
 		   network.c network.h \
 		   nl.c nl.h \
 		   parse.c parse.h \
 		   process_utils.c process_utils.h \
+		   ringbuf.c ringbuf.h \
+		   start.c start.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
@@ -639,18 +757,25 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  tools/arguments.c tools/arguments.h \
 		  af_unix.c af_unix.h \
 		  caps.c caps.h \
+		  commands.c commands.h \
+		  commands_utils.c commands_utils.h \
 		  conf.c conf.h \
 		  confile.c confile.h \
 		  confile_utils.c confile_utils.h \
+		  error.c error.h \
 		  file_utils.c file_utils.h \
 		  initutils.c initutils.h \
 		  log.c log.h \
+		  lxclock.c lxclock.h \
 		  mainloop.c mainloop.h \
+		  monitor.c monitor.h \
 		  namespace.c namespace.h \
 		  network.c network.h \
 		  nl.c nl.h \
 		  parse.c parse.h \
 		  process_utils.c process_utils.h \
+		  ringbuf.c ringbuf.h \
+		  start.c start.h \
 		  string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h
@@ -660,17 +785,25 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       commands.c commands.h \
+		       commands_utils.c commands_utils.h \
 		       conf.c conf.h \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
+		       error.c error.h \
 		       file_utils.c file_utils.h \
 		       initutils.c initutils.h \
 		       log.c log.h \
+		       lxclock.c lxclock.h \
+		       mainloop.c mainloop.h \
+		       monitor.c monitor.h \
 		       namespace.c namespace.h \
 		       network.c network.h \
 		       nl.c nl.h \
 		       parse.c parse.h \
 		       process_utils.c process_utils.h \
+		       ringbuf.c ringbuf.h \
+		       start.c start.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
@@ -680,17 +813,25 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      commands.c commands.h \
+		      commands_utils.c commands_utils.h \
 		      conf.c conf.h \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
+		      error.c error.h \
 		      file_utils.c file_utils.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
+		      lxclock.c lxclock.h \
+		      mainloop.c mainloop.h \
+		      monitor.c monitor.h \
 		      namespace.c namespace.h \
 		      network.c network.h \
 		      nl.c nl.h \
 		      parse.c parse.h \
 		      process_utils.c process_utils.h \
+		      ringbuf.c ringbuf.h \
+		      start.c start.h \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
@@ -702,17 +843,25 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   commands.c commands.h \
+		   commands_utils.c commands_utils.h \
 		   conf.c conf.h \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
+		   error.c error.h \
 		   file_utils.c file_utils.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
+		   lxclock.c lxclock.h \
+		   mainloop.c mainloop.h \
+		   monitor.c monitor.h \
 		   namespace.c namespace.h \
 		   network.c network.h \
 		   nl.c nl.h \
 		   parse.c parse.h \
 		   process_utils.c process_utils.h \
+		   ringbuf.c ringbuf.h \
+		   start.c start.h \
 		   string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_wait_SOURCES += seccomp.c lxcseccomp.h
@@ -722,17 +871,25 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     commands.c commands.h \
+		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     error.c error.h \
 		     file_utils.c file_utils.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
+		     lxclock.c lxclock.h \
+		     mainloop.c mainloop.h \
+		     monitor.c monitor.h \
 		     namespace.c namespace.h \
 		     network.c network.h \
 		     nl.c nl.h \
 		     parse.c parse.h \
 		     process_utils.c process_utils.h \
+		     ringbuf.c ringbuf.h \
+		     start.c start.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
 if ENABLE_SECCOMP
@@ -743,17 +900,25 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       tools/arguments.c tools/arguments.h \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       commands.c commands.h \
+		       commands_utils.c commands_utils.h \
 		       conf.c conf.h \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
+		       error.c error.h \
 		       file_utils.c file_utils.h \
 		       initutils.c initutils.h \
 		       log.c log.h \
+		       lxclock.c lxclock.h \
+		       mainloop.c mainloop.h \
+		       monitor.c monitor.h \
 		       namespace.c namespace.h \
 		       network.c network.h \
 		       nl.c nl.h \
 		       parse.c parse.h \
 		       process_utils.c process_utils.h \
+		       ringbuf.c ringbuf.h \
+		       start.c start.h \
 		       string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
@@ -763,17 +928,25 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 tools/arguments.c tools/arguments.h \
 			 af_unix.c af_unix.h \
 			 caps.c caps.h \
+			 commands.c commands.h \
+			 commands_utils.c commands_utils.h \
 			 conf.c conf.h \
 			 confile.c confile.h \
 			 confile_utils.c confile_utils.h \
+			 error.c error.h \
 			 file_utils.c file_utils.h \
 			 initutils.c initutils.h \
 			 log.c log.h \
+			 lxclock.c lxclock.h \
+			 mainloop.c mainloop.h \
+			 monitor.c monitor.h \
 			 namespace.c namespace.h \
 			 network.c network.h \
 			 nl.c nl.h \
 			 parse.c parse.h \
 			 process_utils.c process_utils.h \
+			 ringbuf.c ringbuf.h \
+			 start.c start.h \
 			 string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
@@ -793,8 +966,9 @@ init_lxc_SOURCES = cmd/lxc_init.c \
 		   memory_utils.h \
 		   parse.c parse.h \
 		   process_utils.c process_utils.h \
-		   syscall_numbers.h \
-		   string_utils.c string_utils.h
+		   ringbuf.c ringbuf.h \
+		   string_utils.c string_utils.h \
+		   syscall_numbers.h
 if ENABLE_SECCOMP
 init_lxc_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -804,12 +978,16 @@ init_lxc_LDFLAGS = -pthread
 lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       commands.c commands.h \
+		       commands_utils.c commands_utils.h \
 		       conf.c conf.h \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
+		       error.c error.h \
 		       file_utils.c file_utils.h \
 		       initutils.c initutils.h \
 		       log.c log.h \
+		       lxclock.c lxclock.h \
 		       mainloop.c mainloop.h \
 		       monitor.c monitor.h \
 		       namespace.c namespace.h \
@@ -817,6 +995,8 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       nl.c nl.h \
 		       parse.c parse.h \
 		       process_utils.c process_utils.h \
+		       ringbuf.c ringbuf.h \
+		       start.c start.h \
 		       string_utils.c string_utils.h \
 		       syscall_numbers.h \
 		       utils.c utils.h
@@ -828,20 +1008,28 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       commands.c commands.h \
+		       commands_utils.c commands_utils.h \
 		       conf.c conf.h \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
+		       error.c error.h \
 		       file_utils.c file_utils.h \
 		       initutils.c initutils.h \
 		       log.c log.h \
+		       lxclock.c lxclock.h \
+		       mainloop.c mainloop.h \
 		       memory_utils.h \
+		       monitor.c monitor.h \
 		       namespace.c namespace.h \
 		       network.c network.h \
 		       nl.c nl.h \
 		       parse.c parse.h \
 		       process_utils.c process_utils.h \
-		       syscall_numbers.h \
+		       ringbuf.c ringbuf.h \
+		       start.c start.h \
 		       string_utils.c string_utils.h \
+		       syscall_numbers.h \
 		       syscall_wrappers.h
 if ENABLE_SECCOMP
 lxc_user_nic_SOURCES += seccomp.c lxcseccomp.h
@@ -850,20 +1038,28 @@ endif
 lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 af_unix.c af_unix.h \
 			 caps.c caps.h \
+			 commands.c commands.h \
+			 commands_utils.c commands_utils.h \
 			 conf.c conf.h \
 			 confile.c confile.h \
 			 confile_utils.c confile_utils.h \
+			 error.c error.h \
 			 file_utils.c file_utils.h \
 			 initutils.c initutils.h \
 			 list.h \
 			 log.c log.h \
+			 lxclock.c lxclock.h \
 			 macro.h \
+			 mainloop.c mainloop.h \
 			 memory_utils.h \
+			 monitor.c monitor.h \
 			 namespace.c namespace.h \
 			 network.c network.h \
 			 nl.c nl.h \
 			 parse.c parse.h \
 			 process_utils.c process_utils.h \
+			 ringbuf.c ringbuf.h \
+			 start.c start.h \
 			 string_utils.c string_utils.h \
 			 syscall_wrappers.h \
 			 utils.c utils.h

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -518,7 +518,7 @@ if ENABLE_COMMANDS
 # Binaries shipping with liblxc
 init_lxc_SOURCES = cmd/lxc_init.c \
 		   compiler.h \
-		   error.h \
+		   error.c error.h \
 		   initutils.c initutils.h \
 		   memory_utils.h \
 		   parse.c parse.h \

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -491,6 +491,7 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      macro.h \
+		      monitor.c monitor.h \
 		      string_utils.c string_utils.h
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -337,6 +337,7 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
+		     initutils.c initutils.h \
 		     rexec.c rexec.h \
 		     string_utils.c string_utils.h
 lxc_autostart_SOURCES = tools/lxc_autostart.c \
@@ -347,6 +348,7 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			confile.c confile.h \
 			confile_utils.c confile_utils.h \
 			file_utils.c file_utils.h \
+			initutils.c initutils.h \
 			string_utils.c string_utils.h
 lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     tools/arguments.c tools/arguments.h \
@@ -356,6 +358,7 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
+		     initutils.c initutils.h \
 		     string_utils.c string_utils.h
 lxc_config_SOURCES = tools/lxc_config.c \
 		     tools/arguments.c tools/arguments.h \
@@ -365,6 +368,7 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
+		     initutils.c initutils.h \
 		     string_utils.c string_utils.h
 lxc_console_SOURCES = tools/lxc_console.c \
 		      tools/arguments.c tools/arguments.h \
@@ -374,6 +378,7 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
 		      file_utils.c file_utils.h \
+		      initutils.c initutils.h \
 		      string_utils.c string_utils.h
 lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      tools/arguments.c tools/arguments.h \
@@ -383,6 +388,7 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
 		      file_utils.c file_utils.h \
+		      initutils.c initutils.h \
 		      string_utils.c string_utils.h
 lxc_device_SOURCES = tools/lxc_device.c \
 		     tools/arguments.c tools/arguments.h \
@@ -392,6 +398,7 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
+		     initutils.c initutils.h \
 		     string_utils.c string_utils.h
 lxc_execute_SOURCES = tools/lxc_execute.c \
 		      tools/arguments.c tools/arguments.h \
@@ -401,6 +408,7 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
 		      file_utils.c file_utils.h \
+		      initutils.c initutils.h \
 		      string_utils.c string_utils.h
 lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     tools/arguments.c tools/arguments.h \
@@ -410,6 +418,7 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
+		     initutils.c initutils.h \
 		     string_utils.c string_utils.h
 lxc_info_SOURCES = tools/lxc_info.c \
 		   tools/arguments.c tools/arguments.h \
@@ -419,6 +428,7 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
 		   file_utils.c file_utils.h \
+		   initutils.c initutils.h \
 		   string_utils.c string_utils.h
 lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      tools/arguments.c tools/arguments.h \
@@ -428,6 +438,7 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
 		      file_utils.c file_utils.h \
+		      initutils.c initutils.h \
 		      macro.h \
 		      string_utils.c string_utils.h
 lxc_ls_SOURCES = tools/lxc_ls.c \
@@ -438,6 +449,7 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 confile.c confile.h \
 		 confile_utils.c confile_utils.h \
 		 file_utils.c file_utils.h \
+		 initutils.c initutils.h \
 		 memory_utils.h \
 		 string_utils.c string_utils.h
 lxc_copy_SOURCES = tools/lxc_copy.c \
@@ -448,6 +460,7 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
 		   file_utils.c file_utils.h \
+		   initutils.c initutils.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
 lxc_start_SOURCES = tools/lxc_start.c \
@@ -458,6 +471,7 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    confile.c confile.h \
 		    confile_utils.c confile_utils.h \
 		    file_utils.c file_utils.h \
+		    initutils.c initutils.h \
 		    string_utils.c string_utils.h
 lxc_stop_SOURCES = tools/lxc_stop.c \
 		   tools/arguments.c tools/arguments.h \
@@ -467,6 +481,7 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
 		   file_utils.c file_utils.h \
+		   initutils.c initutils.h \
 		   string_utils.c string_utils.h
 lxc_top_SOURCES = tools/lxc_top.c \
 		  tools/arguments.c tools/arguments.h \
@@ -476,6 +491,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  confile.c confile.h \
 		  confile_utils.c confile_utils.h \
 		  file_utils.c file_utils.h \
+		  initutils.c initutils.h \
 		  string_utils.c string_utils.h
 lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h \
@@ -485,6 +501,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
 		       file_utils.c file_utils.h \
+		       initutils.c initutils.h \
 		       string_utils.c string_utils.h
 lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      tools/arguments.c tools/arguments.h \
@@ -494,6 +511,7 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
 		      file_utils.c file_utils.h \
+		      initutils.c initutils.h \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
@@ -505,6 +523,7 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
 		   file_utils.c file_utils.h \
+		   initutils.c initutils.h \
 		   string_utils.c string_utils.h
 lxc_create_SOURCES = tools/lxc_create.c \
 		     tools/arguments.c tools/arguments.h \
@@ -514,6 +533,7 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
 		     file_utils.c file_utils.h \
+		     initutils.c initutils.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
 lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
@@ -524,6 +544,7 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
 		       file_utils.c file_utils.h \
+		       initutils.c initutils.h \
 		       string_utils.c string_utils.h
 lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 tools/arguments.c tools/arguments.h \
@@ -533,6 +554,7 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 confile.c confile.h \
 			 confile_utils.c confile_utils.h \
 			 file_utils.c file_utils.h \
+			 initutils.c initutils.h \
 			 string_utils.c string_utils.h
 endif
 
@@ -541,8 +563,8 @@ if ENABLE_COMMANDS
 init_lxc_SOURCES = cmd/lxc_init.c \
 		   compiler.h \
 		   error.c error.h \
-		   initutils.c initutils.h \
 		   file_utils.c file_utils.h \
+		   initutils.c initutils.h \
 		   memory_utils.h \
 		   parse.c parse.h \
 		   process_utils.c process_utils.h \
@@ -558,6 +580,7 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
 		       file_utils.c file_utils.h \
+		       initutils.c initutils.h \
 		       log.c log.h \
 		       mainloop.c mainloop.h \
 		       monitor.c monitor.h \
@@ -573,6 +596,7 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
 		       file_utils.c file_utils.h \
+		       initutils.c initutils.h \
 		       log.c log.h \
 		       memory_utils.h \
 		       network.c network.h \
@@ -589,6 +613,7 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 confile.c confile.h \
 			 confile_utils.c confile_utils.h \
 			 file_utils.c file_utils.h \
+			 initutils.c initutils.h \
 			 list.h \
 			 log.c log.h \
 			 macro.h \
@@ -613,8 +638,8 @@ init_lxc_static_SOURCES = cmd/lxc_init.c \
 			  af_unix.c af_unix.h \
 			  caps.c caps.h \
 			  error.c error.h \
-			  initutils.c initutils.h \
 			  file_utils.c file_utils.h \
+			  initutils.c initutils.h \
 			  log.c log.h \
 			  macro.h \
 			  memory_utils.h \

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -356,7 +356,8 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     state.c state.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
-		     terminal.c terminal.h
+		     terminal.c terminal.h \
+		     utils.c utils.h
 if ENABLE_SECCOMP
 lxc_attach_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -387,7 +388,8 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			state.c state.h \
 			string_utils.c string_utils.h \
 			sync.c sync.h \
-			terminal.c terminal.h
+			terminal.c terminal.h \
+			utils.c utils.h
 if ENABLE_SECCOMP
 lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -418,7 +420,8 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     state.c state.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
-		     terminal.c terminal.h
+		     terminal.c terminal.h \
+		     utils.c utils.h
 if ENABLE_SECCOMP
 lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -449,7 +452,8 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     state.c state.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
-		     terminal.c terminal.h
+		     terminal.c terminal.h \
+		     utils.c utils.h
 if ENABLE_SECCOMP
 lxc_config_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -480,7 +484,8 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      state.c state.h \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
-		      terminal.c terminal.h
+		      terminal.c terminal.h \
+		      utils.c utils.h
 if ENABLE_SECCOMP
 lxc_console_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -511,7 +516,8 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      state.c state.h \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
-		      terminal.c terminal.h
+		      terminal.c terminal.h \
+		      utils.c utils.h
 if ENABLE_SECCOMP
 lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -542,7 +548,8 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     state.c state.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
-		     terminal.c terminal.h
+		     terminal.c terminal.h \
+		     utils.c utils.h
 if ENABLE_SECCOMP
 lxc_device_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -573,7 +580,8 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      state.c state.h \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
-		      terminal.c terminal.h
+		      terminal.c terminal.h \
+		      utils.c utils.h
 if ENABLE_SECCOMP
 lxc_execute_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -604,7 +612,8 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     state.c state.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
-		     terminal.c terminal.h
+		     terminal.c terminal.h \
+		     utils.c utils.h
 if ENABLE_SECCOMP
 lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -635,7 +644,8 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   state.c state.h \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
-		   terminal.c terminal.h
+		   terminal.c terminal.h \
+		   utils.c utils.h
 if ENABLE_SECCOMP
 lxc_info_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -667,7 +677,8 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      state.c state.h \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
-		      terminal.c terminal.h
+		      terminal.c terminal.h \
+		      utils.c utils.h
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -699,7 +710,8 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 state.c state.h \
 		 string_utils.c string_utils.h \
 		 sync.c sync.h \
-		 terminal.c terminal.h
+		 terminal.c terminal.h \
+		 utils.c utils.h
 if ENABLE_SECCOMP
 lxc_ls_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -731,7 +743,8 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
-		   terminal.c terminal.h
+		   terminal.c terminal.h \
+		   utils.c utils.h
 if ENABLE_SECCOMP
 lxc_copy_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -762,7 +775,8 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    state.c state.h \
 		    string_utils.c string_utils.h \
 		    sync.c sync.h \
-		    terminal.c terminal.h
+		    terminal.c terminal.h \
+		    utils.c utils.h
 if ENABLE_SECCOMP
 lxc_start_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -793,7 +807,8 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   state.c state.h \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
-		   terminal.c terminal.h
+		   terminal.c terminal.h \
+		   utils.c utils.h
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -824,7 +839,8 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  state.c state.h \
 		  string_utils.c string_utils.h \
 		  sync.c sync.h \
-		  terminal.c terminal.h
+		  terminal.c terminal.h \
+		  utils.c utils.h
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -855,7 +871,8 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       state.c state.h \
 		       string_utils.c string_utils.h \
 		       sync.c sync.h \
-		       terminal.c terminal.h
+		       terminal.c terminal.h \
+		       utils.c utils.h
 if ENABLE_SECCOMP
 lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -888,7 +905,8 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      sync.c sync.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h \
-		      terminal.c terminal.h
+		      terminal.c terminal.h \
+		      utils.c utils.h
 if ENABLE_SECCOMP
 lxc_unshare_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -919,7 +937,8 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   state.c state.h \
 		   string_utils.c string_utils.h \
 		   sync.c sync.h \
-		   terminal.c terminal.h
+		   terminal.c terminal.h \
+		   utils.c utils.h
 if ENABLE_SECCOMP
 lxc_wait_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -951,7 +970,8 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h \
 		     sync.c sync.h \
-		     terminal.c terminal.h
+		     terminal.c terminal.h \
+		     utils.c utils.h
 if ENABLE_SECCOMP
 lxc_create_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -982,7 +1002,8 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       state.c state.h \
 		       string_utils.c string_utils.h \
 		       sync.c sync.h \
-		       terminal.c terminal.h
+		       terminal.c terminal.h \
+		       utils.c utils.h
 if ENABLE_SECCOMP
 lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1013,7 +1034,8 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 state.c state.h \
 			 string_utils.c string_utils.h \
 			 sync.c sync.h \
-			 terminal.c terminal.h
+			 terminal.c terminal.h \
+			 utils.c utils.h
 if ENABLE_SECCOMP
 lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1102,7 +1124,8 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       sync.c sync.h \
 		       syscall_numbers.h \
 		       syscall_wrappers.h \
-		       terminal.c terminal.h
+		       terminal.c terminal.h \
+		       utils.c utils.h
 if ENABLE_SECCOMP
 lxc_user_nic_SOURCES += seccomp.c lxcseccomp.h
 endif

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -333,6 +333,9 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgroup.c cgroups/cgroup.h \
+		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		     commands.c commands.h \
 		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
@@ -367,6 +370,9 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			tools/arguments.c tools/arguments.h \
 			af_unix.c af_unix.h \
 			caps.c caps.h \
+			cgroups/cgroup.c cgroups/cgroup.h \
+			cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+			cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 			commands.c commands.h \
 			commands_utils.c commands_utils.h \
 			conf.c conf.h \
@@ -400,6 +406,9 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgroup.c cgroups/cgroup.h \
+		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		     commands.c commands.h \
 		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
@@ -433,6 +442,9 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgroup.c cgroups/cgroup.h \
+		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		     commands.c commands.h \
 		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
@@ -466,6 +478,9 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      cgroups/cgroup.c cgroups/cgroup.h \
+		      cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		      cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		      commands.c commands.h \
 		      commands_utils.c commands_utils.h \
 		      conf.c conf.h \
@@ -499,6 +514,9 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      cgroups/cgroup.c cgroups/cgroup.h \
+		      cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		      cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		      commands.c commands.h \
 		      commands_utils.c commands_utils.h \
 		      conf.c conf.h \
@@ -532,6 +550,9 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgroup.c cgroups/cgroup.h \
+		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		     commands.c commands.h \
 		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
@@ -565,6 +586,9 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      cgroups/cgroup.c cgroups/cgroup.h \
+		      cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		      cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		      commands.c commands.h \
 		      commands_utils.c commands_utils.h \
 		      conf.c conf.h \
@@ -598,6 +622,9 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgroup.c cgroups/cgroup.h \
+		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		     commands.c commands.h \
 		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
@@ -631,6 +658,9 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   cgroups/cgroup.c cgroups/cgroup.h \
+		   cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		   cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		   commands.c commands.h \
 		   commands_utils.c commands_utils.h \
 		   conf.c conf.h \
@@ -664,6 +694,9 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      cgroups/cgroup.c cgroups/cgroup.h \
+		      cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		      cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		      commands.c commands.h \
 		      commands_utils.c commands_utils.h \
 		      conf.c conf.h \
@@ -698,6 +731,9 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 tools/arguments.c tools/arguments.h \
 		 af_unix.c af_unix.h \
 		 caps.c caps.h \
+		 cgroups/cgroup.c cgroups/cgroup.h \
+		 cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		 cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		 commands.c commands.h \
 		 commands_utils.c commands_utils.h \
 		 conf.c conf.h \
@@ -732,6 +768,9 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   cgroups/cgroup.c cgroups/cgroup.h \
+		   cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		   cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		   commands.c commands.h \
 		   commands_utils.c commands_utils.h \
 		   conf.c conf.h \
@@ -766,6 +805,9 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    tools/arguments.c tools/arguments.h \
 		    af_unix.c af_unix.h \
 		    caps.c caps.h \
+		    cgroups/cgroup.c cgroups/cgroup.h \
+		    cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		    cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		    commands.c commands.h \
 		    commands_utils.c commands_utils.h \
 		    conf.c conf.h \
@@ -799,6 +841,9 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   cgroups/cgroup.c cgroups/cgroup.h \
+		   cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		   cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		   commands.c commands.h \
 		   commands_utils.c commands_utils.h \
 		   conf.c conf.h \
@@ -832,6 +877,9 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  tools/arguments.c tools/arguments.h \
 		  af_unix.c af_unix.h \
 		  caps.c caps.h \
+		  cgroups/cgroup.c cgroups/cgroup.h \
+		  cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		  cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		  commands.c commands.h \
 		  commands_utils.c commands_utils.h \
 		  conf.c conf.h \
@@ -865,6 +913,9 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       cgroups/cgroup.c cgroups/cgroup.h \
+		       cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		       cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		       commands.c commands.h \
 		       commands_utils.c commands_utils.h \
 		       conf.c conf.h \
@@ -898,6 +949,9 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      cgroups/cgroup.c cgroups/cgroup.h \
+		      cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		      cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		      commands.c commands.h \
 		      commands_utils.c commands_utils.h \
 		      conf.c conf.h \
@@ -933,6 +987,9 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   cgroups/cgroup.c cgroups/cgroup.h \
+		   cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		   cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		   commands.c commands.h \
 		   commands_utils.c commands_utils.h \
 		   conf.c conf.h \
@@ -966,6 +1023,9 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgroup.c cgroups/cgroup.h \
+		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		     commands.c commands.h \
 		     commands_utils.c commands_utils.h \
 		     conf.c conf.h \
@@ -1000,6 +1060,9 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       tools/arguments.c tools/arguments.h \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       cgroups/cgroup.c cgroups/cgroup.h \
+		       cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		       cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		       commands.c commands.h \
 		       commands_utils.c commands_utils.h \
 		       conf.c conf.h \
@@ -1033,6 +1096,9 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 tools/arguments.c tools/arguments.h \
 			 af_unix.c af_unix.h \
 			 caps.c caps.h \
+			 cgroups/cgroup.c cgroups/cgroup.h \
+			 cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+			 cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 			 commands.c commands.h \
 			 commands_utils.c commands_utils.h \
 			 conf.c conf.h \
@@ -1088,6 +1154,9 @@ init_lxc_LDFLAGS = -pthread
 lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       cgroups/cgroup.c cgroups/cgroup.h \
+		       cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		       cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		       commands.c commands.h \
 		       commands_utils.c commands_utils.h \
 		       conf.c conf.h \
@@ -1122,6 +1191,9 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       cgroups/cgroup.c cgroups/cgroup.h \
+		       cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+		       cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 		       commands.c commands.h \
 		       commands_utils.c commands_utils.h \
 		       conf.c conf.h \
@@ -1157,6 +1229,9 @@ endif
 lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 af_unix.c af_unix.h \
 			 caps.c caps.h \
+			 cgroups/cgroup.c cgroups/cgroup.h \
+			 cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
+			 cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
 			 commands.c commands.h \
 			 commands_utils.c commands_utils.h \
 			 conf.c conf.h \

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -336,6 +336,7 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     file_utils.c file_utils.h \
 		     rexec.c rexec.h \
 		     string_utils.c string_utils.h
 lxc_autostart_SOURCES = tools/lxc_autostart.c \
@@ -345,6 +346,7 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			conf.c conf.h \
 			confile.c confile.h \
 			confile_utils.c confile_utils.h \
+			file_utils.c file_utils.h \
 			string_utils.c string_utils.h
 lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     tools/arguments.c tools/arguments.h \
@@ -353,6 +355,7 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     file_utils.c file_utils.h \
 		     string_utils.c string_utils.h
 lxc_config_SOURCES = tools/lxc_config.c \
 		     tools/arguments.c tools/arguments.h \
@@ -361,6 +364,7 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     file_utils.c file_utils.h \
 		     string_utils.c string_utils.h
 lxc_console_SOURCES = tools/lxc_console.c \
 		      tools/arguments.c tools/arguments.h \
@@ -369,6 +373,7 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      conf.c conf.h \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
+		      file_utils.c file_utils.h \
 		      string_utils.c string_utils.h
 lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      tools/arguments.c tools/arguments.h \
@@ -377,6 +382,7 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      conf.c conf.h \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
+		      file_utils.c file_utils.h \
 		      string_utils.c string_utils.h
 lxc_device_SOURCES = tools/lxc_device.c \
 		     tools/arguments.c tools/arguments.h \
@@ -385,6 +391,7 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     file_utils.c file_utils.h \
 		     string_utils.c string_utils.h
 lxc_execute_SOURCES = tools/lxc_execute.c \
 		      tools/arguments.c tools/arguments.h \
@@ -393,6 +400,7 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      conf.c conf.h \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
+		      file_utils.c file_utils.h \
 		      string_utils.c string_utils.h
 lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     tools/arguments.c tools/arguments.h \
@@ -401,6 +409,7 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     file_utils.c file_utils.h \
 		     string_utils.c string_utils.h
 lxc_info_SOURCES = tools/lxc_info.c \
 		   tools/arguments.c tools/arguments.h \
@@ -409,6 +418,7 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   conf.c conf.h \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
+		   file_utils.c file_utils.h \
 		   string_utils.c string_utils.h
 lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      tools/arguments.c tools/arguments.h \
@@ -417,6 +427,7 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      conf.c conf.h \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
+		      file_utils.c file_utils.h \
 		      macro.h \
 		      string_utils.c string_utils.h
 lxc_ls_SOURCES = tools/lxc_ls.c \
@@ -426,6 +437,7 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 conf.c conf.h \
 		 confile.c confile.h \
 		 confile_utils.c confile_utils.h \
+		 file_utils.c file_utils.h \
 		 memory_utils.h \
 		 string_utils.c string_utils.h
 lxc_copy_SOURCES = tools/lxc_copy.c \
@@ -435,6 +447,7 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   conf.c conf.h \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
+		   file_utils.c file_utils.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
 lxc_start_SOURCES = tools/lxc_start.c \
@@ -444,6 +457,7 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    conf.c conf.h \
 		    confile.c confile.h \
 		    confile_utils.c confile_utils.h \
+		    file_utils.c file_utils.h \
 		    string_utils.c string_utils.h
 lxc_stop_SOURCES = tools/lxc_stop.c \
 		   tools/arguments.c tools/arguments.h \
@@ -452,6 +466,7 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   conf.c conf.h \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
+		   file_utils.c file_utils.h \
 		   string_utils.c string_utils.h
 lxc_top_SOURCES = tools/lxc_top.c \
 		  tools/arguments.c tools/arguments.h \
@@ -460,6 +475,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  conf.c conf.h \
 		  confile.c confile.h \
 		  confile_utils.c confile_utils.h \
+		  file_utils.c file_utils.h \
 		  string_utils.c string_utils.h
 lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h \
@@ -468,6 +484,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       conf.c conf.h \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
+		       file_utils.c file_utils.h \
 		       string_utils.c string_utils.h
 lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      tools/arguments.c tools/arguments.h \
@@ -476,6 +493,7 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      conf.c conf.h \
 		      confile.c confile.h \
 		      confile_utils.c confile_utils.h \
+		      file_utils.c file_utils.h \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
@@ -486,6 +504,7 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   conf.c conf.h \
 		   confile.c confile.h \
 		   confile_utils.c confile_utils.h \
+		   file_utils.c file_utils.h \
 		   string_utils.c string_utils.h
 lxc_create_SOURCES = tools/lxc_create.c \
 		     tools/arguments.c tools/arguments.h \
@@ -494,6 +513,7 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     conf.c conf.h \
 		     confile.c confile.h \
 		     confile_utils.c confile_utils.h \
+		     file_utils.c file_utils.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
 lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
@@ -503,6 +523,7 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       conf.c conf.h \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
+		       file_utils.c file_utils.h \
 		       string_utils.c string_utils.h
 lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 tools/arguments.c tools/arguments.h \
@@ -511,6 +532,7 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 conf.c conf.h \
 			 confile.c confile.h \
 			 confile_utils.c confile_utils.h \
+			 file_utils.c file_utils.h \
 			 string_utils.c string_utils.h
 endif
 
@@ -520,6 +542,7 @@ init_lxc_SOURCES = cmd/lxc_init.c \
 		   compiler.h \
 		   error.c error.h \
 		   initutils.c initutils.h \
+		   file_utils.c file_utils.h \
 		   memory_utils.h \
 		   parse.c parse.h \
 		   process_utils.c process_utils.h \
@@ -534,6 +557,7 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       conf.c conf.h \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
+		       file_utils.c file_utils.h \
 		       log.c log.h \
 		       mainloop.c mainloop.h \
 		       monitor.c monitor.h \
@@ -548,6 +572,7 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       conf.c conf.h \
 		       confile.c confile.h \
 		       confile_utils.c confile_utils.h \
+		       file_utils.c file_utils.h \
 		       log.c log.h \
 		       memory_utils.h \
 		       network.c network.h \
@@ -555,7 +580,6 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       parse.c parse.h \
 		       process_utils.c process_utils.h \
 		       syscall_numbers.h \
-		       file_utils.c file_utils.h \
 		       string_utils.c string_utils.h \
 		       syscall_wrappers.h
 lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -151,7 +151,7 @@ liblxc_la_SOURCES = af_unix.c af_unix.h \
 		    sync.c sync.h \
 		    syscall_numbers.h \
 		    syscall_wrappers.h \
-		    terminal.c \
+		    terminal.c terminal.h \
 		    utils.c utils.h \
 		    uuid.c uuid.h \
 		    version.h \
@@ -355,7 +355,8 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     start.c start.h \
 		     state.c state.h \
 		     string_utils.c string_utils.h \
-		     sync.c sync.h
+		     sync.c sync.h \
+		     terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_attach_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -385,7 +386,8 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			start.c start.h \
 			state.c state.h \
 			string_utils.c string_utils.h \
-			sync.c sync.h
+			sync.c sync.h \
+			terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -415,7 +417,8 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     start.c start.h \
 		     state.c state.h \
 		     string_utils.c string_utils.h \
-		     sync.c sync.h
+		     sync.c sync.h \
+		     terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -445,7 +448,8 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     start.c start.h \
 		     state.c state.h \
 		     string_utils.c string_utils.h \
-		     sync.c sync.h
+		     sync.c sync.h \
+		     terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_config_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -475,7 +479,8 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      start.c start.h \
 		      state.c state.h \
 		      string_utils.c string_utils.h \
-		      sync.c sync.h
+		      sync.c sync.h \
+		      terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_console_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -505,7 +510,8 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      start.c start.h \
 		      state.c state.h \
 		      string_utils.c string_utils.h \
-		      sync.c sync.h
+		      sync.c sync.h \
+		      terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -535,7 +541,8 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     start.c start.h \
 		     state.c state.h \
 		     string_utils.c string_utils.h \
-		     sync.c sync.h
+		     sync.c sync.h \
+		     terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_device_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -565,7 +572,8 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      start.c start.h \
 		      state.c state.h \
 		      string_utils.c string_utils.h \
-		      sync.c sync.h
+		      sync.c sync.h \
+		      terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_execute_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -595,7 +603,8 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     start.c start.h \
 		     state.c state.h \
 		     string_utils.c string_utils.h \
-		     sync.c sync.h
+		     sync.c sync.h \
+		     terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -625,7 +634,8 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   start.c start.h \
 		   state.c state.h \
 		   string_utils.c string_utils.h \
-		   sync.c sync.h
+		   sync.c sync.h \
+		   terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_info_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -656,7 +666,8 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      start.c start.h \
 		      state.c state.h \
 		      string_utils.c string_utils.h \
-		      sync.c sync.h
+		      sync.c sync.h \
+		      terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -687,7 +698,8 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 start.c start.h \
 		 state.c state.h \
 		 string_utils.c string_utils.h \
-		 sync.c sync.h
+		 sync.c sync.h \
+		 terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_ls_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -718,7 +730,8 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   state.c state.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h \
-		   sync.c sync.h
+		   sync.c sync.h \
+		   terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_copy_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -748,7 +761,8 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    start.c start.h \
 		    state.c state.h \
 		    string_utils.c string_utils.h \
-		    sync.c sync.h
+		    sync.c sync.h \
+		    terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_start_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -778,7 +792,8 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   start.c start.h \
 		   state.c state.h \
 		   string_utils.c string_utils.h \
-		   sync.c sync.h
+		   sync.c sync.h \
+		   terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_stop_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -808,7 +823,8 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  start.c start.h \
 		  state.c state.h \
 		  string_utils.c string_utils.h \
-		  sync.c sync.h
+		  sync.c sync.h \
+		  terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_top_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -838,7 +854,8 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       start.c start.h \
 		       state.c state.h \
 		       string_utils.c string_utils.h \
-		       sync.c sync.h
+		       sync.c sync.h \
+		       terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -870,7 +887,8 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      string_utils.c string_utils.h \
 		      sync.c sync.h \
 		      syscall_numbers.h \
-		      syscall_wrappers.h
+		      syscall_wrappers.h \
+		      terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_unshare_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -900,7 +918,8 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   start.c start.h \
 		   state.c state.h \
 		   string_utils.c string_utils.h \
-		   sync.c sync.h
+		   sync.c sync.h \
+		   terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_wait_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -931,7 +950,8 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     state.c state.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h \
-		     sync.c sync.h
+		     sync.c sync.h \
+		     terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_create_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -961,7 +981,8 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       start.c start.h \
 		       state.c state.h \
 		       string_utils.c string_utils.h \
-		       sync.c sync.h
+		       sync.c sync.h \
+		       terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -991,7 +1012,8 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 start.c start.h \
 			 state.c state.h \
 			 string_utils.c string_utils.h \
-			 sync.c sync.h
+			 sync.c sync.h \
+			 terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1045,6 +1067,7 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       string_utils.c string_utils.h \
 		       sync.c sync.h \
 		       syscall_numbers.h \
+		       terminal.c terminal.h \
 		       utils.c utils.h
 if ENABLE_SECCOMP
 lxc_monitord_SOURCES += seccomp.c lxcseccomp.h
@@ -1078,7 +1101,8 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       string_utils.c string_utils.h \
 		       sync.c sync.h \
 		       syscall_numbers.h \
-		       syscall_wrappers.h
+		       syscall_wrappers.h \
+		       terminal.c terminal.h
 if ENABLE_SECCOMP
 lxc_user_nic_SOURCES += seccomp.c lxcseccomp.h
 endif
@@ -1112,6 +1136,7 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 string_utils.c string_utils.h \
 			 sync.c sync.h \
 			 syscall_wrappers.h \
+			 terminal.c terminal.h \
 			 utils.c utils.h
 if ENABLE_SECCOMP
 lxc_usernsexec_SOURCES += seccomp.c lxcseccomp.h

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -332,6 +332,7 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgfsng.c \
 		     cgroups/cgroup.c cgroups/cgroup.h \
 		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -342,6 +343,7 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     confile_utils.c confile_utils.h \
 		     error.c error.h \
 		     file_utils.c file_utils.h \
+		     ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     lxclock.c lxclock.h \
@@ -381,6 +383,7 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			tools/arguments.c tools/arguments.h \
 			af_unix.c af_unix.h \
 			caps.c caps.h \
+			cgroups/cgfsng.c \
 			cgroups/cgroup.c cgroups/cgroup.h \
 			cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 			cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -391,6 +394,7 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			confile_utils.c confile_utils.h \
 			error.c error.h \
 			file_utils.c file_utils.h \
+			../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 			initutils.c initutils.h \
 			log.c log.h \
 			lxclock.c lxclock.h \
@@ -429,6 +433,7 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgfsng.c \
 		     cgroups/cgroup.c cgroups/cgroup.h \
 		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -439,6 +444,7 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     confile_utils.c confile_utils.h \
 		     error.c error.h \
 		     file_utils.c file_utils.h \
+		     ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     lxclock.c lxclock.h \
@@ -477,6 +483,7 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgfsng.c \
 		     cgroups/cgroup.c cgroups/cgroup.h \
 		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -487,6 +494,7 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     confile_utils.c confile_utils.h \
 		     error.c error.h \
 		     file_utils.c file_utils.h \
+		     ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     lxclock.c lxclock.h \
@@ -525,6 +533,7 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      cgroups/cgfsng.c \
 		      cgroups/cgroup.c cgroups/cgroup.h \
 		      cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		      cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -535,6 +544,7 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      confile_utils.c confile_utils.h \
 		      error.c error.h \
 		      file_utils.c file_utils.h \
+		      ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      lxclock.c lxclock.h \
@@ -573,6 +583,7 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      cgroups/cgfsng.c \
 		      cgroups/cgroup.c cgroups/cgroup.h \
 		      cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		      cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -583,6 +594,7 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      confile_utils.c confile_utils.h \
 		      error.c error.h \
 		      file_utils.c file_utils.h \
+		      ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      lxclock.c lxclock.h \
@@ -621,6 +633,7 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgfsng.c \
 		     cgroups/cgroup.c cgroups/cgroup.h \
 		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -631,6 +644,7 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     confile_utils.c confile_utils.h \
 		     error.c error.h \
 		     file_utils.c file_utils.h \
+		     ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     lxclock.c lxclock.h \
@@ -669,6 +683,7 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      cgroups/cgfsng.c \
 		      cgroups/cgroup.c cgroups/cgroup.h \
 		      cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		      cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -679,6 +694,7 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      confile_utils.c confile_utils.h \
 		      error.c error.h \
 		      file_utils.c file_utils.h \
+		      ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      lxclock.c lxclock.h \
@@ -717,6 +733,7 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgfsng.c \
 		     cgroups/cgroup.c cgroups/cgroup.h \
 		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -727,6 +744,7 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     confile_utils.c confile_utils.h \
 		     error.c error.h \
 		     file_utils.c file_utils.h \
+		     ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     lxclock.c lxclock.h \
@@ -765,6 +783,7 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   cgroups/cgfsng.c \
 		   cgroups/cgroup.c cgroups/cgroup.h \
 		   cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		   cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -775,6 +794,7 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   confile_utils.c confile_utils.h \
 		   error.c error.h \
 		   file_utils.c file_utils.h \
+		   ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
 		   lxclock.c lxclock.h \
@@ -813,6 +833,7 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      cgroups/cgfsng.c \
 		      cgroups/cgroup.c cgroups/cgroup.h \
 		      cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		      cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -823,6 +844,7 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      confile_utils.c confile_utils.h \
 		      error.c error.h \
 		      file_utils.c file_utils.h \
+		      ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      lxclock.c lxclock.h \
@@ -862,6 +884,7 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 tools/arguments.c tools/arguments.h \
 		 af_unix.c af_unix.h \
 		 caps.c caps.h \
+		 cgroups/cgfsng.c \
 		 cgroups/cgroup.c cgroups/cgroup.h \
 		 cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		 cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -872,6 +895,7 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 confile_utils.c confile_utils.h \
 		 error.c error.h \
 		 file_utils.c file_utils.h \
+		 ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		 initutils.c initutils.h \
 		 log.c log.h \
 		 lxclock.c lxclock.h \
@@ -911,6 +935,7 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   cgroups/cgfsng.c \
 		   cgroups/cgroup.c cgroups/cgroup.h \
 		   cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		   cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -921,6 +946,7 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   confile_utils.c confile_utils.h \
 		   error.c error.h \
 		   file_utils.c file_utils.h \
+		   ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
 		   lxclock.c lxclock.h \
@@ -959,6 +985,7 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    tools/arguments.c tools/arguments.h \
 		    af_unix.c af_unix.h \
 		    caps.c caps.h \
+		    cgroups/cgfsng.c \
 		    cgroups/cgroup.c cgroups/cgroup.h \
 		    cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		    cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -969,6 +996,7 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    confile_utils.c confile_utils.h \
 		    error.c error.h \
 		    file_utils.c file_utils.h \
+		    ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		    initutils.c initutils.h \
 		    log.c log.h \
 		    lxclock.c lxclock.h \
@@ -1007,6 +1035,7 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   cgroups/cgfsng.c \
 		   cgroups/cgroup.c cgroups/cgroup.h \
 		   cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		   cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -1017,6 +1046,7 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   confile_utils.c confile_utils.h \
 		   error.c error.h \
 		   file_utils.c file_utils.h \
+		   ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
 		   lxclock.c lxclock.h \
@@ -1055,6 +1085,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  tools/arguments.c tools/arguments.h \
 		  af_unix.c af_unix.h \
 		  caps.c caps.h \
+		  cgroups/cgfsng.c \
 		  cgroups/cgroup.c cgroups/cgroup.h \
 		  cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		  cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -1065,6 +1096,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  confile_utils.c confile_utils.h \
 		  error.c error.h \
 		  file_utils.c file_utils.h \
+		  ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		  initutils.c initutils.h \
 		  log.c log.h \
 		  lxclock.c lxclock.h \
@@ -1103,6 +1135,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       cgroups/cgfsng.c \
 		       cgroups/cgroup.c cgroups/cgroup.h \
 		       cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		       cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -1113,6 +1146,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       confile_utils.c confile_utils.h \
 		       error.c error.h \
 		       file_utils.c file_utils.h \
+		       ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		       initutils.c initutils.h \
 		       log.c log.h \
 		       lxclock.c lxclock.h \
@@ -1151,6 +1185,7 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
 		      caps.c caps.h \
+		      cgroups/cgfsng.c \
 		      cgroups/cgroup.c cgroups/cgroup.h \
 		      cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		      cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -1161,6 +1196,7 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      confile_utils.c confile_utils.h \
 		      error.c error.h \
 		      file_utils.c file_utils.h \
+		      ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      lxclock.c lxclock.h \
@@ -1201,6 +1237,7 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
 		   caps.c caps.h \
+		   cgroups/cgfsng.c \
 		   cgroups/cgroup.c cgroups/cgroup.h \
 		   cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		   cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -1211,6 +1248,7 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   confile_utils.c confile_utils.h \
 		   error.c error.h \
 		   file_utils.c file_utils.h \
+		   ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		   initutils.c initutils.h \
 		   log.c log.h \
 		   lxclock.c lxclock.h \
@@ -1249,6 +1287,7 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
 		     caps.c caps.h \
+		     cgroups/cgfsng.c \
 		     cgroups/cgroup.c cgroups/cgroup.h \
 		     cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		     cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -1259,6 +1298,7 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     confile_utils.c confile_utils.h \
 		     error.c error.h \
 		     file_utils.c file_utils.h \
+		     ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     lxclock.c lxclock.h \
@@ -1297,6 +1337,7 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       tools/arguments.c tools/arguments.h \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       cgroups/cgfsng.c \
 		       cgroups/cgroup.c cgroups/cgroup.h \
 		       cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		       cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -1307,6 +1348,7 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       confile_utils.c confile_utils.h \
 		       error.c error.h \
 		       file_utils.c file_utils.h \
+		       ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		       initutils.c initutils.h \
 		       log.c log.h \
 		       lxclock.c lxclock.h \
@@ -1345,6 +1387,7 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 tools/arguments.c tools/arguments.h \
 			 af_unix.c af_unix.h \
 			 caps.c caps.h \
+			 cgroups/cgfsng.c \
 			 cgroups/cgroup.c cgroups/cgroup.h \
 			 cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 			 cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -1355,6 +1398,7 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 confile_utils.c confile_utils.h \
 			 error.c error.h \
 			 file_utils.c file_utils.h \
+			 ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 			 initutils.c initutils.h \
 			 log.c log.h \
 			 lxclock.c lxclock.h \
@@ -1415,6 +1459,7 @@ init_lxc_LDFLAGS = -pthread
 lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       cgroups/cgfsng.c \
 		       cgroups/cgroup.c cgroups/cgroup.h \
 		       cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		       cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -1425,6 +1470,7 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       confile_utils.c confile_utils.h \
 		       error.c error.h \
 		       file_utils.c file_utils.h \
+		       ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		       initutils.c initutils.h \
 		       log.c log.h \
 		       lxclock.c lxclock.h \
@@ -1461,9 +1507,9 @@ lxc_monitord_SOURCES += seccomp.c lxcseccomp.h
 endif
 
 lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
-		       ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		       af_unix.c af_unix.h \
 		       caps.c caps.h \
+		       cgroups/cgfsng.c \
 		       cgroups/cgroup.c cgroups/cgroup.h \
 		       cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 		       cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -1474,6 +1520,7 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       confile_utils.c confile_utils.h \
 		       error.c error.h \
 		       file_utils.c file_utils.h \
+		       ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		       initutils.c initutils.h \
 		       log.c log.h \
 		       lxclock.c lxclock.h \
@@ -1514,6 +1561,7 @@ endif
 lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 af_unix.c af_unix.h \
 			 caps.c caps.h \
+			 cgroups/cgfsng.c \
 			 cgroups/cgroup.c cgroups/cgroup.h \
 			 cgroups/cgroup2_devices.c cgroups/cgroup2_devices.h \
 			 cgroups/cgroup_utils.c cgroups/cgroup_utils.h \
@@ -1524,6 +1572,7 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 confile_utils.c confile_utils.h \
 			 error.c error.h \
 			 file_utils.c file_utils.h \
+			 ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 			 initutils.c initutils.h \
 			 list.h \
 			 log.c log.h \

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -335,6 +335,7 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     caps.c caps.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
+		     confile_utils.c confile_utils.h \
 		     rexec.c rexec.h \
 		     string_utils.c string_utils.h
 lxc_autostart_SOURCES = tools/lxc_autostart.c \
@@ -343,6 +344,7 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			caps.c caps.h \
 			conf.c conf.h \
 			confile.c confile.h \
+			confile_utils.c confile_utils.h \
 			string_utils.c string_utils.h
 lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     tools/arguments.c tools/arguments.h \
@@ -350,6 +352,7 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     caps.c caps.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
+		     confile_utils.c confile_utils.h \
 		     string_utils.c string_utils.h
 lxc_config_SOURCES = tools/lxc_config.c \
 		     tools/arguments.c tools/arguments.h \
@@ -357,6 +360,7 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     caps.c caps.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
+		     confile_utils.c confile_utils.h \
 		     string_utils.c string_utils.h
 lxc_console_SOURCES = tools/lxc_console.c \
 		      tools/arguments.c tools/arguments.h \
@@ -364,6 +368,7 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      caps.c caps.h \
 		      conf.c conf.h \
 		      confile.c confile.h \
+		      confile_utils.c confile_utils.h \
 		      string_utils.c string_utils.h
 lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      tools/arguments.c tools/arguments.h \
@@ -371,6 +376,7 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      caps.c caps.h \
 		      conf.c conf.h \
 		      confile.c confile.h \
+		      confile_utils.c confile_utils.h \
 		      string_utils.c string_utils.h
 lxc_device_SOURCES = tools/lxc_device.c \
 		     tools/arguments.c tools/arguments.h \
@@ -378,6 +384,7 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     caps.c caps.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
+		     confile_utils.c confile_utils.h \
 		     string_utils.c string_utils.h
 lxc_execute_SOURCES = tools/lxc_execute.c \
 		      tools/arguments.c tools/arguments.h \
@@ -385,6 +392,7 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      caps.c caps.h \
 		      conf.c conf.h \
 		      confile.c confile.h \
+		      confile_utils.c confile_utils.h \
 		      string_utils.c string_utils.h
 lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     tools/arguments.c tools/arguments.h \
@@ -392,6 +400,7 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     caps.c caps.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
+		     confile_utils.c confile_utils.h \
 		     string_utils.c string_utils.h
 lxc_info_SOURCES = tools/lxc_info.c \
 		   tools/arguments.c tools/arguments.h \
@@ -399,6 +408,7 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   caps.c caps.h \
 		   conf.c conf.h \
 		   confile.c confile.h \
+		   confile_utils.c confile_utils.h \
 		   string_utils.c string_utils.h
 lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      tools/arguments.c tools/arguments.h \
@@ -406,6 +416,7 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      caps.c caps.h \
 		      conf.c conf.h \
 		      confile.c confile.h \
+		      confile_utils.c confile_utils.h \
 		      macro.h \
 		      string_utils.c string_utils.h
 lxc_ls_SOURCES = tools/lxc_ls.c \
@@ -414,6 +425,7 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 caps.c caps.h \
 		 conf.c conf.h \
 		 confile.c confile.h \
+		 confile_utils.c confile_utils.h \
 		 memory_utils.h \
 		 string_utils.c string_utils.h
 lxc_copy_SOURCES = tools/lxc_copy.c \
@@ -422,6 +434,7 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   caps.c caps.h \
 		   conf.c conf.h \
 		   confile.c confile.h \
+		   confile_utils.c confile_utils.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
 lxc_start_SOURCES = tools/lxc_start.c \
@@ -430,6 +443,7 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    caps.c caps.h \
 		    conf.c conf.h \
 		    confile.c confile.h \
+		    confile_utils.c confile_utils.h \
 		    string_utils.c string_utils.h
 lxc_stop_SOURCES = tools/lxc_stop.c \
 		   tools/arguments.c tools/arguments.h \
@@ -437,6 +451,7 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   caps.c caps.h \
 		   conf.c conf.h \
 		   confile.c confile.h \
+		   confile_utils.c confile_utils.h \
 		   string_utils.c string_utils.h
 lxc_top_SOURCES = tools/lxc_top.c \
 		  tools/arguments.c tools/arguments.h \
@@ -444,6 +459,7 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  caps.c caps.h \
 		  conf.c conf.h \
 		  confile.c confile.h \
+		  confile_utils.c confile_utils.h \
 		  string_utils.c string_utils.h
 lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h \
@@ -451,6 +467,7 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       caps.c caps.h \
 		       conf.c conf.h \
 		       confile.c confile.h \
+		       confile_utils.c confile_utils.h \
 		       string_utils.c string_utils.h
 lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      tools/arguments.c tools/arguments.h \
@@ -458,6 +475,7 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      caps.c caps.h \
 		      conf.c conf.h \
 		      confile.c confile.h \
+		      confile_utils.c confile_utils.h \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
@@ -467,6 +485,7 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   caps.c caps.h \
 		   conf.c conf.h \
 		   confile.c confile.h \
+		   confile_utils.c confile_utils.h \
 		   string_utils.c string_utils.h
 lxc_create_SOURCES = tools/lxc_create.c \
 		     tools/arguments.c tools/arguments.h \
@@ -474,6 +493,7 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     caps.c caps.h \
 		     conf.c conf.h \
 		     confile.c confile.h \
+		     confile_utils.c confile_utils.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
 lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
@@ -482,6 +502,7 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       caps.c caps.h \
 		       conf.c conf.h \
 		       confile.c confile.h \
+		       confile_utils.c confile_utils.h \
 		       string_utils.c string_utils.h
 lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 tools/arguments.c tools/arguments.h \
@@ -489,6 +510,7 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 caps.c caps.h \
 			 conf.c conf.h \
 			 confile.c confile.h \
+			 confile_utils.c confile_utils.h \
 			 string_utils.c string_utils.h
 endif
 
@@ -511,6 +533,7 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       caps.c caps.h \
 		       conf.c conf.h \
 		       confile.c confile.h \
+		       confile_utils.c confile_utils.h \
 		       log.c log.h \
 		       mainloop.c mainloop.h \
 		       monitor.c monitor.h \
@@ -524,6 +547,7 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       caps.c caps.h \
 		       conf.c conf.h \
 		       confile.c confile.h \
+		       confile_utils.c confile_utils.h \
 		       log.c log.h \
 		       memory_utils.h \
 		       network.c network.h \
@@ -539,6 +563,7 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 caps.c caps.h \
 			 conf.c conf.h \
 			 confile.c confile.h \
+			 confile_utils.c confile_utils.h \
 			 file_utils.c file_utils.h \
 			 list.h \
 			 log.c log.h \

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -183,7 +183,7 @@ endif
 endif
 
 if ENABLE_SECCOMP
-liblxc_la_SOURCES += seccomp.c
+liblxc_la_SOURCES += seccomp.c lxcseccomp.h
 endif
 
 if !HAVE_STRLCPY
@@ -341,6 +341,10 @@ lxc_attach_SOURCES = tools/lxc_attach.c \
 		     log.c log.h \
 		     rexec.c rexec.h \
 		     string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_attach_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			tools/arguments.c tools/arguments.h \
 			af_unix.c af_unix.h \
@@ -352,6 +356,10 @@ lxc_autostart_SOURCES = tools/lxc_autostart.c \
 			initutils.c initutils.h \
 			log.c log.h \
 			string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_autostart_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
@@ -363,6 +371,10 @@ lxc_cgroup_SOURCES = tools/lxc_cgroup.c \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_cgroup_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_config_SOURCES = tools/lxc_config.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
@@ -374,6 +386,10 @@ lxc_config_SOURCES = tools/lxc_config.c \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_config_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_console_SOURCES = tools/lxc_console.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
@@ -385,6 +401,10 @@ lxc_console_SOURCES = tools/lxc_console.c \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_console_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
@@ -396,6 +416,10 @@ lxc_destroy_SOURCES = tools/lxc_destroy.c \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_destroy_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_device_SOURCES = tools/lxc_device.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
@@ -407,6 +431,10 @@ lxc_device_SOURCES = tools/lxc_device.c \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_device_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_execute_SOURCES = tools/lxc_execute.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
@@ -418,6 +446,10 @@ lxc_execute_SOURCES = tools/lxc_execute.c \
 		      initutils.c initutils.h \
 		      log.c log.h \
 		      string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_execute_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
@@ -429,6 +461,10 @@ lxc_freeze_SOURCES = tools/lxc_freeze.c \
 		     initutils.c initutils.h \
 		     log.c log.h \
 		     string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_freeze_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_info_SOURCES = tools/lxc_info.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
@@ -440,6 +476,10 @@ lxc_info_SOURCES = tools/lxc_info.c \
 		   initutils.c initutils.h \
 		   log.c log.h \
 		   string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_info_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
@@ -452,6 +492,10 @@ lxc_monitor_SOURCES = tools/lxc_monitor.c \
 		      log.c log.h \
 		      macro.h \
 		      string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_monitor_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_ls_SOURCES = tools/lxc_ls.c \
 		 tools/arguments.c tools/arguments.h \
 		 af_unix.c af_unix.h \
@@ -464,6 +508,10 @@ lxc_ls_SOURCES = tools/lxc_ls.c \
 		 log.c log.h \
 		 memory_utils.h \
 		 string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_ls_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_copy_SOURCES = tools/lxc_copy.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
@@ -476,6 +524,10 @@ lxc_copy_SOURCES = tools/lxc_copy.c \
 		   log.c log.h \
 		   storage/storage_utils.c storage/storage_utils.h \
 		   string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_copy_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_start_SOURCES = tools/lxc_start.c \
 		    tools/arguments.c tools/arguments.h \
 		    af_unix.c af_unix.h \
@@ -487,6 +539,10 @@ lxc_start_SOURCES = tools/lxc_start.c \
 		    initutils.c initutils.h \
 		    log.c log.h \
 		    string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_start_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_stop_SOURCES = tools/lxc_stop.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
@@ -498,6 +554,10 @@ lxc_stop_SOURCES = tools/lxc_stop.c \
 		   initutils.c initutils.h \
 		   log.c log.h \
 		   string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_stop_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_top_SOURCES = tools/lxc_top.c \
 		  tools/arguments.c tools/arguments.h \
 		  af_unix.c af_unix.h \
@@ -509,6 +569,10 @@ lxc_top_SOURCES = tools/lxc_top.c \
 		  initutils.c initutils.h \
 		  log.c log.h \
 		  string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_top_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       tools/arguments.c tools/arguments.h \
 		       af_unix.c af_unix.h \
@@ -520,6 +584,10 @@ lxc_unfreeze_SOURCES = tools/lxc_unfreeze.c \
 		       initutils.c initutils.h \
 		       log.c log.h \
 		       string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_unfreeze_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      tools/arguments.c tools/arguments.h \
 		      af_unix.c af_unix.h \
@@ -533,6 +601,10 @@ lxc_unshare_SOURCES = tools/lxc_unshare.c \
 		      string_utils.c string_utils.h \
 		      syscall_numbers.h \
 		      syscall_wrappers.h
+if ENABLE_SECCOMP
+lxc_unshare_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_wait_SOURCES = tools/lxc_wait.c \
 		   tools/arguments.c tools/arguments.h \
 		   af_unix.c af_unix.h \
@@ -544,6 +616,10 @@ lxc_wait_SOURCES = tools/lxc_wait.c \
 		   initutils.c initutils.h \
 		   log.c log.h \
 		   string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_wait_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_create_SOURCES = tools/lxc_create.c \
 		     tools/arguments.c tools/arguments.h \
 		     af_unix.c af_unix.h \
@@ -556,6 +632,10 @@ lxc_create_SOURCES = tools/lxc_create.c \
 		     log.c log.h \
 		     storage/storage_utils.c storage/storage_utils.h \
 		     string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_create_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       tools/arguments.c tools/arguments.h \
 		       af_unix.c af_unix.h \
@@ -567,6 +647,10 @@ lxc_snapshot_SOURCES = tools/lxc_snapshot.c \
 		       initutils.c initutils.h \
 		       log.c log.h \
 		       string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_snapshot_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 tools/arguments.c tools/arguments.h \
 			 af_unix.c af_unix.h \
@@ -578,6 +662,10 @@ lxc_checkpoint_SOURCES = tools/lxc_checkpoint.c \
 			 initutils.c initutils.h \
 			 log.c log.h \
 			 string_utils.c string_utils.h
+if ENABLE_SECCOMP
+lxc_checkpoint_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 endif
 
 if ENABLE_COMMANDS
@@ -594,6 +682,9 @@ init_lxc_SOURCES = cmd/lxc_init.c \
 		   process_utils.c process_utils.h \
 		   syscall_numbers.h \
 		   string_utils.c string_utils.h
+if ENABLE_SECCOMP
+init_lxc_SOURCES += seccomp.c lxcseccomp.h
+endif
 
 init_lxc_LDFLAGS = -pthread
 
@@ -612,6 +703,10 @@ lxc_monitord_SOURCES = cmd/lxc_monitord.c \
 		       string_utils.c string_utils.h \
 		       syscall_numbers.h \
 		       utils.c utils.h
+if ENABLE_SECCOMP
+lxc_monitord_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 		       af_unix.c af_unix.h \
@@ -630,6 +725,10 @@ lxc_user_nic_SOURCES = cmd/lxc_user_nic.c \
 		       syscall_numbers.h \
 		       string_utils.c string_utils.h \
 		       syscall_wrappers.h
+if ENABLE_SECCOMP
+lxc_user_nic_SOURCES += seccomp.c lxcseccomp.h
+endif
+
 lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 af_unix.c af_unix.h \
 			 caps.c caps.h \
@@ -645,6 +744,9 @@ lxc_usernsexec_SOURCES = cmd/lxc_usernsexec.c \
 			 string_utils.c string_utils.h \
 			 syscall_wrappers.h \
 			 utils.c utils.h
+if ENABLE_SECCOMP
+lxc_usernsexec_SOURCES += seccomp.c lxcseccomp.h
+endif
 endif
 
 

--- a/src/lxc/af_unix.c
+++ b/src/lxc/af_unix.c
@@ -14,6 +14,7 @@
 #include <sys/syscall.h>
 #include <sys/un.h>
 
+#include "af_unix.h"
 #include "config.h"
 #include "log.h"
 #include "macro.h"
@@ -349,7 +350,7 @@ int lxc_unix_connect_type(struct sockaddr_un *addr, int type)
 	return move_fd(fd);
 }
 
-int lxc_unix_connect(struct sockaddr_un *addr, int type)
+int lxc_unix_connect(struct sockaddr_un *addr)
 {
 	return lxc_unix_connect_type(addr, SOCK_STREAM);
 }

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -145,7 +145,7 @@ static void must_append_controller(char **klist, char **nlist, char ***clist,
 /* Given a handler's cgroup data, return the struct hierarchy for the controller
  * @c, or NULL if there is none.
  */
-struct hierarchy *get_hierarchy(struct cgroup_ops *ops, const char *controller)
+static struct hierarchy *get_hierarchy(struct cgroup_ops *ops, const char *controller)
 {
 	if (!ops->hierarchies)
 		return log_trace_errno(NULL, errno, "There are no useable cgroup controllers");
@@ -948,8 +948,7 @@ static void lxc_cgfsng_print_basecg_debuginfo(char *basecginfo, char **klist,
 		TRACE("named subsystem %d: %s", k, *it);
 }
 
-static int cgroup_tree_remove(struct hierarchy **hierarchies,
-			const char *container_cgroup)
+static int cgroup_tree_remove(struct hierarchy **hierarchies, const char *container_cgroup)
 {
 	if (!container_cgroup || !hierarchies)
 		return 0;
@@ -1283,8 +1282,7 @@ static bool check_cgroup_dir_config(struct lxc_conf *conf)
 	return true;
 }
 
-__cgfsng_ops static inline bool cgfsng_monitor_create(struct cgroup_ops *ops,
-						      struct lxc_handler *handler)
+__cgfsng_ops static bool cgfsng_monitor_create(struct cgroup_ops *ops, struct lxc_handler *handler)
 {
 	__do_free char *monitor_cgroup = NULL, *__cgroup_tree = NULL;
 	const char *cgroup_tree;
@@ -1372,8 +1370,7 @@ __cgfsng_ops static inline bool cgfsng_monitor_create(struct cgroup_ops *ops,
  * Try to create the same cgroup in all hierarchies. Start with cgroup_pattern;
  * next cgroup_pattern-1, -2, ..., -999.
  */
-__cgfsng_ops static inline bool cgfsng_payload_create(struct cgroup_ops *ops,
-						      struct lxc_handler *handler)
+__cgfsng_ops static bool cgfsng_payload_create(struct cgroup_ops *ops, struct lxc_handler *handler)
 {
 	__do_free char *container_cgroup = NULL,
 		       *__cgroup_tree = NULL,
@@ -1672,7 +1669,7 @@ __cgfsng_ops static bool cgfsng_chown(struct cgroup_ops *ops,
 	return true;
 }
 
-__cgfsng_ops void cgfsng_payload_finalize(struct cgroup_ops *ops)
+__cgfsng_ops static void cgfsng_payload_finalize(struct cgroup_ops *ops)
 {
 	if (!ops)
 		return;
@@ -2947,8 +2944,7 @@ __cgfsng_ops static bool cgfsng_setup_limits(struct cgroup_ops *ops,
 	return log_info(true, "Limits for the unified cgroup hierarchy have been setup");
 }
 
-__cgfsng_ops bool cgfsng_devices_activate(struct cgroup_ops *ops,
-					  struct lxc_handler *handler)
+__cgfsng_ops static bool cgfsng_devices_activate(struct cgroup_ops *ops, struct lxc_handler *handler)
 {
 #ifdef HAVE_STRUCT_BPF_CGROUP_DEV_CTX
 	__do_bpf_program_free struct bpf_program *devices = NULL;
@@ -3023,7 +3019,7 @@ __cgfsng_ops bool cgfsng_devices_activate(struct cgroup_ops *ops,
 	return true;
 }
 
-bool __cgfsng_delegate_controllers(struct cgroup_ops *ops, const char *cgroup)
+static bool __cgfsng_delegate_controllers(struct cgroup_ops *ops, const char *cgroup)
 {
 	__do_free char *add_controllers = NULL, *base_path = NULL;
 	__do_free_string_list char **parts = NULL;
@@ -3082,7 +3078,7 @@ bool __cgfsng_delegate_controllers(struct cgroup_ops *ops, const char *cgroup)
 	return true;
 }
 
-__cgfsng_ops bool cgfsng_monitor_delegate_controllers(struct cgroup_ops *ops)
+__cgfsng_ops static bool cgfsng_monitor_delegate_controllers(struct cgroup_ops *ops)
 {
 	if (!ops)
 		return ret_set_errno(false, ENOENT);
@@ -3090,7 +3086,7 @@ __cgfsng_ops bool cgfsng_monitor_delegate_controllers(struct cgroup_ops *ops)
 	return __cgfsng_delegate_controllers(ops, ops->monitor_cgroup);
 }
 
-__cgfsng_ops bool cgfsng_payload_delegate_controllers(struct cgroup_ops *ops)
+__cgfsng_ops static bool cgfsng_payload_delegate_controllers(struct cgroup_ops *ops)
 {
 	if (!ops)
 		return ret_set_errno(false, ENOENT);

--- a/src/lxc/cgroups/cgroup.c
+++ b/src/lxc/cgroups/cgroup.c
@@ -10,6 +10,7 @@
 
 #include "cgroup.h"
 #include "cgroup2_devices.h"
+#include "compiler.h"
 #include "conf.h"
 #include "config.h"
 #include "initutils.h"
@@ -18,7 +19,7 @@
 
 lxc_log_define(cgroup, lxc);
 
-extern struct cgroup_ops *cgfsng_ops_init(struct lxc_conf *conf);
+__hidden extern struct cgroup_ops *cgfsng_ops_init(struct lxc_conf *conf);
 
 struct cgroup_ops *cgroup_init(struct lxc_conf *conf)
 {

--- a/src/lxc/cgroups/cgroup.h
+++ b/src/lxc/cgroups/cgroup.h
@@ -7,6 +7,7 @@
 #include <stddef.h>
 #include <sys/types.h>
 
+#include "compiler.h"
 #include "macro.h"
 #include "memory_utils.h"
 
@@ -179,15 +180,15 @@ struct cgroup_ops {
 	const char *(*get_limiting_cgroup)(struct cgroup_ops *ops, const char *controller);
 };
 
-extern struct cgroup_ops *cgroup_init(struct lxc_conf *conf);
+__hidden extern struct cgroup_ops *cgroup_init(struct lxc_conf *conf);
 
-extern void cgroup_exit(struct cgroup_ops *ops);
+__hidden extern void cgroup_exit(struct cgroup_ops *ops);
 define_cleanup_function(struct cgroup_ops *, cgroup_exit);
 
-extern void prune_init_scope(char *cg);
+__hidden extern void prune_init_scope(char *cg);
 
-extern int cgroup_attach(const struct lxc_conf *conf, const char *name,
-			 const char *lxcpath, pid_t pid);
+__hidden extern int cgroup_attach(const struct lxc_conf *conf, const char *name,
+				  const char *lxcpath, pid_t pid);
 
 static inline bool pure_unified_layout(const struct cgroup_ops *ops)
 {
@@ -202,4 +203,4 @@ static inline int cgroup_unified_fd(const struct cgroup_ops *ops)
 	return ops->unified->cgfd_con;
 }
 
-#endif
+#endif /* __LXC_CGROUP_H */

--- a/src/lxc/cgroups/cgroup2_devices.h
+++ b/src/lxc/cgroups/cgroup2_devices.h
@@ -15,6 +15,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "compiler.h"
 #include "conf.h"
 #include "config.h"
 #include "syscall_numbers.h"
@@ -52,17 +53,17 @@ struct bpf_program {
 };
 
 #ifdef HAVE_STRUCT_BPF_CGROUP_DEV_CTX
-struct bpf_program *bpf_program_new(uint32_t prog_type);
-int bpf_program_init(struct bpf_program *prog);
-int bpf_program_append_device(struct bpf_program *prog,
-			      struct device_item *device);
-int bpf_program_finalize(struct bpf_program *prog);
-int bpf_program_cgroup_attach(struct bpf_program *prog, int type,
-			      const char *path, uint32_t flags);
-int bpf_program_cgroup_detach(struct bpf_program *prog);
-void bpf_program_free(struct bpf_program *prog);
-void lxc_clear_cgroup2_devices(struct lxc_conf *conf);
-bool bpf_devices_cgroup_supported(void);
+__hidden extern struct bpf_program *bpf_program_new(uint32_t prog_type);
+__hidden extern int bpf_program_init(struct bpf_program *prog);
+__hidden extern int bpf_program_append_device(struct bpf_program *prog, struct device_item *device);
+__hidden extern int bpf_program_finalize(struct bpf_program *prog);
+__hidden extern int bpf_program_cgroup_attach(struct bpf_program *prog, int type, const char *path,
+					      uint32_t flags);
+__hidden extern int bpf_program_cgroup_detach(struct bpf_program *prog);
+__hidden extern void bpf_program_free(struct bpf_program *prog);
+__hidden extern void lxc_clear_cgroup2_devices(struct lxc_conf *conf);
+__hidden extern bool bpf_devices_cgroup_supported(void);
+
 static inline void __auto_bpf_program_free__(struct bpf_program **prog)
 {
 	if (*prog) {
@@ -70,8 +71,11 @@ static inline void __auto_bpf_program_free__(struct bpf_program **prog)
 		*prog = NULL;
 	}
 }
-int bpf_list_add_device(struct lxc_conf *conf, struct device_item *device);
+
+__hidden extern int bpf_list_add_device(struct lxc_conf *conf, struct device_item *device);
+
 #else /* !HAVE_STRUCT_BPF_CGROUP_DEV_CTX */
+
 static inline struct bpf_program *bpf_program_new(uint32_t prog_type)
 {
 	errno = ENOSYS;

--- a/src/lxc/cgroups/cgroup_utils.h
+++ b/src/lxc/cgroups/cgroup_utils.h
@@ -6,26 +6,28 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#include "compiler.h"
+
 /* Retrieve the cgroup version of a given entry from /proc/<pid>/mountinfo. */
-extern int get_cgroup_version(char *line);
+__hidden extern int get_cgroup_version(char *line);
 
 /* Check if given entry from /proc/<pid>/mountinfo is a cgroupfs v1 mount. */
-extern bool is_cgroupfs_v1(char *line);
+__hidden extern bool is_cgroupfs_v1(char *line);
 
 /* Check if given entry from /proc/<pid>/mountinfo is a cgroupfs v2 mount. */
-extern bool is_cgroupfs_v2(char *line);
+__hidden extern bool is_cgroupfs_v2(char *line);
 
 /* Given a v1 hierarchy @mountpoint and base @path, verify that we can create
  * directories underneath it.
  */
-extern bool test_writeable_v1(char *mountpoint, char *path);
+__hidden extern bool test_writeable_v1(char *mountpoint, char *path);
 
 /* Given a v2 hierarchy @mountpoint and base @path, verify that we can create
  * directories underneath it and that we have write access to the cgroup's
  * "cgroup.procs" file.
  */
-extern bool test_writeable_v2(char *mountpoint, char *path);
+__hidden extern bool test_writeable_v2(char *mountpoint, char *path);
 
-extern int unified_cgroup_hierarchy(void);
+__hidden extern int unified_cgroup_hierarchy(void);
 
 #endif /* __LXC_CGROUP_UTILS_H */

--- a/src/lxc/cmd/lxc_usernsexec.c
+++ b/src/lxc/cmd/lxc_usernsexec.c
@@ -20,6 +20,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include "compiler.h"
 #include "conf.h"
 #include "config.h"
 #include "list.h"
@@ -31,7 +32,7 @@
 #include "syscall_wrappers.h"
 #include "utils.h"
 
-extern int lxc_log_fd;
+__hidden extern int lxc_log_fd;
 
 static void usage(const char *name)
 {

--- a/src/lxc/compiler.h
+++ b/src/lxc/compiler.h
@@ -79,4 +79,8 @@
 #define __hidden __attribute__((visibility("hidden")))
 #endif
 
+#ifndef __public
+#define __public __attribute__((visibility("default")))
+#endif
+
 #endif /* __LXC_COMPILER_H */

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -903,7 +903,7 @@ static int lxc_setup_ttys(struct lxc_conf *conf)
 
 define_cleanup_function(struct lxc_tty_info *, lxc_delete_tty);
 
-int lxc_allocate_ttys(struct lxc_conf *conf)
+static int lxc_allocate_ttys(struct lxc_conf *conf)
 {
 	struct lxc_terminal_info *tty_new = NULL;
 	int ret;
@@ -1262,7 +1262,7 @@ static int lxc_mount_rootfs(struct lxc_conf *conf)
 	return 0;
 }
 
-int lxc_chroot(const struct lxc_rootfs *rootfs)
+static int lxc_chroot(const struct lxc_rootfs *rootfs)
 {
 	__do_free char *nroot = NULL;
 	int i, ret;
@@ -2702,7 +2702,7 @@ static int idmaptool_on_path_and_privileged(const char *binary, cap_value_t cap)
 	return 1;
 }
 
-int lxc_map_ids_exec_wrapper(void *args)
+static int lxc_map_ids_exec_wrapper(void *args)
 {
 	execl("/bin/sh", "sh", "-c", (char *)args, (char *)NULL);
 	return -1;
@@ -2898,7 +2898,7 @@ again:
 }
 
 /* NOTE: Must not be called from inside the container namespace! */
-int lxc_create_tmp_proc_mount(struct lxc_conf *conf)
+static int lxc_create_tmp_proc_mount(struct lxc_conf *conf)
 {
 	int mounted;
 

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -206,7 +206,7 @@ enum lxchooks {
 	NUM_LXC_HOOKS
 };
 
-extern char *lxchook_names[NUM_LXC_HOOKS];
+__hidden extern char *lxchook_names[NUM_LXC_HOOKS];
 
 struct lxc_state_client {
 	int clientfd;

--- a/src/lxc/confile.h
+++ b/src/lxc/confile.h
@@ -45,66 +45,61 @@ struct new_config_item {
 };
 
 /* Get the jump table entry for the given configuration key. */
-extern struct lxc_config_t *lxc_get_config(const char *key);
+__hidden extern struct lxc_config_t *lxc_get_config(const char *key);
 
 /* List all available config items. */
-extern int lxc_list_config_items(char *retv, int inlen)
+__hidden extern int lxc_list_config_items(char *retv, int inlen)
 __access_rw(1, 2);
 
 /* Given a configuration key namespace (e.g. lxc.apparmor) list all associated
  * subkeys for that namespace.
  * Must be implemented when adding a new configuration key.
  */
-extern int lxc_list_subkeys(struct lxc_conf *conf, const char *key, char *retv,
-			    int inlen)
-__access_rw(3, 4);
+__hidden extern int lxc_list_subkeys(struct lxc_conf *conf, const char *key, char *retv, int inlen)
+    __access_rw(3, 4);
 
 /* List all configuration items associated with a given network. For example
  * pass "lxc.net.[i]" to retrieve all configuration items associated with
  * the network associated with index [i].
  */
-extern int lxc_list_net(struct lxc_conf *c, const char *key, char *retv,
-			int inlen)
-__access_rw(3, 4);
+__hidden extern int lxc_list_net(struct lxc_conf *c, const char *key, char *retv, int inlen)
+    __access_rw(3, 4);
 
-extern int lxc_config_read(const char *file, struct lxc_conf *conf,
-			   bool from_include);
+__hidden extern int lxc_config_read(const char *file, struct lxc_conf *conf, bool from_include);
 
-extern int append_unexp_config_line(const char *line, struct lxc_conf *conf);
+__hidden extern int append_unexp_config_line(const char *line, struct lxc_conf *conf);
 
-extern int lxc_config_define_add(struct lxc_list *defines, char* arg);
+__hidden extern int lxc_config_define_add(struct lxc_list *defines, char *arg);
 
-extern bool lxc_config_define_load(struct lxc_list *defines,
-				   struct lxc_container *c);
+__hidden extern bool lxc_config_define_load(struct lxc_list *defines, struct lxc_container *c);
 
-extern void lxc_config_define_free(struct lxc_list *defines);
+__hidden extern void lxc_config_define_free(struct lxc_list *defines);
 
 /* needed for lxc-attach */
-extern signed long lxc_config_parse_arch(const char *arch);
+__hidden extern signed long lxc_config_parse_arch(const char *arch);
 
-extern int lxc_fill_elevated_privileges(char *flaglist, int *flags);
+__hidden extern int lxc_fill_elevated_privileges(char *flaglist, int *flags);
 
-extern int lxc_clear_config_item(struct lxc_conf *c, const char *key);
+__hidden extern int lxc_clear_config_item(struct lxc_conf *c, const char *key);
 
-extern int write_config(int fd, const struct lxc_conf *conf);
+__hidden extern int write_config(int fd, const struct lxc_conf *conf);
 
-extern bool do_append_unexp_config_line(struct lxc_conf *conf, const char *key,
-					const char *v);
+__hidden extern bool do_append_unexp_config_line(struct lxc_conf *conf, const char *key,
+						 const char *v);
 
 /* These are used when cloning a container */
-extern void clear_unexp_config_line(struct lxc_conf *conf, const char *key,
-				    bool rm_subkeys);
+__hidden extern void clear_unexp_config_line(struct lxc_conf *conf, const char *key, bool rm_subkeys);
 
-extern bool clone_update_unexp_hooks(struct lxc_conf *conf, const char *oldpath,
-				     const char *newpath, const char *oldname,
-				     const char *newmame);
+__hidden extern bool clone_update_unexp_hooks(struct lxc_conf *conf, const char *oldpath,
+					      const char *newpath, const char *oldname,
+					      const char *newmame);
 
-bool clone_update_unexp_ovl_paths(struct lxc_conf *conf, const char *oldpath,
-				  const char *newpath, const char *oldname,
-				  const char *newname, const char *ovldir);
+__hidden extern bool clone_update_unexp_ovl_paths(struct lxc_conf *conf, const char *oldpath,
+						  const char *newpath, const char *oldname,
+						  const char *newname, const char *ovldir);
 
-extern bool network_new_hwaddrs(struct lxc_conf *conf);
+__hidden extern bool network_new_hwaddrs(struct lxc_conf *conf);
 
-extern int add_elem_to_mount_list(const char *value, struct lxc_conf *lxc_conf);
+__hidden extern int add_elem_to_mount_list(const char *value, struct lxc_conf *lxc_conf);
 
 #endif /* __LXC_CONFILE_H */

--- a/src/lxc/confile_utils.h
+++ b/src/lxc/confile_utils.h
@@ -29,48 +29,44 @@
 		}                                                       \
 	} while (0);
 
-extern int parse_idmaps(const char *idmap, char *type, unsigned long *nsid,
-			unsigned long *hostid, unsigned long *range);
+__hidden extern int parse_idmaps(const char *idmap, char *type, unsigned long *nsid,
+				 unsigned long *hostid, unsigned long *range);
 
-extern bool lxc_config_value_empty(const char *value);
-extern struct lxc_netdev *lxc_network_add(struct lxc_list *networks, int idx,
-					  bool tail);
-extern struct lxc_netdev *
-lxc_get_netdev_by_idx(struct lxc_conf *conf, unsigned int idx, bool allocate);
-extern void lxc_log_configured_netdevs(const struct lxc_conf *conf);
-extern bool lxc_remove_nic_by_idx(struct lxc_conf *conf, unsigned int idx);
-extern void lxc_free_networks(struct lxc_list *networks);
-extern int lxc_veth_mode_to_flag(int *mode, const char *value);
-extern char *lxc_veth_flag_to_mode(int mode);
-extern int lxc_macvlan_mode_to_flag(int *mode, const char *value);
-extern char *lxc_macvlan_flag_to_mode(int mode);
-extern int lxc_ipvlan_mode_to_flag(int *mode, const char *value);
-extern char *lxc_ipvlan_flag_to_mode(int mode);
-extern int lxc_ipvlan_isolation_to_flag(int *mode, const char *value);
-extern char *lxc_ipvlan_flag_to_isolation(int mode);
+__hidden extern bool lxc_config_value_empty(const char *value);
+__hidden extern struct lxc_netdev *lxc_network_add(struct lxc_list *networks, int idx, bool tail);
+__hidden extern struct lxc_netdev *lxc_get_netdev_by_idx(struct lxc_conf *conf, unsigned int idx,
+							 bool allocate);
+__hidden extern void lxc_log_configured_netdevs(const struct lxc_conf *conf);
+__hidden extern bool lxc_remove_nic_by_idx(struct lxc_conf *conf, unsigned int idx);
+__hidden extern void lxc_free_networks(struct lxc_list *networks);
+__hidden extern int lxc_veth_mode_to_flag(int *mode, const char *value);
+__hidden extern char *lxc_veth_flag_to_mode(int mode);
+__hidden extern int lxc_macvlan_mode_to_flag(int *mode, const char *value);
+__hidden extern char *lxc_macvlan_flag_to_mode(int mode);
+__hidden extern int lxc_ipvlan_mode_to_flag(int *mode, const char *value);
+__hidden extern char *lxc_ipvlan_flag_to_mode(int mode);
+__hidden extern int lxc_ipvlan_isolation_to_flag(int *mode, const char *value);
+__hidden extern char *lxc_ipvlan_flag_to_isolation(int mode);
 
-extern int set_config_string_item(char **conf_item, const char *value);
-extern int set_config_string_item_max(char **conf_item, const char *value,
-				      size_t max)
-__access_r(2, 3);
+__hidden extern int set_config_string_item(char **conf_item, const char *value);
+__hidden extern int set_config_string_item_max(char **conf_item, const char *value, size_t max)
+    __access_r(2, 3);
 
-extern int set_config_path_item(char **conf_item, const char *value);
-extern int set_config_bool_item(bool *conf_item, const char *value,
-                                bool empty_conf_action);
-extern int config_ip_prefix(struct in_addr *addr);
-extern int network_ifname(char *valuep, const char *value, size_t size)
-__access_r(2, 3);
+__hidden extern int set_config_path_item(char **conf_item, const char *value);
+__hidden extern int set_config_bool_item(bool *conf_item, const char *value, bool empty_conf_action);
+__hidden extern int config_ip_prefix(struct in_addr *addr);
+__hidden extern int network_ifname(char *valuep, const char *value, size_t size) __access_r(2, 3);
 
-extern void rand_complete_hwaddr(char *hwaddr);
-extern bool lxc_config_net_is_hwaddr(const char *line);
-extern bool new_hwaddr(char *hwaddr);
-extern int lxc_get_conf_str(char *retv, int inlen, const char *value);
-extern int lxc_get_conf_bool(struct lxc_conf *c, char *retv, int inlen, bool v);
-extern int lxc_get_conf_int(struct lxc_conf *c, char *retv, int inlen, int v);
-extern int lxc_get_conf_size_t(struct lxc_conf *c, char *retv, int inlen, size_t v);
-extern int lxc_get_conf_uint64(struct lxc_conf *c, char *retv, int inlen, uint64_t v);
-extern int lxc_inherit_namespace(const char *lxcname_or_pid,
-				 const char *lxcpath, const char *namespace);
-extern int sig_parse(const char *signame);
+__hidden extern void rand_complete_hwaddr(char *hwaddr);
+__hidden extern bool lxc_config_net_is_hwaddr(const char *line);
+__hidden extern bool new_hwaddr(char *hwaddr);
+__hidden extern int lxc_get_conf_str(char *retv, int inlen, const char *value);
+__hidden extern int lxc_get_conf_bool(struct lxc_conf *c, char *retv, int inlen, bool v);
+__hidden extern int lxc_get_conf_int(struct lxc_conf *c, char *retv, int inlen, int v);
+__hidden extern int lxc_get_conf_size_t(struct lxc_conf *c, char *retv, int inlen, size_t v);
+__hidden extern int lxc_get_conf_uint64(struct lxc_conf *c, char *retv, int inlen, uint64_t v);
+__hidden extern int lxc_inherit_namespace(const char *lxcname_or_pid, const char *lxcpath,
+					  const char *namespace);
+__hidden extern int sig_parse(const char *signame);
 
 #endif /* __LXC_CONFILE_UTILS_H */

--- a/src/lxc/criu.h
+++ b/src/lxc/criu.h
@@ -7,9 +7,9 @@
 
 #include <lxc/lxccontainer.h>
 
-extern bool __criu_pre_dump(struct lxc_container *c, struct migrate_opts *opts);
-extern bool __criu_dump(struct lxc_container *c, struct migrate_opts *opts);
-extern bool __criu_restore(struct lxc_container *c, struct migrate_opts *opts);
-extern bool __criu_check_feature(uint64_t *features_to_check);
+__hidden extern bool __criu_pre_dump(struct lxc_container *c, struct migrate_opts *opts);
+__hidden extern bool __criu_dump(struct lxc_container *c, struct migrate_opts *opts);
+__hidden extern bool __criu_restore(struct lxc_container *c, struct migrate_opts *opts);
+__hidden extern bool __criu_check_feature(uint64_t *features_to_check);
 
 #endif

--- a/src/lxc/error.c
+++ b/src/lxc/error.c
@@ -18,7 +18,7 @@ lxc_log_define(error, lxc);
  *   128+n       signal n received by the application
  *   255         lxc error
  */
-extern int lxc_error_set_and_log(int pid, int status)
+int lxc_error_set_and_log(int pid, int status)
 {
 	int ret = 0;
 

--- a/src/lxc/error.h
+++ b/src/lxc/error.h
@@ -6,6 +6,8 @@
 #define LXC_CLONE_ERROR "Failed to clone a new set of namespaces"
 #define LXC_UNPRIV_EOPNOTSUPP "the requested function %s is not currently supported with unprivileged containers"
 
-extern int  lxc_error_set_and_log(int pid, int status);
+#include "compiler.h"
+
+__hidden extern int lxc_error_set_and_log(int pid, int status);
 
 #endif

--- a/src/lxc/file_utils.c
+++ b/src/lxc/file_utils.c
@@ -8,16 +8,16 @@
 #include <linux/magic.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/stat.h>
 #include <sys/sendfile.h>
+#include <sys/stat.h>
 #include <sys/types.h>
+#include <time.h>
 
 #include "config.h"
 #include "file_utils.h"
 #include "macro.h"
 #include "memory_utils.h"
 #include "string_utils.h"
-#include <time.h>
 #include "utils.h"
 
 int lxc_open_dirfd(const char *dir)

--- a/src/lxc/file_utils.h
+++ b/src/lxc/file_utils.h
@@ -15,73 +15,63 @@
 #include "compiler.h"
 
 /* read and write whole files */
-extern int lxc_write_to_file(const char *filename, const void *buf,
-			     size_t count, bool add_newline, mode_t mode)
-__access_r(2, 3);
+__hidden extern int lxc_write_to_file(const char *filename, const void *buf, size_t count,
+				      bool add_newline, mode_t mode) __access_r(2, 3);
 
-extern int lxc_readat(int dirfd, const char *filename, void *buf, size_t count)
-__access_w(3, 4);
+__hidden extern int lxc_readat(int dirfd, const char *filename, void *buf, size_t count)
+    __access_w(3, 4);
 
-extern int lxc_writeat(int dirfd, const char *filename, const void *buf,
-		       size_t count)
-__access_r(3, 4);
+__hidden extern int lxc_writeat(int dirfd, const char *filename, const void *buf, size_t count)
+    __access_r(3, 4);
 
-extern int lxc_write_openat(const char *dir, const char *filename,
-			    const void *buf, size_t count)
-__access_r(3, 4);
+__hidden extern int lxc_write_openat(const char *dir, const char *filename, const void *buf,
+				     size_t count) __access_r(3, 4);
 
-extern int lxc_read_from_file(const char *filename, void *buf, size_t count)
-__access_w(2, 3);
+__hidden extern int lxc_read_from_file(const char *filename, void *buf, size_t count)
+    __access_w(2, 3);
 
 /* send and receive buffers completely */
-extern ssize_t lxc_write_nointr(int fd, const void *buf, size_t count)
-__access_r(2, 3);
+__hidden extern ssize_t lxc_write_nointr(int fd, const void *buf, size_t count) __access_r(2, 3);
 
-extern ssize_t lxc_pwrite_nointr(int fd, const void *buf, size_t count,
-				 off_t offset)
-__access_r(2, 3);
+__hidden extern ssize_t lxc_pwrite_nointr(int fd, const void *buf, size_t count, off_t offset)
+    __access_r(2, 3);
 
-extern ssize_t lxc_send_nointr(int sockfd, void *buf, size_t len, int flags)
-__access_r(2, 3);
+__hidden extern ssize_t lxc_send_nointr(int sockfd, void *buf, size_t len, int flags)
+    __access_r(2, 3);
 
-extern ssize_t lxc_read_nointr(int fd, void *buf, size_t count)
-__access_w(2, 3);
+__hidden extern ssize_t lxc_read_nointr(int fd, void *buf, size_t count) __access_w(2, 3);
 
-extern ssize_t lxc_read_nointr_expect(int fd, void *buf, size_t count,
-				      const void *expected_buf)
-__access_w(2, 3);
+__hidden extern ssize_t lxc_read_nointr_expect(int fd, void *buf, size_t count,
+					       const void *expected_buf) __access_w(2, 3);
 
-extern ssize_t lxc_read_file_expect(const char *path, void *buf, size_t count,
-				      const void *expected_buf)
-__access_w(2, 3);
+__hidden extern ssize_t lxc_read_file_expect(const char *path, void *buf, size_t count,
+					     const void *expected_buf) __access_w(2, 3);
 
-extern ssize_t lxc_recv_nointr(int sockfd, void *buf, size_t len, int flags)
-__access_w(2, 3);
+__hidden extern ssize_t lxc_recv_nointr(int sockfd, void *buf, size_t len, int flags)
+    __access_w(2, 3);
 
-ssize_t lxc_recvmsg_nointr_iov(int sockfd, struct iovec *iov, size_t iovlen,
-			       int flags);
+__hidden extern ssize_t lxc_recvmsg_nointr_iov(int sockfd, struct iovec *iov, size_t iovlen,
+					       int flags);
 
-extern bool file_exists(const char *f);
-extern int print_to_file(const char *file, const char *content);
-extern int is_dir(const char *path);
-extern int lxc_count_file_lines(const char *fn);
-extern int lxc_make_tmpfile(char *template, bool rm);
+__hidden extern bool file_exists(const char *f);
+__hidden extern int print_to_file(const char *file, const char *content);
+__hidden extern int is_dir(const char *path);
+__hidden extern int lxc_count_file_lines(const char *fn);
+__hidden extern int lxc_make_tmpfile(char *template, bool rm);
 
 /* __typeof__ should be safe to use with all compilers. */
 typedef __typeof__(((struct statfs *)NULL)->f_type) fs_type_magic;
-extern bool has_fs_type(const char *path, fs_type_magic magic_val);
-extern bool fhas_fs_type(int fd, fs_type_magic magic_val);
-extern bool is_fs_type(const struct statfs *fs, fs_type_magic magic_val);
-extern FILE *fopen_cloexec(const char *path, const char *mode);
-extern ssize_t lxc_sendfile_nointr(int out_fd, int in_fd, off_t *offset,
-				   size_t count);
-extern char *file_to_buf(const char *path, size_t *length);
-extern int fd_to_buf(int fd, char **buf, size_t *length);
-extern int fd_to_fd(int from, int to);
-extern int lxc_open_dirfd(const char *dir);
-extern FILE *fdopen_cached(int fd, const char *mode, void **caller_freed_buffer);
-extern FILE *fopen_cached(const char *path, const char *mode,
-			  void **caller_freed_buffer);
-extern int timens_offset_write(clockid_t clk_id, int64_t s_offset, int64_t ns_offset);
+__hidden extern bool has_fs_type(const char *path, fs_type_magic magic_val);
+__hidden extern bool fhas_fs_type(int fd, fs_type_magic magic_val);
+__hidden extern bool is_fs_type(const struct statfs *fs, fs_type_magic magic_val);
+__hidden extern FILE *fopen_cloexec(const char *path, const char *mode);
+__hidden extern ssize_t lxc_sendfile_nointr(int out_fd, int in_fd, off_t *offset, size_t count);
+__hidden extern char *file_to_buf(const char *path, size_t *length);
+__hidden extern int fd_to_buf(int fd, char **buf, size_t *length);
+__hidden extern int fd_to_fd(int from, int to);
+__hidden extern int lxc_open_dirfd(const char *dir);
+__hidden extern FILE *fdopen_cached(int fd, const char *mode, void **caller_freed_buffer);
+__hidden extern FILE *fopen_cached(const char *path, const char *mode, void **caller_freed_buffer);
+__hidden extern int timens_offset_write(clockid_t clk_id, int64_t s_offset, int64_t ns_offset);
 
 #endif /* __LXC_FILE_UTILS_H */

--- a/src/lxc/initutils.h
+++ b/src/lxc/initutils.h
@@ -15,6 +15,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "compiler.h"
 #include "string_utils.h"
 
 #define DEFAULT_VG "lxc"
@@ -47,8 +48,8 @@ struct prctl_mm_map {
 };
 #endif
 
-extern const char *lxc_global_config_value(const char *option_name);
+__hidden extern const char *lxc_global_config_value(const char *option_name);
 
-extern int setproctitle(char *title);
+__hidden extern int setproctitle(char *title);
 
 #endif /* __LXC_INITUTILS_H */

--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -45,7 +45,7 @@
 
 int lxc_log_fd = -EBADF;
 static bool wants_syslog = false;
-int lxc_quiet_specified;
+static int lxc_quiet_specified;
 int lxc_log_use_global_fd;
 static int lxc_loglevel_specified;
 

--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -16,6 +16,7 @@
 #include <syslog.h>
 #include <time.h>
 
+#include "compiler.h"
 #include "conf.h"
 #include "config.h"
 
@@ -84,7 +85,7 @@ struct lxc_log_category {
 };
 
 #ifndef NO_LXC_CONF
-extern int lxc_log_use_global_fd;
+__hidden extern int lxc_log_use_global_fd;
 #endif
 
 /*
@@ -560,17 +561,18 @@ __lxc_unused static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 		__internal_ret__;                             \
 	})
 
-extern int lxc_log_fd;
+__hidden extern int lxc_log_fd;
 
-extern int lxc_log_syslog(int facility);
-extern void lxc_log_syslog_enable(void);
-extern void lxc_log_syslog_disable(void);
-extern int lxc_log_set_level(int *dest, int level);
-extern int lxc_log_get_level(void);
-extern bool lxc_log_has_valid_level(void);
-extern int lxc_log_set_file(int *fd, const char *fname);
-extern const char *lxc_log_get_file(void);
-extern void lxc_log_set_prefix(const char *prefix);
-extern const char *lxc_log_get_prefix(void);
-extern void lxc_log_options_no_override(void);
-#endif
+__hidden extern int lxc_log_syslog(int facility);
+__hidden extern void lxc_log_syslog_enable(void);
+__hidden extern void lxc_log_syslog_disable(void);
+__hidden extern int lxc_log_set_level(int *dest, int level);
+__hidden extern int lxc_log_get_level(void);
+__hidden extern bool lxc_log_has_valid_level(void);
+__hidden extern int lxc_log_set_file(int *fd, const char *fname);
+__hidden extern const char *lxc_log_get_file(void);
+__hidden extern void lxc_log_set_prefix(const char *prefix);
+__hidden extern const char *lxc_log_get_prefix(void);
+__hidden extern void lxc_log_options_no_override(void);
+
+#endif /* __LXC_LOG_H */

--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -28,8 +28,8 @@
 #define F_DUPFD_CLOEXEC 1030
 #endif
 
-#define LXC_LOG_PREFIX_SIZE	32
-#define LXC_LOG_BUFFER_SIZE	4096
+#define LXC_LOG_PREFIX_SIZE 32
+#define LXC_LOG_BUFFER_SIZE 4096
 
 /* predefined lxc log priorities. */
 enum lxc_loglevel {
@@ -277,13 +277,13 @@ __lxc_unused static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 /*
  * Helper macro to define and use static categories.
  */
-#define lxc_log_category_define(name, parent)				\
-	extern struct lxc_log_category lxc_log_category_##parent;	\
-	struct lxc_log_category lxc_log_category_##name = {		\
-		#name,							\
-		LXC_LOG_LEVEL_NOTSET,					\
-		NULL,							\
-		&lxc_log_category_##parent				\
+#define lxc_log_category_define(name, parent)					\
+	__hidden extern struct lxc_log_category lxc_log_category_##parent;	\
+	__hidden struct lxc_log_category lxc_log_category_##name = {		\
+		#name,								\
+		LXC_LOG_LEVEL_NOTSET,						\
+		NULL,								\
+		&lxc_log_category_##parent					\
 	};
 
 #define lxc_log_define(name, parent)					\

--- a/src/lxc/lsm/lsm.c
+++ b/src/lxc/lsm/lsm.c
@@ -9,6 +9,7 @@
 #include <sys/param.h>
 #include <unistd.h>
 
+#include "compiler.h"
 #include "conf.h"
 #include "config.h"
 #include "log.h"
@@ -18,9 +19,9 @@ lxc_log_define(lsm, lxc);
 
 static struct lsm_drv *drv = NULL;
 
-extern struct lsm_drv *lsm_apparmor_drv_init(void);
-extern struct lsm_drv *lsm_selinux_drv_init(void);
-extern struct lsm_drv *lsm_nop_drv_init(void);
+__hidden extern struct lsm_drv *lsm_apparmor_drv_init(void);
+__hidden extern struct lsm_drv *lsm_selinux_drv_init(void);
+__hidden extern struct lsm_drv *lsm_nop_drv_init(void);
 
 __attribute__((constructor))
 void lsm_init(void)

--- a/src/lxc/lsm/lsm.h
+++ b/src/lxc/lsm/lsm.h
@@ -7,6 +7,7 @@ struct lxc_conf;
 
 #include <sys/types.h>
 
+#include "compiler.h"
 #include "macro.h"
 #include "utils.h"
 
@@ -22,17 +23,15 @@ struct lsm_drv {
 	void (*cleanup)(struct lxc_conf *conf, const char *lxcpath);
 };
 
-extern void lsm_init(void);
-extern int lsm_enabled(void);
-extern const char *lsm_name(void);
-extern char *lsm_process_label_get(pid_t pid);
-extern int lsm_process_prepare(struct lxc_conf *conf, const char *lxcpath);
-extern int lsm_process_label_set(const char *label, struct lxc_conf *conf,
-				 bool on_exec);
-extern int lsm_process_label_fd_get(pid_t pid, bool on_exec);
-extern int lsm_process_label_set_at(int label_fd, const char *label,
-				    bool on_exec);
-extern void lsm_process_cleanup(struct lxc_conf *conf, const char *lxcpath);
-extern int lsm_keyring_label_set(char *label);
+__hidden extern void lsm_init(void);
+__hidden extern int lsm_enabled(void);
+__hidden extern const char *lsm_name(void);
+__hidden extern char *lsm_process_label_get(pid_t pid);
+__hidden extern int lsm_process_prepare(struct lxc_conf *conf, const char *lxcpath);
+__hidden extern int lsm_process_label_set(const char *label, struct lxc_conf *conf, bool on_exec);
+__hidden extern int lsm_process_label_fd_get(pid_t pid, bool on_exec);
+__hidden extern int lsm_process_label_set_at(int label_fd, const char *label, bool on_exec);
+__hidden extern void lsm_process_cleanup(struct lxc_conf *conf, const char *lxcpath);
+__hidden extern int lsm_keyring_label_set(char *label);
 
 #endif /* __LXC_LSM_H */

--- a/src/lxc/lxc.h
+++ b/src/lxc/lxc.h
@@ -12,6 +12,7 @@ extern "C" {
 #include <sys/select.h>
 #include <sys/types.h>
 
+#include "compiler.h"
 #include "state.h"
 
 struct lxc_msg;
@@ -32,8 +33,8 @@ struct lxc_handler;
  * @daemonize    : whether or not the container is daemonized
  * Returns 0 on success, < 0 otherwise
  */
-extern int lxc_start(char *const argv[], struct lxc_handler *handler,
-		     const char *lxcpath, bool daemonize, int *error_num);
+__hidden extern int lxc_start(char *const argv[], struct lxc_handler *handler, const char *lxcpath,
+			      bool daemonize, int *error_num);
 
 /*
  * Start the specified command inside an application container
@@ -44,39 +45,37 @@ extern int lxc_start(char *const argv[], struct lxc_handler *handler,
  * @daemonize    : whether or not the container is daemonized
  * Returns 0 on success, < 0 otherwise
  */
-extern int lxc_execute(const char *name, char *const argv[], int quiet,
-		       struct lxc_handler *handler, const char *lxcpath,
-		       bool daemonize, int *error_num);
+__hidden extern int lxc_execute(const char *name, char *const argv[], int quiet,
+				struct lxc_handler *handler, const char *lxcpath, bool daemonize,
+				int *error_num);
 
 /*
  * Close the fd associated with the monitoring
  * @fd : the file descriptor provided by lxc_monitor_open
  * Returns 0 on success, < 0 otherwise
  */
-extern int lxc_monitor_close(int fd);
+__hidden extern int lxc_monitor_close(int fd);
 
 /*
  * Freeze all the tasks running inside the container <name>
  * @name : the container name
  * Returns 0 on success, < 0 otherwise
  */
-extern int lxc_freeze(struct lxc_conf *conf, const char *name,
-		      const char *lxcpath);
+__hidden extern int lxc_freeze(struct lxc_conf *conf, const char *name, const char *lxcpath);
 
 /*
  * Unfreeze all previously frozen tasks.
  * @name : the name of the container
  * Return 0 on success, < 0 otherwise
  */
-extern int lxc_unfreeze(struct lxc_conf *conf, const char *name,
-			const char *lxcpath);
+__hidden extern int lxc_unfreeze(struct lxc_conf *conf, const char *name, const char *lxcpath);
 
 /*
  * Retrieve the container state
  * @name : the name of the container
  * Returns the state of the container on success, < 0 otherwise
  */
-extern lxc_state_t lxc_state(const char *name, const char *lxcpath);
+__hidden extern lxc_state_t lxc_state(const char *name, const char *lxcpath);
 
 /*
  * Create and return a new lxccontainer struct.
@@ -105,17 +104,16 @@ extern int lxc_get_wait_states(const char **states);
 /*
  * Add a dependency to a container
  */
-extern int add_rdepend(struct lxc_conf *lxc_conf, char *rdepend);
+__hidden extern int add_rdepend(struct lxc_conf *lxc_conf, char *rdepend);
 
 /*
  * Set a key/value configuration option. Requires that to take a lock on the
  * in-memory config of the container.
  */
-extern int lxc_set_config_item_locked(struct lxc_conf *conf, const char *key,
-				      const char *v);
+__hidden extern int lxc_set_config_item_locked(struct lxc_conf *conf, const char *key, const char *v);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* __LXC_LXC_H */

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3540,7 +3540,7 @@ static bool add_rdepends(struct lxc_container *c, struct lxc_container *c0)
  * then default to those even if not requested.
  * Currently we only do this for btrfs.
  */
-bool should_default_to_snapshot(struct lxc_container *c0,
+static bool should_default_to_snapshot(struct lxc_container *c0,
 				struct lxc_container *c1)
 {
 	__do_free char *p0 = NULL, *p1 = NULL;

--- a/src/lxc/lxclock.h
+++ b/src/lxc/lxclock.h
@@ -11,6 +11,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "compiler.h"
+
 #ifndef F_OFD_GETLK
 #define F_OFD_GETLK	36
 #endif
@@ -71,7 +73,7 @@ struct lxc_lock {
  * freed when the container is freed), and \c u.f.fd = -1.
  *
  */
-extern struct lxc_lock *lxc_newlock(const char *lxcpath, const char *name);
+__hidden extern struct lxc_lock *lxc_newlock(const char *lxcpath, const char *name);
 
 /*!
  * \brief Take an existing lock.
@@ -89,7 +91,7 @@ extern struct lxc_lock *lxc_newlock(const char *lxcpath, const char *name);
  * (except in the test case) I may remove the support for it in sem as
  * well.
  */
-extern int lxclock(struct lxc_lock *lock, int timeout);
+__hidden extern int lxclock(struct lxc_lock *lock, int timeout);
 
 /*!
  * \brief Unlock specified lock previously locked using \ref lxclock().
@@ -99,24 +101,24 @@ extern int lxclock(struct lxc_lock *lock, int timeout);
  * \return \c 0 on success, \c -2 if provided lock was not already held,
  * otherwise \c -1 with \c errno saved from \c fcntl(2) or sem_post function.
  */
-extern int lxcunlock(struct lxc_lock *lock);
+__hidden extern int lxcunlock(struct lxc_lock *lock);
 
 /*!
  * \brief Free a lock created by \ref lxc_newlock().
  *
  * \param lock Lock.
  */
-extern void lxc_putlock(struct lxc_lock *lock);
+__hidden extern void lxc_putlock(struct lxc_lock *lock);
 
 /*!
  * \brief Lock the current process.
  */
-extern void process_lock(void);
+__hidden extern void process_lock(void);
 
 /*!
  * \brief Unlock the current process.
  */
-extern void process_unlock(void);
+__hidden extern void process_unlock(void);
 
 struct lxc_container;
 
@@ -127,14 +129,14 @@ struct lxc_container;
  *
  * \return As for \ref lxclock().
  */
-extern int container_mem_lock(struct lxc_container *c);
+__hidden extern int container_mem_lock(struct lxc_container *c);
 
 /*!
  * \brief Unlock the containers memory.
  *
  * \param c Container.
  */
-extern void container_mem_unlock(struct lxc_container *c);
+__hidden extern void container_mem_unlock(struct lxc_container *c);
 
 /*!
  * \brief Lock the containers disk data.
@@ -144,7 +146,7 @@ extern void container_mem_unlock(struct lxc_container *c);
  * \return \c 0 on success, or an \ref lxclock() error return
  * values on error.
  */
-extern int container_disk_lock(struct lxc_container *c);
+__hidden extern int container_disk_lock(struct lxc_container *c);
 
 /*!
  * \brief Unlock the containers disk data.
@@ -152,6 +154,6 @@ extern int container_disk_lock(struct lxc_container *c);
  * \param c Container.
  *
  */
-extern void container_disk_unlock(struct lxc_container *c);
+__hidden extern void container_disk_unlock(struct lxc_container *c);
 
 #endif

--- a/src/lxc/lxcseccomp.h
+++ b/src/lxc/lxcseccomp.h
@@ -16,6 +16,7 @@
 #include <sys/un.h>
 #endif
 
+#include "compiler.h"
 #include "conf.h"
 #include "config.h"
 #include "memory_utils.h"
@@ -77,21 +78,19 @@ struct lxc_seccomp {
 #endif /* HAVE_DECL_SECCOMP_NOTIFY_FD */
 };
 
-extern int lxc_seccomp_load(struct lxc_conf *conf);
-extern int lxc_read_seccomp_config(struct lxc_conf *conf);
-extern void lxc_seccomp_free(struct lxc_seccomp *seccomp);
-extern int seccomp_notify_handler(int fd, uint32_t events, void *data,
-				  struct lxc_epoll_descr *descr);
-extern void seccomp_conf_init(struct lxc_conf *conf);
-extern int lxc_seccomp_setup_proxy(struct lxc_seccomp *seccomp,
-				   struct lxc_epoll_descr *descr,
-				   struct lxc_handler *handler);
-extern int lxc_seccomp_send_notifier_fd(struct lxc_seccomp *seccomp,
-					int socket_fd);
-extern int lxc_seccomp_recv_notifier_fd(struct lxc_seccomp *seccomp,
-					int socket_fd);
-extern int lxc_seccomp_add_notifier(const char *name, const char *lxcpath,
-				    struct lxc_seccomp *seccomp);
+__hidden extern int lxc_seccomp_load(struct lxc_conf *conf);
+__hidden extern int lxc_read_seccomp_config(struct lxc_conf *conf);
+__hidden extern void lxc_seccomp_free(struct lxc_seccomp *seccomp);
+__hidden extern int seccomp_notify_handler(int fd, uint32_t events, void *data,
+					   struct lxc_epoll_descr *descr);
+__hidden extern void seccomp_conf_init(struct lxc_conf *conf);
+__hidden extern int lxc_seccomp_setup_proxy(struct lxc_seccomp *seccomp,
+					    struct lxc_epoll_descr *descr,
+					    struct lxc_handler *handler);
+__hidden extern int lxc_seccomp_send_notifier_fd(struct lxc_seccomp *seccomp, int socket_fd);
+__hidden extern int lxc_seccomp_recv_notifier_fd(struct lxc_seccomp *seccomp, int socket_fd);
+__hidden extern int lxc_seccomp_add_notifier(const char *name, const char *lxcpath,
+					     struct lxc_seccomp *seccomp);
 static inline int lxc_seccomp_get_notify_fd(struct lxc_seccomp *seccomp)
 {
 #if HAVE_DECL_SECCOMP_NOTIFY_FD

--- a/src/lxc/mainloop.h
+++ b/src/lxc/mainloop.h
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 
+#include "compiler.h"
 #include "list.h"
 #include "memory_utils.h"
 
@@ -20,21 +21,18 @@ struct lxc_epoll_descr {
 typedef int (*lxc_mainloop_callback_t)(int fd, uint32_t event, void *data,
 				       struct lxc_epoll_descr *descr);
 
-extern int lxc_mainloop(struct lxc_epoll_descr *descr, int timeout_ms);
+__hidden extern int lxc_mainloop(struct lxc_epoll_descr *descr, int timeout_ms);
 
-extern int lxc_mainloop_add_handler_events(struct lxc_epoll_descr *descr,
-					   int fd, int events,
-					   lxc_mainloop_callback_t callback,
-					   void *data);
-extern int lxc_mainloop_add_handler(struct lxc_epoll_descr *descr, int fd,
-				    lxc_mainloop_callback_t callback,
-				    void *data);
+__hidden extern int lxc_mainloop_add_handler_events(struct lxc_epoll_descr *descr, int fd, int events,
+						    lxc_mainloop_callback_t callback, void *data);
+__hidden extern int lxc_mainloop_add_handler(struct lxc_epoll_descr *descr, int fd,
+					     lxc_mainloop_callback_t callback, void *data);
 
-extern int lxc_mainloop_del_handler(struct lxc_epoll_descr *descr, int fd);
+__hidden extern int lxc_mainloop_del_handler(struct lxc_epoll_descr *descr, int fd);
 
-extern int lxc_mainloop_open(struct lxc_epoll_descr *descr);
+__hidden extern int lxc_mainloop_open(struct lxc_epoll_descr *descr);
 
-extern void lxc_mainloop_close(struct lxc_epoll_descr *descr);
+__hidden extern void lxc_mainloop_close(struct lxc_epoll_descr *descr);
 
 define_cleanup_function(struct lxc_epoll_descr *, lxc_mainloop_close);
 

--- a/src/lxc/monitor.h
+++ b/src/lxc/monitor.h
@@ -8,6 +8,8 @@
 #include <sys/param.h>
 #include <sys/un.h>
 
+#include "compiler.h"
+
 typedef enum {
 	lxc_msg_state,
 	lxc_msg_priority,
@@ -16,25 +18,23 @@ typedef enum {
 
 struct lxc_msg {
 	lxc_msg_type_t type;
-	char name[NAME_MAX+1];
+	char name[NAME_MAX + 1];
 	int value;
 };
 
-extern int lxc_monitor_sock_name(const char *lxcpath, struct sockaddr_un *addr);
-extern int lxc_monitor_fifo_name(const char *lxcpath, char *fifo_path,
-				 size_t fifo_path_sz, int do_mkdirp);
-extern void lxc_monitor_send_state(const char *name, lxc_state_t state,
-			    const char *lxcpath);
-extern void lxc_monitor_send_exit_code(const char *name, int exit_code,
-			    const char *lxcpath);
-extern int lxc_monitord_spawn(const char *lxcpath);
+__hidden extern int lxc_monitor_sock_name(const char *lxcpath, struct sockaddr_un *addr);
+__hidden extern int lxc_monitor_fifo_name(const char *lxcpath, char *fifo_path, size_t fifo_path_sz,
+					  int do_mkdirp);
+__hidden extern void lxc_monitor_send_state(const char *name, lxc_state_t state, const char *lxcpath);
+__hidden extern void lxc_monitor_send_exit_code(const char *name, int exit_code, const char *lxcpath);
+__hidden extern int lxc_monitord_spawn(const char *lxcpath);
 
 /*
  * Open the monitoring mechanism for a specific container
  * The function will return an fd corresponding to the events
  * Returns a file descriptor on success, < 0 otherwise
  */
-extern int lxc_monitor_open(const char *lxcpath);
+__hidden extern int lxc_monitor_open(const char *lxcpath);
 
 /*
  * Blocking read for the next container state change
@@ -43,7 +43,7 @@ extern int lxc_monitor_open(const char *lxcpath);
  * Returns 0 if the monitored container has exited, > 0 if
  * data was read, < 0 otherwise
  */
-extern int lxc_monitor_read(int fd, struct lxc_msg *msg);
+__hidden extern int lxc_monitor_read(int fd, struct lxc_msg *msg);
 
 /*
  * Blocking read for the next container state change with timeout
@@ -53,7 +53,7 @@ extern int lxc_monitor_read(int fd, struct lxc_msg *msg);
  * Returns 0 if the monitored container has exited, > 0 if
  * data was read, < 0 otherwise
  */
-extern int lxc_monitor_read_timeout(int fd, struct lxc_msg *msg, int timeout);
+__hidden extern int lxc_monitor_read_timeout(int fd, struct lxc_msg *msg, int timeout);
 
 /*
  * Blocking read from multiple monitors for the next container state
@@ -65,8 +65,7 @@ extern int lxc_monitor_read_timeout(int fd, struct lxc_msg *msg, int timeout);
  * Returns 0 if the monitored container has exited, > 0 if
  * data was read, < 0 otherwise
  */
-extern int lxc_monitor_read_fdset(struct pollfd *fds, nfds_t nfds, struct lxc_msg *msg,
-			   int timeout);
+__hidden extern int lxc_monitor_read_fdset(struct pollfd *fds, nfds_t nfds, struct lxc_msg *msg,
+					   int timeout);
 
-
-#endif
+#endif /* __LXC_MONITOR_H */

--- a/src/lxc/namespace.h
+++ b/src/lxc/namespace.h
@@ -7,6 +7,8 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 
+#include "compiler.h"
+
 enum {
 	LXC_NS_USER,
 	LXC_NS_MNT,
@@ -19,16 +21,16 @@ enum {
 	LXC_NS_MAX
 };
 
-extern const struct ns_info {
+__hidden extern const struct ns_info {
 	const char *proc_name;
 	int clone_flag;
 	const char *flag_name;
 	const char *env_name;
 } ns_info[LXC_NS_MAX];
 
-extern int lxc_namespace_2_cloneflag(const char *namespace);
-extern int lxc_namespace_2_ns_idx(const char *namespace);
-extern int lxc_namespace_2_std_identifiers(char *namespaces);
-extern int lxc_fill_namespace_flags(char *flaglist, int *flags);
+__hidden extern int lxc_namespace_2_cloneflag(const char *namespace);
+__hidden extern int lxc_namespace_2_ns_idx(const char *namespace);
+__hidden extern int lxc_namespace_2_std_identifiers(char *namespaces);
+__hidden extern int lxc_fill_namespace_flags(char *flaglist, int *flags);
 
-#endif
+#endif /* __LXC_NAMESPACE_H */

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -1737,7 +1737,7 @@ int netdev_set_flag(const char *name, int flag)
 	return netlink_transaction(nlh_ptr, nlmsg, answer);
 }
 
-int netdev_get_flag(const char *name, int *flag)
+static int netdev_get_flag(const char *name, int *flag)
 {
 	call_cleaner(nlmsg_free) struct nlmsg *answer = NULL, *nlmsg = NULL;
 	struct nl_handler nlh;
@@ -3084,7 +3084,7 @@ static int lxc_delete_network_unpriv_exec(const char *lxcpath, const char *lxcna
 	return 0;
 }
 
-bool lxc_delete_network_unpriv(struct lxc_handler *handler)
+static bool lxc_delete_network_unpriv(struct lxc_handler *handler)
 {
 	int ret;
 	struct lxc_list *iterator;
@@ -3464,7 +3464,7 @@ static int lxc_create_network_unpriv(struct lxc_handler *handler)
 	return 0;
 }
 
-bool lxc_delete_network_priv(struct lxc_handler *handler)
+static bool lxc_delete_network_priv(struct lxc_handler *handler)
 {
 	int ret;
 	struct lxc_list *iterator;

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -10,6 +10,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include "compiler.h"
 #include "list.h"
 
 struct lxc_conf;
@@ -180,107 +181,102 @@ struct lxc_netdev {
 };
 
 /* Convert a string mac address to a socket structure. */
-extern int lxc_convert_mac(char *macaddr, struct sockaddr *sockaddr);
+__hidden extern int lxc_convert_mac(char *macaddr, struct sockaddr *sockaddr);
 
 /* Move a device between namespaces. */
-extern int lxc_netdev_move_by_index(int ifindex, pid_t pid, const char *ifname);
-extern int lxc_netdev_move_by_name(const char *ifname, pid_t pid,
-				   const char *newname);
+__hidden extern int lxc_netdev_move_by_index(int ifindex, pid_t pid, const char *ifname);
+__hidden extern int lxc_netdev_move_by_name(const char *ifname, pid_t pid, const char *newname);
 
 /* Delete a network device. */
-extern int lxc_netdev_delete_by_name(const char *name);
-extern int lxc_netdev_delete_by_index(int ifindex);
+__hidden extern int lxc_netdev_delete_by_name(const char *name);
+__hidden extern int lxc_netdev_delete_by_index(int ifindex);
 
 /* Change the device name. */
-extern int lxc_netdev_rename_by_name(const char *oldname, const char *newname);
-extern int lxc_netdev_rename_by_index(int ifindex, const char *newname);
+__hidden extern int lxc_netdev_rename_by_name(const char *oldname, const char *newname);
+__hidden extern int lxc_netdev_rename_by_index(int ifindex, const char *newname);
 
-extern int netdev_set_flag(const char *name, int flag);
+__hidden extern int netdev_set_flag(const char *name, int flag);
 
 /* Set the device network up or down. */
-extern int lxc_netdev_isup(const char *name);
-extern int lxc_netdev_up(const char *name);
-extern int lxc_netdev_down(const char *name);
+__hidden extern int lxc_netdev_isup(const char *name);
+__hidden extern int lxc_netdev_up(const char *name);
+__hidden extern int lxc_netdev_down(const char *name);
 
 /* Change the mtu size for the specified device. */
-extern int lxc_netdev_set_mtu(const char *name, int mtu);
+__hidden extern int lxc_netdev_set_mtu(const char *name, int mtu);
 
 /* Create a virtual network devices. */
-extern int lxc_veth_create(const char *name1, const char *name2, pid_t pid,
-			   unsigned int mtu);
-extern int lxc_macvlan_create(const char *parent, const char *name, int mode);
-extern int lxc_vlan_create(const char *parent, const char *name,
-			   unsigned short vid);
+__hidden extern int lxc_veth_create(const char *name1, const char *name2, pid_t pid,
+				    unsigned int mtu);
+__hidden extern int lxc_macvlan_create(const char *parent, const char *name, int mode);
+__hidden extern int lxc_vlan_create(const char *parent, const char *name, unsigned short vid);
 
 /* Set ip address. */
-extern int lxc_ipv6_addr_add(int ifindex, struct in6_addr *addr,
-			     struct in6_addr *mcast,
-			     struct in6_addr *acast, int prefix);
+__hidden extern int lxc_ipv6_addr_add(int ifindex, struct in6_addr *addr, struct in6_addr *mcast,
+				      struct in6_addr *acast, int prefix);
 
-extern int lxc_ipv4_addr_add(int ifindex, struct in_addr *addr,
-			     struct in_addr *bcast, int prefix);
+__hidden extern int lxc_ipv4_addr_add(int ifindex, struct in_addr *addr, struct in_addr *bcast,
+				      int prefix);
 
 /* Get ip address. */
-extern int lxc_ipv4_addr_get(int ifindex, struct in_addr **res);
-extern int lxc_ipv6_addr_get(int ifindex, struct in6_addr **res);
+__hidden extern int lxc_ipv4_addr_get(int ifindex, struct in_addr **res);
+__hidden extern int lxc_ipv6_addr_get(int ifindex, struct in6_addr **res);
 
 /* Set default route. */
-extern int lxc_ipv4_gateway_add(int ifindex, struct in_addr *gw);
-extern int lxc_ipv6_gateway_add(int ifindex, struct in6_addr *gw);
+__hidden extern int lxc_ipv4_gateway_add(int ifindex, struct in_addr *gw);
+__hidden extern int lxc_ipv6_gateway_add(int ifindex, struct in6_addr *gw);
 
 /* Attach an interface to the bridge. */
-extern int lxc_bridge_attach(const char *bridge, const char *ifname);
-extern int lxc_ovs_delete_port(const char *bridge, const char *nic);
+__hidden extern int lxc_bridge_attach(const char *bridge, const char *ifname);
+__hidden extern int lxc_ovs_delete_port(const char *bridge, const char *nic);
 
-extern bool is_ovs_bridge(const char *bridge);
+__hidden extern bool is_ovs_bridge(const char *bridge);
 
 /* Create default gateway. */
-extern int lxc_route_create_default(const char *addr, const char *ifname,
-				    int gateway);
+__hidden extern int lxc_route_create_default(const char *addr, const char *ifname, int gateway);
 
 /* Delete default gateway. */
-extern int lxc_route_delete_default(const char *addr, const char *ifname,
-				    int gateway);
+__hidden extern int lxc_route_delete_default(const char *addr, const char *ifname, int gateway);
 
 /* Activate neighbor proxying. */
-extern int lxc_neigh_proxy_on(const char *name, int family);
+__hidden extern int lxc_neigh_proxy_on(const char *name, int family);
 
 /* Disable neighbor proxying. */
-extern int lxc_neigh_proxy_off(const char *name, int family);
+__hidden extern int lxc_neigh_proxy_off(const char *name, int family);
 
 /* Activate IP forwarding. */
-extern int lxc_ip_forwarding_on(const char *name, int family);
+__hidden extern int lxc_ip_forwarding_on(const char *name, int family);
 
 /* Disable IP forwarding. */
-extern int lxc_ip_forwarding_off(const char *name, int family);
+__hidden extern int lxc_ip_forwarding_off(const char *name, int family);
 
 /*
  * Generate a new unique network interface name.
  *
  * Allows for 62^n unique combinations.
  */
-extern char *lxc_ifname_alnum_case_sensitive(char *template);
+__hidden extern char *lxc_ifname_alnum_case_sensitive(char *template);
 
-extern const char *lxc_net_type_to_str(int type);
-extern int setup_private_host_hw_addr(char *veth1);
-extern int netdev_get_mtu(int ifindex);
-extern int lxc_network_move_created_netdev_priv(struct lxc_handler *handler);
-extern void lxc_delete_network(struct lxc_handler *handler);
-extern int lxc_find_gateway_addresses(struct lxc_handler *handler);
-extern int lxc_requests_empty_network(struct lxc_handler *handler);
-extern int lxc_restore_phys_nics_to_netns(struct lxc_handler *handler);
-extern int lxc_setup_network_in_child_namespaces(const struct lxc_conf *conf,
-						 struct lxc_list *network);
-extern int lxc_network_send_to_child(struct lxc_handler *handler);
-extern int lxc_network_recv_from_parent(struct lxc_handler *handler);
-extern int lxc_network_send_name_and_ifindex_to_parent(struct lxc_handler *handler);
-extern int lxc_network_recv_name_and_ifindex_from_child(struct lxc_handler *handler);
-extern int lxc_netns_set_nsid(int netns_fd);
-extern int lxc_netns_get_nsid(__s32 fd);
-extern int lxc_create_network(struct lxc_handler *handler);
+__hidden extern const char *lxc_net_type_to_str(int type);
+__hidden extern int setup_private_host_hw_addr(char *veth1);
+__hidden extern int netdev_get_mtu(int ifindex);
+__hidden extern int lxc_network_move_created_netdev_priv(struct lxc_handler *handler);
+__hidden extern void lxc_delete_network(struct lxc_handler *handler);
+__hidden extern int lxc_find_gateway_addresses(struct lxc_handler *handler);
+__hidden extern int lxc_requests_empty_network(struct lxc_handler *handler);
+__hidden extern int lxc_restore_phys_nics_to_netns(struct lxc_handler *handler);
+__hidden extern int lxc_setup_network_in_child_namespaces(const struct lxc_conf *conf,
+							  struct lxc_list *network);
+__hidden extern int lxc_network_send_to_child(struct lxc_handler *handler);
+__hidden extern int lxc_network_recv_from_parent(struct lxc_handler *handler);
+__hidden extern int lxc_network_send_name_and_ifindex_to_parent(struct lxc_handler *handler);
+__hidden extern int lxc_network_recv_name_and_ifindex_from_child(struct lxc_handler *handler);
+__hidden extern int lxc_netns_set_nsid(int netns_fd);
+__hidden extern int lxc_netns_get_nsid(__s32 fd);
+__hidden extern int lxc_create_network(struct lxc_handler *handler);
 
-extern char *is_wlan(const char *ifname);
-extern int lxc_netdev_move_wlan(char *physname, const char *ifname, pid_t pid,
-				const char *newname);
+__hidden extern char *is_wlan(const char *ifname);
+__hidden extern int lxc_netdev_move_wlan(char *physname, const char *ifname, pid_t pid,
+					 const char *newname);
 
 #endif /* __LXC_NETWORK_H */

--- a/src/lxc/nl.h
+++ b/src/lxc/nl.h
@@ -122,7 +122,7 @@ __hidden extern int __netlink_transaction(struct nl_handler *handler, struct nlm
  *
  * Returns 0 on success, < 0 otherwise
  */
-__hidden int nla_put_string(struct nlmsg *nlmsg, int attr, const char *string);
+__hidden extern int nla_put_string(struct nlmsg *nlmsg, int attr, const char *string);
 
 /*
  * nla_put_buffer: copy a buffer with a specified size to a netlink
@@ -135,8 +135,7 @@ __hidden int nla_put_string(struct nlmsg *nlmsg, int attr, const char *string);
  *
  * Returns 0 on success, < 0 otherwise
  */
-int nla_put_buffer(struct nlmsg *nlmsg, int attr,
-		   const void *data, size_t size);
+__hidden extern int nla_put_buffer(struct nlmsg *nlmsg, int attr, const void *data, size_t size);
 
 /*
  * nla_put_u32: copy an integer to a netlink message attribute
@@ -147,7 +146,7 @@ int nla_put_buffer(struct nlmsg *nlmsg, int attr,
  *
  * Returns 0 on success, < 0 otherwise
  */
-int nla_put_u32(struct nlmsg *nlmsg, int attr, int value);
+__hidden extern int nla_put_u32(struct nlmsg *nlmsg, int attr, int value);
 
 /*
  * nla_put_u16: copy an integer to a netlink message attribute
@@ -158,7 +157,7 @@ int nla_put_u32(struct nlmsg *nlmsg, int attr, int value);
  *
  * Returns 0 on success, < 0 otherwise
  */
-int nla_put_u16(struct nlmsg *nlmsg, int attr, unsigned short value);
+__hidden extern int nla_put_u16(struct nlmsg *nlmsg, int attr, unsigned short value);
 
 /*
  * nla_put_attr: add an attribute name to a netlink
@@ -168,7 +167,7 @@ int nla_put_u16(struct nlmsg *nlmsg, int attr, unsigned short value);
  *
  * Returns 0 on success, < 0 otherwise
  */
-int nla_put_attr(struct nlmsg *nlmsg, int attr);
+__hidden extern int nla_put_attr(struct nlmsg *nlmsg, int attr);
 
 /*
  * nla_begin_nested: begin the nesting attribute

--- a/src/lxc/parse.h
+++ b/src/lxc/parse.h
@@ -13,17 +13,16 @@ typedef int (*lxc_dir_cb)(const char *name, const char *directory,
 
 typedef int (*lxc_file_cb)(char *buffer, void *data);
 
-__hot extern int lxc_file_for_each_line(const char *file, lxc_file_cb callback,
-					void *data);
+__hidden __hot extern int lxc_file_for_each_line(const char *file, lxc_file_cb callback, void *data);
 
-__hot extern int lxc_file_for_each_line_mmap(const char *file,
-					     lxc_file_cb callback, void *data);
+__hidden __hot extern int lxc_file_for_each_line_mmap(const char *file, lxc_file_cb callback,
+						      void *data);
 
 /* mmap() wrapper. lxc_strmmap() will take care to \0-terminate files so that
  * normal string-handling functions can be used on the buffer. */
-extern void *lxc_strmmap(void *addr, size_t length, int prot, int flags, int fd,
-			 off_t offset);
+__hidden extern void *lxc_strmmap(void *addr, size_t length, int prot, int flags, int fd,
+				  off_t offset);
 /* munmap() wrapper. Use it to free memory mmap()ed with lxc_strmmap(). */
-extern int lxc_strmunmap(void *addr, size_t length);
+__hidden extern int lxc_strmunmap(void *addr, size_t length);
 
-#endif
+#endif /* __LXC_PARSE_H */

--- a/src/lxc/process_utils.h
+++ b/src/lxc/process_utils.h
@@ -209,7 +209,7 @@ int clone(int (*fn)(void *), void *child_stack, int flags, void *arg, ...
  * - should call lxc_raw_getpid():
  *   The child should use lxc_raw_getpid() to retrieve its pid.
  */
-extern pid_t lxc_clone(int (*fn)(void *), void *arg, int flags, int *pidfd);
+__hidden extern pid_t lxc_clone(int (*fn)(void *), void *arg, int flags, int *pidfd);
 
 
 /*
@@ -239,8 +239,8 @@ extern pid_t lxc_clone(int (*fn)(void *), void *arg, int flags, int *pidfd);
  * - must call lxc_raw_getpid():
  *   The child must use lxc_raw_getpid() to retrieve its pid.
  */
-extern pid_t lxc_raw_clone(unsigned long flags, int *pidfd);
-extern pid_t lxc_raw_legacy_clone(unsigned long flags, int *pidfd);
+__hidden extern pid_t lxc_raw_clone(unsigned long flags, int *pidfd);
+__hidden extern pid_t lxc_raw_legacy_clone(unsigned long flags, int *pidfd);
 
 /*
  * lxc_raw_clone_cb() - create a new process
@@ -253,8 +253,8 @@ extern pid_t lxc_raw_legacy_clone(unsigned long flags, int *pidfd);
  * All other comments that apply to lxc_raw_clone() apply to lxc_raw_clone_cb()
  * as well.
  */
-extern pid_t lxc_raw_clone_cb(int (*fn)(void *), void *args,
-			      unsigned long flags, int *pidfd);
+__hidden extern pid_t lxc_raw_clone_cb(int (*fn)(void *), void *args, unsigned long flags,
+				       int *pidfd);
 
 #ifndef HAVE_EXECVEAT
 static inline int execveat(int dirfd, const char *pathname, char *const argv[],
@@ -285,7 +285,7 @@ static inline pid_t lxc_raw_gettid(void)
 #endif
 }
 
-extern int lxc_raw_pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
-				     unsigned int flags);
+__hidden extern int lxc_raw_pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
+					      unsigned int flags);
 
 #endif /* __LXC_PROCESS_UTILS_H */

--- a/src/lxc/rexec.c
+++ b/src/lxc/rexec.c
@@ -14,6 +14,7 @@
 #include "macro.h"
 #include "memory_utils.h"
 #include "process_utils.h"
+#include "rexec.h"
 #include "string_utils.h"
 #include "syscall_wrappers.h"
 

--- a/src/lxc/rexec.h
+++ b/src/lxc/rexec.h
@@ -3,6 +3,8 @@
 #ifndef __LXC_REXEC_H
 #define __LXC_REXEC_H
 
-extern int lxc_rexec(const char *memfd_name);
+#include "compiler.h"
+
+__hidden extern int lxc_rexec(const char *memfd_name);
 
 #endif /* __LXC_REXEC_H */

--- a/src/lxc/ringbuf.h
+++ b/src/lxc/ringbuf.h
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <sys/mman.h>
 
+#include "compiler.h"
+
 /**
  * lxc_ringbuf - Implements a simple and efficient memory mapped ringbuffer.
  * - The "addr" field of struct lxc_ringbuf is considered immutable. Instead the
@@ -29,10 +31,10 @@ struct lxc_ringbuf {
  *
  * @param[in] size	Size of the new ringbuffer as a power of 2.
  */
-extern int lxc_ringbuf_create(struct lxc_ringbuf *buf, size_t size);
-extern void lxc_ringbuf_move_read_addr(struct lxc_ringbuf *buf, size_t len);
-extern int lxc_ringbuf_write(struct lxc_ringbuf *buf, const char *msg, size_t len);
-extern int lxc_ringbuf_read(struct lxc_ringbuf *buf, char *out, size_t *len);
+__hidden extern int lxc_ringbuf_create(struct lxc_ringbuf *buf, size_t size);
+__hidden extern void lxc_ringbuf_move_read_addr(struct lxc_ringbuf *buf, size_t len);
+__hidden extern int lxc_ringbuf_write(struct lxc_ringbuf *buf, const char *msg, size_t len);
+__hidden extern int lxc_ringbuf_read(struct lxc_ringbuf *buf, char *out, size_t *len);
 
 static inline void lxc_ringbuf_release(struct lxc_ringbuf *buf)
 {

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -317,7 +317,7 @@ enum lxc_hostarch_t {
 	lxc_seccomp_arch_unknown = 999,
 };
 
-int get_hostarch(void)
+static int get_hostarch(void)
 {
 	struct utsname uts;
 	if (uname(&uts) < 0) {
@@ -351,8 +351,8 @@ int get_hostarch(void)
 	return lxc_seccomp_arch_unknown;
 }
 
-scmp_filter_ctx get_new_ctx(enum lxc_hostarch_t n_arch,
-			    uint32_t default_policy_action, bool *needs_merge)
+static scmp_filter_ctx get_new_ctx(enum lxc_hostarch_t n_arch, uint32_t default_policy_action,
+				   bool *needs_merge)
 {
 	int ret;
 	uint32_t arch;
@@ -485,8 +485,8 @@ scmp_filter_ctx get_new_ctx(enum lxc_hostarch_t n_arch,
 	return ctx;
 }
 
-bool do_resolve_add_rule(uint32_t arch, char *line, scmp_filter_ctx ctx,
-			 struct seccomp_v2_rule *rule)
+static bool do_resolve_add_rule(uint32_t arch, char *line, scmp_filter_ctx ctx,
+				struct seccomp_v2_rule *rule)
 {
 	int i, nr, ret;
 	struct scmp_arg_cmp arg_cmp[6];

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -2126,30 +2126,28 @@ int __lxc_start(struct lxc_handler *handler, struct lxc_operations *ops,
 	if (error_num)
 		*error_num = handler->exit_status;
 
-/* These are not the droids you are looking for. */
-__private_goto1:
 	lxc_delete_network(handler);
-
-__private_goto2:
 	detach_block_device(handler->conf);
-
-__private_goto3:
 	lxc_end(handler);
-
 	return ret;
 
-/* These are the droids you are looking for. */
 out_abort:
 	lxc_abort(handler);
-	goto __private_goto3;
+	lxc_end(handler);
+	return ret;
 
 out_detach_blockdev:
 	lxc_abort(handler);
-	goto __private_goto2;
+	detach_block_device(handler->conf);
+	lxc_end(handler);
+	return ret;
 
 out_delete_network:
 	lxc_abort(handler);
-	goto __private_goto1;
+	lxc_delete_network(handler);
+	detach_block_device(handler->conf);
+	lxc_end(handler);
+	return ret;
 }
 
 struct start_args {

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -30,6 +30,7 @@
 #include "cgroup.h"
 #include "commands.h"
 #include "commands_utils.h"
+#include "compiler.h"
 #include "conf.h"
 #include "config.h"
 #include "confile_utils.h"

--- a/src/lxc/start.h
+++ b/src/lxc/start.h
@@ -11,6 +11,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
+#include "compiler.h"
 #include "conf.h"
 #include "macro.h"
 #include "namespace.h"
@@ -140,20 +141,17 @@ struct lxc_operations {
 	int (*post_start)(struct lxc_handler *, void *);
 };
 
-extern int lxc_poll(const char *name, struct lxc_handler *handler);
-extern int lxc_set_state(const char *name, struct lxc_handler *handler,
-			 lxc_state_t state);
-extern int lxc_serve_state_clients(const char *name,
-				   struct lxc_handler *handler,
-				   lxc_state_t state);
-extern void lxc_abort(struct lxc_handler *handler);
-extern struct lxc_handler *lxc_init_handler(struct lxc_handler *old,
-					    const char *name,
-					    struct lxc_conf *conf,
-					    const char *lxcpath, bool daemonize);
-extern void lxc_put_handler(struct lxc_handler *handler);
-extern int lxc_init(const char *name, struct lxc_handler *handler);
-extern void lxc_end(struct lxc_handler *handler);
+__hidden extern int lxc_poll(const char *name, struct lxc_handler *handler);
+__hidden extern int lxc_set_state(const char *name, struct lxc_handler *handler, lxc_state_t state);
+__hidden extern int lxc_serve_state_clients(const char *name, struct lxc_handler *handler,
+					    lxc_state_t state);
+__hidden extern void lxc_abort(struct lxc_handler *handler);
+__hidden extern struct lxc_handler *lxc_init_handler(struct lxc_handler *old, const char *name,
+						     struct lxc_conf *conf, const char *lxcpath,
+						     bool daemonize);
+__hidden extern void lxc_put_handler(struct lxc_handler *handler);
+__hidden extern int lxc_init(const char *name, struct lxc_handler *handler);
+__hidden extern void lxc_end(struct lxc_handler *handler);
 
 /* lxc_check_inherited: Check for any open file descriptors and close them if
  *                      requested.
@@ -162,16 +160,17 @@ extern void lxc_end(struct lxc_handler *handler);
  * @param[in] fds_to_ignore Array of file descriptors to ignore.
  * @param[in] len_fds       Length of fds_to_ignore array.
  */
-extern int lxc_check_inherited(struct lxc_conf *conf, bool closeall,
-			       int *fds_to_ignore, size_t len_fds);
+__hidden extern int lxc_check_inherited(struct lxc_conf *conf, bool closeall, int *fds_to_ignore,
+					size_t len_fds);
 static inline int inherit_fds(struct lxc_handler *handler, bool closeall)
 {
 	return lxc_check_inherited(handler->conf, closeall, handler->keep_fds,
 				   ARRAY_SIZE(handler->keep_fds));
 }
-extern int __lxc_start(struct lxc_handler *, struct lxc_operations *, void *,
-		       const char *, bool, int *);
 
-extern int resolve_clone_flags(struct lxc_handler *handler);
+__hidden extern int __lxc_start(struct lxc_handler *, struct lxc_operations *, void *, const char *,
+				bool, int *);
+
+__hidden extern int resolve_clone_flags(struct lxc_handler *handler);
 
 #endif

--- a/src/lxc/state.h
+++ b/src/lxc/state.h
@@ -3,6 +3,8 @@
 #ifndef __LXC_STATE_H
 #define __LXC_STATE_H
 
+#include "compiler.h"
+
 #define MAX_STATE_LENGTH (8 + 1)
 
 typedef enum {
@@ -23,10 +25,11 @@ enum {
 	REBOOT_INIT
 };
 
-extern lxc_state_t lxc_getstate(const char *name, const char *lxcpath);
+__hidden extern lxc_state_t lxc_getstate(const char *name, const char *lxcpath);
 
-extern lxc_state_t lxc_str2state(const char *state);
-extern const char *lxc_state2str(lxc_state_t state);
-extern int lxc_wait(const char *lxcname, const char *states, int timeout, const char *lxcpath);
+__hidden extern lxc_state_t lxc_str2state(const char *state);
+__hidden extern const char *lxc_state2str(lxc_state_t state);
+__hidden extern int lxc_wait(const char *lxcname, const char *states, int timeout,
+			     const char *lxcpath);
 
-#endif
+#endif /* __LXC_STATE_H */

--- a/src/lxc/storage/btrfs.h
+++ b/src/lxc/storage/btrfs.h
@@ -8,8 +8,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "compiler.h"
+
 #ifndef BTRFS_SUPER_MAGIC
-#  define BTRFS_SUPER_MAGIC       0x9123683E
+#define BTRFS_SUPER_MAGIC 0x9123683E
 #endif
 
 typedef uint8_t u8;
@@ -31,8 +33,7 @@ struct btrfs_ioctl_space_args {
 
 #define BTRFS_IOCTL_MAGIC 0x94
 #define BTRFS_IOC_SUBVOL_GETFLAGS _IOR(BTRFS_IOCTL_MAGIC, 25, unsigned long long)
-#define BTRFS_IOC_SPACE_INFO _IOWR(BTRFS_IOCTL_MAGIC, 20, \
-                                    struct btrfs_ioctl_space_args)
+#define BTRFS_IOC_SPACE_INFO _IOWR(BTRFS_IOCTL_MAGIC, 20, struct btrfs_ioctl_space_args)
 
 #define BTRFS_FSID_SIZE 16
 struct btrfs_ioctl_fs_info_args {
@@ -42,9 +43,7 @@ struct btrfs_ioctl_fs_info_args {
 	unsigned long long reserved[124];
 };
 
-#define BTRFS_IOC_FS_INFO _IOR(BTRFS_IOCTL_MAGIC, 31, \
-		struct btrfs_ioctl_fs_info_args)
-
+#define BTRFS_IOC_FS_INFO _IOR(BTRFS_IOCTL_MAGIC, 31, struct btrfs_ioctl_fs_info_args)
 
 #define BTRFS_SUBVOL_NAME_MAX 4039
 #define BTRFS_PATH_NAME_MAX 4087
@@ -55,14 +54,10 @@ struct btrfs_ioctl_vol_args {
 };
 
 #define BTRFS_IOCTL_MAGIC 0x94
-#define BTRFS_IOC_SUBVOL_CREATE_V2 _IOW(BTRFS_IOCTL_MAGIC, 24, \
-                                   struct btrfs_ioctl_vol_args_v2)
-#define BTRFS_IOC_SNAP_CREATE_V2 _IOW(BTRFS_IOCTL_MAGIC, 23, \
-                                   struct btrfs_ioctl_vol_args_v2)
-#define BTRFS_IOC_SUBVOL_CREATE _IOW(BTRFS_IOCTL_MAGIC, 14, \
-                                   struct btrfs_ioctl_vol_args)
-#define BTRFS_IOC_SNAP_DESTROY _IOW(BTRFS_IOCTL_MAGIC, 15, \
-                                   struct btrfs_ioctl_vol_args)
+#define BTRFS_IOC_SUBVOL_CREATE_V2 _IOW(BTRFS_IOCTL_MAGIC, 24, struct btrfs_ioctl_vol_args_v2)
+#define BTRFS_IOC_SNAP_CREATE_V2 _IOW(BTRFS_IOCTL_MAGIC, 23, struct btrfs_ioctl_vol_args_v2)
+#define BTRFS_IOC_SUBVOL_CREATE _IOW(BTRFS_IOCTL_MAGIC, 14, struct btrfs_ioctl_vol_args)
+#define BTRFS_IOC_SNAP_DESTROY _IOW(BTRFS_IOCTL_MAGIC, 15, struct btrfs_ioctl_vol_args)
 
 #define BTRFS_QGROUP_INHERIT_SET_LIMITS (1ULL << 0)
 
@@ -185,8 +180,7 @@ struct btrfs_ioctl_search_args {
 	char buf[BTRFS_SEARCH_ARGS_BUFSIZE];
 };
 
-#define BTRFS_IOC_TREE_SEARCH _IOWR(BTRFS_IOCTL_MAGIC, 17, \
-                                   struct btrfs_ioctl_search_args)
+#define BTRFS_IOC_TREE_SEARCH _IOWR(BTRFS_IOCTL_MAGIC, 17, struct btrfs_ioctl_search_args)
 #define BTRFS_UUID_SIZE 16
 
 struct btrfs_timespec {
@@ -283,8 +277,7 @@ struct btrfs_root_item {
 	__le64 reserved[8]; /* for future */
 } __attribute__ ((__packed__));
 
-#define BTRFS_IOC_INO_LOOKUP _IOWR(BTRFS_IOCTL_MAGIC, 18, \
-                                   struct btrfs_ioctl_ino_lookup_args)
+#define BTRFS_IOC_INO_LOOKUP _IOWR(BTRFS_IOCTL_MAGIC, 18, struct btrfs_ioctl_ino_lookup_args)
 
 #define BTRFS_INO_LOOKUP_PATH_MAX 4080
 struct btrfs_ioctl_ino_lookup_args {
@@ -362,30 +355,28 @@ struct my_btrfs_tree {
 	int num;
 };
 
-extern int btrfs_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
-			    const char *oldname, const char *cname,
-			    const char *oldpath, const char *lxcpath, int snap,
-			    uint64_t newsize, struct lxc_conf *conf);
-extern int btrfs_create(struct lxc_storage *bdev, const char *dest, const char *n,
-			struct bdev_specs *specs, const struct lxc_conf *conf);
-extern int btrfs_destroy(struct lxc_storage *orig);
-extern bool btrfs_detect(const char *path);
-extern int btrfs_mount(struct lxc_storage *bdev);
-extern int btrfs_umount(struct lxc_storage *bdev);
+__hidden extern int btrfs_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
+				     const char *oldname, const char *cname, const char *oldpath,
+				     const char *lxcpath, int snap, uint64_t newsize,
+				     struct lxc_conf *conf);
+__hidden extern int btrfs_create(struct lxc_storage *bdev, const char *dest, const char *n,
+				 struct bdev_specs *specs, const struct lxc_conf *conf);
+__hidden extern int btrfs_destroy(struct lxc_storage *orig);
+__hidden extern bool btrfs_detect(const char *path);
+__hidden extern int btrfs_mount(struct lxc_storage *bdev);
+__hidden extern int btrfs_umount(struct lxc_storage *bdev);
 
-extern char *get_btrfs_subvol_path(int fd, u64 dir_id, u64 objid, char *name,
-				   u16 name_len);
-extern int btrfs_list_get_path_rootid(int fd, u64 *treeid);
-extern bool is_btrfs_fs(const char *path);
-extern int is_btrfs_subvol(const char *path);
-extern bool btrfs_try_remove_subvol(const char *path);
-extern int btrfs_same_fs(const char *orig, const char *new);
-extern int btrfs_snapshot(const char *orig, const char *new);
-extern int btrfs_snapshot_wrapper(void *data);
-extern bool btrfs_create_clone(struct lxc_conf *conf, struct lxc_storage *orig,
-			       struct lxc_storage *new, uint64_t newsize);
-extern bool btrfs_create_snapshot(struct lxc_conf *conf,
-				  struct lxc_storage *orig,
-				  struct lxc_storage *new, uint64_t newsize);
+__hidden extern char *get_btrfs_subvol_path(int fd, u64 dir_id, u64 objid, char *name, u16 name_len);
+__hidden extern int btrfs_list_get_path_rootid(int fd, u64 *treeid);
+__hidden extern bool is_btrfs_fs(const char *path);
+__hidden extern int is_btrfs_subvol(const char *path);
+__hidden extern bool btrfs_try_remove_subvol(const char *path);
+__hidden extern int btrfs_same_fs(const char *orig, const char *new);
+__hidden extern int btrfs_snapshot(const char *orig, const char *new);
+__hidden extern int btrfs_snapshot_wrapper(void *data);
+__hidden extern bool btrfs_create_clone(struct lxc_conf *conf, struct lxc_storage *orig,
+					struct lxc_storage *new, uint64_t newsize);
+__hidden extern bool btrfs_create_snapshot(struct lxc_conf *conf, struct lxc_storage *orig,
+					   struct lxc_storage *new, uint64_t newsize);
 
 #endif /* __LXC_BTRFS_H */

--- a/src/lxc/storage/dir.h
+++ b/src/lxc/storage/dir.h
@@ -6,21 +6,23 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "compiler.h"
+
 struct lxc_storage;
 
 struct bdev_specs;
 
 struct lxc_conf;
 
-extern int dir_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
-			  const char *oldname, const char *cname,
-			  const char *oldpath, const char *lxcpath, int snap,
-			  uint64_t newsize, struct lxc_conf *conf);
-extern int dir_create(struct lxc_storage *bdev, const char *dest, const char *n,
-		      struct bdev_specs *specs, const struct lxc_conf *conf);
-extern int dir_destroy(struct lxc_storage *orig);
-extern bool dir_detect(const char *path);
-extern int dir_mount(struct lxc_storage *bdev);
-extern int dir_umount(struct lxc_storage *bdev);
+__hidden extern int dir_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
+				   const char *oldname, const char *cname, const char *oldpath,
+				   const char *lxcpath, int snap, uint64_t newsize,
+				   struct lxc_conf *conf);
+__hidden extern int dir_create(struct lxc_storage *bdev, const char *dest, const char *n,
+			       struct bdev_specs *specs, const struct lxc_conf *conf);
+__hidden extern int dir_destroy(struct lxc_storage *orig);
+__hidden extern bool dir_detect(const char *path);
+__hidden extern int dir_mount(struct lxc_storage *bdev);
+__hidden extern int dir_umount(struct lxc_storage *bdev);
 
 #endif /* __LXC_DIR_H */

--- a/src/lxc/storage/loop.h
+++ b/src/lxc/storage/loop.h
@@ -6,21 +6,23 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "compiler.h"
+
 struct lxc_storage;
 
 struct bdev_specs;
 
 struct lxc_conf;
 
-extern int loop_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
-			   const char *oldname, const char *cname,
-			   const char *oldpath, const char *lxcpath, int snap,
-			   uint64_t newsize, struct lxc_conf *conf);
-extern int loop_create(struct lxc_storage *bdev, const char *dest,
-		       const char *n, struct bdev_specs *specs, const struct lxc_conf *conf);
-extern int loop_destroy(struct lxc_storage *orig);
-extern bool loop_detect(const char *path);
-extern int loop_mount(struct lxc_storage *bdev);
-extern int loop_umount(struct lxc_storage *bdev);
+__hidden extern int loop_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
+				    const char *oldname, const char *cname, const char *oldpath,
+				    const char *lxcpath, int snap, uint64_t newsize,
+				    struct lxc_conf *conf);
+__hidden extern int loop_create(struct lxc_storage *bdev, const char *dest, const char *n,
+				struct bdev_specs *specs, const struct lxc_conf *conf);
+__hidden extern int loop_destroy(struct lxc_storage *orig);
+__hidden extern bool loop_detect(const char *path);
+__hidden extern int loop_mount(struct lxc_storage *bdev);
+__hidden extern int loop_umount(struct lxc_storage *bdev);
 
 #endif /* __LXC_LOOP_H */

--- a/src/lxc/storage/lvm.h
+++ b/src/lxc/storage/lvm.h
@@ -6,28 +6,30 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "compiler.h"
+
 struct lxc_storage;
 
 struct bdev_specs;
 
 struct lxc_conf;
 
-extern bool lvm_detect(const char *path);
-extern int lvm_mount(struct lxc_storage *bdev);
-extern int lvm_umount(struct lxc_storage *bdev);
-extern int lvm_compare_lv_attr(const char *path, int pos, const char expected);
-extern int lvm_is_thin_volume(const char *path);
-extern int lvm_is_thin_pool(const char *path);
-extern int lvm_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
-			  const char *oldname, const char *cname,
-			  const char *oldpath, const char *lxcpath, int snap,
-			  uint64_t newsize, struct lxc_conf *conf);
-extern int lvm_destroy(struct lxc_storage *orig);
-extern int lvm_create(struct lxc_storage *bdev, const char *dest, const char *n,
-		      struct bdev_specs *specs, const struct lxc_conf *conf);
-extern bool lvm_create_clone(struct lxc_conf *conf, struct lxc_storage *orig,
-			     struct lxc_storage *new, uint64_t newsize);
-extern bool lvm_create_snapshot(struct lxc_conf *conf, struct lxc_storage *orig,
-				struct lxc_storage *new, uint64_t newsize);
+__hidden extern bool lvm_detect(const char *path);
+__hidden extern int lvm_mount(struct lxc_storage *bdev);
+__hidden extern int lvm_umount(struct lxc_storage *bdev);
+__hidden extern int lvm_compare_lv_attr(const char *path, int pos, const char expected);
+__hidden extern int lvm_is_thin_volume(const char *path);
+__hidden extern int lvm_is_thin_pool(const char *path);
+__hidden extern int lvm_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
+				   const char *oldname, const char *cname, const char *oldpath,
+				   const char *lxcpath, int snap, uint64_t newsize,
+				   struct lxc_conf *conf);
+__hidden extern int lvm_destroy(struct lxc_storage *orig);
+__hidden extern int lvm_create(struct lxc_storage *bdev, const char *dest, const char *n,
+			       struct bdev_specs *specs, const struct lxc_conf *conf);
+__hidden extern bool lvm_create_clone(struct lxc_conf *conf, struct lxc_storage *orig,
+				      struct lxc_storage *new, uint64_t newsize);
+__hidden extern bool lvm_create_snapshot(struct lxc_conf *conf, struct lxc_storage *orig,
+					 struct lxc_storage *new, uint64_t newsize);
 
 #endif /* __LXC_LVM_H */

--- a/src/lxc/storage/nbd.h
+++ b/src/lxc/storage/nbd.h
@@ -6,25 +6,26 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "compiler.h"
+
 struct lxc_storage;
 
 struct bdev_specs;
 
 struct lxc_conf;
 
-extern int nbd_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
-			  const char *oldname, const char *cname,
-			  const char *oldpath, const char *lxcpath, int snap,
-			  uint64_t newsize, struct lxc_conf *conf);
-extern int nbd_create(struct lxc_storage *bdev, const char *dest, const char *n,
-		      struct bdev_specs *specs, const struct lxc_conf *conf);
-extern int nbd_destroy(struct lxc_storage *orig);
-extern bool nbd_detect(const char *path);
-extern int nbd_mount(struct lxc_storage *bdev);
-extern int nbd_umount(struct lxc_storage *bdev);
-
-extern bool attach_nbd(char *src, struct lxc_conf *conf);
-extern void detach_nbd_idx(int idx);
-extern bool requires_nbd(const char *path);
+__hidden extern int nbd_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
+				   const char *oldname, const char *cname, const char *oldpath,
+				   const char *lxcpath, int snap, uint64_t newsize,
+				   struct lxc_conf *conf);
+__hidden extern int nbd_create(struct lxc_storage *bdev, const char *dest, const char *n,
+			       struct bdev_specs *specs, const struct lxc_conf *conf);
+__hidden extern int nbd_destroy(struct lxc_storage *orig);
+__hidden extern bool nbd_detect(const char *path);
+__hidden extern int nbd_mount(struct lxc_storage *bdev);
+__hidden extern int nbd_umount(struct lxc_storage *bdev);
+__hidden extern bool attach_nbd(char *src, struct lxc_conf *conf);
+__hidden extern void detach_nbd_idx(int idx);
+__hidden extern bool requires_nbd(const char *path);
 
 #endif /* __LXC_NBD_H */

--- a/src/lxc/storage/overlay.h
+++ b/src/lxc/storage/overlay.h
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
+#include "compiler.h"
 #include "storage.h"
 
 struct lxc_storage;
@@ -20,16 +21,16 @@ struct lxc_conf;
 
 struct lxc_rootfs;
 
-extern int ovl_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
-			  const char *oldname, const char *cname,
-			  const char *oldpath, const char *lxcpath, int snap,
-			  uint64_t newsize, struct lxc_conf *conf);
-extern int ovl_create(struct lxc_storage *bdev, const char *dest, const char *n,
-		      struct bdev_specs *specs, const struct lxc_conf *conf);
-extern int ovl_destroy(struct lxc_storage *orig);
-extern bool ovl_detect(const char *path);
-extern int ovl_mount(struct lxc_storage *bdev);
-extern int ovl_umount(struct lxc_storage *bdev);
+__hidden extern int ovl_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
+				   const char *oldname, const char *cname, const char *oldpath,
+				   const char *lxcpath, int snap, uint64_t newsize,
+				   struct lxc_conf *conf);
+__hidden extern int ovl_create(struct lxc_storage *bdev, const char *dest, const char *n,
+			       struct bdev_specs *specs, const struct lxc_conf *conf);
+__hidden extern int ovl_destroy(struct lxc_storage *orig);
+__hidden extern bool ovl_detect(const char *path);
+__hidden extern int ovl_mount(struct lxc_storage *bdev);
+__hidden extern int ovl_umount(struct lxc_storage *bdev);
 
 /* To be called from lxcapi_clone() in lxccontainer.c: When we clone a container
  * with overlay lxc.mount.entry entries we need to update absolute paths for
@@ -38,24 +39,23 @@ extern int ovl_umount(struct lxc_storage *bdev);
  * independent of each other since lxc_conf->mountlist may container more mount
  * entries (e.g. from other included files) than lxc_conf->unexpanded_config .
  */
-extern int ovl_update_abs_paths(struct lxc_conf *lxc_conf, const char *lxc_path,
-				const char *lxc_name, const char *newpath,
-				const char *newname);
+__hidden extern int ovl_update_abs_paths(struct lxc_conf *lxc_conf, const char *lxc_path,
+					 const char *lxc_name, const char *newpath,
+					 const char *newname);
 
 /* To be called from functions in lxccontainer.c: Get lower directory for
  * overlay rootfs.
  */
-extern const char *ovl_get_lower(const char *rootfs_path);
+__hidden extern const char *ovl_get_lower(const char *rootfs_path);
 
 /* Get rootfs path for overlay backed containers. Allocated memory must be freed
  * by caller.
  */
-extern char *ovl_get_rootfs(const char *rootfs_path, size_t *rootfslen);
+__hidden extern char *ovl_get_rootfs(const char *rootfs_path, size_t *rootfslen);
 
 /* Create upper- and workdirs for overlay mounts.
  */
-extern int ovl_mkdir(const struct mntent *mntent,
-		     const struct lxc_rootfs *rootfs, const char *lxc_name,
-		     const char *lxc_path);
+__hidden extern int ovl_mkdir(const struct mntent *mntent, const struct lxc_rootfs *rootfs,
+			      const char *lxc_name, const char *lxc_path);
 
 #endif /* __LXC_OVERLAY_H */

--- a/src/lxc/storage/rbd.c
+++ b/src/lxc/storage/rbd.c
@@ -29,7 +29,7 @@ struct rbd_args {
 	const char *size;
 };
 
-int rbd_create_wrapper(void *data)
+static int rbd_create_wrapper(void *data)
 {
 	struct rbd_args *args = data;
 
@@ -39,7 +39,7 @@ int rbd_create_wrapper(void *data)
 	return -1;
 }
 
-int rbd_map_wrapper(void *data)
+static int rbd_map_wrapper(void *data)
 {
 	struct rbd_args *args = data;
 
@@ -49,7 +49,7 @@ int rbd_map_wrapper(void *data)
 	return -1;
 }
 
-int rbd_unmap_wrapper(void *data)
+static int rbd_unmap_wrapper(void *data)
 {
 	struct rbd_args *args = data;
 
@@ -58,7 +58,7 @@ int rbd_unmap_wrapper(void *data)
 	return -1;
 }
 
-int rbd_delete_wrapper(void *data)
+static int rbd_delete_wrapper(void *data)
 {
 	struct rbd_args *args = data;
 

--- a/src/lxc/storage/rbd.h
+++ b/src/lxc/storage/rbd.h
@@ -6,21 +6,23 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "compiler.h"
+
 struct lxc_storage;
 
 struct bdev_specs;
 
 struct lxc_conf;
 
-extern int rbd_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
-			  const char *oldname, const char *cname,
-			  const char *oldpath, const char *lxcpath, int snap,
-			  uint64_t newsize, struct lxc_conf *conf);
-extern int rbd_create(struct lxc_storage *bdev, const char *dest, const char *n,
-		      struct bdev_specs *specs, const struct lxc_conf *conf);
-extern int rbd_destroy(struct lxc_storage *orig);
-extern bool rbd_detect(const char *path);
-extern int rbd_mount(struct lxc_storage *bdev);
-extern int rbd_umount(struct lxc_storage *bdev);
+__hidden extern int rbd_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
+				   const char *oldname, const char *cname, const char *oldpath,
+				   const char *lxcpath, int snap, uint64_t newsize,
+				   struct lxc_conf *conf);
+__hidden extern int rbd_create(struct lxc_storage *bdev, const char *dest, const char *n,
+			       struct bdev_specs *specs, const struct lxc_conf *conf);
+__hidden extern int rbd_destroy(struct lxc_storage *orig);
+__hidden extern bool rbd_detect(const char *path);
+__hidden extern int rbd_mount(struct lxc_storage *bdev);
+__hidden extern int rbd_umount(struct lxc_storage *bdev);
 
 #endif /* __LXC_RDB_H */

--- a/src/lxc/storage/rsync.h
+++ b/src/lxc/storage/rsync.h
@@ -5,6 +5,8 @@
 
 #include <stdio.h>
 
+#include "compiler.h"
+
 struct rsync_data {
 	struct lxc_storage *orig;
 	struct lxc_storage *new;
@@ -16,9 +18,9 @@ struct rsync_data_char {
 };
 
 /* new helpers */
-extern int lxc_rsync_exec_wrapper(void *data);
-extern int lxc_storage_rsync_exec_wrapper(void *data);
-extern int lxc_rsync_exec(const char *src, const char *dest);
-extern int lxc_rsync(struct rsync_data *data);
+__hidden extern int lxc_rsync_exec_wrapper(void *data);
+__hidden extern int lxc_storage_rsync_exec_wrapper(void *data);
+__hidden extern int lxc_rsync_exec(const char *src, const char *dest);
+__hidden extern int lxc_rsync(struct rsync_data *data);
 
 #endif /* __LXC_RSYNC_H */

--- a/src/lxc/storage/storage.c
+++ b/src/lxc/storage/storage.c
@@ -109,7 +109,7 @@ static const struct lxc_storage_ops lvm_ops = {
 };
 
 /* nbd */
-const struct lxc_storage_ops nbd_ops = {
+static const struct lxc_storage_ops nbd_ops = {
     .detect = &nbd_detect,
     .mount = &nbd_mount,
     .umount = &nbd_umount,
@@ -234,7 +234,7 @@ static const struct lxc_storage_type *storage_query(struct lxc_conf *conf)
 	return &bdevs[i];
 }
 
-struct lxc_storage *storage_get(const char *type)
+static struct lxc_storage *storage_get(const char *type)
 {
 	size_t i;
 	struct lxc_storage *bdev;

--- a/src/lxc/storage/storage.h
+++ b/src/lxc/storage/storage.h
@@ -14,6 +14,8 @@
 #include <mntent.h>
 #endif
 
+#include "compiler.h"
+
 #ifndef MS_DIRSYNC
 #define MS_DIRSYNC 128
 #endif
@@ -99,23 +101,19 @@ struct lxc_storage {
  *                  type specifications.  If the <storage type> prefix is not
  *                  detected liblxc will try to detect the storage type.
  */
-extern bool storage_is_dir(struct lxc_conf *conf);
-extern bool storage_can_backup(struct lxc_conf *conf);
-
-extern struct lxc_storage *storage_init(struct lxc_conf *conf);
-
-extern struct lxc_storage *storage_copy(struct lxc_container *c,
-					const char *cname, const char *lxcpath,
-					const char *bdevtype, int flags,
-					const char *bdevdata, uint64_t newsize,
-					bool *needs_rdep);
-extern struct lxc_storage *storage_create(const char *dest, const char *type,
-					  const char *cname,
-					  struct bdev_specs *specs,
-					  const struct lxc_conf *conf);
-extern void storage_put(struct lxc_storage *bdev);
-extern bool storage_destroy(struct lxc_conf *conf);
-extern bool rootfs_is_blockdev(struct lxc_conf *conf);
-extern const char *lxc_storage_get_path(char *src, const char *prefix);
+__hidden extern bool storage_is_dir(struct lxc_conf *conf);
+__hidden extern bool storage_can_backup(struct lxc_conf *conf);
+__hidden extern struct lxc_storage *storage_init(struct lxc_conf *conf);
+__hidden extern struct lxc_storage *storage_copy(struct lxc_container *c, const char *cname,
+						 const char *lxcpath, const char *bdevtype,
+						 int flags, const char *bdevdata, uint64_t newsize,
+						 bool *needs_rdep);
+__hidden extern struct lxc_storage *storage_create(const char *dest, const char *type,
+						   const char *cname, struct bdev_specs *specs,
+						   const struct lxc_conf *conf);
+__hidden extern void storage_put(struct lxc_storage *bdev);
+__hidden extern bool storage_destroy(struct lxc_conf *conf);
+__hidden extern bool rootfs_is_blockdev(struct lxc_conf *conf);
+__hidden extern const char *lxc_storage_get_path(char *src, const char *prefix);
 
 #endif /* #define __LXC_STORAGE_H */

--- a/src/lxc/storage/storage_utils.h
+++ b/src/lxc/storage/storage_utils.h
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "compiler.h"
 #include "conf.h"
 #include "macro.h"
 
@@ -22,20 +23,19 @@
 struct lxc_storage;
 struct lxc_conf;
 
-extern bool attach_block_device(struct lxc_conf *conf);
-extern void detach_block_device(struct lxc_conf *conf);
-extern int blk_getsize(struct lxc_storage *bdev, uint64_t *size);
-extern int detect_fs(struct lxc_storage *bdev, char *type, int len);
-extern int do_mkfs_exec_wrapper(void *args);
-extern int is_blktype(struct lxc_storage *b);
-extern int mount_unknown_fs(const char *rootfs, const char *target,
-			    const char *options);
-extern int find_fstype_cb(char *buffer, void *data);
-extern const char *linkderef(const char *path, char *dest);
-extern bool unpriv_snap_allowed(struct lxc_storage *b, const char *t, bool snap,
-				bool maybesnap);
-extern uint64_t get_fssize(char *s);
-extern bool is_valid_storage_type(const char *type);
-extern int storage_destroy_wrapper(void *data);
+__hidden extern bool attach_block_device(struct lxc_conf *conf);
+__hidden extern void detach_block_device(struct lxc_conf *conf);
+__hidden extern int blk_getsize(struct lxc_storage *bdev, uint64_t *size);
+__hidden extern int detect_fs(struct lxc_storage *bdev, char *type, int len);
+__hidden extern int do_mkfs_exec_wrapper(void *args);
+__hidden extern int is_blktype(struct lxc_storage *b);
+__hidden extern int mount_unknown_fs(const char *rootfs, const char *target, const char *options);
+__hidden extern int find_fstype_cb(char *buffer, void *data);
+__hidden extern const char *linkderef(const char *path, char *dest);
+__hidden extern bool unpriv_snap_allowed(struct lxc_storage *b, const char *t, bool snap,
+					 bool maybesnap);
+__hidden extern uint64_t get_fssize(char *s);
+__hidden extern bool is_valid_storage_type(const char *type);
+__hidden extern int storage_destroy_wrapper(void *data);
 
 #endif /* __LXC_STORAGE_UTILS_H */

--- a/src/lxc/storage/zfs.c
+++ b/src/lxc/storage/zfs.c
@@ -28,7 +28,7 @@ struct zfs_args {
 	void *argv;
 };
 
-int zfs_detect_exec_wrapper(void *data)
+static int zfs_detect_exec_wrapper(void *data)
 {
 	struct zfs_args *args = data;
 
@@ -38,7 +38,7 @@ int zfs_detect_exec_wrapper(void *data)
 	return -1;
 }
 
-int zfs_create_exec_wrapper(void *args)
+static int zfs_create_exec_wrapper(void *args)
 {
 	struct zfs_args *zfs_args = args;
 
@@ -47,7 +47,7 @@ int zfs_create_exec_wrapper(void *args)
 	return -1;
 }
 
-int zfs_delete_exec_wrapper(void *args)
+static int zfs_delete_exec_wrapper(void *args)
 {
 	struct zfs_args *zfs_args = args;
 
@@ -56,7 +56,7 @@ int zfs_delete_exec_wrapper(void *args)
 	return -1;
 }
 
-int zfs_snapshot_exec_wrapper(void *args)
+static int zfs_snapshot_exec_wrapper(void *args)
 {
 	struct zfs_args *zfs_args = args;
 
@@ -65,7 +65,7 @@ int zfs_snapshot_exec_wrapper(void *args)
 	return -1;
 }
 
-int zfs_clone_exec_wrapper(void *args)
+static int zfs_clone_exec_wrapper(void *args)
 {
 	struct zfs_args *zfs_args = args;
 
@@ -76,7 +76,7 @@ int zfs_clone_exec_wrapper(void *args)
 	return -1;
 }
 
-int zfs_get_parent_snapshot_exec_wrapper(void *args)
+static int zfs_get_parent_snapshot_exec_wrapper(void *args)
 {
 	struct zfs_args *zfs_args = args;
 

--- a/src/lxc/storage/zfs.h
+++ b/src/lxc/storage/zfs.h
@@ -7,26 +7,27 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#include "compiler.h"
+
 struct lxc_storage;
 
 struct bdev_specs;
 
 struct lxc_conf;
 
-extern int zfs_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
-			  const char *oldname, const char *cname,
-			  const char *oldpath, const char *lxcpath, int snap,
-			  uint64_t newsize, struct lxc_conf *conf);
-extern int zfs_create(struct lxc_storage *bdev, const char *dest, const char *n,
-		      struct bdev_specs *specs, const struct lxc_conf *conf);
-extern int zfs_destroy(struct lxc_storage *orig);
-extern bool zfs_detect(const char *path);
-extern int zfs_mount(struct lxc_storage *bdev);
-extern int zfs_umount(struct lxc_storage *bdev);
-
-extern bool zfs_copy(struct lxc_conf *conf, struct lxc_storage *orig,
-		     struct lxc_storage *new, uint64_t newsize);
-extern bool zfs_snapshot(struct lxc_conf *conf, struct lxc_storage *orig,
-			 struct lxc_storage *new, uint64_t newsize);
+__hidden extern int zfs_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
+				   const char *oldname, const char *cname, const char *oldpath,
+				   const char *lxcpath, int snap, uint64_t newsize,
+				   struct lxc_conf *conf);
+__hidden extern int zfs_create(struct lxc_storage *bdev, const char *dest, const char *n,
+			       struct bdev_specs *specs, const struct lxc_conf *conf);
+__hidden extern int zfs_destroy(struct lxc_storage *orig);
+__hidden extern bool zfs_detect(const char *path);
+__hidden extern int zfs_mount(struct lxc_storage *bdev);
+__hidden extern int zfs_umount(struct lxc_storage *bdev);
+__hidden extern bool zfs_copy(struct lxc_conf *conf, struct lxc_storage *orig,
+			      struct lxc_storage *new, uint64_t newsize);
+__hidden extern bool zfs_snapshot(struct lxc_conf *conf, struct lxc_storage *orig,
+				  struct lxc_storage *new, uint64_t newsize);
 
 #endif /* __LXC_ZFS_H */

--- a/src/lxc/sync.h
+++ b/src/lxc/sync.h
@@ -3,30 +3,32 @@
 #ifndef __LXC_SYNC_H
 #define __LXC_SYNC_H
 
+#include "compiler.h"
+
 struct lxc_handler;
 
 enum {
-	LXC_SYNC_STARTUP,
-	LXC_SYNC_CONFIGURE,
-	LXC_SYNC_POST_CONFIGURE,
-	LXC_SYNC_CGROUP,
-	LXC_SYNC_CGROUP_UNSHARE,
-	LXC_SYNC_CGROUP_LIMITS,
-	LXC_SYNC_READY_START,
-	LXC_SYNC_RESTART,
-	LXC_SYNC_POST_RESTART,
-	LXC_SYNC_ERROR = -1 /* Used to report errors from another process */
+	LXC_SYNC_STARTUP	= 0,
+	LXC_SYNC_CONFIGURE	= 1,
+	LXC_SYNC_POST_CONFIGURE	= 2,
+	LXC_SYNC_CGROUP		= 3,
+	LXC_SYNC_CGROUP_UNSHARE	= 4,
+	LXC_SYNC_CGROUP_LIMITS	= 5,
+	LXC_SYNC_READY_START	= 6,
+	LXC_SYNC_RESTART	= 7,
+	LXC_SYNC_POST_RESTART	= 8,
+	LXC_SYNC_ERROR		= -1 /* Used to report errors from another process */
 };
 
-int lxc_sync_init(struct lxc_handler *handler);
-void lxc_sync_fini(struct lxc_handler *);
-void lxc_sync_fini_parent(struct lxc_handler *);
-void lxc_sync_fini_child(struct lxc_handler *);
-int lxc_sync_wake_child(struct lxc_handler *, int);
-int lxc_sync_wait_child(struct lxc_handler *, int);
-int lxc_sync_wake_parent(struct lxc_handler *, int);
-int lxc_sync_wait_parent(struct lxc_handler *, int);
-int lxc_sync_barrier_parent(struct lxc_handler *, int);
-int lxc_sync_barrier_child(struct lxc_handler *, int);
+__hidden extern int lxc_sync_init(struct lxc_handler *handler);
+__hidden extern void lxc_sync_fini(struct lxc_handler *);
+__hidden extern void lxc_sync_fini_parent(struct lxc_handler *);
+__hidden extern void lxc_sync_fini_child(struct lxc_handler *);
+__hidden extern int lxc_sync_wake_child(struct lxc_handler *, int);
+__hidden extern int lxc_sync_wait_child(struct lxc_handler *, int);
+__hidden extern int lxc_sync_wake_parent(struct lxc_handler *, int);
+__hidden extern int lxc_sync_wait_parent(struct lxc_handler *, int);
+__hidden extern int lxc_sync_barrier_parent(struct lxc_handler *, int);
+__hidden extern int lxc_sync_barrier_child(struct lxc_handler *, int);
 
-#endif
+#endif /* __LXC_SYNC_H */

--- a/src/lxc/terminal.h
+++ b/src/lxc/terminal.h
@@ -6,6 +6,7 @@
 #include <signal.h>
 #include <stdio.h>
 
+#include "compiler.h"
 #include "list.h"
 #include "macro.h"
 #include "ringbuf.h"
@@ -98,7 +99,7 @@ struct lxc_terminal {
  *            indication that the console or tty is no longer in use
  * @ttyreq  : the tty requested to be opened, -1 for any, 0 for the console
  */
-extern int  lxc_terminal_allocate(struct lxc_conf *conf, int sockfd, int *ttynum);
+__hidden extern int  lxc_terminal_allocate(struct lxc_conf *conf, int sockfd, int *ttynum);
 
 /**
  * Create a new terminal:
@@ -109,19 +110,19 @@ extern int  lxc_terminal_allocate(struct lxc_conf *conf, int sockfd, int *ttynum
  * - sets up SIGWINCH handler, winsz, and new terminal settings
  *   (Handlers for SIGWINCH and I/O are not registered in a mainloop.)
  */
-extern int lxc_terminal_create(struct lxc_terminal *console);
+__hidden extern int lxc_terminal_create(struct lxc_terminal *console);
 
 /**
  * lxc_terminal_setup: Create a new terminal.
  * - In addition to lxc_terminal_create() also sets up logging.
  */
-extern int lxc_terminal_setup(struct lxc_conf *);
+__hidden extern int lxc_terminal_setup(struct lxc_conf *);
 
 /**
  * Delete a terminal created via lxc_terminal_create() or lxc_terminal_setup():
  * Note, registered handlers are not automatically deleted.
  */
-extern void lxc_terminal_delete(struct lxc_terminal *);
+__hidden extern void lxc_terminal_delete(struct lxc_terminal *);
 
 /**
  * lxc_terminal_free: mark the terminal as unallocated and free any resources
@@ -132,17 +133,17 @@ extern void lxc_terminal_delete(struct lxc_terminal *);
  *         the terminal is no longer in use. this is used to match
  *         which terminal is being freed.
  */
-extern void lxc_terminal_free(struct lxc_conf *conf, int fd);
+__hidden extern void lxc_terminal_free(struct lxc_conf *conf, int fd);
 
 /**
  * Register terminal event handlers in an open mainloop.
  */
-extern int  lxc_terminal_mainloop_add(struct lxc_epoll_descr *, struct lxc_terminal *);
+__hidden extern int lxc_terminal_mainloop_add(struct lxc_epoll_descr *, struct lxc_terminal *);
 
 /**
  * Handle SIGWINCH events on the allocated terminals.
  */
-extern void lxc_terminal_sigwinch(int sig);
+__hidden extern void lxc_terminal_sigwinch(int sig);
 
 /**
  * Connect to one of the ttys given to the container via lxc.tty.max.
@@ -153,9 +154,8 @@ extern void lxc_terminal_sigwinch(int sig);
  * - registers SIGWINCH, I/O handlers in the mainloop
  * - performs all necessary cleanup operations
  */
-extern int  lxc_console(struct lxc_container *c, int ttynum,
-		        int stdinfd, int stdoutfd, int stderrfd,
-		        int escape);
+__hidden extern int lxc_console(struct lxc_container *c, int ttynum, int stdinfd, int stdoutfd,
+				int stderrfd, int escape);
 
 /**
  * Allocate one of the tty given to the container via lxc.tty.max. Returns an
@@ -163,15 +163,14 @@ extern int  lxc_console(struct lxc_container *c, int ttynum,
  * Set ttynum to -1 to allocate the first available tty, or to a value within
  * the range specified by lxc.tty.max to allocate a specific tty.
  */
-extern int lxc_terminal_getfd(struct lxc_container *c, int *ttynum,
-			      int *ptxfd);
+__hidden extern int lxc_terminal_getfd(struct lxc_container *c, int *ttynum, int *ptxfd);
 
 /**
  * Make fd a duplicate of the standard file descriptors. The fd is made a
  * duplicate of a specific standard file descriptor iff the standard file
  * descriptor refers to a terminal.
  */
-extern int lxc_terminal_set_stdfds(int fd);
+__hidden extern int lxc_terminal_set_stdfds(int fd);
 
 /**
  * Handler for events on the stdin fd of the terminal. To be registered via the
@@ -179,8 +178,8 @@ extern int lxc_terminal_set_stdfds(int fd);
  * lxc_terminal_mainloop_add().
  * This function exits the loop cleanly when an EPOLLHUP event is received.
  */
-extern int lxc_terminal_stdin_cb(int fd, uint32_t events, void *cbdata,
-				 struct lxc_epoll_descr *descr);
+__hidden extern int lxc_terminal_stdin_cb(int fd, uint32_t events, void *cbdata,
+					  struct lxc_epoll_descr *descr);
 
 /**
  * Handler for events on the ptx fd of the terminal. To be registered via
@@ -188,15 +187,14 @@ extern int lxc_terminal_stdin_cb(int fd, uint32_t events, void *cbdata,
  * lxc_terminal_mainloop_add().
  * This function exits the loop cleanly when an EPOLLHUP event is received.
  */
-extern int lxc_terminal_ptx_cb(int fd, uint32_t events, void *cbdata,
-				  struct lxc_epoll_descr *descr);
+__hidden extern int lxc_terminal_ptx_cb(int fd, uint32_t events, void *cbdata,
+					struct lxc_epoll_descr *descr);
 
 /**
  * Setup new terminal properties. The old terminal settings are stored in
  * oldtios.
  */
-extern int lxc_setup_tios(int fd, struct termios *oldtios);
-
+__hidden extern int lxc_setup_tios(int fd, struct termios *oldtios);
 
 /**
  * lxc_terminal_winsz: propagate winsz from one terminal to another
@@ -206,7 +204,7 @@ extern int lxc_setup_tios(int fd, struct termios *oldtios);
  * @dstfd
  * - terminal to set size on (typically a ptx pty)
  */
-extern void lxc_terminal_winsz(int srcfd, int dstfd);
+__hidden extern void lxc_terminal_winsz(int srcfd, int dstfd);
 
 /*
  * lxc_terminal_signal_init: install signal handler
@@ -232,26 +230,25 @@ extern void lxc_terminal_winsz(int srcfd, int dstfd);
  *
  * This function allocates memory. It is up to the caller to free it.
  */
-extern struct lxc_terminal_state *lxc_terminal_signal_init(int srcfd, int dstfd);
+__hidden extern struct lxc_terminal_state *lxc_terminal_signal_init(int srcfd, int dstfd);
 
 /**
  * Handler for signal events. To be registered via the corresponding functions
  * declared and defined in mainloop.{c,h} or lxc_terminal_mainloop_add().
  */
-extern int lxc_terminal_signalfd_cb(int fd, uint32_t events, void *cbdata,
-				    struct lxc_epoll_descr *descr);
+__hidden extern int lxc_terminal_signalfd_cb(int fd, uint32_t events, void *cbdata,
+					     struct lxc_epoll_descr *descr);
 
-extern int lxc_terminal_write_ringbuffer(struct lxc_terminal *terminal);
-extern int lxc_terminal_create_log_file(struct lxc_terminal *terminal);
-extern int lxc_terminal_io_cb(int fd, uint32_t events, void *data,
-			      struct lxc_epoll_descr *descr);
+__hidden extern int lxc_terminal_write_ringbuffer(struct lxc_terminal *terminal);
+__hidden extern int lxc_terminal_create_log_file(struct lxc_terminal *terminal);
+__hidden extern int lxc_terminal_io_cb(int fd, uint32_t events, void *data,
+				       struct lxc_epoll_descr *descr);
 
-extern int lxc_make_controlling_terminal(int fd);
-extern int lxc_terminal_prepare_login(int fd);
-extern void lxc_terminal_conf_free(struct lxc_terminal *terminal);
-extern void lxc_terminal_info_init(struct lxc_terminal_info *terminal);
-extern void lxc_terminal_init(struct lxc_terminal *terminal);
-extern int lxc_terminal_map_ids(struct lxc_conf *c,
-				struct lxc_terminal *terminal);
+__hidden extern int lxc_make_controlling_terminal(int fd);
+__hidden extern int lxc_terminal_prepare_login(int fd);
+__hidden extern void lxc_terminal_conf_free(struct lxc_terminal *terminal);
+__hidden extern void lxc_terminal_info_init(struct lxc_terminal_info *terminal);
+__hidden extern void lxc_terminal_init(struct lxc_terminal *terminal);
+__hidden extern int lxc_terminal_map_ids(struct lxc_conf *c, struct lxc_terminal *terminal);
 
 #endif /* __LXC_TERMINAL_H */

--- a/src/lxc/tools/arguments.h
+++ b/src/lxc/tools/arguments.h
@@ -11,6 +11,8 @@
 
 #include <lxc/lxccontainer.h>
 
+#include "compiler.h"
+
 struct lxc_arguments;
 
 typedef int (*lxc_arguments_parser_t)(struct lxc_arguments *, int, char *);
@@ -152,13 +154,11 @@ struct lxc_arguments {
 #define OPT_SHARE_UTS OPT_USAGE - 5
 #define OPT_SHARE_PID OPT_USAGE - 6
 
-extern int lxc_arguments_parse(struct lxc_arguments *args, int argc,
-			       char *const argv[]);
+__hidden extern int lxc_arguments_parse(struct lxc_arguments *args, int argc, char *const argv[]);
 
-extern int lxc_arguments_str_to_int(struct lxc_arguments *args,
-				    const char *str);
+__hidden extern int lxc_arguments_str_to_int(struct lxc_arguments *args, const char *str);
 
-extern bool lxc_setup_shared_ns(struct lxc_arguments *args, struct lxc_container *c);
+__hidden extern bool lxc_setup_shared_ns(struct lxc_arguments *args, struct lxc_container *c);
 
 #define lxc_info(arg, fmt, args...)                                                \
 	do {                                                                       \

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1544,7 +1544,7 @@ pop_stack:
 	return umounts;
 }
 
-int run_command_internal(char *buf, size_t buf_size, int (*child_fn)(void *), void *args, bool wait_status)
+static int run_command_internal(char *buf, size_t buf_size, int (*child_fn)(void *), void *args, bool wait_status)
 {
 	pid_t child;
 	int ret, fret, pipefd[2];

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -21,6 +21,7 @@
 #include <sys/vfs.h>
 #include <unistd.h>
 
+#include "compiler.h"
 #include "file_utils.h"
 #include "initutils.h"
 #include "macro.h"
@@ -29,10 +30,10 @@
 #include "string_utils.h"
 
 /* returns 1 on success, 0 if there were any failures */
-extern int lxc_rmdir_onedev(const char *path, const char *exclude);
-extern int get_u16(unsigned short *val, const char *arg, int base);
-extern int mkdir_p(const char *dir, mode_t mode);
-extern char *get_rundir(void);
+__hidden extern int lxc_rmdir_onedev(const char *path, const char *exclude);
+__hidden extern int get_u16(unsigned short *val, const char *arg, int base);
+__hidden extern int mkdir_p(const char *dir, mode_t mode);
+__hidden extern char *get_rundir(void);
 
 /* Define getline() if missing from the C library */
 #ifndef HAVE_GETLINE
@@ -64,14 +65,14 @@ struct lxc_popen_FILE {
  * Returns pointer to struct lxc_popen_FILE, that should be freed with lxc_pclose().
  * On error returns NULL.
  */
-extern struct lxc_popen_FILE *lxc_popen(const char *command);
+__hidden extern struct lxc_popen_FILE *lxc_popen(const char *command);
 
 /* pclose() replacement to be used on struct lxc_popen_FILE *,
  * returned by lxc_popen().
  * Waits for associated process to terminate, returns its exit status and
  * frees resources, pointed to by struct lxc_popen_FILE *.
  */
-extern int lxc_pclose(struct lxc_popen_FILE *fp);
+__hidden extern int lxc_pclose(struct lxc_popen_FILE *fp);
 
 static inline void __auto_lxc_pclose__(struct lxc_popen_FILE **f)
 {
@@ -83,16 +84,16 @@ static inline void __auto_lxc_pclose__(struct lxc_popen_FILE **f)
 /*
  * wait on a child we forked
  */
-extern int wait_for_pid(pid_t pid);
-extern int lxc_wait_for_pid_status(pid_t pid);
-extern int wait_for_pidfd(int pidfd);
+__hidden extern int wait_for_pid(pid_t pid);
+__hidden extern int lxc_wait_for_pid_status(pid_t pid);
+__hidden extern int wait_for_pidfd(int pidfd);
 
 #if HAVE_OPENSSL
-extern int sha1sum_file(char *fnam, unsigned char *md_value, unsigned int *md_len);
+__hidden extern int sha1sum_file(char *fnam, unsigned char *md_value, unsigned int *md_len);
 #endif
 
 /* initialize rand with urandom */
-extern int randseed(bool);
+__hidden extern int randseed(bool);
 
 /* are we unprivileged with respect to our namespaces */
 inline static bool am_guest_unpriv(void) {
@@ -126,52 +127,51 @@ inline static bool am_host_unpriv(void)
 /*
  * parse /proc/self/uid_map to find what @orig maps to
  */
-extern uid_t get_ns_uid(uid_t orig);
+__hidden extern uid_t get_ns_uid(uid_t orig);
 /*
  * parse /proc/self/gid_map to find what @orig maps to
  */
-extern gid_t get_ns_gid(gid_t orig);
+__hidden extern gid_t get_ns_gid(gid_t orig);
 
-extern bool dir_exists(const char *path);
+__hidden extern bool dir_exists(const char *path);
 
 #define FNV1A_64_INIT ((uint64_t)0xcbf29ce484222325ULL)
-extern uint64_t fnv_64a_buf(void *buf, size_t len, uint64_t hval);
+__hidden extern uint64_t fnv_64a_buf(void *buf, size_t len, uint64_t hval);
 
-extern bool is_shared_mountpoint(const char *path);
-extern int detect_shared_rootfs(void);
-extern bool detect_ramfs_rootfs(void);
-extern char *on_path(const char *cmd, const char *rootfs);
-extern bool cgns_supported(void);
-extern char *choose_init(const char *rootfs);
-extern bool switch_to_ns(pid_t pid, const char *ns);
-extern char *get_template_path(const char *t);
-extern int safe_mount(const char *src, const char *dest, const char *fstype,
-		      unsigned long flags, const void *data,
-		      const char *rootfs);
-extern int lxc_mount_proc_if_needed(const char *rootfs);
-extern int open_devnull(void);
-extern int set_stdfds(int fd);
-extern int null_stdfds(void);
-extern int lxc_preserve_ns(const int pid, const char *ns);
+__hidden extern bool is_shared_mountpoint(const char *path);
+__hidden extern int detect_shared_rootfs(void);
+__hidden extern bool detect_ramfs_rootfs(void);
+__hidden extern char *on_path(const char *cmd, const char *rootfs);
+__hidden extern bool cgns_supported(void);
+__hidden extern char *choose_init(const char *rootfs);
+__hidden extern bool switch_to_ns(pid_t pid, const char *ns);
+__hidden extern char *get_template_path(const char *t);
+__hidden extern int safe_mount(const char *src, const char *dest, const char *fstype,
+			       unsigned long flags, const void *data, const char *rootfs);
+__hidden extern int lxc_mount_proc_if_needed(const char *rootfs);
+__hidden extern int open_devnull(void);
+__hidden extern int set_stdfds(int fd);
+__hidden extern int null_stdfds(void);
+__hidden extern int lxc_preserve_ns(const int pid, const char *ns);
 
 /* Check whether a signal is blocked by a process. */
-extern bool task_blocks_signal(pid_t pid, int signal);
+__hidden extern bool task_blocks_signal(pid_t pid, int signal);
 
 /* Switch to a new uid and gid.
  * If LXC_INVALID_{G,U}ID is passed then the set{g,u}id() will not be called.
  */
-extern bool lxc_switch_uid_gid(uid_t uid, gid_t gid);
-extern bool lxc_setgroups(int size, gid_t list[]);
+__hidden extern bool lxc_switch_uid_gid(uid_t uid, gid_t gid);
+__hidden extern bool lxc_setgroups(int size, gid_t list[]);
 
 /* Find an unused loop device and associate it with source. */
-extern int lxc_prepare_loop_dev(const char *source, char *loop_dev, int flags);
+__hidden extern int lxc_prepare_loop_dev(const char *source, char *loop_dev, int flags);
 
 /* Clear all mounts on a given node.
  * >= 0 successfully cleared. The number returned is the number of umounts
  *      performed.
  * < 0  error umounting. Return -errno.
  */
-extern int lxc_unstack_mountpoint(const char *path, bool lazy);
+__hidden extern int lxc_unstack_mountpoint(const char *path, bool lazy);
 
 /*
  * run_command runs a command and collect it's std{err,out} output in buf.
@@ -185,8 +185,7 @@ extern int lxc_unstack_mountpoint(const char *path, bool lazy);
  *                     function must exec.
  * @param[in] args     Arguments to be passed to child_fn.
  */
-extern int run_command(char *buf, size_t buf_size, int (*child_fn)(void *),
-		       void *args);
+__hidden extern int run_command(char *buf, size_t buf_size, int (*child_fn)(void *), void *args);
 
 /*
  * run_command runs a command and collect it's std{err,out} output in buf, returns exit status.
@@ -200,10 +199,10 @@ extern int run_command(char *buf, size_t buf_size, int (*child_fn)(void *),
  *                     function must exec.
  * @param[in] args     Arguments to be passed to child_fn.
  */
-extern int run_command_status(char *buf, size_t buf_size, int (*child_fn)(void *),
-		       void *args);
+__hidden extern int run_command_status(char *buf, size_t buf_size, int (*child_fn)(void *),
+				       void *args);
 
-extern bool lxc_nic_exists(char *nic);
+__hidden extern bool lxc_nic_exists(char *nic);
 
 static inline uint64_t lxc_getpagesize(void)
 {
@@ -224,16 +223,16 @@ static inline uint64_t lxc_getpagesize(void)
  * If the caller passes in 0 they will receive 0 in return since this is invalid
  * input and 0 is not a power of 2.
  */
-extern uint64_t lxc_find_next_power2(uint64_t n);
+__hidden extern uint64_t lxc_find_next_power2(uint64_t n);
 
 /* Set a signal the child process will receive after the parent has died. */
-extern int lxc_set_death_signal(int signal, pid_t parent, int parent_status_fd);
-extern int fd_cloexec(int fd, bool cloexec);
-extern int lxc_rm_rf(const char *dirname);
-extern int lxc_setup_keyring(char *keyring_label);
-extern bool lxc_can_use_pidfd(int pidfd);
+__hidden extern int lxc_set_death_signal(int signal, pid_t parent, int parent_status_fd);
+__hidden extern int fd_cloexec(int fd, bool cloexec);
+__hidden extern int lxc_rm_rf(const char *dirname);
+__hidden extern int lxc_setup_keyring(char *keyring_label);
+__hidden extern bool lxc_can_use_pidfd(int pidfd);
 
-extern int fix_stdio_permissions(uid_t uid);
+__hidden extern int fix_stdio_permissions(uid_t uid);
 
 static inline bool uid_valid(uid_t uid)
 {
@@ -245,6 +244,6 @@ static inline bool gid_valid(gid_t gid)
 	return gid != LXC_INVALID_GID;
 }
 
-extern bool multiply_overflow(int64_t base, uint64_t mult, int64_t *res);
+__hidden extern bool multiply_overflow(int64_t base, uint64_t mult, int64_t *res);
 
 #endif /* __LXC_UTILS_H */

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -203,12 +203,6 @@ extern int run_command(char *buf, size_t buf_size, int (*child_fn)(void *),
 extern int run_command_status(char *buf, size_t buf_size, int (*child_fn)(void *),
 		       void *args);
 
-/* return copy of string @entry;  do not fail. */
-extern char *must_copy_string(const char *entry);
-
-/* Re-allocate a pointer, do not fail */
-extern void *must_realloc(void *orig, size_t sz);
-
 extern bool lxc_nic_exists(char *nic);
 
 static inline uint64_t lxc_getpagesize(void)

--- a/src/lxc/uuid.h
+++ b/src/lxc/uuid.h
@@ -9,16 +9,18 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+#include "compiler.h"
+
 typedef union lxc_id128 lxc_id128_t;
 
 union lxc_id128 {
-        uint8_t bytes[16];
-        uint64_t qwords[2];
-}
-;
-extern int lxc_id128_randomize(lxc_id128_t *ret);
-extern int lxc_id128_write(const char *p, lxc_id128_t id);
-extern int lxc_id128_write_fd(int fd, lxc_id128_t id);
-extern char *id128_to_uuid_string(lxc_id128_t id, char s[37]);
+	uint8_t bytes[16];
+	uint64_t qwords[2];
+};
+
+__hidden extern int lxc_id128_randomize(lxc_id128_t *ret);
+__hidden extern int lxc_id128_write(const char *p, lxc_id128_t id);
+__hidden extern int lxc_id128_write_fd(int fd, lxc_id128_t id);
+__hidden extern char *id128_to_uuid_string(lxc_id128_t id, char s[37]);
 
 #endif /* __LXC_UUID_H */

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -2,9 +2,31 @@ if ENABLE_TESTS
 
 LDADD = ../lxc/liblxc.la
 
-lxc_test_api_reboot_SOURCES = api_reboot.c
+lxc_test_api_reboot_SOURCES = api_reboot.c \
+			      ../lxc/af_unix.c ../lxc/af_unix.h \
+			      ../lxc/caps.c ../lxc/caps.h \
+			      ../lxc/commands.c ../lxc/commands.h \
+			      ../lxc/commands_utils.c ../lxc/commands_utils.h \
+			      ../lxc/conf.c ../lxc/conf.h \
+			      ../lxc/confile.c ../lxc/confile.h \
+			      ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			      ../lxc/file_utils.c ../lxc/file_utils.h \
+			      ../lxc/network.c ../lxc/network.h \
+			      ../lxc/nl.c ../lxc/nl.h \
+			      ../lxc/string_utils.c ../lxc/string_utils.h
 lxc_test_apparmor_SOURCES = aa.c
-lxc_test_attach_SOURCES = attach.c
+lxc_test_attach_SOURCES = attach.c \
+			  ../lxc/af_unix.c ../lxc/af_unix.h \
+			  ../lxc/caps.c ../lxc/caps.h \
+			  ../lxc/commands.c ../lxc/commands.h \
+			  ../lxc/commands_utils.c ../lxc/commands_utils.h \
+			  ../lxc/conf.c ../lxc/conf.h \
+			  ../lxc/confile.c ../lxc/confile.h \
+			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			  ../lxc/file_utils.c ../lxc/file_utils.h \
+			  ../lxc/network.c ../lxc/network.h \
+			  ../lxc/nl.c ../lxc/nl.h \
+			  ../lxc/string_utils.c ../lxc/string_utils.h
 lxc_test_basic_SOURCES = basic.c
 lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/af_unix.c ../lxc/af_unix.h \
@@ -14,6 +36,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/conf.c ../lxc/conf.h \
 			  ../lxc/confile.c ../lxc/confile.h \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			  ../lxc/file_utils.c ../lxc/file_utils.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -28,6 +51,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/conf.c ../lxc/conf.h \
 				     ../lxc/confile.c ../lxc/confile.h \
 				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
+				     ../lxc/file_utils.c ../lxc/file_utils.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
@@ -45,7 +69,10 @@ lxc_test_list_SOURCES = list.c
 lxc_test_locktests_SOURCES = locktests.c
 lxc_test_lxcpath_SOURCES = lxcpath.c
 lxc_test_may_control_SOURCES = may_control.c
-lxc_test_mount_injection_SOURCES = mount_injection.c lxctest.h
+lxc_test_mount_injection_SOURCES = mount_injection.c \
+				   lxctest.h \
+				   ../lxc/file_utils.c ../lxc/file_utils.h \
+				   ../lxc/string_utils.c ../lxc/string_utils.h
 lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     lxctest.h \
 				     ../lxc/af_unix.c ../lxc/af_unix.h \
@@ -53,6 +80,7 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/conf.c ../lxc/conf.h \
 				     ../lxc/confile.c ../lxc/confile.h \
 				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
+				     ../lxc/file_utils.c ../lxc/file_utils.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
@@ -67,7 +95,9 @@ lxc_test_saveconfig_SOURCES = saveconfig.c
 lxc_test_share_ns_SOURCES = share_ns.c \
 			    lxctest.h \
 			    ../lxc/compiler.h
-lxc_test_shortlived_SOURCES = shortlived.c
+lxc_test_shortlived_SOURCES = shortlived.c \
+			      ../lxc/file_utils.c ../lxc/file_utils.h \
+			      ../lxc/string_utils.c ../lxc/string_utils.h
 lxc_test_shutdowntest_SOURCES = shutdowntest.c
 lxc_test_snapshot_SOURCES = snapshot.c
 lxc_test_startone_SOURCES = startone.c
@@ -83,6 +113,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/conf.c ../lxc/conf.h \
 			  ../lxc/confile.c ../lxc/confile.h \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			  ../lxc/file_utils.c ../lxc/file_utils.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -31,7 +31,8 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/start.c ../lxc/start.h \
 			      ../lxc/state.c ../lxc/state.h \
 			      ../lxc/sync.c ../lxc/sync.h \
-			      ../lxc/string_utils.c ../lxc/string_utils.h
+			      ../lxc/string_utils.c ../lxc/string_utils.h \
+			      ../lxc/terminal.c ../lxc/terminal.h
 if ENABLE_SECCOMP
 lxc_test_api_reboot_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -61,7 +62,8 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/state.c ../lxc/state.h \
 			  ../lxc/sync.c ../lxc/sync.h \
-			  ../lxc/string_utils.c ../lxc/string_utils.h
+			  ../lxc/string_utils.c ../lxc/string_utils.h \
+			  ../lxc/terminal.c ../lxc/terminal.h
 if ENABLE_SECCOMP
 lxc_test_attach_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -91,7 +93,8 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/state.c ../lxc/state.h \
 			  ../lxc/sync.c ../lxc/sync.h \
-			  ../lxc/string_utils.c ../lxc/string_utils.h
+			  ../lxc/string_utils.c ../lxc/string_utils.h \
+			  ../lxc/terminal.c ../lxc/terminal.h
 if ENABLE_SECCOMP
 lxc_test_cgpath_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -123,7 +126,8 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/start.c ../lxc/start.h \
 				     ../lxc/state.c ../lxc/state.h \
 				     ../lxc/sync.c ../lxc/sync.h \
-				     ../lxc/string_utils.c ../lxc/string_utils.h
+				     ../lxc/string_utils.c ../lxc/string_utils.h \
+				     ../lxc/terminal.c ../lxc/terminal.h
 if ENABLE_SECCOMP
 lxc_test_config_jump_table_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -176,7 +180,8 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/start.c ../lxc/start.h \
 				     ../lxc/state.c ../lxc/state.h \
 				     ../lxc/sync.c ../lxc/sync.h \
-				     ../lxc/string_utils.c ../lxc/string_utils.h
+				     ../lxc/string_utils.c ../lxc/string_utils.h \
+				     ../lxc/terminal.c ../lxc/terminal.h
 if ENABLE_SECCOMP
 lxc_test_parse_config_file_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -229,7 +234,8 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/state.c ../lxc/state.h \
 			  ../lxc/sync.c ../lxc/sync.h \
-			  ../lxc/string_utils.c ../lxc/string_utils.h
+			  ../lxc/string_utils.c ../lxc/string_utils.h \
+			  ../lxc/terminal.c ../lxc/terminal.h
 if ENABLE_SECCOMP
 lxc_test_utils_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -1,6 +1,11 @@
 if ENABLE_TESTS
 
-LDADD = ../lxc/liblxc.la
+LDADD = ../lxc/liblxc.la \
+	@CAP_LIBS@ \
+	@OPENSSL_LIBS@ \
+	@SECCOMP_LIBS@ \
+	@SELINUX_LIBS@ \
+	@DLOG_LIBS@
 
 lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/af_unix.c ../lxc/af_unix.h \
@@ -16,6 +21,10 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/network.c ../lxc/network.h \
 			      ../lxc/nl.c ../lxc/nl.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h
+if ENABLE_SECCOMP
+lxc_test_api_reboot_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
+endif
+
 lxc_test_apparmor_SOURCES = aa.c
 lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/af_unix.c ../lxc/af_unix.h \
@@ -31,6 +40,10 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
+if ENABLE_SECCOMP
+lxc_test_attach_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
+endif
+
 lxc_test_basic_SOURCES = basic.c
 lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/af_unix.c ../lxc/af_unix.h \
@@ -46,6 +59,10 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
+if ENABLE_SECCOMP
+lxc_test_cgpath_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
+endif
+
 lxc_test_clonetest_SOURCES = clonetest.c
 lxc_test_concurrent_SOURCES = concurrent.c
 lxc_test_config_jump_table_SOURCES = config_jump_table.c \
@@ -63,6 +80,10 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
+if ENABLE_SECCOMP
+lxc_test_config_jump_table_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
+endif
+
 lxc_test_console_SOURCES = console.c
 lxc_test_console_log_SOURCES = console_log.c lxctest.h
 lxc_test_containertests_SOURCES = containertests.c
@@ -99,6 +120,10 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
+if ENABLE_SECCOMP
+lxc_test_parse_config_file_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
+endif
+
 lxc_test_raw_clone_SOURCES = lxc_raw_clone.c \
 			     lxctest.h \
 			     ../lxc/caps.c ../lxc/caps.h \
@@ -137,6 +162,9 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
+if ENABLE_SECCOMP
+lxc_test_utils_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
+endif
 
 AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	  -DLXCPATH=\"$(LXCPATH)\" \

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -33,7 +33,8 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/sync.c ../lxc/sync.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h \
 			      ../lxc/terminal.c ../lxc/terminal.h \
-			      ../lxc/utils.c ../lxc/utils.h
+			      ../lxc/utils.c ../lxc/utils.h \
+			      ../lxc/uuid.c ../lxc/uuid.h
 if ENABLE_SECCOMP
 lxc_test_api_reboot_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -64,7 +65,8 @@ lxc_test_apparmor_SOURCES = aa.c \
 			    ../lxc/sync.c ../lxc/sync.h \
 			    ../lxc/string_utils.c ../lxc/string_utils.h \
 			    ../lxc/terminal.c ../lxc/terminal.h \
-			    ../lxc/utils.c ../lxc/utils.h
+			    ../lxc/utils.c ../lxc/utils.h \
+			    ../lxc/uuid.c ../lxc/uuid.h
 if ENABLE_SECCOMP
 lxc_test_apparmor_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -95,7 +97,8 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
 			  ../lxc/terminal.c ../lxc/terminal.h \
-			  ../lxc/utils.c ../lxc/utils.h
+			  ../lxc/utils.c ../lxc/utils.h \
+			  ../lxc/uuid.c ../lxc/uuid.h
 if ENABLE_SECCOMP
 lxc_test_attach_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -127,7 +130,8 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
 			  ../lxc/terminal.c ../lxc/terminal.h \
-			  ../lxc/utils.c ../lxc/utils.h
+			  ../lxc/utils.c ../lxc/utils.h \
+			  ../lxc/uuid.c ../lxc/uuid.h
 if ENABLE_SECCOMP
 lxc_test_cgpath_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -161,7 +165,8 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/sync.c ../lxc/sync.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h \
 				     ../lxc/terminal.c ../lxc/terminal.h \
-				     ../lxc/utils.c ../lxc/utils.h
+				     ../lxc/utils.c ../lxc/utils.h \
+				     ../lxc/uuid.c ../lxc/uuid.h
 if ENABLE_SECCOMP
 lxc_test_config_jump_table_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -203,7 +208,8 @@ lxc_test_locktests_SOURCES = locktests.c \
 			     ../lxc/sync.c ../lxc/sync.h \
 			     ../lxc/string_utils.c ../lxc/string_utils.h \
 			     ../lxc/terminal.c ../lxc/terminal.h \
-			     ../lxc/utils.c ../lxc/utils.h
+			     ../lxc/utils.c ../lxc/utils.h \
+			     ../lxc/uuid.c ../lxc/uuid.h
 if ENABLE_SECCOMP
 lxc_test_locktests_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -237,7 +243,8 @@ lxc_test_mount_injection_SOURCES = mount_injection.c \
 				   ../lxc/sync.c ../lxc/sync.h \
 				   ../lxc/string_utils.c ../lxc/string_utils.h \
 				   ../lxc/terminal.c ../lxc/terminal.h \
-				   ../lxc/utils.c ../lxc/utils.h
+				   ../lxc/utils.c ../lxc/utils.h \
+				   ../lxc/uuid.c ../lxc/uuid.h
 if ENABLE_SECCOMP
 lxc_test_mount_injection_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -269,7 +276,8 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/sync.c ../lxc/sync.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h \
 				     ../lxc/terminal.c ../lxc/terminal.h \
-				     ../lxc/utils.c ../lxc/utils.h
+				     ../lxc/utils.c ../lxc/utils.h \
+				     ../lxc/uuid.c ../lxc/uuid.h
 if ENABLE_SECCOMP
 lxc_test_parse_config_file_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -324,7 +332,8 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
 			  ../lxc/terminal.c ../lxc/terminal.h \
-			  ../lxc/utils.c ../lxc/utils.h
+			  ../lxc/utils.c ../lxc/utils.h \
+			  ../lxc/uuid.c ../lxc/uuid.h
 if ENABLE_SECCOMP
 lxc_test_utils_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -24,6 +24,7 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/nl.c ../lxc/nl.h \
 			      ../lxc/parse.c ../lxc/parse.h \
 			      ../lxc/process_utils.c ../lxc/process_utils.h \
+			      ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_api_reboot_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -47,6 +48,7 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/parse.c ../lxc/parse.h \
 			  ../lxc/process_utils.c ../lxc/process_utils.h \
+			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_attach_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -70,6 +72,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/parse.c ../lxc/parse.h \
 			  ../lxc/process_utils.c ../lxc/process_utils.h \
+			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_cgpath_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -95,6 +98,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/parse.c ../lxc/parse.h \
 				     ../lxc/process_utils.c ../lxc/process_utils.h \
+				     ../lxc/ringbuf.c ../lxc/ringbuf.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_config_jump_table_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -138,6 +142,7 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/parse.c ../lxc/parse.h \
 				     ../lxc/process_utils.c ../lxc/process_utils.h \
+				     ../lxc/ringbuf.c ../lxc/ringbuf.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_parse_config_file_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -184,6 +189,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/parse.c ../lxc/parse.h \
 			  ../lxc/process_utils.c ../lxc/process_utils.h \
+			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_utils_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -22,6 +22,7 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/namespace.c ../lxc/namespace.h \
 			      ../lxc/network.c ../lxc/network.h \
 			      ../lxc/nl.c ../lxc/nl.h \
+			      ../lxc/parse.c ../lxc/parse.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_api_reboot_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -43,6 +44,7 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/namespace.c ../lxc/namespace.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
+			  ../lxc/parse.c ../lxc/parse.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_attach_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -64,6 +66,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/namespace.c ../lxc/namespace.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
+			  ../lxc/parse.c ../lxc/parse.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_cgpath_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -87,6 +90,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/namespace.c ../lxc/namespace.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
+				     ../lxc/parse.c ../lxc/parse.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_config_jump_table_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -128,6 +132,7 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/namespace.c ../lxc/namespace.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
+				     ../lxc/parse.c ../lxc/parse.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_parse_config_file_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -172,6 +177,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/namespace.c ../lxc/namespace.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
+			  ../lxc/parse.c ../lxc/parse.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_utils_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -22,6 +22,7 @@ endif
 lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/af_unix.c ../lxc/af_unix.h \
 			      ../lxc/caps.c ../lxc/caps.h \
+			      ../lxc/cgroups/cgfsng.c \
 			      ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
 			      ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
 			      ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
@@ -32,6 +33,7 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			      ../lxc/error.c ../lxc/error.h \
 			      ../lxc/file_utils.c ../lxc/file_utils.h \
+			      ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 			      ../lxc/initutils.c ../lxc/initutils.h \
 			      ../lxc/log.c ../lxc/log.h \
 			      ../lxc/lxclock.c ../lxc/lxclock.h \
@@ -69,6 +71,7 @@ endif
 lxc_test_apparmor_SOURCES = aa.c \
 			    ../lxc/af_unix.c ../lxc/af_unix.h \
 			    ../lxc/caps.c ../lxc/caps.h \
+			    ../lxc/cgroups/cgfsng.c \
 			    ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
 			    ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
 			    ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
@@ -79,6 +82,7 @@ lxc_test_apparmor_SOURCES = aa.c \
 			    ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			    ../lxc/error.c ../lxc/error.h \
 			    ../lxc/file_utils.c ../lxc/file_utils.h \
+			    ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 			    ../lxc/initutils.c ../lxc/initutils.h \
 			    ../lxc/log.c ../lxc/log.h \
 			    ../lxc/lxclock.c ../lxc/lxclock.h \
@@ -116,6 +120,7 @@ endif
 lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/af_unix.c ../lxc/af_unix.h \
 			  ../lxc/caps.c ../lxc/caps.h \
+			  ../lxc/cgroups/cgfsng.c \
 			  ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
 			  ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
 			  ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
@@ -126,6 +131,7 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			  ../lxc/error.c ../lxc/error.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
+			  ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
 			  ../lxc/lxclock.c ../lxc/lxclock.h \
@@ -164,6 +170,7 @@ lxc_test_basic_SOURCES = basic.c
 lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/af_unix.c ../lxc/af_unix.h \
 			  ../lxc/caps.c ../lxc/caps.h \
+			  ../lxc/cgroups/cgfsng.c \
 			  ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
 			  ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
 			  ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
@@ -174,6 +181,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			  ../lxc/error.c ../lxc/error.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
+			  ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
 			  ../lxc/lxclock.c ../lxc/lxclock.h \
@@ -214,6 +222,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     lxctest.h \
 				     ../lxc/af_unix.c ../lxc/af_unix.h \
 				     ../lxc/caps.c ../lxc/caps.h \
+				     ../lxc/cgroups/cgfsng.c \
 				     ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
 				     ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
 				     ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
@@ -224,6 +233,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
 				     ../lxc/error.c ../lxc/error.h \
 				     ../lxc/file_utils.c ../lxc/file_utils.h \
+				     ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 				     ../lxc/initutils.c ../lxc/initutils.h \
 				     ../lxc/log.c ../lxc/log.h \
 				     ../lxc/lxclock.c ../lxc/lxclock.h \
@@ -272,6 +282,7 @@ lxc_test_list_SOURCES = list.c
 lxc_test_locktests_SOURCES = locktests.c \
 			     ../lxc/af_unix.c ../lxc/af_unix.h \
 			     ../lxc/caps.c ../lxc/caps.h \
+			     ../lxc/cgroups/cgfsng.c \
 			     ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
 			     ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
 			     ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
@@ -282,6 +293,7 @@ lxc_test_locktests_SOURCES = locktests.c \
 			     ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			     ../lxc/error.c ../lxc/error.h \
 			     ../lxc/file_utils.c ../lxc/file_utils.h \
+			     ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 			     ../lxc/initutils.c ../lxc/initutils.h \
 			     ../lxc/log.c ../lxc/log.h \
 			     ../lxc/lxclock.c ../lxc/lxclock.h \
@@ -322,6 +334,7 @@ lxc_test_mount_injection_SOURCES = mount_injection.c \
 				   lxctest.h \
 				   ../lxc/af_unix.c ../lxc/af_unix.h \
 				   ../lxc/caps.c ../lxc/caps.h \
+				   ../lxc/cgroups/cgfsng.c \
 				   ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
 				   ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
 				   ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
@@ -332,6 +345,7 @@ lxc_test_mount_injection_SOURCES = mount_injection.c \
 				   ../lxc/confile_utils.c ../lxc/confile_utils.h \
 				   ../lxc/error.c ../lxc/error.h \
 				   ../lxc/file_utils.c ../lxc/file_utils.h \
+				   ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 				   ../lxc/initutils.c ../lxc/initutils.h \
 				   ../lxc/log.c ../lxc/log.h \
 				   ../lxc/lxclock.c ../lxc/lxclock.h \
@@ -370,6 +384,7 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     lxctest.h \
 				     ../lxc/af_unix.c ../lxc/af_unix.h \
 				     ../lxc/caps.c ../lxc/caps.h \
+				     ../lxc/cgroups/cgfsng.c \
 				     ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
 				     ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
 				     ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
@@ -380,6 +395,7 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
 				     ../lxc/error.c ../lxc/error.h \
 				     ../lxc/file_utils.c ../lxc/file_utils.h \
+				     ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 				     ../lxc/initutils.c ../lxc/initutils.h \
 				     ../lxc/log.c ../lxc/log.h \
 				     ../lxc/lxclock.c ../lxc/lxclock.h \
@@ -418,6 +434,7 @@ lxc_test_raw_clone_SOURCES = lxc_raw_clone.c \
 			     lxctest.h \
 			     ../lxc/af_unix.c ../lxc/af_unix.h \
 			     ../lxc/caps.c ../lxc/caps.h \
+			     ../lxc/cgroups/cgfsng.c \
 			     ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
 			     ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
 			     ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
@@ -428,6 +445,7 @@ lxc_test_raw_clone_SOURCES = lxc_raw_clone.c \
 			     ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			     ../lxc/error.c ../lxc/error.h \
 			     ../lxc/file_utils.c ../lxc/file_utils.h \
+			     ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 			     ../lxc/initutils.c ../lxc/initutils.h \
 			     ../lxc/log.c ../lxc/log.h \
 			     ../lxc/lxclock.c ../lxc/lxclock.h \
@@ -480,6 +498,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			 lxctest.h \
 			  ../lxc/af_unix.c ../lxc/af_unix.h \
 			  ../lxc/caps.c ../lxc/caps.h \
+			  ../lxc/cgroups/cgfsng.c \
 			  ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
 			  ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
 			  ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
@@ -490,6 +509,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			  ../lxc/error.c ../lxc/error.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
+			  ../include/netns_ifaddrs.c ../include/netns_ifaddrs.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
 			  ../lxc/lxclock.c ../lxc/lxclock.h \

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -8,12 +8,25 @@ lxc_test_attach_SOURCES = attach.c
 lxc_test_basic_SOURCES = basic.c
 lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/af_unix.c ../lxc/af_unix.h \
+			  ../lxc/caps.c ../lxc/caps.h \
 			  ../lxc/commands.c ../lxc/commands.h \
 			  ../lxc/commands_utils.c ../lxc/commands_utils.h \
+			  ../lxc/conf.c ../lxc/conf.h \
+			  ../lxc/confile.c ../lxc/confile.h \
+			  ../lxc/network.c ../lxc/network.h \
+			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 lxc_test_clonetest_SOURCES = clonetest.c
 lxc_test_concurrent_SOURCES = concurrent.c
-lxc_test_config_jump_table_SOURCES = config_jump_table.c lxctest.h
+lxc_test_config_jump_table_SOURCES = config_jump_table.c \
+				     lxctest.h \
+				     ../lxc/af_unix.c ../lxc/af_unix.h \
+				     ../lxc/caps.c ../lxc/caps.h \
+				     ../lxc/conf.c ../lxc/conf.h \
+				     ../lxc/confile.c ../lxc/confile.h \
+				     ../lxc/network.c ../lxc/network.h \
+				     ../lxc/nl.c ../lxc/nl.h \
+				     ../lxc/string_utils.c ../lxc/string_utils.h
 lxc_test_console_SOURCES = console.c
 lxc_test_console_log_SOURCES = console_log.c lxctest.h
 lxc_test_containertests_SOURCES = containertests.c
@@ -56,12 +69,15 @@ AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	  -DLXCPATH=\"$(LXCPATH)\" \
 	  -DLXC_GLOBAL_CONF=\"$(LXC_GLOBAL_CONF)\" \
 	  -DLXCINITDIR=\"$(LXCINITDIR)\" \
+	  -DLIBEXECDIR=\"$(LIBEXECDIR)\" \
 	  -DLXC_DEFAULT_CONFIG=\"$(LXC_DEFAULT_CONFIG)\" \
 	  -DRUNTIME_PATH=\"$(RUNTIME_PATH)\" \
+	  -DSBINDIR=\"$(SBINDIR)\" \
 	  -I $(top_srcdir)/src \
 	  -I $(top_srcdir)/src/lxc \
 	  -I $(top_srcdir)/src/lxc/cgroups \
 	  -I $(top_srcdir)/src/lxc/tools \
+	  -I $(top_srcdir)/src/lxc/storage \
 	  -pthread
 
 if ENABLE_APPARMOR

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -18,6 +18,7 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/file_utils.c ../lxc/file_utils.h \
 			      ../lxc/initutils.c ../lxc/initutils.h \
 			      ../lxc/log.c ../lxc/log.h \
+			      ../lxc/mainloop.c ../lxc/mainloop.h \
 			      ../lxc/network.c ../lxc/network.h \
 			      ../lxc/nl.c ../lxc/nl.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h
@@ -37,6 +38,7 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
+			  ../lxc/mainloop.c ../lxc/mainloop.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -56,6 +58,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
+			  ../lxc/mainloop.c ../lxc/mainloop.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -77,6 +80,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/file_utils.c ../lxc/file_utils.h \
 				     ../lxc/initutils.c ../lxc/initutils.h \
 				     ../lxc/log.c ../lxc/log.h \
+				     ../lxc/mainloop.c ../lxc/mainloop.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
@@ -159,6 +163,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
+			  ../lxc/mainloop.c ../lxc/mainloop.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -32,12 +32,43 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/state.c ../lxc/state.h \
 			      ../lxc/sync.c ../lxc/sync.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h \
-			      ../lxc/terminal.c ../lxc/terminal.h
+			      ../lxc/terminal.c ../lxc/terminal.h \
+			      ../lxc/utils.c ../lxc/utils.h
 if ENABLE_SECCOMP
 lxc_test_api_reboot_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
 
-lxc_test_apparmor_SOURCES = aa.c
+lxc_test_apparmor_SOURCES = aa.c \
+			    ../lxc/af_unix.c ../lxc/af_unix.h \
+			    ../lxc/caps.c ../lxc/caps.h \
+			    ../lxc/commands.c ../lxc/commands.h \
+			    ../lxc/commands_utils.c ../lxc/commands_utils.h \
+			    ../lxc/conf.c ../lxc/conf.h \
+			    ../lxc/confile.c ../lxc/confile.h \
+			    ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			    ../lxc/error.c ../lxc/error.h \
+			    ../lxc/file_utils.c ../lxc/file_utils.h \
+			    ../lxc/initutils.c ../lxc/initutils.h \
+			    ../lxc/log.c ../lxc/log.h \
+			    ../lxc/lxclock.c ../lxc/lxclock.h \
+			    ../lxc/mainloop.c ../lxc/mainloop.h \
+			    ../lxc/monitor.c ../lxc/monitor.h \
+			    ../lxc/namespace.c ../lxc/namespace.h \
+			    ../lxc/network.c ../lxc/network.h \
+			    ../lxc/nl.c ../lxc/nl.h \
+			    ../lxc/parse.c ../lxc/parse.h \
+			    ../lxc/process_utils.c ../lxc/process_utils.h \
+			    ../lxc/ringbuf.c ../lxc/ringbuf.h \
+			    ../lxc/start.c ../lxc/start.h \
+			    ../lxc/state.c ../lxc/state.h \
+			    ../lxc/sync.c ../lxc/sync.h \
+			    ../lxc/string_utils.c ../lxc/string_utils.h \
+			    ../lxc/terminal.c ../lxc/terminal.h \
+			    ../lxc/utils.c ../lxc/utils.h
+if ENABLE_SECCOMP
+lxc_test_apparmor_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
+endif
+
 lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/af_unix.c ../lxc/af_unix.h \
 			  ../lxc/caps.c ../lxc/caps.h \
@@ -63,7 +94,8 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/state.c ../lxc/state.h \
 			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
-			  ../lxc/terminal.c ../lxc/terminal.h
+			  ../lxc/terminal.c ../lxc/terminal.h \
+			  ../lxc/utils.c ../lxc/utils.h
 if ENABLE_SECCOMP
 lxc_test_attach_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -94,7 +126,8 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/state.c ../lxc/state.h \
 			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
-			  ../lxc/terminal.c ../lxc/terminal.h
+			  ../lxc/terminal.c ../lxc/terminal.h \
+			  ../lxc/utils.c ../lxc/utils.h
 if ENABLE_SECCOMP
 lxc_test_cgpath_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -127,7 +160,8 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/state.c ../lxc/state.h \
 				     ../lxc/sync.c ../lxc/sync.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h \
-				     ../lxc/terminal.c ../lxc/terminal.h
+				     ../lxc/terminal.c ../lxc/terminal.h \
+				     ../lxc/utils.c ../lxc/utils.h
 if ENABLE_SECCOMP
 lxc_test_config_jump_table_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -144,17 +178,70 @@ lxc_test_getkeys_SOURCES = getkeys.c
 lxc_test_get_item_SOURCES = get_item.c
 lxc_test_list_SOURCES = list.c
 lxc_test_locktests_SOURCES = locktests.c \
+			     ../lxc/af_unix.c ../lxc/af_unix.h \
 			     ../lxc/caps.c ../lxc/caps.h \
+			     ../lxc/commands.c ../lxc/commands.h \
+			     ../lxc/commands_utils.c ../lxc/commands_utils.h \
+			     ../lxc/conf.c ../lxc/conf.h \
+			     ../lxc/confile.c ../lxc/confile.h \
+			     ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			     ../lxc/error.c ../lxc/error.h \
 			     ../lxc/file_utils.c ../lxc/file_utils.h \
+			     ../lxc/initutils.c ../lxc/initutils.h \
 			     ../lxc/log.c ../lxc/log.h \
 			     ../lxc/lxclock.c ../lxc/lxclock.h \
-			     ../lxc/string_utils.c ../lxc/string_utils.h
+			     ../lxc/mainloop.c ../lxc/mainloop.h \
+			     ../lxc/monitor.c ../lxc/monitor.h \
+			     ../lxc/namespace.c ../lxc/namespace.h \
+			     ../lxc/network.c ../lxc/network.h \
+			     ../lxc/nl.c ../lxc/nl.h \
+			     ../lxc/parse.c ../lxc/parse.h \
+			     ../lxc/process_utils.c ../lxc/process_utils.h \
+			     ../lxc/ringbuf.c ../lxc/ringbuf.h \
+			     ../lxc/start.c ../lxc/start.h \
+			     ../lxc/state.c ../lxc/state.h \
+			     ../lxc/sync.c ../lxc/sync.h \
+			     ../lxc/string_utils.c ../lxc/string_utils.h \
+			     ../lxc/terminal.c ../lxc/terminal.h \
+			     ../lxc/utils.c ../lxc/utils.h
+if ENABLE_SECCOMP
+lxc_test_locktests_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
+endif
+
 lxc_test_lxcpath_SOURCES = lxcpath.c
 lxc_test_may_control_SOURCES = may_control.c
 lxc_test_mount_injection_SOURCES = mount_injection.c \
 				   lxctest.h \
+				   ../lxc/af_unix.c ../lxc/af_unix.h \
+				   ../lxc/caps.c ../lxc/caps.h \
+				   ../lxc/commands.c ../lxc/commands.h \
+				   ../lxc/commands_utils.c ../lxc/commands_utils.h \
+				   ../lxc/conf.c ../lxc/conf.h \
+				   ../lxc/confile.c ../lxc/confile.h \
+				   ../lxc/confile_utils.c ../lxc/confile_utils.h \
+				   ../lxc/error.c ../lxc/error.h \
 				   ../lxc/file_utils.c ../lxc/file_utils.h \
-				   ../lxc/string_utils.c ../lxc/string_utils.h
+				   ../lxc/initutils.c ../lxc/initutils.h \
+				   ../lxc/log.c ../lxc/log.h \
+				   ../lxc/lxclock.c ../lxc/lxclock.h \
+				   ../lxc/mainloop.c ../lxc/mainloop.h \
+				   ../lxc/monitor.c ../lxc/monitor.h \
+				   ../lxc/namespace.c ../lxc/namespace.h \
+				   ../lxc/network.c ../lxc/network.h \
+				   ../lxc/nl.c ../lxc/nl.h \
+				   ../lxc/parse.c ../lxc/parse.h \
+				   ../lxc/process_utils.c ../lxc/process_utils.h \
+				   ../lxc/ringbuf.c ../lxc/ringbuf.h \
+				   ../lxc/start.c ../lxc/start.h \
+				   ../lxc/state.c ../lxc/state.h \
+				   ../lxc/sync.c ../lxc/sync.h \
+				   ../lxc/string_utils.c ../lxc/string_utils.h \
+				   ../lxc/terminal.c ../lxc/terminal.h \
+				   ../lxc/utils.c ../lxc/utils.h
+if ENABLE_SECCOMP
+lxc_test_mount_injection_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
+endif
+
 lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     lxctest.h \
 				     ../lxc/af_unix.c ../lxc/af_unix.h \
@@ -181,7 +268,8 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/state.c ../lxc/state.h \
 				     ../lxc/sync.c ../lxc/sync.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h \
-				     ../lxc/terminal.c ../lxc/terminal.h
+				     ../lxc/terminal.c ../lxc/terminal.h \
+				     ../lxc/utils.c ../lxc/utils.h
 if ENABLE_SECCOMP
 lxc_test_parse_config_file_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -235,7 +323,8 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/state.c ../lxc/state.h \
 			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
-			  ../lxc/terminal.c ../lxc/terminal.h
+			  ../lxc/terminal.c ../lxc/terminal.h \
+			  ../lxc/utils.c ../lxc/utils.h
 if ENABLE_SECCOMP
 lxc_test_utils_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -10,6 +10,9 @@ LDADD = ../lxc/liblxc.la \
 lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/af_unix.c ../lxc/af_unix.h \
 			      ../lxc/caps.c ../lxc/caps.h \
+			      ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
+			      ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
+			      ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
 			      ../lxc/commands.c ../lxc/commands.h \
 			      ../lxc/commands_utils.c ../lxc/commands_utils.h \
 			      ../lxc/conf.c ../lxc/conf.h \
@@ -42,6 +45,9 @@ endif
 lxc_test_apparmor_SOURCES = aa.c \
 			    ../lxc/af_unix.c ../lxc/af_unix.h \
 			    ../lxc/caps.c ../lxc/caps.h \
+			    ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
+			    ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
+			    ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
 			    ../lxc/commands.c ../lxc/commands.h \
 			    ../lxc/commands_utils.c ../lxc/commands_utils.h \
 			    ../lxc/conf.c ../lxc/conf.h \
@@ -74,6 +80,9 @@ endif
 lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/af_unix.c ../lxc/af_unix.h \
 			  ../lxc/caps.c ../lxc/caps.h \
+			  ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
+			  ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
+			  ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
 			  ../lxc/commands.c ../lxc/commands.h \
 			  ../lxc/commands_utils.c ../lxc/commands_utils.h \
 			  ../lxc/conf.c ../lxc/conf.h \
@@ -107,6 +116,9 @@ lxc_test_basic_SOURCES = basic.c
 lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/af_unix.c ../lxc/af_unix.h \
 			  ../lxc/caps.c ../lxc/caps.h \
+			  ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
+			  ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
+			  ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
 			  ../lxc/commands.c ../lxc/commands.h \
 			  ../lxc/commands_utils.c ../lxc/commands_utils.h \
 			  ../lxc/conf.c ../lxc/conf.h \
@@ -142,6 +154,9 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     lxctest.h \
 				     ../lxc/af_unix.c ../lxc/af_unix.h \
 				     ../lxc/caps.c ../lxc/caps.h \
+				     ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
+				     ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
+				     ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
 				     ../lxc/commands.c ../lxc/commands.h \
 				     ../lxc/commands_utils.c ../lxc/commands_utils.h \
 				     ../lxc/conf.c ../lxc/conf.h \
@@ -185,6 +200,9 @@ lxc_test_list_SOURCES = list.c
 lxc_test_locktests_SOURCES = locktests.c \
 			     ../lxc/af_unix.c ../lxc/af_unix.h \
 			     ../lxc/caps.c ../lxc/caps.h \
+			     ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
+			     ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
+			     ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
 			     ../lxc/commands.c ../lxc/commands.h \
 			     ../lxc/commands_utils.c ../lxc/commands_utils.h \
 			     ../lxc/conf.c ../lxc/conf.h \
@@ -220,6 +238,9 @@ lxc_test_mount_injection_SOURCES = mount_injection.c \
 				   lxctest.h \
 				   ../lxc/af_unix.c ../lxc/af_unix.h \
 				   ../lxc/caps.c ../lxc/caps.h \
+				   ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
+				   ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
+				   ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
 				   ../lxc/commands.c ../lxc/commands.h \
 				   ../lxc/commands_utils.c ../lxc/commands_utils.h \
 				   ../lxc/conf.c ../lxc/conf.h \
@@ -253,6 +274,9 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     lxctest.h \
 				     ../lxc/af_unix.c ../lxc/af_unix.h \
 				     ../lxc/caps.c ../lxc/caps.h \
+				     ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
+				     ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
+				     ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
 				     ../lxc/commands.c ../lxc/commands.h \
 				     ../lxc/commands_utils.c ../lxc/commands_utils.h \
 				     ../lxc/conf.c ../lxc/conf.h \
@@ -285,6 +309,9 @@ endif
 lxc_test_raw_clone_SOURCES = lxc_raw_clone.c \
 			     lxctest.h \
 			     ../lxc/caps.c ../lxc/caps.h \
+			     ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
+			     ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
+			     ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
 			     ../lxc/file_utils.c ../lxc/file_utils.h \
 			     ../lxc/log.c ../lxc/log.h \
 			     ../lxc/namespace.c ../lxc/namespace.h \
@@ -309,6 +336,9 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			 lxctest.h \
 			  ../lxc/af_unix.c ../lxc/af_unix.h \
 			  ../lxc/caps.c ../lxc/caps.h \
+			  ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
+			  ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
+			  ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
 			  ../lxc/commands.c ../lxc/commands.h \
 			  ../lxc/commands_utils.c ../lxc/commands_utils.h \
 			  ../lxc/conf.c ../lxc/conf.h \

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -7,6 +7,18 @@ LDADD = ../lxc/liblxc.la \
 	@SELINUX_LIBS@ \
 	@DLOG_LIBS@
 
+LSM_SOURCES = ../lxc/lsm/lsm.c \
+	      ../lxc/lsm/lsm.h \
+	      ../lxc/lsm/nop.c
+
+if ENABLE_APPARMOR
+LSM_SOURCES += ../lxc/lsm/apparmor.c
+endif
+
+if ENABLE_SELINUX
+LSM_SOURCES += ../lxc/lsm/selinux.c
+endif
+
 lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/af_unix.c ../lxc/af_unix.h \
 			      ../lxc/caps.c ../lxc/caps.h \
@@ -37,7 +49,8 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/string_utils.c ../lxc/string_utils.h \
 			      ../lxc/terminal.c ../lxc/terminal.h \
 			      ../lxc/utils.c ../lxc/utils.h \
-			      ../lxc/uuid.c ../lxc/uuid.h
+			      ../lxc/uuid.c ../lxc/uuid.h \
+			      $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_test_api_reboot_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -72,7 +85,8 @@ lxc_test_apparmor_SOURCES = aa.c \
 			    ../lxc/string_utils.c ../lxc/string_utils.h \
 			    ../lxc/terminal.c ../lxc/terminal.h \
 			    ../lxc/utils.c ../lxc/utils.h \
-			    ../lxc/uuid.c ../lxc/uuid.h
+			    ../lxc/uuid.c ../lxc/uuid.h \
+			    $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_test_apparmor_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -107,7 +121,8 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
 			  ../lxc/terminal.c ../lxc/terminal.h \
 			  ../lxc/utils.c ../lxc/utils.h \
-			  ../lxc/uuid.c ../lxc/uuid.h
+			  ../lxc/uuid.c ../lxc/uuid.h \
+			  $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_test_attach_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -143,7 +158,8 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
 			  ../lxc/terminal.c ../lxc/terminal.h \
 			  ../lxc/utils.c ../lxc/utils.h \
-			  ../lxc/uuid.c ../lxc/uuid.h
+			  ../lxc/uuid.c ../lxc/uuid.h \
+			  $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_test_cgpath_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -181,7 +197,8 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/string_utils.c ../lxc/string_utils.h \
 				     ../lxc/terminal.c ../lxc/terminal.h \
 				     ../lxc/utils.c ../lxc/utils.h \
-				     ../lxc/uuid.c ../lxc/uuid.h
+				     ../lxc/uuid.c ../lxc/uuid.h \
+				     $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_test_config_jump_table_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -227,7 +244,8 @@ lxc_test_locktests_SOURCES = locktests.c \
 			     ../lxc/string_utils.c ../lxc/string_utils.h \
 			     ../lxc/terminal.c ../lxc/terminal.h \
 			     ../lxc/utils.c ../lxc/utils.h \
-			     ../lxc/uuid.c ../lxc/uuid.h
+			     ../lxc/uuid.c ../lxc/uuid.h \
+			     $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_test_locktests_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -265,7 +283,8 @@ lxc_test_mount_injection_SOURCES = mount_injection.c \
 				   ../lxc/string_utils.c ../lxc/string_utils.h \
 				   ../lxc/terminal.c ../lxc/terminal.h \
 				   ../lxc/utils.c ../lxc/utils.h \
-				   ../lxc/uuid.c ../lxc/uuid.h
+				   ../lxc/uuid.c ../lxc/uuid.h \
+				   $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_test_mount_injection_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
@@ -301,23 +320,49 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/string_utils.c ../lxc/string_utils.h \
 				     ../lxc/terminal.c ../lxc/terminal.h \
 				     ../lxc/utils.c ../lxc/utils.h \
-				     ../lxc/uuid.c ../lxc/uuid.h
+				     ../lxc/uuid.c ../lxc/uuid.h \
+				     $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_test_parse_config_file_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif
 
 lxc_test_raw_clone_SOURCES = lxc_raw_clone.c \
 			     lxctest.h \
+			     ../lxc/af_unix.c ../lxc/af_unix.h \
 			     ../lxc/caps.c ../lxc/caps.h \
 			     ../lxc/cgroups/cgroup.c ../lxc/cgroups/cgroup.h \
 			     ../lxc/cgroups/cgroup2_devices.c ../lxc/cgroups/cgroup2_devices.h \
 			     ../lxc/cgroups/cgroup_utils.c ../lxc/cgroups/cgroup_utils.h \
+			     ../lxc/commands.c ../lxc/commands.h \
+			     ../lxc/commands_utils.c ../lxc/commands_utils.h \
+			     ../lxc/conf.c ../lxc/conf.h \
+			     ../lxc/confile.c ../lxc/confile.h \
+			     ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			     ../lxc/error.c ../lxc/error.h \
 			     ../lxc/file_utils.c ../lxc/file_utils.h \
+			     ../lxc/initutils.c ../lxc/initutils.h \
 			     ../lxc/log.c ../lxc/log.h \
+			     ../lxc/lxclock.c ../lxc/lxclock.h \
+			     ../lxc/mainloop.c ../lxc/mainloop.h \
+			     ../lxc/monitor.c ../lxc/monitor.h \
 			     ../lxc/namespace.c ../lxc/namespace.h \
+			     ../lxc/network.c ../lxc/network.h \
+			     ../lxc/nl.c ../lxc/nl.h \
+			     ../lxc/parse.c ../lxc/parse.h \
 			     ../lxc/process_utils.c ../lxc/process_utils.h \
+			     ../lxc/ringbuf.c ../lxc/ringbuf.h \
+			     ../lxc/start.c ../lxc/start.h \
+			     ../lxc/state.c ../lxc/state.h \
+			     ../lxc/sync.c ../lxc/sync.h \
 			     ../lxc/string_utils.c ../lxc/string_utils.h \
-			     ../lxc/utils.c ../lxc/utils.h
+			     ../lxc/terminal.c ../lxc/terminal.h \
+			     ../lxc/utils.c ../lxc/utils.h \
+			     ../lxc/uuid.c ../lxc/uuid.h \
+			     $(LSM_SOURCES)
+if ENABLE_SECCOMP
+lxc_test_raw_clone_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
+endif
+
 lxc_test_reboot_SOURCES = reboot.c
 lxc_test_saveconfig_SOURCES = saveconfig.c
 lxc_test_share_ns_SOURCES = share_ns.c \
@@ -363,7 +408,8 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
 			  ../lxc/terminal.c ../lxc/terminal.h \
 			  ../lxc/utils.c ../lxc/utils.h \
-			  ../lxc/uuid.c ../lxc/uuid.h
+			  ../lxc/uuid.c ../lxc/uuid.h \
+			  $(LSM_SOURCES)
 if ENABLE_SECCOMP
 lxc_test_utils_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
 endif

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -45,6 +45,17 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			      ../lxc/start.c ../lxc/start.h \
 			      ../lxc/state.c ../lxc/state.h \
+			      ../lxc/storage/btrfs.c ../lxc/storage/btrfs.h \
+			      ../lxc/storage/dir.c ../lxc/storage/dir.h \
+			      ../lxc/storage/loop.c ../lxc/storage/loop.h \
+			      ../lxc/storage/lvm.c ../lxc/storage/lvm.h \
+			      ../lxc/storage/nbd.c ../lxc/storage/nbd.h \
+			      ../lxc/storage/overlay.c ../lxc/storage/overlay.h \
+			      ../lxc/storage/rbd.c ../lxc/storage/rbd.h \
+			      ../lxc/storage/rsync.c ../lxc/storage/rsync.h \
+			      ../lxc/storage/storage.c ../lxc/storage/storage.h \
+			      ../lxc/storage/storage_utils.c ../lxc/storage/storage_utils.h \
+			      ../lxc/storage/zfs.c ../lxc/storage/zfs.h \
 			      ../lxc/sync.c ../lxc/sync.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h \
 			      ../lxc/terminal.c ../lxc/terminal.h \
@@ -81,6 +92,17 @@ lxc_test_apparmor_SOURCES = aa.c \
 			    ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			    ../lxc/start.c ../lxc/start.h \
 			    ../lxc/state.c ../lxc/state.h \
+			    ../lxc/storage/btrfs.c ../lxc/storage/btrfs.h \
+			    ../lxc/storage/dir.c ../lxc/storage/dir.h \
+			    ../lxc/storage/loop.c ../lxc/storage/loop.h \
+			    ../lxc/storage/lvm.c ../lxc/storage/lvm.h \
+			    ../lxc/storage/nbd.c ../lxc/storage/nbd.h \
+			    ../lxc/storage/overlay.c ../lxc/storage/overlay.h \
+			    ../lxc/storage/rbd.c ../lxc/storage/rbd.h \
+			    ../lxc/storage/rsync.c ../lxc/storage/rsync.h \
+			    ../lxc/storage/storage.c ../lxc/storage/storage.h \
+			    ../lxc/storage/storage_utils.c ../lxc/storage/storage_utils.h \
+			    ../lxc/storage/zfs.c ../lxc/storage/zfs.h \
 			    ../lxc/sync.c ../lxc/sync.h \
 			    ../lxc/string_utils.c ../lxc/string_utils.h \
 			    ../lxc/terminal.c ../lxc/terminal.h \
@@ -117,6 +139,17 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/state.c ../lxc/state.h \
+			  ../lxc/storage/btrfs.c ../lxc/storage/btrfs.h \
+			  ../lxc/storage/dir.c ../lxc/storage/dir.h \
+			  ../lxc/storage/loop.c ../lxc/storage/loop.h \
+			  ../lxc/storage/lvm.c ../lxc/storage/lvm.h \
+			  ../lxc/storage/nbd.c ../lxc/storage/nbd.h \
+			  ../lxc/storage/overlay.c ../lxc/storage/overlay.h \
+			  ../lxc/storage/rbd.c ../lxc/storage/rbd.h \
+			  ../lxc/storage/rsync.c ../lxc/storage/rsync.h \
+			  ../lxc/storage/storage.c ../lxc/storage/storage.h \
+			  ../lxc/storage/storage_utils.c ../lxc/storage/storage_utils.h \
+			  ../lxc/storage/zfs.c ../lxc/storage/zfs.h \
 			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
 			  ../lxc/terminal.c ../lxc/terminal.h \
@@ -154,6 +187,17 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/state.c ../lxc/state.h \
+			  ../lxc/storage/btrfs.c ../lxc/storage/btrfs.h \
+			  ../lxc/storage/dir.c ../lxc/storage/dir.h \
+			  ../lxc/storage/loop.c ../lxc/storage/loop.h \
+			  ../lxc/storage/lvm.c ../lxc/storage/lvm.h \
+			  ../lxc/storage/nbd.c ../lxc/storage/nbd.h \
+			  ../lxc/storage/overlay.c ../lxc/storage/overlay.h \
+			  ../lxc/storage/rbd.c ../lxc/storage/rbd.h \
+			  ../lxc/storage/rsync.c ../lxc/storage/rsync.h \
+			  ../lxc/storage/storage.c ../lxc/storage/storage.h \
+			  ../lxc/storage/storage_utils.c ../lxc/storage/storage_utils.h \
+			  ../lxc/storage/zfs.c ../lxc/storage/zfs.h \
 			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
 			  ../lxc/terminal.c ../lxc/terminal.h \
@@ -193,6 +237,17 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/ringbuf.c ../lxc/ringbuf.h \
 				     ../lxc/start.c ../lxc/start.h \
 				     ../lxc/state.c ../lxc/state.h \
+				     ../lxc/storage/btrfs.c ../lxc/storage/btrfs.h \
+				     ../lxc/storage/dir.c ../lxc/storage/dir.h \
+				     ../lxc/storage/loop.c ../lxc/storage/loop.h \
+				     ../lxc/storage/lvm.c ../lxc/storage/lvm.h \
+				     ../lxc/storage/nbd.c ../lxc/storage/nbd.h \
+				     ../lxc/storage/overlay.c ../lxc/storage/overlay.h \
+				     ../lxc/storage/rbd.c ../lxc/storage/rbd.h \
+				     ../lxc/storage/rsync.c ../lxc/storage/rsync.h \
+				     ../lxc/storage/storage.c ../lxc/storage/storage.h \
+				     ../lxc/storage/storage_utils.c ../lxc/storage/storage_utils.h \
+				     ../lxc/storage/zfs.c ../lxc/storage/zfs.h \
 				     ../lxc/sync.c ../lxc/sync.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h \
 				     ../lxc/terminal.c ../lxc/terminal.h \
@@ -240,6 +295,17 @@ lxc_test_locktests_SOURCES = locktests.c \
 			     ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			     ../lxc/start.c ../lxc/start.h \
 			     ../lxc/state.c ../lxc/state.h \
+			     ../lxc/storage/btrfs.c ../lxc/storage/btrfs.h \
+			     ../lxc/storage/dir.c ../lxc/storage/dir.h \
+			     ../lxc/storage/loop.c ../lxc/storage/loop.h \
+			     ../lxc/storage/lvm.c ../lxc/storage/lvm.h \
+			     ../lxc/storage/nbd.c ../lxc/storage/nbd.h \
+			     ../lxc/storage/overlay.c ../lxc/storage/overlay.h \
+			     ../lxc/storage/rbd.c ../lxc/storage/rbd.h \
+			     ../lxc/storage/rsync.c ../lxc/storage/rsync.h \
+			     ../lxc/storage/storage.c ../lxc/storage/storage.h \
+			     ../lxc/storage/storage_utils.c ../lxc/storage/storage_utils.h \
+			     ../lxc/storage/zfs.c ../lxc/storage/zfs.h \
 			     ../lxc/sync.c ../lxc/sync.h \
 			     ../lxc/string_utils.c ../lxc/string_utils.h \
 			     ../lxc/terminal.c ../lxc/terminal.h \
@@ -279,6 +345,17 @@ lxc_test_mount_injection_SOURCES = mount_injection.c \
 				   ../lxc/ringbuf.c ../lxc/ringbuf.h \
 				   ../lxc/start.c ../lxc/start.h \
 				   ../lxc/state.c ../lxc/state.h \
+				   ../lxc/storage/btrfs.c ../lxc/storage/btrfs.h \
+				   ../lxc/storage/dir.c ../lxc/storage/dir.h \
+				   ../lxc/storage/loop.c ../lxc/storage/loop.h \
+				   ../lxc/storage/lvm.c ../lxc/storage/lvm.h \
+				   ../lxc/storage/nbd.c ../lxc/storage/nbd.h \
+				   ../lxc/storage/overlay.c ../lxc/storage/overlay.h \
+				   ../lxc/storage/rbd.c ../lxc/storage/rbd.h \
+				   ../lxc/storage/rsync.c ../lxc/storage/rsync.h \
+				   ../lxc/storage/storage.c ../lxc/storage/storage.h \
+				   ../lxc/storage/storage_utils.c ../lxc/storage/storage_utils.h \
+				   ../lxc/storage/zfs.c ../lxc/storage/zfs.h \
 				   ../lxc/sync.c ../lxc/sync.h \
 				   ../lxc/string_utils.c ../lxc/string_utils.h \
 				   ../lxc/terminal.c ../lxc/terminal.h \
@@ -316,6 +393,17 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/ringbuf.c ../lxc/ringbuf.h \
 				     ../lxc/start.c ../lxc/start.h \
 				     ../lxc/state.c ../lxc/state.h \
+				     ../lxc/storage/btrfs.c ../lxc/storage/btrfs.h \
+				     ../lxc/storage/dir.c ../lxc/storage/dir.h \
+				     ../lxc/storage/loop.c ../lxc/storage/loop.h \
+				     ../lxc/storage/lvm.c ../lxc/storage/lvm.h \
+				     ../lxc/storage/nbd.c ../lxc/storage/nbd.h \
+				     ../lxc/storage/overlay.c ../lxc/storage/overlay.h \
+				     ../lxc/storage/rbd.c ../lxc/storage/rbd.h \
+				     ../lxc/storage/rsync.c ../lxc/storage/rsync.h \
+				     ../lxc/storage/storage.c ../lxc/storage/storage.h \
+				     ../lxc/storage/storage_utils.c ../lxc/storage/storage_utils.h \
+				     ../lxc/storage/zfs.c ../lxc/storage/zfs.h \
 				     ../lxc/sync.c ../lxc/sync.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h \
 				     ../lxc/terminal.c ../lxc/terminal.h \
@@ -353,6 +441,17 @@ lxc_test_raw_clone_SOURCES = lxc_raw_clone.c \
 			     ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			     ../lxc/start.c ../lxc/start.h \
 			     ../lxc/state.c ../lxc/state.h \
+			     ../lxc/storage/btrfs.c ../lxc/storage/btrfs.h \
+			     ../lxc/storage/dir.c ../lxc/storage/dir.h \
+			     ../lxc/storage/loop.c ../lxc/storage/loop.h \
+			     ../lxc/storage/lvm.c ../lxc/storage/lvm.h \
+			     ../lxc/storage/nbd.c ../lxc/storage/nbd.h \
+			     ../lxc/storage/overlay.c ../lxc/storage/overlay.h \
+			     ../lxc/storage/rbd.c ../lxc/storage/rbd.h \
+			     ../lxc/storage/rsync.c ../lxc/storage/rsync.h \
+			     ../lxc/storage/storage.c ../lxc/storage/storage.h \
+			     ../lxc/storage/storage_utils.c ../lxc/storage/storage_utils.h \
+			     ../lxc/storage/zfs.c ../lxc/storage/zfs.h \
 			     ../lxc/sync.c ../lxc/sync.h \
 			     ../lxc/string_utils.c ../lxc/string_utils.h \
 			     ../lxc/terminal.c ../lxc/terminal.h \
@@ -404,6 +503,17 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/state.c ../lxc/state.h \
+			  ../lxc/storage/btrfs.c ../lxc/storage/btrfs.h \
+			  ../lxc/storage/dir.c ../lxc/storage/dir.h \
+			  ../lxc/storage/loop.c ../lxc/storage/loop.h \
+			  ../lxc/storage/lvm.c ../lxc/storage/lvm.h \
+			  ../lxc/storage/nbd.c ../lxc/storage/nbd.h \
+			  ../lxc/storage/overlay.c ../lxc/storage/overlay.h \
+			  ../lxc/storage/rbd.c ../lxc/storage/rbd.h \
+			  ../lxc/storage/rsync.c ../lxc/storage/rsync.h \
+			  ../lxc/storage/storage.c ../lxc/storage/storage.h \
+			  ../lxc/storage/storage_utils.c ../lxc/storage/storage_utils.h \
+			  ../lxc/storage/zfs.c ../lxc/storage/zfs.h \
 			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h \
 			  ../lxc/terminal.c ../lxc/terminal.h \

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -29,6 +29,7 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/process_utils.c ../lxc/process_utils.h \
 			      ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			      ../lxc/start.c ../lxc/start.h \
+			      ../lxc/state.c ../lxc/state.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_api_reboot_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -57,6 +58,7 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/process_utils.c ../lxc/process_utils.h \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/start.c ../lxc/start.h \
+			  ../lxc/state.c ../lxc/state.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_attach_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -85,6 +87,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/process_utils.c ../lxc/process_utils.h \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/start.c ../lxc/start.h \
+			  ../lxc/state.c ../lxc/state.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_cgpath_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -115,6 +118,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/process_utils.c ../lxc/process_utils.h \
 				     ../lxc/ringbuf.c ../lxc/ringbuf.h \
 				     ../lxc/start.c ../lxc/start.h \
+				     ../lxc/state.c ../lxc/state.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_config_jump_table_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -166,6 +170,7 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/process_utils.c ../lxc/process_utils.h \
 				     ../lxc/ringbuf.c ../lxc/ringbuf.h \
 				     ../lxc/start.c ../lxc/start.h \
+				     ../lxc/state.c ../lxc/state.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_parse_config_file_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -217,6 +222,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/process_utils.c ../lxc/process_utils.h \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/start.c ../lxc/start.h \
+			  ../lxc/state.c ../lxc/state.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_utils_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -23,6 +23,7 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/network.c ../lxc/network.h \
 			      ../lxc/nl.c ../lxc/nl.h \
 			      ../lxc/parse.c ../lxc/parse.h \
+			      ../lxc/process_utils.c ../lxc/process_utils.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_api_reboot_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -45,6 +46,7 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/parse.c ../lxc/parse.h \
+			  ../lxc/process_utils.c ../lxc/process_utils.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_attach_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -67,6 +69,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/parse.c ../lxc/parse.h \
+			  ../lxc/process_utils.c ../lxc/process_utils.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_cgpath_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -91,6 +94,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/parse.c ../lxc/parse.h \
+				     ../lxc/process_utils.c ../lxc/process_utils.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_config_jump_table_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -133,6 +137,7 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/parse.c ../lxc/parse.h \
+				     ../lxc/process_utils.c ../lxc/process_utils.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_parse_config_file_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -178,6 +183,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/parse.c ../lxc/parse.h \
+			  ../lxc/process_utils.c ../lxc/process_utils.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_utils_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -19,6 +19,7 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/initutils.c ../lxc/initutils.h \
 			      ../lxc/log.c ../lxc/log.h \
 			      ../lxc/mainloop.c ../lxc/mainloop.h \
+			      ../lxc/namespace.c ../lxc/namespace.h \
 			      ../lxc/network.c ../lxc/network.h \
 			      ../lxc/nl.c ../lxc/nl.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h
@@ -39,6 +40,7 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
 			  ../lxc/mainloop.c ../lxc/mainloop.h \
+			  ../lxc/namespace.c ../lxc/namespace.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -59,6 +61,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
 			  ../lxc/mainloop.c ../lxc/mainloop.h \
+			  ../lxc/namespace.c ../lxc/namespace.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -81,6 +84,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/initutils.c ../lxc/initutils.h \
 				     ../lxc/log.c ../lxc/log.h \
 				     ../lxc/mainloop.c ../lxc/mainloop.h \
+				     ../lxc/namespace.c ../lxc/namespace.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
@@ -121,6 +125,7 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/file_utils.c ../lxc/file_utils.h \
 				     ../lxc/initutils.c ../lxc/initutils.h \
 				     ../lxc/log.c ../lxc/log.h \
+				     ../lxc/namespace.c ../lxc/namespace.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
@@ -164,6 +169,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
 			  ../lxc/mainloop.c ../lxc/mainloop.h \
+			  ../lxc/namespace.c ../lxc/namespace.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -15,16 +15,20 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/conf.c ../lxc/conf.h \
 			      ../lxc/confile.c ../lxc/confile.h \
 			      ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			      ../lxc/error.c ../lxc/error.h \
 			      ../lxc/file_utils.c ../lxc/file_utils.h \
 			      ../lxc/initutils.c ../lxc/initutils.h \
 			      ../lxc/log.c ../lxc/log.h \
+			      ../lxc/lxclock.c ../lxc/lxclock.h \
 			      ../lxc/mainloop.c ../lxc/mainloop.h \
+			      ../lxc/monitor.c ../lxc/monitor.h \
 			      ../lxc/namespace.c ../lxc/namespace.h \
 			      ../lxc/network.c ../lxc/network.h \
 			      ../lxc/nl.c ../lxc/nl.h \
 			      ../lxc/parse.c ../lxc/parse.h \
 			      ../lxc/process_utils.c ../lxc/process_utils.h \
 			      ../lxc/ringbuf.c ../lxc/ringbuf.h \
+			      ../lxc/start.c ../lxc/start.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_api_reboot_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -39,16 +43,20 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/conf.c ../lxc/conf.h \
 			  ../lxc/confile.c ../lxc/confile.h \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			  ../lxc/error.c ../lxc/error.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
+			  ../lxc/lxclock.c ../lxc/lxclock.h \
 			  ../lxc/mainloop.c ../lxc/mainloop.h \
+			  ../lxc/monitor.c ../lxc/monitor.h \
 			  ../lxc/namespace.c ../lxc/namespace.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/parse.c ../lxc/parse.h \
 			  ../lxc/process_utils.c ../lxc/process_utils.h \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
+			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_attach_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -63,16 +71,20 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/conf.c ../lxc/conf.h \
 			  ../lxc/confile.c ../lxc/confile.h \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			  ../lxc/error.c ../lxc/error.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
+			  ../lxc/lxclock.c ../lxc/lxclock.h \
 			  ../lxc/mainloop.c ../lxc/mainloop.h \
+			  ../lxc/monitor.c ../lxc/monitor.h \
 			  ../lxc/namespace.c ../lxc/namespace.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/parse.c ../lxc/parse.h \
 			  ../lxc/process_utils.c ../lxc/process_utils.h \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
+			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_cgpath_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -89,16 +101,20 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/conf.c ../lxc/conf.h \
 				     ../lxc/confile.c ../lxc/confile.h \
 				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
+				     ../lxc/error.c ../lxc/error.h \
 				     ../lxc/file_utils.c ../lxc/file_utils.h \
 				     ../lxc/initutils.c ../lxc/initutils.h \
 				     ../lxc/log.c ../lxc/log.h \
+				     ../lxc/lxclock.c ../lxc/lxclock.h \
 				     ../lxc/mainloop.c ../lxc/mainloop.h \
+				     ../lxc/monitor.c ../lxc/monitor.h \
 				     ../lxc/namespace.c ../lxc/namespace.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/parse.c ../lxc/parse.h \
 				     ../lxc/process_utils.c ../lxc/process_utils.h \
 				     ../lxc/ringbuf.c ../lxc/ringbuf.h \
+				     ../lxc/start.c ../lxc/start.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_config_jump_table_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -131,18 +147,25 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     lxctest.h \
 				     ../lxc/af_unix.c ../lxc/af_unix.h \
 				     ../lxc/caps.c ../lxc/caps.h \
+				     ../lxc/commands.c ../lxc/commands.h \
+				     ../lxc/commands_utils.c ../lxc/commands_utils.h \
 				     ../lxc/conf.c ../lxc/conf.h \
 				     ../lxc/confile.c ../lxc/confile.h \
 				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
+				     ../lxc/error.c ../lxc/error.h \
 				     ../lxc/file_utils.c ../lxc/file_utils.h \
 				     ../lxc/initutils.c ../lxc/initutils.h \
 				     ../lxc/log.c ../lxc/log.h \
+				     ../lxc/lxclock.c ../lxc/lxclock.h \
+				     ../lxc/mainloop.c ../lxc/mainloop.h \
+				     ../lxc/monitor.c ../lxc/monitor.h \
 				     ../lxc/namespace.c ../lxc/namespace.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/parse.c ../lxc/parse.h \
 				     ../lxc/process_utils.c ../lxc/process_utils.h \
 				     ../lxc/ringbuf.c ../lxc/ringbuf.h \
+				     ../lxc/start.c ../lxc/start.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_parse_config_file_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -180,16 +203,20 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/conf.c ../lxc/conf.h \
 			  ../lxc/confile.c ../lxc/confile.h \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			  ../lxc/error.c ../lxc/error.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/log.c ../lxc/log.h \
+			  ../lxc/lxclock.c ../lxc/lxclock.h \
 			  ../lxc/mainloop.c ../lxc/mainloop.h \
+			  ../lxc/monitor.c ../lxc/monitor.h \
 			  ../lxc/namespace.c ../lxc/namespace.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/parse.c ../lxc/parse.h \
 			  ../lxc/process_utils.c ../lxc/process_utils.h \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
+			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_utils_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -74,7 +74,12 @@ lxc_test_device_add_remove_SOURCES = device_add_remove.c
 lxc_test_getkeys_SOURCES = getkeys.c
 lxc_test_get_item_SOURCES = get_item.c
 lxc_test_list_SOURCES = list.c
-lxc_test_locktests_SOURCES = locktests.c
+lxc_test_locktests_SOURCES = locktests.c \
+			     ../lxc/caps.c ../lxc/caps.h \
+			     ../lxc/file_utils.c ../lxc/file_utils.h \
+			     ../lxc/log.c ../lxc/log.h \
+			     ../lxc/lxclock.c ../lxc/lxclock.h \
+			     ../lxc/string_utils.c ../lxc/string_utils.h
 lxc_test_lxcpath_SOURCES = lxcpath.c
 lxc_test_may_control_SOURCES = may_control.c
 lxc_test_mount_injection_SOURCES = mount_injection.c \

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -30,6 +30,7 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			      ../lxc/start.c ../lxc/start.h \
 			      ../lxc/state.c ../lxc/state.h \
+			      ../lxc/sync.c ../lxc/sync.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_api_reboot_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -59,6 +60,7 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/state.c ../lxc/state.h \
+			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_attach_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -88,6 +90,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/state.c ../lxc/state.h \
+			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_cgpath_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -119,6 +122,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/ringbuf.c ../lxc/ringbuf.h \
 				     ../lxc/start.c ../lxc/start.h \
 				     ../lxc/state.c ../lxc/state.h \
+				     ../lxc/sync.c ../lxc/sync.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_config_jump_table_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -171,6 +175,7 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/ringbuf.c ../lxc/ringbuf.h \
 				     ../lxc/start.c ../lxc/start.h \
 				     ../lxc/state.c ../lxc/state.h \
+				     ../lxc/sync.c ../lxc/sync.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_parse_config_file_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h
@@ -223,6 +228,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/ringbuf.c ../lxc/ringbuf.h \
 			  ../lxc/start.c ../lxc/start.h \
 			  ../lxc/state.c ../lxc/state.h \
+			  ../lxc/sync.c ../lxc/sync.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
 if ENABLE_SECCOMP
 lxc_test_utils_SOURCES += ../lxc/seccomp.c ../lxc/lxcseccomp.h

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -12,6 +12,7 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			      ../lxc/file_utils.c ../lxc/file_utils.h \
 			      ../lxc/initutils.c ../lxc/initutils.h \
+			      ../lxc/log.c ../lxc/log.h \
 			      ../lxc/network.c ../lxc/network.h \
 			      ../lxc/nl.c ../lxc/nl.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h
@@ -26,6 +27,7 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
+			  ../lxc/log.c ../lxc/log.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -40,6 +42,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
+			  ../lxc/log.c ../lxc/log.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -56,6 +59,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
 				     ../lxc/file_utils.c ../lxc/file_utils.h \
 				     ../lxc/initutils.c ../lxc/initutils.h \
+				     ../lxc/log.c ../lxc/log.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
@@ -86,15 +90,19 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
 				     ../lxc/file_utils.c ../lxc/file_utils.h \
 				     ../lxc/initutils.c ../lxc/initutils.h \
+				     ../lxc/log.c ../lxc/log.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
 lxc_test_raw_clone_SOURCES = lxc_raw_clone.c \
 			     lxctest.h \
+			     ../lxc/caps.c ../lxc/caps.h \
+			     ../lxc/file_utils.c ../lxc/file_utils.h \
+			     ../lxc/log.c ../lxc/log.h \
 			     ../lxc/namespace.c ../lxc/namespace.h \
-			     ../lxc/process_utils.c ../lxc/process_utils.h
-			     ../lxc/utils.c ../lxc/utils.h \
-			     ../lxc/string_utils.c ../lxc/string_utils.h
+			     ../lxc/process_utils.c ../lxc/process_utils.h \
+			     ../lxc/string_utils.c ../lxc/string_utils.h \
+			     ../lxc/utils.c ../lxc/utils.h
 lxc_test_reboot_SOURCES = reboot.c
 lxc_test_saveconfig_SOURCES = saveconfig.c
 lxc_test_share_ns_SOURCES = share_ns.c \
@@ -120,6 +128,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
 			  ../lxc/initutils.c ../lxc/initutils.h \
+			  ../lxc/log.c ../lxc/log.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -129,6 +138,8 @@ AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	  -DLXC_GLOBAL_CONF=\"$(LXC_GLOBAL_CONF)\" \
 	  -DLXCINITDIR=\"$(LXCINITDIR)\" \
 	  -DLIBEXECDIR=\"$(LIBEXECDIR)\" \
+	  -DLOGPATH=\"$(LOGPATH)\" \
+	  -DLXCTEMPLATEDIR=\"$(LXCTEMPLATEDIR)\" \
 	  -DLXC_DEFAULT_CONFIG=\"$(LXC_DEFAULT_CONFIG)\" \
 	  -DDEFAULT_CGROUP_PATTERN=\"$(DEFAULT_CGROUP_PATTERN)\" \
 	  -DRUNTIME_PATH=\"$(RUNTIME_PATH)\" \

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -11,6 +11,7 @@ lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/confile.c ../lxc/confile.h \
 			      ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			      ../lxc/file_utils.c ../lxc/file_utils.h \
+			      ../lxc/initutils.c ../lxc/initutils.h \
 			      ../lxc/network.c ../lxc/network.h \
 			      ../lxc/nl.c ../lxc/nl.h \
 			      ../lxc/string_utils.c ../lxc/string_utils.h
@@ -24,6 +25,7 @@ lxc_test_attach_SOURCES = attach.c \
 			  ../lxc/confile.c ../lxc/confile.h \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
+			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -37,6 +39,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/confile.c ../lxc/confile.h \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
+			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -52,6 +55,7 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     ../lxc/confile.c ../lxc/confile.h \
 				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
 				     ../lxc/file_utils.c ../lxc/file_utils.h \
+				     ../lxc/initutils.c ../lxc/initutils.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
@@ -81,6 +85,7 @@ lxc_test_parse_config_file_SOURCES = parse_config_file.c \
 				     ../lxc/confile.c ../lxc/confile.h \
 				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
 				     ../lxc/file_utils.c ../lxc/file_utils.h \
+				     ../lxc/initutils.c ../lxc/initutils.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
@@ -114,6 +119,7 @@ lxc_test_utils_SOURCES = lxc-test-utils.c \
 			  ../lxc/confile.c ../lxc/confile.h \
 			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			  ../lxc/file_utils.c ../lxc/file_utils.h \
+			  ../lxc/initutils.c ../lxc/initutils.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -124,6 +130,7 @@ AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	  -DLXCINITDIR=\"$(LXCINITDIR)\" \
 	  -DLIBEXECDIR=\"$(LIBEXECDIR)\" \
 	  -DLXC_DEFAULT_CONFIG=\"$(LXC_DEFAULT_CONFIG)\" \
+	  -DDEFAULT_CGROUP_PATTERN=\"$(DEFAULT_CGROUP_PATTERN)\" \
 	  -DRUNTIME_PATH=\"$(RUNTIME_PATH)\" \
 	  -DSBINDIR=\"$(SBINDIR)\" \
 	  -I $(top_srcdir)/src \

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -13,6 +13,7 @@ lxc_test_cgpath_SOURCES = cgpath.c \
 			  ../lxc/commands_utils.c ../lxc/commands_utils.h \
 			  ../lxc/conf.c ../lxc/conf.h \
 			  ../lxc/confile.c ../lxc/confile.h \
+			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
 			  ../lxc/network.c ../lxc/network.h \
 			  ../lxc/nl.c ../lxc/nl.h \
 			  ../lxc/string_utils.c ../lxc/string_utils.h
@@ -22,8 +23,11 @@ lxc_test_config_jump_table_SOURCES = config_jump_table.c \
 				     lxctest.h \
 				     ../lxc/af_unix.c ../lxc/af_unix.h \
 				     ../lxc/caps.c ../lxc/caps.h \
+				     ../lxc/commands.c ../lxc/commands.h \
+				     ../lxc/commands_utils.c ../lxc/commands_utils.h \
 				     ../lxc/conf.c ../lxc/conf.h \
 				     ../lxc/confile.c ../lxc/confile.h \
+				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
 				     ../lxc/network.c ../lxc/network.h \
 				     ../lxc/nl.c ../lxc/nl.h \
 				     ../lxc/string_utils.c ../lxc/string_utils.h
@@ -43,7 +47,15 @@ lxc_test_lxcpath_SOURCES = lxcpath.c
 lxc_test_may_control_SOURCES = may_control.c
 lxc_test_mount_injection_SOURCES = mount_injection.c lxctest.h
 lxc_test_parse_config_file_SOURCES = parse_config_file.c \
-				     lxctest.h
+				     lxctest.h \
+				     ../lxc/af_unix.c ../lxc/af_unix.h \
+				     ../lxc/caps.c ../lxc/caps.h \
+				     ../lxc/conf.c ../lxc/conf.h \
+				     ../lxc/confile.c ../lxc/confile.h \
+				     ../lxc/confile_utils.c ../lxc/confile_utils.h \
+				     ../lxc/network.c ../lxc/network.h \
+				     ../lxc/nl.c ../lxc/nl.h \
+				     ../lxc/string_utils.c ../lxc/string_utils.h
 lxc_test_raw_clone_SOURCES = lxc_raw_clone.c \
 			     lxctest.h \
 			     ../lxc/namespace.c ../lxc/namespace.h \
@@ -62,8 +74,18 @@ lxc_test_startone_SOURCES = startone.c
 lxc_test_state_server_SOURCES = state_server.c \
 				lxctest.h \
 				../lxc/compiler.h
-lxc_test_utils_SOURCES = lxc-test-utils.c lxctest.h \
-			 ../lxc/string_utils.c ../lxc/string_utils.h
+lxc_test_utils_SOURCES = lxc-test-utils.c \
+			 lxctest.h \
+			  ../lxc/af_unix.c ../lxc/af_unix.h \
+			  ../lxc/caps.c ../lxc/caps.h \
+			  ../lxc/commands.c ../lxc/commands.h \
+			  ../lxc/commands_utils.c ../lxc/commands_utils.h \
+			  ../lxc/conf.c ../lxc/conf.h \
+			  ../lxc/confile.c ../lxc/confile.h \
+			  ../lxc/confile_utils.c ../lxc/confile_utils.h \
+			  ../lxc/network.c ../lxc/network.h \
+			  ../lxc/nl.c ../lxc/nl.h \
+			  ../lxc/string_utils.c ../lxc/string_utils.h
 
 AM_CFLAGS=-DLXCROOTFSMOUNT=\"$(LXCROOTFSMOUNT)\" \
 	  -DLXCPATH=\"$(LXCPATH)\" \


### PR DESCRIPTION
Do it file-by-file until we switch to `-fvsibility=hidden`.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>