### PR TITLE
conf: fix block-device based rootfs mounting

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3135,6 +3135,10 @@ int lxc_setup_rootfs_prepare_root(struct lxc_conf *conf, const char *name,
 		if (ret < 0)
 			return log_error(-1, "Failed to bind mount container / onto itself");
 
+		conf->rootfs.mntpt_fd = openat(-EBADF, path, O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_PATH | O_NOCTTY);
+		if (conf->rootfs.mntpt_fd < 0)
+			return log_error_errno(-errno, errno, "Failed to open file descriptor for container rootfs");
+
 		return log_trace(0, "Bind mounted container / onto itself");
 	}
 


### PR DESCRIPTION
Fixes: #3598
Cc: stable-4.0
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>