### PR TITLE
apparmor: prefer /proc/.../attr/apparmor/current over legacy interface

### DIFF
--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -333,11 +333,13 @@
  *               +
  * /attr/        = 6
  *               +
+ * /apparmor/    = 10
+ *               +
  * /current      = 8
  *               +
  * \0            = 1
  */
-#define LXC_LSMATTRLEN (6 + INTTYPE_TO_STRLEN(pid_t) + 6 + 8 + 1)
+#define LXC_LSMATTRLEN (6 + INTTYPE_TO_STRLEN(pid_t) + 6 + 10 + 8 + 1)
 
 /* MAX_NS_PROC_NAME = MAX_NS_PROC_NAME
  *                  +


### PR DESCRIPTION
It turns out that since Linux 5.1 there are now per-LSM subdirectories
for major LSMs, [which users are recommended to use over the "legacy"
top-level /proc/$pid/attr/... files][1]:

> Process attributes associated with “major” security modules should be
> accessed and maintained using the special files in /proc/.../attr. A
> security module may maintain a module specific subdirectory there,
> named after the module. /proc/.../attr/smack is provided by the Smack
> security module and contains all its special files. The files directly
> in /proc/.../attr remain as legacy interfaces for modules that provide
> subdirectories.

[AppArmor has had such a directory since Linux 5.8][2], and it turns out
that with certain CONFIG_LSM configurations you can end up with AppArmor
files not being accessible from the legacy interface. Arch Linux
recently added BPF as one of the enabled LSM in their configuration, [and
this broke runc][3] and LXC.

The solution is to first try to use /proc/$pid/attr/apparmor/current and
fall back to /proc/$pid/attr/current if the former is not available.

[1]: https://www.kernel.org/doc/html/latest/admin-guide/LSM/index.html
[2]: https://github.com/torvalds/linux/commit/6413f852ce086c0f95817012c08d481ce24d8b1a
[3]: https://github.com/opencontainers/runc/issues/2801

**NOTE**: I have not tested this thoroughly, I've only compile-tested it.

Fixes #3685
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>