### PR TITLE
macro: define __aligned_u64 to handle kernels without such support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -641,6 +641,7 @@ AC_HEADER_MAJOR
 
 # Check for some syscalls functions
 AC_CHECK_FUNCS([setns pivot_root sethostname unshare rand_r confstr faccessat gettid memfd_create move_mount open_tree execveat clone3 fsopen fspick fsconfig fsmount, openat2, close_range, statvfs])
+AC_CHECK_TYPES([__aligned_u64], [], [], [[#include <linux/types.h>]])
 AC_CHECK_TYPES([struct open_how], [], [], [[#include <linux/openat2.h>]])
 AC_CHECK_TYPES([struct clone_args], [], [], [[#include <linux/sched.h>]])
 AC_CHECK_MEMBERS([struct clone_args.set_tid],[],[],[[#include <linux/sched.h>]])

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -733,4 +733,8 @@ enum {
 #define hweight32(w) __const_hweight32(w)
 #define hweight64(w) __const_hweight64(w)
 
+#ifndef HAVE___ALIGNED_U64
+#define __aligned_u64 __u64 __attribute__((aligned(8)))
+#endif
+
 #endif /* __LXC_MACRO_H */


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>