### PR TITLE
network: fix LXC_NET_NONE cleanup

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -3605,6 +3605,13 @@ int lxc_restore_phys_nics_to_netns(struct lxc_handler *handler)
 	char ifname[IFNAMSIZ];
 	struct lxc_list *iterator;
 
+	/*
+	 * If we weren't asked to clone a new network namespace, there's
+	 * nothing to restore.
+	 */
+	if (!(handler->ns_clone_flags & CLONE_NEWNET))
+		return 0;
+
 	/* We need CAP_NET_ADMIN in the parent namespace in order to setns() to
 	 * the parent network namespace. We won't have this capability if we are
 	 * unprivileged.


### PR DESCRIPTION
We have a case where we have a nested container with LXC_NET_NONE run
inside a container that's *also* got no network namespace (run by
lxc-usernsexec).

The "am I root" check in this function then does not suffice, since the
euid of the task is 0 but it does not have privilege over its network
namespace, and thus cannot do any of the restore operations:

lxc foo 20201201232059.271 TRACE    network - network.c:lxc_restore_phys_nics_to_netns:3299 - Moving physical network devices back to parent network namespace
lxc foo 20201201232059.271 ERROR    network - network.c:lxc_restore_phys_nics_to_netns:3307 - Operation not permitted - Failed to enter network namespace
lxc foo 20201201232059.271 ERROR    start - start.c:__lxc_start:2045 - Failed to move physical network devices back to parent network namespace

Let's check that we indeed did clone the network namespace, and thus have
things to restore to their correct namespace before attempting to actually
restore them.

I suspect it's possible we can also get rid of some of the network namespace
preservation stuff in start.c in the LXC_NET_NONE case.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>