### PR TITLE
Remove obsolete setting regarding the Standard Output

### DIFF
--- a/config/init/systemd/lxc-monitord.service.in
+++ b/config/init/systemd/lxc-monitord.service.in
@@ -6,8 +6,6 @@ Documentation=man:lxc
 [Service]
 Type=simple
 ExecStart=@LIBEXECDIR@/lxc/lxc-monitord --daemon
-StandardOutput=syslog
-StandardError=syslog
 
 [Install]
 WantedBy=multi-user.target

--- a/config/init/systemd/lxc@.service.in
+++ b/config/init/systemd/lxc@.service.in
@@ -14,8 +14,6 @@ ExecStop=@BINDIR@/lxc-stop -n %i
 # Environment=BOOTUP=serial
 # Environment=CONSOLETYPE=serial
 Delegate=yes
-StandardOutput=syslog
-StandardError=syslog
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The Standard output type "syslog" is obsolete, causing a warning since systemd
version 246 [1].

Please consider using "journal" or "journal+console"

[1] https://github.com/systemd/systemd/blob/master/NEWS#L202

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>