### PR TITLE
syscall: don't fail if __NR_signalfd is not defined

### DIFF
--- a/src/lxc/syscall_numbers.h
+++ b/src/lxc/syscall_numbers.h
@@ -228,9 +228,6 @@
 		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
 			#define __NR_signalfd 5276
 		#endif
-	#else
-		#define -1
-		#warning "__NR_signalfd not defined for your architecture"
 	#endif
 #endif
 

--- a/src/lxc/syscall_wrappers.h
+++ b/src/lxc/syscall_wrappers.h
@@ -112,8 +112,10 @@ static inline int signalfd(int fd, const sigset_t *mask, int flags)
 	int retval;
 
 	retval = syscall(__NR_signalfd4, fd, mask, _NSIG / 8, flags);
+#ifdef __NR_signalfd
 	if (errno == ENOSYS && flags == 0)
 		retval = syscall(__NR_signalfd, fd, mask, _NSIG / 8);
+#endif
 
 	return retval;
 }


### PR DESCRIPTION
lxc fails to build if `__NR_signalfd` is not defined since version 4.0.0 and https://github.com/lxc/lxc/commit/bed09c9cc0bec7bbd2442fcce4a2a0f03994cb09

However, some architectures don't define `__NR_signalfd` but only
`__NR_signalfd4.` This is the case for example for nios2 or csky:
https://github.com/bminor/glibc/blob/f9ac84f92f151e07586c55e14ed628d493a5929d/sysdeps/unix/sysv/linux/nios2/arch-syscall.h
https://github.com/bminor/glibc/blob/f9ac84f92f151e07586c55e14ed628d493a5929d/sysdeps/unix/sysv/linux/csky/arch-syscall.h

Fixes:
 - http://autobuild.buildroot.org/results/75096a48d2dbda57459523db3ed0952e63f93535

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>