### PR TITLE
Initial support for idmapped mounts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -652,8 +652,9 @@ AC_CHECK_HEADER([ifaddrs.h],
 AC_HEADER_MAJOR
 
 # Check for some syscalls functions
-AC_CHECK_FUNCS([setns pivot_root sethostname unshare rand_r confstr faccessat gettid memfd_create move_mount open_tree execveat clone3 fsopen fspick fsconfig fsmount, openat2, close_range, statvfs])
+AC_CHECK_FUNCS([setns pivot_root sethostname unshare rand_r confstr faccessat gettid memfd_create move_mount open_tree execveat clone3 fsopen fspick fsconfig fsmount, openat2, close_range, statvfs, mount_setattr])
 AC_CHECK_TYPES([__aligned_u64], [], [], [[#include <linux/types.h>]])
+AC_CHECK_TYPES([struct mount_attr], [], [], [[#include <linux/mount.h>]])
 AC_CHECK_TYPES([struct open_how], [], [], [[#include <linux/openat2.h>]])
 AC_CHECK_TYPES([struct clone_args], [], [], [[#include <linux/sched.h>]])
 AC_CHECK_MEMBERS([struct clone_args.set_tid],[],[],[[#include <linux/sched.h>]])

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -181,10 +181,12 @@ static struct attach_context *alloc_attach_context(void)
 	if (!ctx)
 		return ret_set_errno(NULL, ENOMEM);
 
+	ctx->init_pid		= -ESRCH;
+
 	ctx->dfd_self_pid	= -EBADF;
 	ctx->dfd_init_pid	= -EBADF;
 	ctx->init_pidfd		= -EBADF;
-	ctx->init_pid		= -ESRCH;
+
 	ctx->setup_ns_uid	= LXC_INVALID_UID;
 	ctx->setup_ns_gid	= LXC_INVALID_GID;
 	ctx->target_ns_uid	= LXC_INVALID_UID;

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -194,7 +194,7 @@ static struct attach_context *alloc_attach_context(void)
 	ctx->target_host_uid	= LXC_INVALID_UID;
 	ctx->target_host_gid	= LXC_INVALID_GID;
 
-	for (int i = 0; i < LXC_NS_MAX; i++)
+	for (lxc_namespace_t i = 0; i < LXC_NS_MAX; i++)
 		ctx->ns_fd[i] = -EBADF;
 
 	return ctx;
@@ -438,7 +438,7 @@ static int get_attach_context(struct attach_context *ctx,
 		if (options->namespaces == -1)
 			return log_error_errno(-EINVAL, EINVAL, "Failed to automatically determine the namespaces which the container uses");
 
-		for (int i = 0; i < LXC_NS_MAX; i++) {
+		for (lxc_namespace_t i = 0; i < LXC_NS_MAX; i++) {
 			if (ns_info[i].clone_flag & CLONE_NEWCGROUP)
 				if (!(options->attach_flags & LXC_ATTACH_MOVE_TO_CGROUP) ||
 				    !cgns_supported())
@@ -533,7 +533,7 @@ static int same_ns(int dfd_pid1, int dfd_pid2, const char *ns_path)
 
 static int __prepare_namespaces_pidfd(struct attach_context *ctx)
 {
-	for (int i = 0; i < LXC_NS_MAX; i++) {
+	for (lxc_namespace_t i = 0; i < LXC_NS_MAX; i++) {
 		int ret;
 
 		ret = same_nsfd(ctx->dfd_self_pid,
@@ -561,8 +561,8 @@ static int __prepare_namespaces_pidfd(struct attach_context *ctx)
 static int __prepare_namespaces_nsfd(struct attach_context *ctx,
 				     lxc_attach_options_t *options)
 {
-	for (int i = 0; i < LXC_NS_MAX; i++) {
-		int j;
+	for (lxc_namespace_t i = 0; i < LXC_NS_MAX; i++) {
+		lxc_namespace_t j;
 
 		if (options->namespaces & ns_info[i].clone_flag)
 			ctx->ns_fd[i] = open_at(ctx->dfd_init_pid,
@@ -644,7 +644,7 @@ static int __attach_namespaces_nsfd(struct attach_context *ctx,
 {
 	int fret = 0;
 
-	for (int i = 0; i < LXC_NS_MAX; i++) {
+	for (lxc_namespace_t i = 0; i < LXC_NS_MAX; i++) {
 		int ret;
 
 		if (ctx->ns_fd[i] < 0)
@@ -672,7 +672,7 @@ static int attach_namespaces(struct attach_context *ctx,
 			     lxc_attach_options_t *options)
 {
 	if (lxc_log_trace()) {
-		for (int i = 0; i < LXC_NS_MAX; i++) {
+		for (lxc_namespace_t i = 0; i < LXC_NS_MAX; i++) {
 			if (ns_info[i].clone_flag & options->namespaces) {
 				TRACE("Attaching to %s namespace", ns_info[i].proc_name);
 				continue;

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2123,9 +2123,8 @@ const char *lxc_mount_options_info[LXC_MOUNT_MAX] = {
 /* Remove "optional", "create=dir", and "create=file" from mntopt */
 int parse_lxc_mntopts(struct lxc_mount_options *opts, char *mnt_opts)
 {
-	__do_close int fd_userns = -EBADF;
-
 	for (size_t i = LXC_MOUNT_CREATE_DIR; i < LXC_MOUNT_MAX; i++) {
+		__do_close int fd_userns = -EBADF;
 		const char *opt_name = lxc_mount_options_info[i];
 		size_t len;
 		char *idmap_path, *p, *p2;
@@ -2159,7 +2158,6 @@ int parse_lxc_mntopts(struct lxc_mount_options *opts, char *mnt_opts)
 			if (is_empty_string(opts->userns_path))
 				return syserror_set(-EINVAL, "Missing idmap path for \"idmap=<path>\" LXC specific mount option");
 
-			close_prot_errno_disarm(fd_userns);
 			fd_userns = open(opts->userns_path, O_RDONLY | O_NOCTTY | O_CLOEXEC);
 			if (fd_userns < 0)
 				return syserror("Failed to open user namespace");

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -494,6 +494,12 @@ int lxc_rootfs_prepare(struct lxc_rootfs *rootfs, bool userns)
 	struct statfs stfs;
 
 	if (!is_empty_string(rootfs->mnt_opts.userns_path)) {
+		if (!rootfs->path)
+			return syserror_set(-EINVAL, "Idmapped rootfs currently only supported with separate rootfs for container");
+
+		if (rootfs->bdev_type && !strequal(rootfs->bdev_type, "dir"))
+			return syserror_set(-EINVAL, "Idmapped rootfs currently only supports the \"dir\" storage driver");
+
 		fd_userns = open_at(-EBADF, rootfs->mnt_opts.userns_path,
 				    PROTECT_OPEN_WITH_TRAILING_SYMLINKS, 0, 0);
 		if (fd_userns < 0)

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2258,6 +2258,9 @@ static inline int mount_entry_on_generic(struct mntent *mntent,
 	if (ret < 0)
 		return ret;
 
+	if (!is_empty_string(opts.userns_path))
+		return syserror_set(-EINVAL, "Idmapped mount entries not yet supported");
+
 	ret = parse_propagationopts(mntent->mnt_opts, &pflags);
 	if (ret < 0)
 		return -1;

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -186,7 +186,8 @@ typedef enum lxc_mount_options_t {
 	LXC_MOUNT_CREATE_FILE	= 1,
 	LXC_MOUNT_OPTIONAL	= 2,
 	LXC_MOUNT_RELATIVE	= 3,
-	LXC_MOUNT_MAX		= 4,
+	LXC_MOUNT_IDMAP		= 4,
+	LXC_MOUNT_MAX		= 5,
 } lxc_mount_options_t;
 
 __hidden extern const char *lxc_mount_options_info[LXC_MOUNT_MAX];
@@ -196,6 +197,7 @@ struct lxc_mount_options {
 	int create_file : 1;
 	int optional : 1;
 	int relative : 1;
+	char userns_path[PATH_MAX];
 };
 
 /* Defines a structure to store the rootfs location, the

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -198,6 +198,7 @@ struct lxc_mount_options {
 	int optional : 1;
 	int relative : 1;
 	char userns_path[PATH_MAX];
+	int userns_fd;
 };
 
 /* Defines a structure to store the rootfs location, the
@@ -575,12 +576,18 @@ static inline const char *get_rootfs_mnt(const struct lxc_rootfs *rootfs)
 	return !is_empty_string(rootfs->path) ? rootfs->mount : s;
 }
 
+static inline bool idmapped_rootfs_mnt(const struct lxc_rootfs *rootfs)
+{
+	return rootfs->mnt_opts.userns_fd >= 0;
+}
+
 static inline void put_lxc_rootfs(struct lxc_rootfs *rootfs, bool unpin)
 {
 	if (rootfs) {
 		close_prot_errno_disarm(rootfs->dfd_host);
 		close_prot_errno_disarm(rootfs->dfd_mnt);
 		close_prot_errno_disarm(rootfs->dfd_dev);
+		close_prot_errno_disarm(rootfs->mnt_opts.userns_fd);
 		if (unpin)
 			close_prot_errno_disarm(rootfs->fd_path_pin);
 	}

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -529,7 +529,7 @@ __hidden extern int userns_exec_full(struct lxc_conf *conf, int (*fn)(void *), v
 				     const char *fn_name);
 __hidden extern int parse_mntopts(const char *mntopts, unsigned long *mntflags, char **mntdata);
 __hidden extern int parse_propagationopts(const char *mntopts, unsigned long *pflags);
-__hidden extern void parse_lxc_mntopts(struct lxc_mount_options *opts, char *mnt_opts);
+__hidden extern int parse_lxc_mntopts(struct lxc_mount_options *opts, char *mnt_opts);
 __hidden extern void tmp_proc_unmount(struct lxc_conf *lxc_conf);
 __hidden extern void suggest_default_idmap(void);
 __hidden extern FILE *make_anonymous_mount_file(struct lxc_list *mount, bool include_nesting_helpers);

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -181,6 +181,23 @@ struct lxc_tty_info {
 	struct lxc_terminal_info *tty;
 };
 
+typedef enum lxc_mount_options_t {
+	LXC_MOUNT_CREATE_DIR	= 0,
+	LXC_MOUNT_CREATE_FILE	= 1,
+	LXC_MOUNT_OPTIONAL	= 2,
+	LXC_MOUNT_RELATIVE	= 3,
+	LXC_MOUNT_MAX		= 4,
+} lxc_mount_options_t;
+
+__hidden extern const char *lxc_mount_options_info[LXC_MOUNT_MAX];
+
+struct lxc_mount_options {
+	int create_dir : 1;
+	int create_file : 1;
+	int optional : 1;
+	int relative : 1;
+};
+
 /* Defines a structure to store the rootfs location, the
  * optionals pivot_root, rootfs mount paths
  * @path         : the rootfs source (directory or device)
@@ -211,6 +228,7 @@ struct lxc_rootfs {
 	unsigned long mountflags;
 	char *data;
 	bool managed;
+	struct lxc_mount_options mnt_opts;
 };
 
 /*
@@ -509,6 +527,7 @@ __hidden extern int userns_exec_full(struct lxc_conf *conf, int (*fn)(void *), v
 				     const char *fn_name);
 __hidden extern int parse_mntopts(const char *mntopts, unsigned long *mntflags, char **mntdata);
 __hidden extern int parse_propagationopts(const char *mntopts, unsigned long *pflags);
+__hidden extern void parse_lxc_mntopts(struct lxc_mount_options *opts, char *mnt_opts);
 __hidden extern void tmp_proc_unmount(struct lxc_conf *lxc_conf);
 __hidden extern void suggest_default_idmap(void);
 __hidden extern FILE *make_anonymous_mount_file(struct lxc_list *mount, bool include_nesting_helpers);

--- a/src/lxc/lsm/apparmor.c
+++ b/src/lxc/lsm/apparmor.c
@@ -1165,15 +1165,15 @@ static int apparmor_process_label_fd_get(struct lsm_ops *ops, pid_t pid, bool on
 
 static int apparmor_process_label_set_at(struct lsm_ops *ops, int label_fd, const char *label, bool on_exec)
 {
+	__do_free char *command = NULL;
 	int ret = -1;
 	size_t len;
-	__do_free char *command = NULL;
 
 	if (on_exec)
-		log_trace(0, "Changing AppArmor profile on exec not supported");
+		TRACE("Changing AppArmor profile on exec not supported");
 
 	len = strlen(label) + strlen("changeprofile ") + 1;
-	command = malloc(len);
+	command = zalloc(len);
 	if (!command)
 		return ret_errno(ENOMEM);
 

--- a/src/lxc/mount_utils.c
+++ b/src/lxc/mount_utils.c
@@ -236,6 +236,63 @@ int fs_attach(int fd_fs,
 	return 0;
 }
 
+int create_detached_idmapped_mount(const char *path, int userns_fd, bool recursive)
+{
+	__do_close int fd_tree_from = -EBADF;
+	unsigned int open_tree_flags = OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC;
+	struct lxc_mount_attr attr = {
+		.attr_set	= MOUNT_ATTR_IDMAP,
+		.userns_fd	= userns_fd,
+
+	};
+	int ret;
+
+	TRACE("Idmapped mount \"%s\" requested with user namespace fd %d", path, userns_fd);
+
+	if (recursive)
+		open_tree_flags |= AT_RECURSIVE;
+
+	fd_tree_from = open_tree(-EBADF, path, open_tree_flags);
+	if (fd_tree_from < 0)
+		return syserror("Failed to create detached mount");
+
+	ret = mount_setattr(fd_tree_from, "",
+			    AT_EMPTY_PATH | (recursive ? AT_RECURSIVE : 0),
+			    &attr, sizeof(attr));
+	if (ret < 0)
+		return syserror("Failed to change mount attributes");
+
+	return move_fd(fd_tree_from);
+}
+
+int move_detached_mount(int dfd_from, int dfd_to, const char *path_to,
+			__u64 o_flags_to, __u64 resolve_flags_to)
+{
+	__do_close int __fd_to = -EBADF;
+	int fd_to, ret;
+
+	if (!is_empty_string(path_to)) {
+		struct lxc_open_how how = {
+			.flags		= o_flags_to,
+			.resolve	= resolve_flags_to,
+		};
+
+		__fd_to = openat2(dfd_to, path_to, &how, sizeof(how));
+		if (__fd_to < 0)
+			return -errno;
+		fd_to = __fd_to;
+	} else {
+		fd_to = dfd_to;
+	}
+
+	ret = move_mount(dfd_from, "", fd_to, "", MOVE_MOUNT_F_EMPTY_PATH | MOVE_MOUNT_T_EMPTY_PATH);
+	if (ret)
+		return syserror("Failed to attach detached mount %d to filesystem at %d", dfd_from, fd_to);
+
+	TRACE("Attach detached mount %d to filesystem at %d", dfd_from, fd_to);
+	return 0;
+}
+
 static int __fd_bind_mount(int dfd_from, const char *path_from,
 			   __u64 o_flags_from, __u64 resolve_flags_from,
 			   int dfd_to, const char *path_to, __u64 o_flags_to,
@@ -245,10 +302,10 @@ static int __fd_bind_mount(int dfd_from, const char *path_from,
 	struct lxc_mount_attr attr = {
 		.attr_set = attr_flags,
 	};
-	__do_close int __fd_from = -EBADF, __fd_to = -EBADF;
+	__do_close int __fd_from = -EBADF;
 	__do_close int fd_tree_from = -EBADF;
 	unsigned int open_tree_flags = AT_EMPTY_PATH | OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC;
-	int fd_from, fd_to, ret;
+	int fd_from, ret;
 
 	if (!is_empty_string(path_from)) {
 		struct lxc_open_how how = {
@@ -274,36 +331,19 @@ static int __fd_bind_mount(int dfd_from, const char *path_from,
 	if (userns_fd >= 0) {
 		attr.attr_set	|= MOUNT_ATTR_IDMAP;
 		attr.userns_fd	= userns_fd;
+		TRACE("Idmapped mount requested with user namespace fd %d", userns_fd);
 	}
 
 	if (attr.attr_set) {
 		ret = mount_setattr(fd_tree_from, "",
-				    AT_EMPTY_PATH | AT_RECURSIVE,
+				    AT_EMPTY_PATH | (recursive ? AT_RECURSIVE : 0),
 				    &attr, sizeof(attr));
 		if (ret < 0)
 			return syserror("Failed to change mount attributes");
 	}
 
-	if (!is_empty_string(path_to)) {
-		struct lxc_open_how how = {
-			.flags		= o_flags_to,
-			.resolve	= resolve_flags_to,
-		};
-
-		__fd_to = openat2(dfd_to, path_to, &how, sizeof(how));
-		if (__fd_to < 0)
-			return -errno;
-		fd_to = __fd_to;
-	} else {
-		fd_to = dfd_to;
-	}
-
-	ret = move_mount(fd_tree_from, "", fd_to, "", MOVE_MOUNT_F_EMPTY_PATH | MOVE_MOUNT_T_EMPTY_PATH);
-	if (ret)
-		return syserror("Failed to attach detached mount %d to filesystem at %d", fd_tree_from, fd_to);
-
-	TRACE("Attach detached mount %d to filesystem at %d", fd_tree_from, fd_to);
-	return 0;
+	return move_detached_mount(fd_tree_from, dfd_to, path_to, o_flags_to,
+				   resolve_flags_to);
 }
 
 int fd_mount_idmapped(int dfd_from, const char *path_from,

--- a/src/lxc/mount_utils.c
+++ b/src/lxc/mount_utils.c
@@ -488,3 +488,28 @@ bool can_use_mount_api(void)
 
 	return supported == 1;
 }
+
+bool can_use_bind_mounts(void)
+{
+	static int supported = -1;
+
+	if (supported == -1) {
+		int ret;
+
+		if (!can_use_mount_api()) {
+			supported = 0;
+			return false;
+		}
+
+		ret = mount_setattr(-EBADF, NULL, 0, NULL, 0);
+		if (!ret || errno == ENOSYS) {
+			supported = 0;
+			return false;
+		}
+
+		supported = 1;
+		TRACE("Kernel supports bind mounts in the new mount api");
+	}
+
+	return supported == 1;
+}

--- a/src/lxc/mount_utils.h
+++ b/src/lxc/mount_utils.h
@@ -152,6 +152,10 @@
 #define MOUNT_ATTR_NODIRATIME 0x00000080 /* Do not update directory access times */
 #endif
 
+#ifndef MOUNT_ATTR_IDMAP
+#define MOUNT_ATTR_IDMAP 0x00100000
+#endif
+
 __hidden extern int mnt_attributes_new(unsigned int old_flags, unsigned int *new_flags);
 
 __hidden extern int mnt_attributes_old(unsigned int new_flags, unsigned int *old_flags);

--- a/src/lxc/mount_utils.h
+++ b/src/lxc/mount_utils.h
@@ -189,6 +189,13 @@ __hidden extern int fd_bind_mount(int dfd_from, const char *path_from,
 				  __u64 o_flags_to, __u64 resolve_flags_to,
 				  unsigned int attr_flags, bool recursive);
 
+__hidden extern int fd_mount_idmapped(int dfd_from, const char *path_from,
+				      __u64 o_flags_from, __u64 resolve_flags_from,
+				      int dfd_to, const char *path_to,
+				      __u64 o_flags_to, __u64 resolve_flags_to,
+				      unsigned int attr_flags, int userns_fd,
+				      bool recursive);
+
 __hidden extern int calc_remount_flags_new(int dfd_from, const char *path_from,
 					   __u64 o_flags_from,
 					   __u64 resolve_flags_from,

--- a/src/lxc/mount_utils.h
+++ b/src/lxc/mount_utils.h
@@ -206,5 +206,6 @@ __hidden extern unsigned long add_required_remount_flags(const char *s,
 							 unsigned long flags);
 
 __hidden extern bool can_use_mount_api(void);
+__hidden extern bool can_use_bind_mounts(void);
 
 #endif /* __LXC_MOUNT_UTILS_H */

--- a/src/lxc/mount_utils.h
+++ b/src/lxc/mount_utils.h
@@ -195,6 +195,11 @@ __hidden extern int fd_mount_idmapped(int dfd_from, const char *path_from,
 				      __u64 o_flags_to, __u64 resolve_flags_to,
 				      unsigned int attr_flags, int userns_fd,
 				      bool recursive);
+__hidden extern int create_detached_idmapped_mount(const char *path,
+						   int userns_fd, bool recursive);
+__hidden extern int move_detached_mount(int dfd_from, int dfd_to,
+					const char *path_to, __u64 o_flags_to,
+					__u64 resolve_flags_to);
 
 __hidden extern int calc_remount_flags_new(int dfd_from, const char *path_from,
 					   __u64 o_flags_from,

--- a/src/lxc/storage/dir.c
+++ b/src/lxc/storage/dir.c
@@ -148,23 +148,46 @@ int dir_mount(struct lxc_storage *bdev)
 
 	src = lxc_storage_get_path(bdev->src, bdev->type);
 
-	ret = mount(src, bdev->dest, "bind", MS_BIND | MS_REC | mntflags | pflags, mntdata);
-	if (ret < 0)
-		return log_error_errno(-errno, errno, "Failed to mount \"%s\" on \"%s\"", src, bdev->dest);
+	if (can_use_bind_mounts()) {
+		__do_close int fd_source = -EBADF, fd_target = -EBADF;
 
-	if (ret == 0 && (mntflags & MS_RDONLY)) {
-		mflags = add_required_remount_flags(src, bdev->dest, MS_BIND | MS_REC | mntflags | pflags | MS_REMOUNT);
-		ret = mount(src, bdev->dest, "bind", mflags, mntdata);
+		fd_source = open_at(-EBADF, src, PROTECT_OPATH_DIRECTORY, PROTECT_LOOKUP_ABSOLUTE, 0);
+		if (fd_source < 0)
+			return syserror("Failed to open \"%s\"", src);
+
+		fd_target = open_at(-EBADF, bdev->dest, PROTECT_OPATH_DIRECTORY, PROTECT_LOOKUP_ABSOLUTE, 0);
+		if (fd_target < 0)
+			return syserror("Failed to open \"%s\"", bdev->dest);
+
+		ret = fd_mount_idmapped(fd_source, "", PROTECT_OPATH_DIRECTORY,
+					PROTECT_LOOKUP_BENEATH, fd_target, "",
+					PROTECT_OPATH_DIRECTORY,
+					PROTECT_LOOKUP_BENEATH, 0,
+					bdev->rootfs->mnt_opts.userns_fd, true);
 		if (ret < 0)
-			return log_error_errno(-errno, errno, "Failed to remount \"%s\" on \"%s\" read-only with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
-					       src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, pflags);
-		else
-			DEBUG("Remounted \"%s\" on \"%s\" read-only with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
-			      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, pflags);
+			return syserror("Failed to mount \"%s\" onto \"%s\"", src, bdev->dest);
+	} else {
+		ret = mount(src, bdev->dest, "bind", MS_BIND | MS_REC | mntflags | pflags, mntdata);
+		if (ret < 0)
+			return log_error_errno(-errno, errno, "Failed to mount \"%s\" on \"%s\"", src, bdev->dest);
+
+		if (ret == 0 && (mntflags & MS_RDONLY)) {
+			mflags = add_required_remount_flags(src, bdev->dest, MS_BIND | MS_REC | mntflags | pflags | MS_REMOUNT);
+
+			ret = mount(src, bdev->dest, "bind", mflags, mntdata);
+			if (ret < 0)
+				return log_error_errno(-errno, errno, "Failed to remount \"%s\" on \"%s\" read-only with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
+						       src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, pflags);
+			else
+				DEBUG("Remounted \"%s\" on \"%s\" read-only with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
+				      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, pflags);
+		}
+
+		TRACE("Mounted \"%s\" on \"%s\" with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
+		      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, pflags);
 	}
 
-	TRACE("Mounted \"%s\" on \"%s\" with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
-	      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, pflags);
+	TRACE("Mounted \"%s\" onto \"%s\"", src, bdev->dest);
 	return 0;
 }
 

--- a/src/lxc/storage/storage.c
+++ b/src/lxc/storage/storage.c
@@ -598,14 +598,13 @@ struct lxc_storage *storage_init(struct lxc_conf *conf)
 	if (!q)
 		return NULL;
 
-	bdev = malloc(sizeof(struct lxc_storage));
+	bdev = zalloc(sizeof(struct lxc_storage));
 	if (!bdev)
 		return NULL;
 
-	memset(bdev, 0, sizeof(struct lxc_storage));
-
-	bdev->ops = q->ops;
-	bdev->type = q->name;
+	bdev->ops	= q->ops;
+	bdev->type	= q->name;
+	bdev->rootfs	= &conf->rootfs;
 
 	if (mntopts)
 		bdev->mntopts = strdup(mntopts);

--- a/src/lxc/storage/storage.h
+++ b/src/lxc/storage/storage.h
@@ -15,6 +15,7 @@
 #endif
 
 #include "compiler.h"
+#include "conf.h"
 
 #ifndef MS_DIRSYNC
 #define MS_DIRSYNC 128
@@ -87,6 +88,7 @@ struct lxc_storage {
 	/* index for the connected nbd device. */
 	int nbd_idx;
 	int flags;
+	struct lxc_rootfs *rootfs;
 };
 
 /**

--- a/src/lxc/syscall_numbers.h
+++ b/src/lxc/syscall_numbers.h
@@ -680,4 +680,24 @@
 	#endif
 #endif
 
+#ifndef __NR_mount_setattr
+	#if defined __alpha__
+		#define __NR_mount_setattr 552
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_mount_setattr (442 + 4000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_mount_setattr (442 + 6000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_mount_setattr (442 + 5000)
+		#endif
+	#elif defined __ia64__
+		#define __NR_mount_setattr (442 + 1024)
+	#else
+		#define __NR_mount_setattr 442
+	#endif
+#endif
+
 #endif /* __LXC_SYSCALL_NUMBERS_H */

--- a/src/lxc/syscall_wrappers.h
+++ b/src/lxc/syscall_wrappers.h
@@ -209,6 +209,24 @@ extern int fsmount(int fs_fd, unsigned int flags, unsigned int attr_flags);
 #endif
 
 /*
+ * mount_setattr()
+ */
+struct lxc_mount_attr {
+	__u64 attr_set;
+	__u64 attr_clr;
+	__u64 propagation;
+	__u64 userns_fd;
+};
+
+#ifndef HAVE_MOUNT_SETATTR
+static inline int mount_setattr(int dfd, const char *path, unsigned int flags,
+				struct lxc_mount_attr *attr, size_t size)
+{
+	return syscall(__NR_mount_setattr, dfd, path, flags, attr, size);
+}
+#endif
+
+/*
  * Arguments for how openat2(2) should open the target path. If only @flags and
  * @mode are non-zero, then openat2(2) operates very similarly to openat(2).
  *


### PR DESCRIPTION
```
lxc.rootfs.options = idmap=/path/to/user/ns/to/idmap/to
```

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>