### PR TITLE
seccomp: Check if syscall is supported on compat architecture.

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -531,6 +531,11 @@ static bool do_resolve_add_rule(uint32_t arch, char *line, scmp_filter_ctx ctx,
 		return true;
 	}
 
+	if (arch != SCMP_ARCH_NATIVE && seccomp_syscall_resolve_name_arch(arch, line) < 0) {
+		INFO("The syscall \"%s\" nr:%d is not supported on compat arch:%d", line, nr, arch);
+		return true;
+	}
+
 	memset(&arg_cmp, 0, sizeof(arg_cmp));
 	for (i = 0; i < rule->args_num; i++) {
 		INFO("arg_cmp[%d]: SCMP_CMP(%u, %llu, %llu, %llu)", i,


### PR DESCRIPTION
While trying to implement seccomp profile generation for OCI container spec in crio-lxc I noticed the following error:

shortened log output:
```
seccomp - seccomp.c:parse_config_v2:790 - Processing "epoll_ctl_old allow"
seccomp - seccomp.c:parse_config_v2:987 - Added native rule for arch 0 for epoll_ctl_old action 2147418112(allow)
seccomp - seccomp.c:do_resolve_add_rule:558 - Numerical argument out of domain - Failed loading rule for epoll_ctl_old (nr 214 action 2147418112 (allow))
start - start.c:lxc_init:827 - Failed loading seccomp policy
```

The stripped down seccomp profile
```
2
allowlist errno 0
[X86_64]
epoll_ctl_old allow
```

The syscall `epoll_ctl_old` resolves on the native host architecture (here x86_64) but is not available in the compat architectures `X32` and ` i386`. But currently the seccomp code tries to add a syscall that resolves on the host arch to all supported architectures. This fails with the following error:

```
seccomp.c:do_resolve_add_rule:558 - Numerical argument out of domain - Failed loading rule for epoll_ctl_old (nr 214 action 2147418112 (allow))
```

I've added code to check whether the syscall is actually supported by the target architecture of the current seccomp context.
Logging the arch constant from seccomp is ugly - but neither is the architecture name available in this context, nor is it possible to resolve seccomp architecture constants without a mapping. See https://github.com/seccomp/libseccomp/issues/295


Only a fraction oft the `x86_64` syscalls is actually supported by `X32` and/or `i386`.
Output from bootstrapping kubernetes with my crio-lxc fork.
```
root@k8s-cluster2-controller:~/k8s-examples# grep seccomp /var/log/crio-lxc.log  | grep "not supported on compat arch" | grep -o 'syscall.*$' | sort | uniq
syscall "accept4" nr:288 is not supported on compat arch:1073741827
syscall "accept" nr:43 is not supported on compat arch:1073741827
syscall "bind" nr:49 is not supported on compat arch:1073741827
syscall "connect" nr:42 is not supported on compat arch:1073741827
syscall "epoll_ctl_old" nr:214 is not supported on compat arch:1073741827
syscall "epoll_ctl_old" nr:214 is not supported on compat arch:1073741886
syscall "epoll_wait_old" nr:215 is not supported on compat arch:1073741827
syscall "epoll_wait_old" nr:215 is not supported on compat arch:1073741886
syscall "getpeername" nr:52 is not supported on compat arch:1073741827
syscall "getsockname" nr:51 is not supported on compat arch:1073741827
syscall "getsockopt" nr:55 is not supported on compat arch:1073741827
syscall "get_thread_area" nr:211 is not supported on compat arch:1073741886
syscall "listen" nr:50 is not supported on compat arch:1073741827
syscall "msgctl" nr:71 is not supported on compat arch:1073741827
syscall "msgget" nr:68 is not supported on compat arch:1073741827
syscall "msgrcv" nr:70 is not supported on compat arch:1073741827
syscall "msgsnd" nr:69 is not supported on compat arch:1073741827
syscall "newfstatat" nr:262 is not supported on compat arch:1073741827
syscall "recvfrom" nr:45 is not supported on compat arch:1073741827
syscall "recvmmsg" nr:299 is not supported on compat arch:1073741827
syscall "recvmsg" nr:47 is not supported on compat arch:1073741827
syscall "semctl" nr:66 is not supported on compat arch:1073741827
syscall "semget" nr:64 is not supported on compat arch:1073741827
syscall "semop" nr:65 is not supported on compat arch:1073741827
syscall "semtimedop" nr:220 is not supported on compat arch:1073741827
syscall "sendmmsg" nr:307 is not supported on compat arch:1073741827
syscall "sendmsg" nr:46 is not supported on compat arch:1073741827
syscall "sendto" nr:44 is not supported on compat arch:1073741827
syscall "setsockopt" nr:54 is not supported on compat arch:1073741827
syscall "set_thread_area" nr:205 is not supported on compat arch:1073741886
syscall "shmat" nr:30 is not supported on compat arch:1073741827
syscall "shmctl" nr:31 is not supported on compat arch:1073741827
syscall "shmdt" nr:67 is not supported on compat arch:1073741827
syscall "shmget" nr:29 is not supported on compat arch:1073741827
syscall "shutdown" nr:48 is not supported on compat arch:1073741827
syscall "socket" nr:41 is not supported on compat arch:1073741827
syscall "socketpair" nr:53 is not supported on compat arch:1073741827
```