### PR TITLE
make lxc-net's dnsmasq hermetic

### DIFF
--- a/config/init/common/lxc-net.in
+++ b/config/init/common/lxc-net.in
@@ -115,10 +115,9 @@ start() {
         LXC_DOMAIN_ARG="-s $LXC_DOMAIN -S /$LXC_DOMAIN/"
     fi
 
-    LXC_DHCP_CONFILE_ARG=""
-    if [ -n "$LXC_DHCP_CONFILE" ]; then
-        LXC_DHCP_CONFILE_ARG="--conf-file=${LXC_DHCP_CONFILE}"
-    fi
+    # lxc's dnsmasq should be hermetic and not read `/etc/dnsmasq.conf` (which
+    # it does by default if `--conf-file` is not present
+    LXC_DHCP_CONFILE_ARG="--conf-file=${LXC_DHCP_CONFILE:-/dev/null}"
 
     # https://lists.linuxcontainers.org/pipermail/lxc-devel/2014-October/010561.html
     for DNSMASQ_USER in lxc-dnsmasq dnsmasq nobody


### PR DESCRIPTION
lxc's dnsmasq will try to read system's dnsmasq if `--conf-file` is not
specified. This is likely not desirable, as lxc's dnsmasq should be
self-contained.

On my system the conflicting options are `--bind-interfaces` and
`--bind-dynamic`, since the same host is doing other DNS-y things
unrelated to lxc.

This is an incompatible change, since lxc's dnsmasq will stop honoring
system's `/etc/dnsmasq.conf`, and some systems may be relying on it.
Given that, I believe it should not depend on it by default, since
dnsmasq is lxc's implementation detail. However, if the user desires,
the old behavior could be brought back by setting
`LXC_DHCP_CONFILE=/etc/dnsmasq.conf` in `/etc/default/lxc-net`.

Signed-off-by: Motiejus Jakštys <motiejus@jakstys.lt>