### PR TITLE
confile_utils: don't free netdev twice

### DIFF
--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -465,7 +465,6 @@ bool lxc_remove_nic_by_idx(struct lxc_conf *conf, unsigned int idx)
 			continue;
 
 		lxc_list_del(cur);
-		free(cur);
 		return true;
 	}
 
@@ -480,7 +479,6 @@ void lxc_free_networks(struct lxc_list *networks)
 		struct lxc_netdev *netdev = cur->elem;
 		netdev = cur->elem;
 		lxc_free_netdev(netdev);
-		free(cur);
 	}
 
 	/* prevent segfaults */


### PR DESCRIPTION
lxc_free_netdev() will already free the list element.

Fixes: https://github.com/google/oss-fuzz/pull/5498
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>