### PR TITLE
seccomp: don't close the mainloop, simply remove the handler

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1374,8 +1374,11 @@ int seccomp_notify_handler(int fd, uint32_t events, void *data,
 	char *cookie = conf->seccomp.notifier.cookie;
 	uint64_t req_id;
 
-	if (events & EPOLLHUP)
-		return log_trace(LXC_MAINLOOP_CLOSE, "Syscall supervisee already exited");
+	if (events & EPOLLHUP) {
+		lxc_mainloop_del_handler(descr, fd);
+		close(fd);
+		return log_trace(0, "Removing seccomp notifier fd %d", fd);
+	}
 
 	memset(req, 0, sizeof(*req));
 	ret = seccomp_notify_receive(fd, req);


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>