### PR TITLE
Check only rootfs as filesystem type

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -704,7 +704,7 @@ bool detect_ramfs_rootfs(void)
 		if (strcmp(p + 1, "/") == 0) {
 			/* This is '/'. Is it the ramfs? */
 			p = strchr(p2 + 1, '-');
-			if (p && strncmp(p, "- rootfs rootfs ", 16) == 0)
+			if (p && strncmp(p, "- rootfs ", 9) == 0)
 				return true;
 		}
 	}


### PR DESCRIPTION
When detecting if rootfs is on ramfs instead of checking "- rootfs
rootfs" which is the " - <file_system> <device>" information only check
the file system type. This is due to a change introduced in kernel where
ramfs file system doesn't set the device to "rootfs" but instead mark it
as "none". By making sure we only check for "rootfs" as the file system
name we also offer backward compatibility with earlier kernels as well.

The kernel commit that introduced this change was

commit f32356261d44d580649a7abce1156d15d49cf20f
Author: David Howells <dhowells@redhat.com>
Date:   Mon Mar 25 16:38:31 2019 +0000

    vfs: Convert ramfs, shmem, tmpfs, devtmpfs, rootfs to use the new
    mount API

Signed-off-by: Pranay Kr. Srivastava <pranay.srivastava@pantacor.com>