### PR TITLE
avoid a NULL pointer dereference in lxc-attach

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1384,14 +1384,10 @@ int lxc_attach(struct lxc_container *container, lxc_attach_exec_t exec_function,
 
 	if (pid == 0) {
 		if (options->attach_flags & LXC_ATTACH_TERMINAL) {
-			if (terminal.tty_state)
-			{
-				ret = pthread_sigmask(SIG_SETMASK,
-							  &terminal.tty_state->oldmask, NULL);
-				if (ret < 0) {
-					SYSERROR("Failed to reset signal mask");
-					_exit(EXIT_FAILURE);
-				}
+			ret = lxc_terminal_signal_sigmask_safe_blocked(&terminal);
+			if (ret < 0) {
+				SYSERROR("Failed to reset signal mask");
+				_exit(EXIT_FAILURE);
 			}
 		}
 

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1384,11 +1384,14 @@ int lxc_attach(struct lxc_container *container, lxc_attach_exec_t exec_function,
 
 	if (pid == 0) {
 		if (options->attach_flags & LXC_ATTACH_TERMINAL) {
-			ret = pthread_sigmask(SIG_SETMASK,
-					      &terminal.tty_state->oldmask, NULL);
-			if (ret < 0) {
-				SYSERROR("Failed to reset signal mask");
-				_exit(EXIT_FAILURE);
+			if (terminal.tty_state)
+			{
+				ret = pthread_sigmask(SIG_SETMASK,
+							  &terminal.tty_state->oldmask, NULL);
+				if (ret < 0) {
+					SYSERROR("Failed to reset signal mask");
+					_exit(EXIT_FAILURE);
+				}
 			}
 		}
 

--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -147,6 +147,16 @@ struct lxc_terminal_state *lxc_terminal_signal_init(int srcfd, int dstfd)
 	return move_ptr(ts);
 }
 
+int lxc_terminal_signal_sigmask_safe_blocked(struct lxc_terminal *terminal)
+{
+	struct lxc_terminal_state *state = terminal->tty_state;
+
+	if (!state)
+		return 0;
+
+	return pthread_sigmask(SIG_SETMASK, &state->oldmask, NULL);
+}
+
 /**
  * lxc_terminal_signal_fini: uninstall signal handler
  *

--- a/src/lxc/terminal.h
+++ b/src/lxc/terminal.h
@@ -251,5 +251,6 @@ __hidden extern int lxc_terminal_prepare_login(int fd);
 __hidden extern void lxc_terminal_conf_free(struct lxc_terminal *terminal);
 __hidden extern void lxc_terminal_info_init(struct lxc_terminal_info *terminal);
 __hidden extern void lxc_terminal_init(struct lxc_terminal *terminal);
+__hidden extern int lxc_terminal_signal_sigmask_safe_blocked(struct lxc_terminal *terminal);
 
 #endif /* __LXC_TERMINAL_H */


### PR DESCRIPTION
Seems to appear when stderr is a terminal and not stdin or stdout.

Signed-off-by: Scott Parlane <scott.parlane@alliedtelesis.co.nz>