### PR TITLE
oss-fuzz: make it possible to build the fuzzer without docker

### DIFF
--- a/src/tests/fuzz-lxc-config-read.c
+++ b/src/tests/fuzz-lxc-config-read.c
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "conf.h"
+#include "confile.h"
+#include "lxctest.h"
+#include "utils.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	int fd = -1;
+	char tmpf[] = "fuzz-lxc-config-read-XXXXXX";
+	struct lxc_conf *conf = NULL;
+
+	fd = lxc_make_tmpfile(tmpf, false);
+	lxc_test_assert_abort(fd >= 0);
+	lxc_write_nointr(fd, data, size);
+	close(fd);
+
+	conf = lxc_conf_init();
+	lxc_test_assert_abort(conf);
+	lxc_config_read(tmpf, conf, false);
+	lxc_conf_free(conf);
+
+	(void) unlink(tmpf);
+	return 0;
+}

--- a/src/tests/oss-fuzz.sh
+++ b/src/tests/oss-fuzz.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -ex
+
+export SANITIZER=${SANITIZER:-address}
+flags="-O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
+sanitizer_flags="-fsanitize=address -fsanitize-address-use-after-scope"
+coverage_flags="-fsanitize=fuzzer-no-link"
+
+export CC=${CC:-clang}
+export CFLAGS=${CFLAGS:-$flags $sanitizer_flags $coverage_flags}
+
+export CXX=${CXX:-clang++}
+export CXXFLAGS=${CXXFLAGS:-$flags $sanitizer_flags $coverage_flags}
+
+export OUT=${OUT:-$(pwd)/out}
+mkdir -p $OUT
+
+export LIB_FUZZING_ENGINE=${LIB_FUZZING_ENGINE:--fsanitize=fuzzer}
+
+# -fsanitize=... isn't compatible with -Wl,-no-undefined
+# https://github.com/google/sanitizers/issues/380
+sed -i 's/-Wl,-no-undefined *\\/\\/' src/lxc/Makefile.am
+
+# AFL++ and hoggfuzz are both incompatible with lto=thin apparently
+sed -i '/-flto=thin/d' configure.ac
+
+# turn off the libutil dependency
+sed -i 's/^AC_CHECK_LIB(util/#/' configure.ac
+
+./autogen.sh
+./configure \
+    --disable-tools \
+    --disable-commands \
+    --disable-apparmor \
+    --disable-openssl \
+    --disable-selinux \
+    --disable-seccomp \
+    --disable-capabilities
+
+make -j$(nproc)
+
+$CC -c -o fuzz-lxc-config-read.o $CFLAGS -Isrc -Isrc/lxc src/tests/fuzz-lxc-config-read.c
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-lxc-config-read.o src/lxc/.libs/liblxc.a -o $OUT/fuzz-lxc-config-read
+
+zip -r $OUT/fuzz-lxc-config-read_seed_corpus.zip doc/examples


### PR DESCRIPTION
With this patch applied the fuzz target can be built (with ASan)
and run with
```
./src/tests/oss-fuzz.sh
./out/fuzz-lxc-config-read doc/examples/
```

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=32475 can be
reproduced by running
```
$ echo "lxc.console.buffer.size=d" >oss-fuzz-32475
$ ./out/fuzz-lxc-config-read ./oss-fuzz-32475
INFO: Seed: 1044753468
INFO: Loaded 1 modules   (18770 inline 8-bit counters): 18770 [0x883cc0, 0x888612),
INFO: Loaded 1 PC tables (18770 PCs): 18770 [0x888618,0x8d1b38),
./out/fuzz-lxc-config-read: Running 1 inputs 1 time(s) each.
Running: oss-fuzz-32475
=================================================================
==2052097==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffcca063e7f at pc 0x000000659e0d bp 0x7ffcca063e30 sp 0x7ffcca063e28
READ of size 1 at 0x7ffcca063e7f thread T0
...
```

I'll point OSS-Fuzz to the build script once this patch is merged.

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>