### PR TITLE
Implementation of additional group IDs for init and attach process

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1204,7 +1204,7 @@ __noreturn static void do_attach(struct attach_payload *ap)
 			goto on_error;
 	}
 
-	if (options->groups.size > 0) {
+	if (options->attach_flags & LXC_ATTACH_SETGROUPS && options->groups.size > 0) {
 		if (!lxc_setgroups(options->groups.size, options->groups.list))
 			goto on_error;
 	} else {

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -277,11 +277,6 @@ static int userns_setup_ids(struct attach_context *ctx,
 	if (ctx->setup_ns_gid == LXC_INVALID_UID)
 		ctx->setup_ns_gid = init_ns_gid;
 
-	/*
-	 * TODO: we should also parse supplementary groups and use
-	 * setgroups() to set them.
-	 */
-
 	return 0;
 }
 
@@ -359,11 +354,6 @@ static int parse_init_status(struct attach_context *ctx, lxc_attach_options_t *o
 	if (ret)
 		return log_error_errno(ret, errno, "Failed to get setup ids");
 	userns_target_ids(ctx, options);
-
-	/*
-	 * TODO: we should also parse supplementary groups and use
-	 * setgroups() to set them.
-	 */
 
 	return 0;
 }
@@ -1214,8 +1204,13 @@ __noreturn static void do_attach(struct attach_payload *ap)
 			goto on_error;
 	}
 
-	if (!lxc_setgroups(0, NULL) && errno != EPERM)
-		goto on_error;
+	if (options->groups.size > 0) {
+		if (!lxc_setgroups(options->groups.size, options->groups.list))
+			goto on_error;
+	} else {
+		if (!lxc_setgroups(0, NULL) && errno != EPERM)
+			goto on_error;
+	}
 
 	if (options->namespaces & CLONE_NEWUSER)
 		if (!lxc_switch_uid_gid(ctx->setup_ns_uid, ctx->setup_ns_gid))

--- a/src/lxc/attach_options.h
+++ b/src/lxc/attach_options.h
@@ -52,6 +52,11 @@ enum {
  */
 typedef int (*lxc_attach_exec_t)(void* payload);
 
+typedef struct lxc_groups_t {
+	int size;
+	gid_t *list;
+} lxc_groups_t;
+
 /*!
  * LXC attach options for \ref lxc_container \c attach().
  */
@@ -87,6 +92,12 @@ typedef struct lxc_attach_options_t {
 	 * containers or \c 0 (super-user) if detection fails).
 	 */
 	gid_t gid;
+
+	/*! The additional group GIDs to run with.
+	 *
+	 * If unset all additional groups are dropped.
+	 */
+	lxc_groups_t groups;
 
 	/*! Environment policy */
 	lxc_attach_env_policy_t env_policy;
@@ -128,6 +139,7 @@ typedef struct lxc_attach_options_t {
 		/* .initial_cwd = */    NULL,                                  \
 		/* .uid = */            (uid_t)-1,                             \
 		/* .gid = */            (gid_t)-1,                             \
+		/* .groups = */         { 0, NULL},                            \
 		/* .env_policy = */     LXC_ATTACH_KEEP_ENV,                   \
 		/* .extra_env_vars = */ NULL,                                  \
 		/* .extra_keep_env = */ NULL,                                  \

--- a/src/lxc/attach_options.h
+++ b/src/lxc/attach_options.h
@@ -31,6 +31,7 @@ enum {
 	LXC_ATTACH_NO_NEW_PRIVS		 = 0x00040000, /*!< PR_SET_NO_NEW_PRIVS */
 	LXC_ATTACH_TERMINAL              = 0x00080000, /*!< Allocate new terminal for attached process. */
 	LXC_ATTACH_LSM_LABEL             = 0x00100000, /*!< Set custom LSM label specified in @lsm_label. */
+	LXC_ATTACH_SETGROUPS             = 0x00200000, /*!< Set additional group ids specified in @groups. */
 
 	/* We have 16 bits for things that are on by default and 16 bits that
 	 * are off by default, that should be sufficient to keep binary
@@ -93,12 +94,6 @@ typedef struct lxc_attach_options_t {
 	 */
 	gid_t gid;
 
-	/*! The additional group GIDs to run with.
-	 *
-	 * If unset all additional groups are dropped.
-	 */
-	lxc_groups_t groups;
-
 	/*! Environment policy */
 	lxc_attach_env_policy_t env_policy;
 
@@ -128,6 +123,13 @@ typedef struct lxc_attach_options_t {
 
 	/*! lsm label to set. */
 	char *lsm_label;
+
+	/*! The additional group GIDs to run with.
+	 *
+	 * If unset all additional groups are dropped.
+	 */
+	lxc_groups_t groups;
+
 } lxc_attach_options_t;
 
 /*! Default attach options to use */
@@ -139,7 +141,6 @@ typedef struct lxc_attach_options_t {
 		/* .initial_cwd = */    NULL,                                  \
 		/* .uid = */            (uid_t)-1,                             \
 		/* .gid = */            (gid_t)-1,                             \
-		/* .groups = */         { 0, NULL},                            \
 		/* .env_policy = */     LXC_ATTACH_KEEP_ENV,                   \
 		/* .extra_env_vars = */ NULL,                                  \
 		/* .extra_keep_env = */ NULL,                                  \

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3893,6 +3893,7 @@ void lxc_conf_free(struct lxc_conf *conf)
 	free(conf->rcfile);
 	free(conf->execute_cmd);
 	free(conf->init_cmd);
+	free(conf->init_groups.list);
 	free(conf->init_cwd);
 	free(conf->unexpanded_config);
 	free(conf->syslog);

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -415,6 +415,10 @@ struct lxc_conf {
 	 * should run under when using lxc-execute */
 	uid_t init_uid;
 	gid_t init_gid;
+	struct {
+		int size;
+		gid_t *list;
+	} init_groups;
 
 	/* indicator if the container will be destroyed on shutdown */
 	unsigned int ephemeral;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1195,7 +1195,7 @@ static int set_config_init_groups(const char *key, const char *value,
 	if (!value_dup)
 		return -1;
 
-	lxc_iterate_parts(token, value_dup, " \t") num_groups++;
+	lxc_iterate_parts(token, value_dup, ",") num_groups++;
 
 	if (num_groups == 0) {
 		free(value_dup);
@@ -1209,7 +1209,7 @@ static int set_config_init_groups(const char *key, const char *value,
 	}
 
 	strcpy(value_dup, value);
-	lxc_iterate_parts(token, value_dup, " \t")
+	lxc_iterate_parts(token, value_dup, ",")
 	{
 		gid_t group;
 		if (lxc_safe_uint(token, &group) < 0) {
@@ -4342,7 +4342,7 @@ static int get_config_init_groups(const char *key, char *retv, int inlen,
 	}
 
 	for (int i = 0; i < c->init_groups.size; i++)
-		strprint(retv, inlen, "%s%d", (i > 0) ? " " : "",
+		strprint(retv, inlen, "%s%d", (i > 0) ? "," : "",
 			 c->init_groups.list[i]);
 
 	return fulllen;

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1410,8 +1410,16 @@ static int do_start(void *data)
 		#if HAVE_LIBCAP
 		if (lxc_proc_cap_is_set(CAP_SETGID, CAP_EFFECTIVE))
 		#endif
-			if (!lxc_setgroups(0, NULL))
-				goto out_warn_father;
+		{
+			if (handler->conf->init_groups.size > 0) {
+				if (!lxc_setgroups(handler->conf->init_groups.size,
+						   handler->conf->init_groups.list))
+					goto out_warn_father;
+			} else {
+				if (!lxc_setgroups(0, NULL))
+					goto out_warn_father;
+			}
+		}
 
 	if (!lxc_switch_uid_gid(new_uid, new_gid))
 		goto out_warn_father;

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1346,7 +1346,12 @@ bool lxc_setgroups(int size, gid_t list[])
 		SYSERROR("Failed to setgroups()");
 		return false;
 	}
-	NOTICE("Dropped additional groups");
+	if (size == 0)
+		NOTICE("Dropped additional groups");
+	else {
+		for(int i = 0; i < size; i++)
+			NOTICE("Kept additional group with GID %d", list[i]);
+	}
 
 	return true;
 }

--- a/src/tests/get_item.c
+++ b/src/tests/get_item.c
@@ -141,13 +141,13 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	if (!c->set_config_item(c, "lxc.init.groups", "10 20 foo 40")) {
-		printf("%d: failed to set init_groups\n", __LINE__);
+	if (!c->set_config_item(c, "lxc.init.groups", "10,20,foo,40")) {
+		printf("failed to set init_groups to '10,20,foo,40' as expected\n");
 	} else {
 		goto out;
 	}
 
-	if (!c->set_config_item(c, "lxc.init.groups", "10 20 30 40")) {
+	if (!c->set_config_item(c, "lxc.init.groups", "10,20,30,40")) {
 		fprintf(stderr, "%d: failed to set init_groups\n", __LINE__);
 		goto out;
 	}
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
 			__LINE__, ret);
 		goto out;
 	}
-	ret = strcmp("10 20 30 40", v2);
+	ret = strcmp("10,20,30,40", v2);
 	printf("lxc.init_groups returned %d %s\n", ret, v2);
 	if (ret != 0) {
 		goto out;

--- a/src/tests/get_item.c
+++ b/src/tests/get_item.c
@@ -136,6 +136,34 @@ int main(int argc, char *argv[])
 	}
 	printf("lxc.init_gid returned %d %s\n", ret, v2);
 
+	if (!c->set_config_item(c, "lxc.init.groups", "")) {
+		fprintf(stderr, "%d: failed to set init_groups\n", __LINE__);
+		goto out;
+	}
+
+	if (!c->set_config_item(c, "lxc.init.groups", "10 20 foo 40")) {
+		printf("%d: failed to set init_groups\n", __LINE__);
+	} else {
+		goto out;
+	}
+
+	if (!c->set_config_item(c, "lxc.init.groups", "10 20 30 40")) {
+		fprintf(stderr, "%d: failed to set init_groups\n", __LINE__);
+		goto out;
+	}
+
+	ret = c->get_config_item(c, "lxc.init.groups", v2, 255);
+	if (ret < 0) {
+		fprintf(stderr, "%d: get_config_item(lxc.init_gid) returned %d\n",
+			__LINE__, ret);
+		goto out;
+	}
+	ret = strcmp("10 20 30 40", v2);
+	printf("lxc.init_groups returned %d %s\n", ret, v2);
+	if (ret != 0) {
+		goto out;
+	}
+
 #define HNAME "hostname1"
 	// demonstrate proper usage:
 	char *alloced;


### PR DESCRIPTION
Hi lxc team,
I've implemented additional group ID handling for the init / attach process.
The newly introduced config options are are `lxc.init.groups`  for lxc config
 and `groups.size`  / `groups.list` for attach options.
Please review the changes carefully. 

Regards,
Ruben