### PR TITLE
Fix compilation without seccomp when libseccomp is installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -312,6 +312,14 @@ AM_COND_IF([ENABLE_SECCOMP],
 		AC_CHECK_LIB([seccomp], [seccomp_init],[],[AC_MSG_ERROR([You must install the seccomp development package in order to compile lxc])])
 		AC_SUBST([SECCOMP_LIBS], [-lseccomp])
 		])
+	# HAVE_SCMP_FILTER_CTX=1 will tell us we have libseccomp api >= 1.0.0
+	OLD_CFLAGS="$CFLAGS"
+	CFLAGS="$CFLAGS $SECCOMP_CFLAGS"
+	AC_CHECK_TYPES([scmp_filter_ctx], [], [], [[#include <seccomp.h>]])
+	AC_CHECK_DECLS([seccomp_notify_fd], [], [], [[#include <seccomp.h>]])
+	AC_CHECK_TYPES([struct seccomp_notif_sizes], [], [], [[#include <seccomp.h>]])
+	AC_CHECK_DECLS([seccomp_syscall_resolve_name_arch], [], [], [[#include <seccomp.h>]])
+	CFLAGS="$OLD_CFLAGS"
 	])
 
 AC_MSG_CHECKING(for static libcap)
@@ -358,15 +366,6 @@ AM_COND_IF([ENABLE_CAP],
         # Test whether we support getting file capabilities via cap_get_file().
         AC_CHECK_LIB(cap,cap_get_file, AC_DEFINE(LIBCAP_SUPPORTS_FILE_CAPABILITIES,1,[Have cap_get_file]),[],[])
         AC_SUBST([CAP_LIBS], [-lcap])])
-
-# HAVE_SCMP_FILTER_CTX=1 will tell us we have libseccomp api >= 1.0.0
-OLD_CFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS $SECCOMP_CFLAGS"
-AC_CHECK_TYPES([scmp_filter_ctx], [], [], [[#include <seccomp.h>]])
-AC_CHECK_DECLS([seccomp_notify_fd], [], [], [[#include <seccomp.h>]])
-AC_CHECK_TYPES([struct seccomp_notif_sizes], [], [], [[#include <seccomp.h>]])
-AC_CHECK_DECLS([seccomp_syscall_resolve_name_arch], [], [], [[#include <seccomp.h>]])
-CFLAGS="$OLD_CFLAGS"
 
 AC_CHECK_HEADERS([linux/bpf.h], [
 	AC_CHECK_TYPES([struct bpf_cgroup_dev_ctx], [], [], [[#include <linux/bpf.h>]])

--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -501,7 +501,7 @@ static int lxc_cmd_get_devpts_fd_callback(int fd, struct lxc_cmd_req *req,
 
 int lxc_cmd_get_seccomp_notify_fd(const char *name, const char *lxcpath)
 {
-#if HAVE_DECL_SECCOMP_NOTIFY_FD
+#ifdef HAVE_SECCOMP_NOTIFY
 	int ret, stopped;
 	struct lxc_cmd_rr cmd = {
 		.req = {
@@ -526,7 +526,7 @@ static int lxc_cmd_get_seccomp_notify_fd_callback(int fd, struct lxc_cmd_req *re
 						  struct lxc_handler *handler,
 						  struct lxc_epoll_descr *descr)
 {
-#if HAVE_DECL_SECCOMP_NOTIFY_FD
+#ifdef HAVE_SECCOMP_NOTIFY
 	struct lxc_cmd_rsp rsp = {
 		.ret = 0,
 	};


### PR DESCRIPTION
`configure` checks for libseccomp features even if `--disable-seccomp` is given.  Then `command.c` will use these features to conditionally compile support for seccomp features, without checking if seccomp should be enabled.  `lxcseccomp.h`, OTOH, does the proper checking, and disables seccomp's features.  This results in build failure when `--disable-seccomp` is given, and `configure` finds `libseccomp` headers and library:
```
commands.c: In function 'lxc_cmd_get_seccomp_notify_fd_callback':
commands.c:532:46: error: 'struct lxc_seccomp' has no member named 'notifier'
  if (!handler->conf || handler->conf->seccomp.notifier.notify_fd < 0)
                                              ^
commands.c:534:62: error: 'struct lxc_seccomp' has no member named 'notifier'
  ret = lxc_abstract_unix_send_fds(fd, &handler->conf->seccomp.notifier.notify_fd, 1, &rsp, sizeof(rsp));
                                                              ^
make[6]: *** [Makefile:3958: liblxc_la-commands.lo] Error 1
```

This series changes `command.c` checking of seccomp checks from `HAVE_DECL_SECCOMP_NOTIFY_FD` to `HAVE_SECCOMP_NOTIFY`, as it is done elsewhere in the same file.  Also, the `configure.ac` cheking of libseccomp features is skipped if `--disable-seccomp` is given.

Either one of the commits by itself will fix the build failure, but the change in `command.c` achieves consistency, and the `configure.ac` change saves a tiny bit of build time.

This was tested with openwrt, with and without enabling seccomp.