### PR TITLE
api-extension: add missing seccomp_proxy_send_notify_fd extension

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -140,3 +140,7 @@ the container.
 ## seccomp\_notify\_fd\_active
 
 Retrieve the seccomp notifier fd from a running container.
+
+## seccomp\_proxy\_send\_notify\_fd
+
+Whether the seccomp notify proxy sends a long a notify fd file descriptor.

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -45,6 +45,7 @@ static char *api_extensions[] = {
 	"seccomp_allow_deny_syntax",
 	"devpts_fd",
 	"seccomp_notify_fd_active",
+	"seccomp_proxy_send_notify_fd",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>