### PR TITLE
cgroups: Introduce lxc.cgroup.dir.monitor.pivot - fixes cgroup removal on termination

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -1606,6 +1606,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
         </varlistentry>
         <varlistentry>
           <term>
+            <option>lxc.cgroup.dir.monitor.pivot</option>
+          </term>
+          <listitem>
+            <para>
+              On container termination the PID of the monitor process is attached to this cgroup.
+              This path should not be a subpath of any other configured cgroup dir to ensure
+              proper removal of other cgroup paths on container termination.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
             <option>lxc.cgroup.dir.container.inner</option>
           </term>
           <listitem>

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1093,7 +1093,10 @@ __cgfsng_ops static void cgfsng_monitor_destroy(struct cgroup_ops *ops,
 			goto try_lxc_rm_rf;
 		}
 
-		if (conf && conf->cgroup_meta.monitor_dir)
+		if (conf && conf->cgroup_meta.monitor_pivot_dir)
+			pivot_path = must_make_path(h->mountpoint, h->container_base_path,
+						    conf->cgroup_meta.monitor_pivot_dir, CGROUP_PIVOT, NULL);
+		else if (conf && conf->cgroup_meta.monitor_dir)
 			pivot_path = must_make_path(h->mountpoint, h->container_base_path,
 						    conf->cgroup_meta.monitor_dir, CGROUP_PIVOT, NULL);
 		else if (conf && conf->cgroup_meta.dir)

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -61,6 +61,7 @@ struct lxc_cgroup {
 			char *controllers;
 			char *dir;
 			char *monitor_dir;
+			char *monitor_pivot_dir;
 			char *container_dir;
 			char *namespace_dir;
 			bool relative;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -73,6 +73,7 @@ lxc_config_define(cgroup_controller);
 lxc_config_define(cgroup2_controller);
 lxc_config_define(cgroup_dir);
 lxc_config_define(cgroup_monitor_dir);
+lxc_config_define(cgroup_monitor_pivot_dir);
 lxc_config_define(cgroup_container_dir);
 lxc_config_define(cgroup_container_inner_dir);
 lxc_config_define(cgroup_relative);
@@ -178,6 +179,7 @@ static struct lxc_config_t config_jump_table[] = {
 	{ "lxc.cap.drop",                   set_config_cap_drop,                   get_config_cap_drop,                   clr_config_cap_drop,                   },
 	{ "lxc.cap.keep",                   set_config_cap_keep,                   get_config_cap_keep,                   clr_config_cap_keep,                   },
 	{ "lxc.cgroup2",                    set_config_cgroup2_controller,         get_config_cgroup2_controller,         clr_config_cgroup2_controller,         },
+	{ "lxc.cgroup.dir.monitor.pivot",   set_config_cgroup_monitor_pivot_dir,   get_config_cgroup_monitor_pivot_dir,   clr_config_cgroup_monitor_pivot_dir,   },
 	{ "lxc.cgroup.dir.monitor",         set_config_cgroup_monitor_dir,         get_config_cgroup_monitor_dir,         clr_config_cgroup_monitor_dir,         },
 	{ "lxc.cgroup.dir.container.inner", set_config_cgroup_container_inner_dir, get_config_cgroup_container_inner_dir, clr_config_cgroup_container_inner_dir, },
 	{ "lxc.cgroup.dir.container",       set_config_cgroup_container_dir,       get_config_cgroup_container_dir,       clr_config_cgroup_container_dir,       },
@@ -1811,6 +1813,16 @@ static int set_config_cgroup_monitor_dir(const char *key, const char *value,
 		return clr_config_cgroup_monitor_dir(key, lxc_conf, NULL);
 
 	return set_config_string_item(&lxc_conf->cgroup_meta.monitor_dir,
+				      value);
+}
+
+static int set_config_cgroup_monitor_pivot_dir(const char *key, const char *value,
+					 struct lxc_conf *lxc_conf, void *data)
+{
+	if (lxc_config_value_empty(value))
+		return clr_config_cgroup_monitor_pivot_dir(key, lxc_conf, NULL);
+
+	return set_config_string_item(&lxc_conf->cgroup_meta.monitor_pivot_dir,
 				      value);
 }
 
@@ -3858,6 +3870,22 @@ static int get_config_cgroup_monitor_dir(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
+static int get_config_cgroup_monitor_pivot_dir(const char *key, char *retv, int inlen,
+					 struct lxc_conf *lxc_conf, void *data)
+{
+	int len;
+	int fulllen = 0;
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
+
+	strprint(retv, inlen, "%s", lxc_conf->cgroup_meta.monitor_pivot_dir);
+
+	return fulllen;
+}
+
 static int get_config_cgroup_container_dir(const char *key, char *retv,
 					   int inlen,
 					   struct lxc_conf *lxc_conf,
@@ -4753,6 +4781,14 @@ static int clr_config_cgroup_monitor_dir(const char *key,
 					 void *data)
 {
 	free_disarm(lxc_conf->cgroup_meta.monitor_dir);
+	return 0;
+}
+
+static int clr_config_cgroup_monitor_pivot_dir(const char *key,
+					 struct lxc_conf *lxc_conf,
+					 void *data)
+{
+	free_disarm(lxc_conf->cgroup_meta.monitor_pivot_dir);
 	return 0;
 }
 


### PR DESCRIPTION
On termination lxc may fail to remove either `lxc.cgroup.dir` or `lxc.cgroup.dir.monitor`,
because the monitor process may still be a member of either of these cgroups.
The pivot cgroup should not be a member (subpath) of any other container cgroup (dir)
because only empty cgroups can be removed.

Although I've used the newly introduced option `lxc.cgroup.dir.monitor` as prefix this option should work fine
with with either `lxc.cgroup.dir`  or `lxc.cgroup.dir.monitor`.

I've discovered this when working on `crio-lxc` - I found the following warning in the log.

```
Oct 07 14:27:20 k8s-cluster2-controller kubelet[3725]: W1007 14:27:20.906211    3725 pod_container_manager_linux.go:200] failed to delete cgroup paths for [kubepods besteffort pod2159cf63-66b6-4fa5-88b1-23489e084727] : unable to destroy cgroup paths for cgroup [kubepods besteffort pod2159cf63-66b6-4fa5-88b1-23489e084727] : remove /sys/fs/cgroup/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod2159cf63_66b6_4fa5_88b1_23489e084727.slice: device or resource busy
```

The lxc config with this option will look like this (for `crio-lxc`):

```
lxc.cgroup.dir.container = kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podcf6a372f_513a_47e3_aa9f_51f72e046812.slice/crio-f591102de92279a1cb2bc405cfd8a738061ffd36a95957297449b69ed0c7dea6.scope
lxc.cgroup.dir.monitor = crio-lxc-monitor.slice/f591102de92279a1cb2bc405cfd8a738061ffd36a95957297449b69ed0c7dea6.scope
lxc.cgroup.dir.monitor.pivot = crio-lxc-monitor.slice
```