### PR TITLE
cgroups: fix armhf builds

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -2217,7 +2217,7 @@ static int cgroup_attach_leaf(const struct lxc_conf *conf, int unified_fd, pid_t
 	do {
 		bool rm = false;
 		char attach_cgroup[STRLITERALLEN(".lxc-/cgroup.procs") + INTTYPE_TO_STRLEN(int) + 1];
-		char *slash;
+		char *slash = attach_cgroup;
 
 		ret = snprintf(attach_cgroup, sizeof(attach_cgroup), ".lxc-%d/cgroup.procs", idx);
 		if (ret < 0 || (size_t)ret >= sizeof(attach_cgroup))
@@ -2231,7 +2231,7 @@ static int cgroup_attach_leaf(const struct lxc_conf *conf, int unified_fd, pid_t
 		if (ret < STRLITERALLEN(".lxc-/cgroup.procs"))
 			return log_error_errno(-EINVAL, EINVAL, "Unexpected short write would cause buffer-overrun");
 
-		slash = &attach_cgroup[ret] - STRLITERALLEN("/cgroup.procs");
+		slash += (ret - STRLITERALLEN("/cgroup.procs"));
 		*slash = '\0';
 
 		ret = mkdirat(unified_fd, attach_cgroup, 0755);


### PR DESCRIPTION
Link: https://launchpadlibrarian.net/494473462/buildlog_ubuntu-groovy-armhf.lxc_1%3A4.0.4-0ubuntu2_BUILDING.txt.gz
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>