### PR TITLE
commands_utils: fix lxc-wait

### DIFF
--- a/src/lxc/commands_utils.c
+++ b/src/lxc/commands_utils.c
@@ -62,7 +62,7 @@ int lxc_cmd_sock_get_state(const char *name, const char *lxcpath,
 
 	ret = lxc_cmd_add_state_client(name, lxcpath, states, &state_client_fd);
 	if (ret < 0)
-		return ret_errno(EINVAL);
+		return -errno;
 
 	if (ret < MAX_STATE)
 		return ret;

--- a/src/lxc/state.c
+++ b/src/lxc/state.c
@@ -100,10 +100,8 @@ int lxc_wait(const char *lxcname, const char *states, int timeout,
 		if (state >= 0)
 			break;
 
-		if (errno != ECONNREFUSED) {
-			SYSERROR("Failed to receive state from monitor");
-			return -1;
-		}
+		if (errno != ECONNREFUSED)
+			return log_error_errno(-1, errno, "Failed to receive state from monitor");
 
 		if (timeout > 0)
 			timeout--;


### PR DESCRIPTION
Closes: #3570
Fixes: 7792a5b60f79 ("commands: add additional check to lxc_cmd_sock_get_state()")
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>