### PR TITLE
Add missing free for monitor_pivot_dir.

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3848,6 +3848,7 @@ void lxc_conf_free(struct lxc_conf *conf)
 	lxc_clear_namespace(conf);
 	free(conf->cgroup_meta.dir);
 	free(conf->cgroup_meta.monitor_dir);
+	free(conf->cgroup_meta.monitor_pivot_dir);
 	free(conf->cgroup_meta.container_dir);
 	free(conf->cgroup_meta.namespace_dir);
 	free(conf->cgroup_meta.controllers);


### PR DESCRIPTION
I missed a free in my previous seccomp fixes.