### PR TITLE
commands: don't fail if unfreeze fails

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -894,12 +894,11 @@ static int lxc_cmd_stop_callback(int fd, struct lxc_cmd_req *req,
 		else
 			TRACE("Sent signal %d to pidfd %d", stopsignal, handler->pid);
 
-		rsp.ret = cgroup_ops->unfreeze(cgroup_ops, -1);
-		if (!rsp.ret)
-			return 0;
+		ret = cgroup_ops->unfreeze(cgroup_ops, -1);
+		if (ret)
+			WARN("Failed to unfreeze container \"%s\"", handler->name);
 
-		ERROR("Failed to unfreeze container \"%s\"", handler->name);
-		rsp.ret = -errno;
+		return 0;
 	} else {
 		rsp.ret = -errno;
 	}


### PR DESCRIPTION
We can e.g. fail the unfreeze because the freezer cgroup is not available and
then we erronously report that stopping the container failed.

Closes: #3471.
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>