### PR TITLE
conf: fix a memory leak

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3962,6 +3962,7 @@ void lxc_conf_free(struct lxc_conf *conf)
 	free(conf->lsm_aa_profile);
 	free(conf->lsm_aa_profile_computed);
 	free(conf->lsm_se_context);
+	free(conf->lsm_se_keyring_context);
 	lxc_seccomp_free(&conf->seccomp);
 	lxc_clear_config_caps(conf);
 	lxc_clear_config_keepcaps(conf);


### PR DESCRIPTION
It was triggered by passing "lxc.selinux.context.keyring=xroot" to the
fuzz target introduced in https://github.com/google/oss-fuzz/pull/5498
```
=================================================================
==22==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x538ca4 in __strdup /src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:468:3
    #1 0x5c40e8 in set_config_string_item /src/lxc/src/lxc/confile_utils.c:635:14
    #2 0x44394e in set_config_selinux_context_keyring /src/lxc/src/lxc/confile.c:1596:9
    #3 0x5af955 in parse_line /src/lxc/src/lxc/confile.c:2953:9
    #4 0x4475cd in lxc_file_for_each_line_mmap /src/lxc/src/lxc/parse.c:125:9
    #5 0x5af24f in lxc_config_read /src/lxc/src/lxc/confile.c:3024:9
    #6 0x580b04 in LLVMFuzzerTestOneInput /src/fuzz-lxc-config-read.c:36:2
    #7 0x483643 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:599:15
    #8 0x46d4a2 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:323:6
    #9 0x4732ea in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:856:9
    #10 0x49f022 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #11 0x7f16d09b883f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
```

This is a follow-up to https://github.com/lxc/lxc/commit/4fef78bc332a2d186dca6f

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>