### PR TITLE
cgroup: do not fail if there are no writable heirarchies

### DIFF
--- a/src/lxc/cgroups/cgroup.c
+++ b/src/lxc/cgroups/cgroup.c
@@ -34,11 +34,6 @@ struct cgroup_ops *cgroup_init(struct lxc_conf *conf)
 	if (!cgroup_ops)
 		return log_error_errno(NULL, errno, "Failed to initialize cgroup driver");
 
-	if (!cgroup_ops->hierarchies) {
-		cgroup_exit(cgroup_ops);
-		return log_error_errno(NULL, ENOENT, "No cgroup hierarchies found");
-	}
-
 	if (cgroup_ops->data_init(cgroup_ops)) {
 		cgroup_exit(cgroup_ops);
 		return log_error_errno(NULL, errno, "Failed to initialize cgroup data");


### PR DESCRIPTION
This is a spiritual revert of 5c7b81439cecfbd885b3c10f9edfefdc1ac7c45b (it
doesn't add back any of the logs, just removes the bad check).

Not having writable hierarchies is not actually a problem:

1. if I remove this check, things work just fine; below is a successful log
   of a run where there are no writable hierarchies

2. I believe the test for writability is slightly incorrect.
   unified_hierarchy_delegated() and legacy_hierarchy_delegated() both test
   the writability of $current_hierarchy/cgroup.procs. On my system, I
   have:

~ cat /proc/self/cgroup
12:hugetlb:/
11:pids:/user.slice/user-1000.slice/session-c38.scope
10:memory:/user.slice/user-1000.slice/session-c38.scope
9:freezer:/user/tycho/0
8:cpuset:/
7:net_cls,net_prio:/
6:blkio:/user.slice
5:devices:/user.slice
4:rdma:/
3:cpu,cpuacct:/user.slice
2:perf_event:/
1:name=systemd:/user.slice/user-1000.slice/session-c38.scope
0::/user.slice/user-1000.slice/session-c38.scope
~ ls -al /sys/fs/cgroup/freezer/user/tycho/0/
total 0
drwxr-xr-x 2 tycho tycho 0 Feb 22 09:17 ./
drwxr-xr-x 3 root  root  0 Mar  2 14:07 ../
-rw-r--r-- 1 root  root  0 Mar  2 14:07 cgroup.clone_children
-rw-r--r-- 1 root  root  0 Mar  2 14:09 cgroup.procs
-r--r--r-- 1 root  root  0 Mar  2 14:07 freezer.parent_freezing
-r--r--r-- 1 root  root  0 Mar  2 14:07 freezer.self_freezing
-rw-r--r-- 1 root  root  0 Mar  2 14:07 freezer.state
-rw-r--r-- 1 root  root  0 Mar  2 14:07 notify_on_release
-rw-r--r-- 1 root  root  0 Mar  2 14:07 tasks

i.e. the cgroup.procs is not writable by me. but since the directory is
owned by me, it is actually usable in the way LXC would use it. When I
start an unprivileged container, it could make a subdirectory in whatever
current hierarchy I happen to be before applying rules.

In any case, let's just revert the bad check for now.

lxc 20210302210944.785 INFO     confile - confile.c:set_config_idmaps:2151 - Read uid map: type u nsid 0 hostid 1000 range 1
lxc 20210302210944.785 INFO     confile - confile.c:set_config_idmaps:2151 - Read uid map: type u nsid 1 hostid 100001 range 65535
lxc 20210302210944.785 INFO     confile - confile.c:set_config_idmaps:2151 - Read uid map: type g nsid 0 hostid 1000 range 1
lxc 20210302210944.785 INFO     confile - confile.c:set_config_idmaps:2151 - Read uid map: type g nsid 1 hostid 100001 range 65535
lxc 20210302210944.786 INFO     conf - conf.c:userns_exec_mapped_root:4644 - Container root id is mapped to our uid
lxc 20210302210944.799 TRACE    commands - commands.c:lxc_cmd:510 - Connection refused - Command "get_init_pid" failed to connect command socket
lxc base 20210302210944.801 TRACE    commands - commands.c:lxc_server_init:2065 - Created abstract unix socket "lxc/9beb6bd65573affd/command"
lxc base 20210302210944.801 TRACE    start - start.c:lxc_init_handler:726 - Unix domain socket 3 for command server is ready
lxc base 20210302210944.801 TRACE    execute - execute.c:lxc_execute:97 - Doing lxc_execute
lxc base 20210302210944.801 WARN     apparmor - lsm/apparmor.c:lsm_apparmor_ops_init:1268 - Per-container AppArmor profiles are disabled because the mac_admin capability is missing
lxc base 20210302210944.801 INFO     lsm - lsm/lsm.c:lsm_init_static:40 - Initialized LSM security driver AppArmor
lxc base 20210302210944.801 TRACE    start - start.c:lxc_init:750 - Initialized LSM
lxc base 20210302210944.801 TRACE    start - start.c:lxc_serve_state_clients:448 - Set container state to STARTING
lxc base 20210302210944.801 TRACE    start - start.c:lxc_serve_state_clients:451 - No state clients registered
lxc base 20210302210944.801 INFO     utils - utils.c:get_rundir:260 - XDG_RUNTIME_DIR isn't set in the environment
lxc base 20210302210944.801 TRACE    start - start.c:lxc_init:756 - Set container state to "STARTING"
lxc base 20210302210944.801 TRACE    start - start.c:lxc_init:812 - Set environment variables
lxc base 20210302210944.801 TRACE    start - start.c:lxc_init:817 - Ran pre-start hooks
lxc base 20210302210944.801 TRACE    start - start.c:setup_signal_fd:341 - Created signal file descriptor 6
lxc base 20210302210944.801 TRACE    start - start.c:lxc_init:826 - Set up signal fd
lxc base 20210302210944.803 INFO     conf - conf.c:userns_exec_mapped_root:4644 - Container root id is mapped to our uid
lxc base 20210302210944.803 TRACE    terminal - terminal.c:lxc_terminal_map_ids:859 - Chowned terminal 8((null))
lxc base 20210302210944.803 DEBUG    terminal - terminal.c:lxc_terminal_peer_default:665 - No such device - The process does not have a controlling terminal
lxc base 20210302210944.803 TRACE    start - start.c:lxc_init:834 - Created console
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:legacy_hierarchy_delegated:3076 - Permission denied - The cgroup.procs file is not writable, skipping legacy hierarchy
lxc base 20210302210944.803 INFO     cgfsng - cgroups/cgfsng.c:unified_hierarchy_delegated:3066 - Permission denied - The cgroup.threads file is not writable, skipping unified hierarchy
lxc base 20210302210944.803 TRACE    cgroup - cgroups/cgroup.c:cgroup_init:49 - Initialized cgroup driver cgfsng
lxc base 20210302210944.803 WARN     cgroup - cgroups/cgroup.c:cgroup_init:58 - Unsupported cgroup layout
lxc base 20210302210944.803 TRACE    start - start.c:lxc_init:841 - Initialized cgroup driver
lxc base 20210302210944.803 TRACE    start - start.c:lxc_init:846 - Read seccomp policy
lxc base 20210302210944.803 TRACE    start - start.c:lxc_init:853 - Initialized LSM
lxc base 20210302210944.803 INFO     start - start.c:lxc_init:855 - Container "base" is initialized
lxc base 20210302210944.803 TRACE    sync - sync.c:lxc_sync_init:141 - Initialized synchronization infrastructure
lxc base 20210302210944.803 TRACE    conf - conf.c:lxc_rootfs_prepare:511 - Not pinning because container runs in user namespace
lxc base 20210302210944.804 TRACE    start - start.c:lxc_spawn:1732 - Cloned child process 923788
lxc base 20210302210944.804 TRACE    utils - utils.c:lxc_can_use_pidfd:1799 - Kernel supports pidfds
lxc base 20210302210944.804 INFO     start - start.c:lxc_spawn:1748 - Cloned CLONE_NEWUSER
lxc base 20210302210944.804 INFO     start - start.c:lxc_spawn:1748 - Cloned CLONE_NEWNS
lxc base 20210302210944.804 INFO     start - start.c:lxc_spawn:1748 - Cloned CLONE_NEWPID
lxc base 20210302210944.804 INFO     start - start.c:lxc_spawn:1748 - Cloned CLONE_NEWUTS
lxc base 20210302210944.804 INFO     start - start.c:lxc_spawn:1748 - Cloned CLONE_NEWIPC
lxc base 20210302210944.804 DEBUG    start - start.c:lxc_try_preserve_namespace:139 - Preserved user namespace via fd 15 and stashed path as user:/proc/923785/fd/15
lxc base 20210302210944.804 DEBUG    start - start.c:lxc_try_preserve_namespace:139 - Preserved mnt namespace via fd 16 and stashed path as mnt:/proc/923785/fd/16
lxc base 20210302210944.804 DEBUG    start - start.c:lxc_try_preserve_namespace:139 - Preserved pid namespace via fd 17 and stashed path as pid:/proc/923785/fd/17
lxc base 20210302210944.804 DEBUG    start - start.c:lxc_try_preserve_namespace:139 - Preserved uts namespace via fd 18 and stashed path as uts:/proc/923785/fd/18
lxc base 20210302210944.804 DEBUG    start - start.c:lxc_try_preserve_namespace:139 - Preserved ipc namespace via fd 19 and stashed path as ipc:/proc/923785/fd/19
lxc base 20210302210944.804 DEBUG    conf - conf.c:idmaptool_on_path_and_privileged:2798 - The binary "/usr/bin/newuidmap" does have the setuid bit set
lxc base 20210302210944.804 DEBUG    conf - conf.c:idmaptool_on_path_and_privileged:2798 - The binary "/usr/bin/newgidmap" does have the setuid bit set
lxc base 20210302210944.804 DEBUG    conf - conf.c:lxc_map_ids:2866 - Functional newuidmap and newgidmap binary found
lxc base 20210302210944.813 TRACE    sync - sync.c:lxc_sync_wait_parent:112 - Parent waiting for child with sequence startup
lxc base 20210302210944.825 TRACE    conf - conf.c:lxc_map_ids:2936 - newuidmap wrote mapping "newuidmap 923788 0 1000 1 1 100001 65535"
lxc base 20210302210944.834 TRACE    conf - conf.c:lxc_map_ids:2936 - newgidmap wrote mapping "newgidmap 923788 0 1000 1 1 100001 65535"
lxc base 20210302210944.834 TRACE    sync - sync.c:lxc_sync_wake_child:124 - Child waking parent with sequence startup
lxc base 20210302210944.834 TRACE    sync - sync.c:lxc_sync_wait_child:118 - Child waiting for parent with sequence configure
lxc base 20210302210944.834 TRACE    sync - sync.c:lxc_sync_barrier_parent:92 - Child waking parent with sequence configure and waiting for sequence post-configure
lxc base 20210302210944.834 DEBUG    start - start.c:lxc_try_preserve_namespace:139 - Preserved net namespace via fd 4 and stashed path as net:/proc/923785/fd/4
lxc base 20210302210944.834 WARN     start - start.c:lxc_spawn:1821 - Operation not permitted - Failed to allocate new network namespace id
lxc base 20210302210944.834 TRACE    sync - sync.c:lxc_sync_barrier_child:99 - Parent waking child with sequence post-configure and waiting with sequence cgroup
lxc base 20210302210944.834 NOTICE   utils - utils.c:lxc_drop_groups:1345 - Dropped supplimentary groups
lxc base 20210302210944.834 NOTICE   utils - utils.c:lxc_switch_uid_gid:1321 - Switched to gid 0
lxc base 20210302210944.834 NOTICE   utils - utils.c:lxc_switch_uid_gid:1330 - Switched to uid 0
lxc base 20210302210944.834 TRACE    sync - sync.c:lxc_sync_barrier_parent:92 - Child waking parent with sequence cgroup and waiting for sequence cgroup-unshare
lxc base 20210302210944.834 TRACE    sync - sync.c:lxc_sync_barrier_child:99 - Parent waking child with sequence cgroup-unshare and waiting with sequence cgroup-limits
lxc base 20210302210944.834 INFO     start - start.c:do_start:1196 - Unshared CLONE_NEWCGROUP
lxc base 20210302210944.834 TRACE    conf - conf.c:turn_into_dependent_mounts:3192 - Turned all mount table entries into dependent mount
lxc base 20210302210944.834 DEBUG    storage - storage/storage.c:get_storage_by_name:211 - Detected rootfs type "dir"
lxc base 20210302210944.835 TRACE    dir - storage/dir.c:dir_mount:166 - Mounted "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/roots/base/rootfs" on "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/rootfsPivot" with options "(null)", mount flags "0", and propagation flags "0"
lxc base 20210302210944.835 DEBUG    conf - conf.c:lxc_mount_rootfs:1289 - Mounted rootfs "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/roots/base/rootfs" onto "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/rootfsPivot" with options "(null)"
lxc base 20210302210944.835 INFO     conf - conf.c:setup_utsname:732 - Set hostname to "base"
lxc base 20210302210944.835 INFO     conf - conf.c:mount_autodev:1068 - Preparing "/dev"
lxc base 20210302210944.835 TRACE    mount_utils - mount_utils.c:can_use_mount_api:486 - Kernel supports mount api
lxc base 20210302210944.835 TRACE    mount_utils - mount_utils.c:__fs_prepare:158 - Finished initializing new tmpfs filesystem context 16
lxc base 20210302210944.835 TRACE    mount_utils - mount_utils.c:fs_set_property:196 - Set "mode" to "0755" on filesystem context 16
lxc base 20210302210944.835 TRACE    mount_utils - mount_utils.c:fs_set_property:196 - Set "size" to "500000" on filesystem context 16
lxc base 20210302210944.835 TRACE    mount_utils - mount_utils.c:fs_attach:235 - Mounted 18 onto 17
lxc base 20210302210944.835 INFO     conf - conf.c:mount_autodev:1128 - Prepared "/dev"
lxc base 20210302210944.835 DEBUG    conf - conf.c:mount_entry:2077 - Mounted "none" on "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/rootfsPivot/dev/shm" with filesystem type "tmpfs"
lxc base 20210302210944.835 DEBUG    conf - conf.c:mount_entry:2014 - Remounting "/sys" on "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/rootfsPivot/sys" to respect bind or remount options
lxc base 20210302210944.835 DEBUG    conf - conf.c:mount_entry:2033 - Flags for "/sys" were 4110, required extra flags are 14
lxc base 20210302210944.835 DEBUG    conf - conf.c:mount_entry:2077 - Mounted "/sys" on "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/rootfsPivot/sys" with filesystem type "none"
lxc base 20210302210944.835 DEBUG    conf - conf.c:mount_entry:2014 - Remounting "/etc/resolv.conf" on "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/rootfsPivot/etc/resolv.conf" to respect bind or remount options
lxc base 20210302210944.835 DEBUG    conf - conf.c:mount_entry:2033 - Flags for "/etc/resolv.conf" were 4110, required extra flags are 14
lxc base 20210302210944.835 DEBUG    conf - conf.c:mount_entry:2077 - Mounted "/etc/resolv.conf" on "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/rootfsPivot/etc/resolv.conf" with filesystem type "none"
lxc base 20210302210944.836 DEBUG    conf - conf.c:mount_entry:2014 - Remounting "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/imports/base" on "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/rootfsPivot/stacker" to respect bind or remount options
lxc base 20210302210944.836 DEBUG    conf - conf.c:mount_entry:2033 - Flags for "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/imports/base" were 4096, required extra flags are 0
lxc base 20210302210944.836 DEBUG    conf - conf.c:mount_entry:2077 - Mounted "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/imports/base" on "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/rootfsPivot/stacker" with filesystem type "none"
lxc base 20210302210944.836 INFO     conf - conf.c:lxc_fill_autodev:1165 - Populating "/dev"
lxc base 20210302210944.836 TRACE    mount_utils - mount_utils.c:fd_bind_mount:289 - Attach detached mount 19 to filesystem at 20
lxc base 20210302210944.836 DEBUG    conf - conf.c:lxc_fill_autodev:1245 - Bind mounted host device 14(dev/full) to 16(full)
lxc base 20210302210944.836 TRACE    mount_utils - mount_utils.c:fd_bind_mount:289 - Attach detached mount 19 to filesystem at 20
lxc base 20210302210944.836 DEBUG    conf - conf.c:lxc_fill_autodev:1245 - Bind mounted host device 14(dev/null) to 16(null)
lxc base 20210302210944.836 TRACE    mount_utils - mount_utils.c:fd_bind_mount:289 - Attach detached mount 19 to filesystem at 20
lxc base 20210302210944.836 DEBUG    conf - conf.c:lxc_fill_autodev:1245 - Bind mounted host device 14(dev/random) to 16(random)
lxc base 20210302210944.836 TRACE    mount_utils - mount_utils.c:fd_bind_mount:289 - Attach detached mount 19 to filesystem at 20
lxc base 20210302210944.836 DEBUG    conf - conf.c:lxc_fill_autodev:1245 - Bind mounted host device 14(dev/tty) to 16(tty)
lxc base 20210302210944.836 TRACE    mount_utils - mount_utils.c:fd_bind_mount:289 - Attach detached mount 19 to filesystem at 20
lxc base 20210302210944.836 DEBUG    conf - conf.c:lxc_fill_autodev:1245 - Bind mounted host device 14(dev/urandom) to 16(urandom)
lxc base 20210302210944.836 TRACE    mount_utils - mount_utils.c:fd_bind_mount:289 - Attach detached mount 19 to filesystem at 20
lxc base 20210302210944.836 DEBUG    conf - conf.c:lxc_fill_autodev:1245 - Bind mounted host device 14(dev/zero) to 16(zero)
lxc base 20210302210944.836 INFO     conf - conf.c:lxc_fill_autodev:1249 - Populated "/dev"
lxc base 20210302210944.836 INFO     conf - conf.c:lxc_transient_proc:3044 - Caller's PID is 1; /proc/self points to 1
lxc base 20210302210944.836 TRACE    conf - conf.c:lxc_transient_proc:3052 - Correct procfs instance mounted
lxc base 20210302210944.836 TRACE    mount_utils - mount_utils.c:fd_bind_mount:289 - Attach detached mount 19 to filesystem at 20
lxc base 20210302210944.836 DEBUG    conf - conf.c:lxc_setup_dev_console:1734 - Mounted pty device 8(/dev/pts/11) onto "/dev/console"
lxc base 20210302210944.839 TRACE    conf - conf.c:lxc_pivot_root:1459 - Changed into new rootfs "/home/tycho/packages/stacker/stackertest-test_stacker_switching_privilege_modes_fails.Og4LqB/.stacker/rootfsPivot"
lxc base 20210302210944.839 DEBUG    conf - conf.c:lxc_setup_devpts_child:1574 - Mount new devpts instance with options "gid=5,newinstance,ptmxmode=0666,mode=0620,max=1024"
lxc base 20210302210944.839 TRACE    conf - conf.c:lxc_setup_devpts_child:1587 - Sent devpts file descriptor 8 to parent
lxc base 20210302210944.839 DEBUG    conf - conf.c:lxc_setup_devpts_child:1602 - Created dummy "/dev/ptmx" file as bind mount target
lxc base 20210302210944.839 DEBUG    conf - conf.c:lxc_setup_devpts_child:1607 - Bind mounted "/dev/pts/ptmx" to "/dev/ptmx"
lxc base 20210302210944.839 DEBUG    conf - conf.c:setup_caps:2487 - Capabilities have been setup
lxc base 20210302210944.839 NOTICE   conf - conf.c:lxc_setup:3576 - The container "base" is set up
lxc base 20210302210944.839 TRACE    apparmor - lsm/apparmor.c:__apparmor_process_label_open:405 - On-exec not supported with AppArmor
lxc base 20210302210944.839 TRACE    apparmor - lsm/apparmor.c:apparmor_process_label_set_at:1166 - Changing AppArmor profile on exec not supported
lxc base 20210302210944.839 INFO     apparmor - lsm/apparmor.c:apparmor_process_label_set_at:1179 - Set AppArmor label to "lxc-container-default-cgns"
lxc base 20210302210944.839 INFO     apparmor - lsm/apparmor.c:apparmor_process_label_set:1224 - Changed AppArmor profile to lxc-container-default-cgns
lxc base 20210302210944.842 TRACE    sync - sync.c:lxc_sync_barrier_parent:92 - Child waking parent with sequence cgroup-limits and waiting for sequence ready-start
lxc base 20210302210944.842 TRACE    start - start.c:lxc_spawn:1872 - Set up legacy device cgroup controller limits
lxc base 20210302210944.842 TRACE    start - start.c:lxc_spawn:1878 - Set up cgroup2 device controller limits
lxc base 20210302210944.842 DEBUG    start - start.c:lxc_try_preserve_namespace:139 - Preserved cgroup namespace via fd 10 and stashed path as cgroup:/proc/923785/fd/10
lxc base 20210302210944.842 TRACE    start - start.c:lxc_spawn:1892 - Finished setting up cgroups
lxc base 20210302210944.842 TRACE    sync - sync.c:lxc_sync_barrier_child:99 - Parent waking child with sequence ready-start and waiting with sequence restart
lxc base 20210302210944.842 NOTICE   execute - execute.c:execute_start:66 - Exec'ing "/stacker/.stacker-run.sh"
lxc base 20210302210944.842 TRACE    conf - conf.c:lxc_setup_devpts_parent:1519 - Received devpts file descriptor 20 from child
lxc base 20210302210944.842 TRACE    confile_utils - confile_utils.c:lxc_log_configured_netdevs:244 - index: 0
lxc base 20210302210944.842 TRACE    confile_utils - confile_utils.c:lxc_log_configured_netdevs:245 - ifindex: 0
lxc base 20210302210944.842 TRACE    confile_utils - confile_utils.c:lxc_log_configured_netdevs:311 - type: none
lxc base 20210302210944.842 TRACE    confile_utils - confile_utils.c:lxc_log_configured_netdevs:319 - flags: none
lxc base 20210302210944.842 TRACE    confile_utils - confile_utils.c:lxc_log_configured_netdevs:344 - ipv4 gateway auto: false
lxc base 20210302210944.842 TRACE    confile_utils - confile_utils.c:lxc_log_configured_netdevs:347 - ipv4 gateway dev: false
lxc base 20210302210944.842 TRACE    confile_utils - confile_utils.c:lxc_log_configured_netdevs:363 - ipv6 gateway auto: false
lxc base 20210302210944.842 TRACE    confile_utils - confile_utils.c:lxc_log_configured_netdevs:366 - ipv6 gateway dev: false
lxc base 20210302210944.842 NOTICE   execute - execute.c:execute_post_start:82 - '/stacker/.stacker-run.sh' started with pid '923788'
lxc base 20210302210944.842 TRACE    start - start.c:lxc_serve_state_clients:448 - Set container state to RUNNING
lxc base 20210302210944.842 TRACE    start - start.c:lxc_serve_state_clients:451 - No state clients registered
lxc base 20210302210944.842 INFO     utils - utils.c:get_rundir:260 - XDG_RUNTIME_DIR isn't set in the environment
lxc base 20210302210944.842 TRACE    start - start.c:lxc_poll:602 - Mainloop is ready
lxc base 20210302210944.842 NOTICE   start - start.c:signal_handler:414 - Received 17 from pid 923789 instead of container init 923788
lxc base 20210302210944.862 DEBUG    start - start.c:signal_handler:432 - Container init process 923788 exited
lxc base 20210302210944.862 TRACE    start - start.c:lxc_poll:615 - Closed console mainloop
lxc base 20210302210944.862 TRACE    start - start.c:lxc_poll:620 - Closed mainloop
lxc base 20210302210944.862 TRACE    start - start.c:lxc_poll:623 - Closed signal file descriptor 6
lxc base 20210302210944.862 INFO     utils - utils.c:get_rundir:260 - XDG_RUNTIME_DIR isn't set in the environment
lxc base 20210302210944.862 TRACE    start - start.c:lxc_expose_namespace_environment:883 - Set environment variable LXC_USER_NS=/proc/923785/fd/15
lxc base 20210302210944.862 TRACE    start - start.c:lxc_expose_namespace_environment:883 - Set environment variable LXC_MNT_NS=/proc/923785/fd/16
lxc base 20210302210944.862 TRACE    start - start.c:lxc_expose_namespace_environment:883 - Set environment variable LXC_PID_NS=/proc/923785/fd/17
lxc base 20210302210944.862 TRACE    start - start.c:lxc_expose_namespace_environment:883 - Set environment variable LXC_UTS_NS=/proc/923785/fd/18
lxc base 20210302210944.862 TRACE    start - start.c:lxc_expose_namespace_environment:883 - Set environment variable LXC_IPC_NS=/proc/923785/fd/19
lxc base 20210302210944.862 TRACE    start - start.c:lxc_expose_namespace_environment:883 - Set environment variable LXC_NET_NS=/proc/923785/fd/4
lxc base 20210302210944.862 TRACE    start - start.c:lxc_expose_namespace_environment:883 - Set environment variable LXC_CGROUP_NS=/proc/923785/fd/10
lxc base 20210302210944.862 DEBUG    network - network.c:lxc_delete_network:4167 - Deleted network devices
lxc base 20210302210944.862 TRACE    start - start.c:lxc_serve_state_clients:448 - Set container state to STOPPING
lxc base 20210302210944.862 TRACE    start - start.c:lxc_serve_state_clients:451 - No state clients registered
lxc base 20210302210944.862 INFO     utils - utils.c:get_rundir:260 - XDG_RUNTIME_DIR isn't set in the environment
lxc base 20210302210944.862 TRACE    start - start.c:lxc_end:940 - Closed command socket
lxc base 20210302210944.862 INFO     utils - utils.c:get_rundir:260 - XDG_RUNTIME_DIR isn't set in the environment
lxc base 20210302210944.862 TRACE    start - start.c:lxc_end:951 - Set container state to "STOPPED"

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>