### PR TITLE
Changed Version from 2.*.* to 4.*.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ LXC also supports at least the following C standard libraries:
 
 LXC has always focused on strong backwards compatibility. In fact, the API
 hasn't been broken from release `1.0.0` onwards. Main LXC is currently at
-version `2.*.*`.
+version `4.*.*`.
 
 ## Reporting Security Issues
 


### PR DESCRIPTION
Changed Version from 2.. to 4.. because the current latest release is 4.0.5
Please note that I can be wrong to I am new here first time reading the README.md

Signed-off-by: sirh3e <marvin.huber@bluewin.ch>