### PR TITLE
seccomp: add missing header

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -7,6 +7,7 @@
 #include <seccomp.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/epoll.h>
 #include <sys/mount.h>
 #include <sys/utsname.h>
 


### PR DESCRIPTION
Fixes: https://launchpadlibrarian.net/490341075/buildlog_snap_ubuntu_bionic_amd64_lxd-latest-edge_BUILDING.txt.gz
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>