### PR TITLE
lxc-attach: Enable setting the SELinux context

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -657,6 +657,7 @@ static int attach_child_main(struct attach_clone_payload *payload)
 	bool needs_lsm = (options->namespaces & CLONE_NEWNS) &&
 			 (options->attach_flags & LXC_ATTACH_LSM) &&
 			 init_ctx->lsm_label;
+	char *lsm_label = NULL;
 
 	/* A description of the purpose of this functionality is provided in the
 	 * lxc-attach(1) manual page. We have to remount here and not in the
@@ -778,9 +779,9 @@ static int attach_child_main(struct attach_clone_payload *payload)
 
 		/* Change into our new LSM profile. */
 		on_exec = options->attach_flags & LXC_ATTACH_LSM_EXEC ? true : false;
-
+		lsm_label = options->lsm_label ? options->lsm_label : init_ctx->lsm_label;
 		ret = init_ctx->lsm_ops->process_label_set_at(init_ctx->lsm_ops, lsm_fd,
-							      init_ctx->lsm_label, on_exec);
+							      lsm_label, on_exec);
 		close(lsm_fd);
 		if (ret < 0)
 			goto on_error;

--- a/src/lxc/attach_options.h
+++ b/src/lxc/attach_options.h
@@ -113,6 +113,9 @@ typedef struct lxc_attach_options_t {
 
 	/*! File descriptor to log output. */
 	int log_fd;
+
+	/*! lsm label to set. */
+	char *lsm_label;
 } lxc_attach_options_t;
 
 /*! Default attach options to use */

--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -59,6 +59,7 @@ static char **extra_env;
 static ssize_t extra_env_size;
 static char **extra_keep;
 static ssize_t extra_keep_size;
+static char *selinux_context = NULL;
 
 static const struct option my_longopts[] = {
 	{"elevated-privileges", optional_argument, 0, 'e'},
@@ -74,6 +75,7 @@ static const struct option my_longopts[] = {
 	{"rcfile", required_argument, 0, 'f'},
 	{"uid", required_argument, 0, 'u'},
 	{"gid", required_argument, 0, 'g'},
+        {"context", required_argument, 0, 'c'},
 	LXC_COMMON_OPTIONS
 };
 
@@ -126,6 +128,8 @@ Options :\n\
                     Load configuration file FILE\n\
   -u, --uid=UID     Execute COMMAND with UID inside the container\n\
   -g, --gid=GID     Execute COMMAND with GID inside the container\n\
+  -c, --context=context\n\
+                    SELinux Context to transition into\n\
 ",
 	.options      = my_longopts,
 	.parser       = my_parser,
@@ -201,6 +205,9 @@ static int my_parser(struct lxc_arguments *args, int c, char *arg)
 		if (lxc_safe_uint(arg, &args->gid) < 0)
 			return -1;
 		break;
+        case 'c':
+                selinux_context = arg;
+                break;
 	}
 
 	return 0;
@@ -352,6 +359,9 @@ int main(int argc, char *argv[])
 
 	if (my_args.gid != LXC_INVALID_GID)
 		attach_options.gid = my_args.gid;
+
+	// selinux_context will be NULL if not set
+	attach_options.lsm_label = selinux_context;
 
 	if (command.program) {
 		ret = c->attach_run_wait(c, &attach_options, command.program,


### PR DESCRIPTION
Enable lxc-attach to set the SELinux context that the user will end up
in when attaching to a container (This can be used to overwrite the
context set in the config file). If the option is not used, behavior
will be as before