### PR TITLE
Restore interfaces to the correct namespace on error

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -2144,6 +2144,7 @@ out_detach_blockdev:
 
 out_delete_network:
 	lxc_abort(handler);
+	lxc_restore_phys_nics_to_netns(handler);
 	lxc_delete_network(handler);
 	detach_block_device(handler->conf);
 	lxc_end(handler);


### PR DESCRIPTION
If the container unexpectedly exists we may need to restore physical
interfaces back into the main namespace in a tidy way.

Signed-off-by: Blair Steven <blair.steven@alliedtelesis.co.nz>