### PR TITLE
lxccontainer: fix lxc_config_item_is_supported

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -278,6 +278,18 @@ static struct lxc_config_t config_jump_table[] = {
 
 static const size_t config_jump_table_size = sizeof(config_jump_table) / sizeof(struct lxc_config_t);
 
+struct lxc_config_t *lxc_get_config_exact(const char *key)
+{
+	size_t i;
+
+	for (i = 0; i < config_jump_table_size; i++)
+		if (!strcmp(config_jump_table[i].name, key))
+			return &config_jump_table[i];
+
+	return NULL;
+}
+
+
 struct lxc_config_t *lxc_get_config(const char *key)
 {
 	size_t i;

--- a/src/lxc/confile.h
+++ b/src/lxc/confile.h
@@ -45,6 +45,9 @@ struct new_config_item {
 };
 
 /* Get the jump table entry for the given configuration key. */
+__hidden extern struct lxc_config_t *lxc_get_config_exact(const char *key);
+
+/* Get the jump table entry if entry name is a prefix of the given configuration key. */
 __hidden extern struct lxc_config_t *lxc_get_config(const char *key);
 
 /* List all available config items. */

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -5749,7 +5749,7 @@ free_ct_name:
 
 bool lxc_config_item_is_supported(const char *key)
 {
-	return !!lxc_get_config(key);
+	return !!lxc_get_config_exact(key);
 }
 
 bool lxc_has_api_extension(const char *extension)

--- a/src/tests/get_item.c
+++ b/src/tests/get_item.c
@@ -600,6 +600,11 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
+	if (lxc_config_item_is_supported("lxc.arch.nonsense")) {
+		fprintf(stderr, "%d: failed to detect \"lxc.arch.nonsense\" as unsupported configuration item\n", __LINE__);
+		goto out;
+	}
+
 	if (c->set_config_item(c, "lxc.notaconfigkey", "invalid")) {
 		fprintf(stderr, "%d: Managed to set \"lxc.notaconfigkey\"\n", __LINE__);
 		goto out;


### PR DESCRIPTION
Use exact match instead of longest prefix match to check whether a config item is supported.

The current implementation matches the longest prefix which does not work when checking for sub-options.
E. g. checking whether `lxc.cgroup.dir.container` is supported will match on `lxc.cgroup.dir`,
and return true even if `lxc.cgroup.dir.container` is not implemented. See the added test-case.

Signed-off-by: Ruben Jenster <r.jenster@drachenfels.de>