### PR TITLE
rexec: don't close stderr

### DIFF
--- a/src/lxc/rexec.c
+++ b/src/lxc/rexec.c
@@ -162,7 +162,7 @@ static void lxc_rexec_as_memfd(char **argv, char **envp, const char *memfd_name)
 	if (execfd < 0)
 		return;
 
-	ret = close_range(STDERR_FILENO, MAX_FILENO, CLOSE_RANGE_CLOEXEC);
+	ret = close_range(STDERR_FILENO + 1, MAX_FILENO, CLOSE_RANGE_CLOEXEC);
 	if (ret && (errno != ENOSYS && errno != EINVAL))
 		fprintf(stderr, "%m - Failed to mark all file descriptors as close-on-exec\n");
 	fexecve(execfd, argv, envp);


### PR DESCRIPTION
Otherwise we'll fail to attach to containers later on.

Fixes: https://discuss.linuxcontainers.org/t/error-failed-to-retrieve-pid-of-executing-child-process
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>