### PR TITLE
lxc-usernsexec: setgroups() similar to other places shouldn't fail on…

### DIFF
--- a/src/lxc/cmd/lxc_usernsexec.c
+++ b/src/lxc/cmd/lxc_usernsexec.c
@@ -88,7 +88,7 @@ static int do_child(void *vargv)
 	int ret;
 	char **argv = (char **)vargv;
 
-	if (!lxc_setgroups(0, NULL))
+	if (!lxc_setgroups(0, NULL) && errno != EPERM)
 		return -1;
 
 	/* Assume we want to become root */


### PR DESCRIPTION
… EPERM

```
FAIL: lxc-tests: lxc-test-usernsexec (1s)
---
as test-userns executing /tmp/autopkgtest.waGEXj/build.Hm3/src/src/tests/lxc-test-usernsexec
uid=1001 gid=1001 name=test-userns subuid=165536 subgid=165536 ver=1:4.0.4-0ubuntu3
lxc-utils=1:4.0.4-0ubuntu3 kver=5.8.0-19-generic
USERNSEXEC=lxc-usernsexec
nouidgid: PASS
myuidgid: FAIL - runtest failed 1
  $ lxc-usernsexec -mu:0:1001:1 -mg:0:1001:1 -- /tmp/autopkgtest.waGEXj/build.Hm3/src/src/tests/lxc-test-usernsexec inside f0
  lxc 20200914222824.562 ERROR    utils - utils.c:lxc_setgroups:1363 - Operation not permitted - Failed to setgroups()
  kid 73112 is gone 1
subuidgid: PASS
bothsets: PASS
mismatch: PASS
ERRORS: myuidgid
---
```

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>