### PR TITLE
seccomp: remove seccomp fd from event loop after task exited

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1373,6 +1373,9 @@ int seccomp_notify_handler(int fd, uint32_t events, void *data,
 	char *cookie = conf->seccomp.notifier.cookie;
 	uint64_t req_id;
 
+	if (events & EPOLLHUP)
+		return log_trace(LXC_MAINLOOP_CLOSE, "Syscall supervisee already exited");
+
 	memset(req, 0, sizeof(*req));
 	ret = seccomp_notify_receive(fd, req);
 	if (ret) {


### PR DESCRIPTION
Linux v5.8 will land my patch where seccomp notifies when a filter goes unused,
i.e. when the last task using a given seccomp filter has exited. This wasn't
possible before and so we accumulated file descriptors in the container's event
loop whenever we attached to the container.
I'm not sure whether the task exiting before we could handle its syscall should
cause us to report and error or not. For now, let's simply close the event loop
and not report an error.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>