### PR TITLE
network: handle name collisions when returning interfaces to host

### DIFF
--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -136,6 +136,7 @@ union netdev_p {
  * @created_name      : the name with which this interface got created before
  *			being renamed to final_name.
  *			Currenly only used for veth devices.
+ * @transient_name    : temporary name to avoid namespace collisions
  * @hwaddr            : mac address
  * @mtu               : maximum transmission unit
  * @priv              : information specific to the specificed network type


### PR DESCRIPTION

Reviewed-by: Blair Steven <blair.steven@alliedtelesis.co.nz>
Signed-off-by: Sam Boyles <sam.boyles@alliedtelesis.co.nz>