### PR TITLE
apparmor: Allow ro remount of boot_id

### DIFF
--- a/config/apparmor/abstractions/start-container.in
+++ b/config/apparmor/abstractions/start-container.in
@@ -22,6 +22,7 @@
   mount -> /var/lib/lxc/{**,},
 
   mount /dev/.lxc-boot-id -> /proc/sys/kernel/random/boot_id,
+  mount options=(ro, nosuid, nodev, noexec, remount, bind) -> /proc/sys/kernel/random/boot_id,
 
   # required for some pre-mount hooks
   mount fstype=overlayfs,


### PR DESCRIPTION
The rule added in 863845075d3f77d27c91bd9f47d2f8ddc4867bd5 did not cover all
necessary mount calls for /proc/sys/kernel/random/boot_id
(in src/lxc/conf.c: lxc_setup_boot_id) - the ro remount is missing.

Signed-off-by: Stoiko Ivanov <s.ivanov@proxmox.com>