### PR TITLE
seccomp: add seccomp_notify_fd_active api extension

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -136,3 +136,7 @@ This adds the ability to use "denylist" and "allowlist" in seccomp v2 policies.
 
 This adds the ability to allocate a file descriptor for the devpts instance of
 the container.
+
+## seccomp\_notify\_fd\_active
+
+Retrieve the seccomp notifier fd from a running container.

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -44,6 +44,7 @@ static char *api_extensions[] = {
 	"time_namespace",
 	"seccomp_allow_deny_syntax",
 	"devpts_fd",
+	"seccomp_notify_fd_active",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);

--- a/src/lxc/commands.h
+++ b/src/lxc/commands.h
@@ -42,6 +42,7 @@ typedef enum {
 	LXC_CMD_GET_LIMITING_CGROUP,
 	LXC_CMD_GET_LIMITING_CGROUP2_FD,
 	LXC_CMD_GET_DEVPTS_FD,
+	LXC_CMD_GET_SECCOMP_NOTIFY_FD,
 	LXC_CMD_MAX,
 } lxc_cmd_t;
 
@@ -120,6 +121,7 @@ __hidden extern int lxc_cmd_mainloop_add(const char *name, struct lxc_epoll_desc
 __hidden extern int lxc_try_cmd(const char *name, const char *lxcpath);
 __hidden extern int lxc_cmd_console_log(const char *name, const char *lxcpath,
 					struct lxc_console_log *log);
+__hidden extern int lxc_cmd_get_seccomp_notify_fd(const char *name, const char *lxcpath);
 __hidden extern int lxc_cmd_seccomp_notify_add_listener(const char *name, const char *lxcpath, int fd,
 							/* unused */ unsigned int command,
 							/* unused */ unsigned int flags);

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -5240,6 +5240,16 @@ static int do_lxcapi_seccomp_notify_fd(struct lxc_container *c)
 
 WRAP_API(int, lxcapi_seccomp_notify_fd)
 
+static int do_lxcapi_seccomp_notify_fd_active(struct lxc_container *c)
+{
+	if (!c || !c->lxc_conf)
+		return ret_set_errno(-1, -EINVAL);
+
+	return lxc_cmd_get_seccomp_notify_fd(c->name, c->config_path);
+}
+
+WRAP_API(int, lxcapi_seccomp_notify_fd_active)
+
 struct lxc_container *lxc_container_new(const char *name, const char *configpath)
 {
 	struct lxc_container *c;
@@ -5382,6 +5392,7 @@ struct lxc_container *lxc_container_new(const char *name, const char *configpath
 	c->mount = lxcapi_mount;
 	c->umount = lxcapi_umount;
 	c->seccomp_notify_fd = lxcapi_seccomp_notify_fd;
+	c->seccomp_notify_fd_active = lxcapi_seccomp_notify_fd_active;
 
 	return c;
 

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -858,6 +858,15 @@ struct lxc_container {
 	int (*seccomp_notify_fd)(struct lxc_container *c);
 
 	/*!
+	 * \brief Retrieve a file descriptor for the running container's seccomp filter.
+	 *
+	 * \param c Container
+	 *
+	 * \return file descriptor for the running container's seccomp filter
+	 */
+	int (*seccomp_notify_fd_active)(struct lxc_container *c);
+
+	/*!
 	 * \brief Retrieve a pidfd for the container's init process.
 	 *
 	 * \param c Container.

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1357,7 +1357,7 @@ int seccomp_notify_handler(int fd, uint32_t events, void *data,
 	__do_close int fd_mem = -EBADF;
 	int ret;
 	ssize_t bytes;
-	int send_fd_list[2];
+	int send_fd_list[3];
 	struct iovec iov[4];
 	size_t iov_len, msg_base_size, msg_full_size;
 	char mem_path[6 /* /proc/ */
@@ -1460,10 +1460,10 @@ int seccomp_notify_handler(int fd, uint32_t events, void *data,
 
 	send_fd_list[0] = fd_pid;
 	send_fd_list[1] = fd_mem;
+	send_fd_list[2] = fd;
 
 retry:
-	bytes = lxc_abstract_unix_send_fds_iov(listener_proxy_fd, send_fd_list,
-					       2, iov, iov_len);
+	bytes = lxc_abstract_unix_send_fds_iov(listener_proxy_fd, send_fd_list, 3, iov, iov_len);
 	if (bytes != (ssize_t)msg_full_size) {
 		SYSERROR("Failed to forward message to seccomp proxy");
 		if (!reconnected) {


### PR DESCRIPTION
which allows to retrieve an active seccomp notifier fd from a running
container.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>