### PR TITLE
confile: fix a memory leak in set_config_net_hwaddr

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           oss-fuzz-project-name: 'lxc'
           fuzz-seconds: 180
-          dry-run: true
+          dry-run: ${{ matrix.sanitizer != 'address' }}
           sanitizer: ${{ matrix.sanitizer }}
       - name: Upload Crash
         uses: actions/upload-artifact@v1

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3674,11 +3674,9 @@ int lxc_clear_config_keepcaps(struct lxc_conf *c)
 
 int lxc_clear_namespace(struct lxc_conf *c)
 {
-	int i;
-	for (i = 0; i < LXC_NS_MAX; i++) {
-		free(c->ns_share[i]);
-		c->ns_share[i] = NULL;
-	}
+	for (int i = 0; i < LXC_NS_MAX; i++)
+		free_disarm(c->ns_share[i]);
+
 	return 0;
 }
 
@@ -3711,7 +3709,7 @@ int lxc_clear_cgroups(struct lxc_conf *c, const char *key, int version)
 	else
 		return ret_errno(EINVAL);
 
-	lxc_list_for_each_safe (it, list, next) {
+	lxc_list_for_each_safe(it, list, next) {
 		struct lxc_cgroup *cg = it->elem;
 
 		if (!all && !strequal(cg->subsystem, k))
@@ -3814,7 +3812,7 @@ int lxc_clear_procs(struct lxc_conf *c, const char *key)
 	else
 		return -1;
 
-	lxc_list_for_each_safe (it, &c->procs, next) {
+	lxc_list_for_each_safe(it, &c->procs, next) {
 		struct lxc_proc *proc = it->elem;
 
 		if (!all && !strequal(proc->filename, k))
@@ -3883,7 +3881,6 @@ int lxc_clear_automounts(struct lxc_conf *c)
 
 int lxc_clear_hooks(struct lxc_conf *c, const char *key)
 {
-	int i;
 	struct lxc_list *it, *next;
 	const char *k = NULL;
 	bool all = false, done = false;
@@ -3895,7 +3892,7 @@ int lxc_clear_hooks(struct lxc_conf *c, const char *key)
 	else
 		return -1;
 
-	for (i = 0; i < NUM_LXC_HOOKS; i++) {
+	for (int i = 0; i < NUM_LXC_HOOKS; i++) {
 		if (all || strequal(k, lxchook_names[i])) {
 			lxc_list_for_each_safe (it, &c->hooks[i], next) {
 				lxc_list_del(it);
@@ -3931,7 +3928,7 @@ void lxc_clear_includes(struct lxc_conf *conf)
 {
 	struct lxc_list *it, *next;
 
-	lxc_list_for_each_safe (it, &conf->includes, next) {
+	lxc_list_for_each_safe(it, &conf->includes, next) {
 		lxc_list_del(it);
 		free(it->elem);
 		free(it);

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3627,6 +3627,7 @@ int lxc_clear_config_caps(struct lxc_conf *c)
 		free(it);
 	}
 
+	lxc_list_init(&c->caps);
 	return 0;
 }
 
@@ -3640,6 +3641,7 @@ static int lxc_free_idmap(struct lxc_list *id_map)
 		free(it);
 	}
 
+	lxc_list_init(id_map);
 	return 0;
 }
 
@@ -3666,6 +3668,7 @@ int lxc_clear_config_keepcaps(struct lxc_conf *c)
 		free(it);
 	}
 
+	lxc_list_init(&c->keepcaps);
 	return 0;
 }
 
@@ -3720,6 +3723,9 @@ int lxc_clear_cgroups(struct lxc_conf *c, const char *key, int version)
 		free(cg);
 		free(it);
 	}
+
+	if (all)
+		lxc_list_init(list);
 
 	return 0;
 }
@@ -3821,6 +3827,9 @@ int lxc_clear_procs(struct lxc_conf *c, const char *key)
 		free(it);
 	}
 
+	if (all)
+		lxc_list_init(&c->procs);
+
 	return 0;
 }
 
@@ -3834,6 +3843,7 @@ int lxc_clear_groups(struct lxc_conf *c)
 		free(it);
 	}
 
+	lxc_list_init(&c->groups);
 	return 0;
 }
 
@@ -3847,6 +3857,7 @@ int lxc_clear_environment(struct lxc_conf *c)
 		free(it);
 	}
 
+	lxc_list_init(&c->environment);
 	return 0;
 }
 
@@ -3860,6 +3871,7 @@ int lxc_clear_mount_entries(struct lxc_conf *c)
 		free(it);
 	}
 
+	lxc_list_init(&c->mount_list);
 	return 0;
 }
 
@@ -3890,6 +3902,7 @@ int lxc_clear_hooks(struct lxc_conf *c, const char *key)
 				free(it->elem);
 				free(it);
 			}
+			lxc_list_init(&c->hooks[i]);
 
 			done = true;
 		}
@@ -3910,6 +3923,8 @@ static inline void lxc_clear_aliens(struct lxc_conf *conf)
 		free(it->elem);
 		free(it);
 	}
+
+	lxc_list_init(&conf->aliens);
 }
 
 void lxc_clear_includes(struct lxc_conf *conf)
@@ -3921,6 +3936,8 @@ void lxc_clear_includes(struct lxc_conf *conf)
 		free(it->elem);
 		free(it);
 	}
+
+	lxc_list_init(&conf->includes);
 }
 
 int lxc_clear_apparmor_raw(struct lxc_conf *c)
@@ -3933,6 +3950,7 @@ int lxc_clear_apparmor_raw(struct lxc_conf *c)
 		free(it);
 	}
 
+	lxc_list_init(&c->lsm_aa_raw);
 	return 0;
 }
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -657,9 +657,8 @@ static int set_config_net_hwaddr(const char *key, const char *value,
 
 	rand_complete_hwaddr(new_value);
 
-	if (lxc_config_value_empty(new_value))
-		free_disarm(netdev->hwaddr);
-	else
+	free_disarm(netdev->hwaddr);
+	if (!lxc_config_value_empty(new_value))
 		netdev->hwaddr = move_ptr(new_value);
 
 	return 0;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -5171,7 +5171,7 @@ static struct lxc_config_t *get_network_config_ops(const char *key,
 	char *idx_start, *idx_end;
 
 	/* check that this is a sensible network key */
-	if (!strnequal("lxc.net.", key, 8))
+	if (!strnequal("lxc.net.", key, STRLITERALLEN("lxc.net.")))
 		return log_error_errno(NULL, EINVAL, "Invalid network configuration key \"%s\"", key);
 
 	copy = strdup(key);
@@ -5179,15 +5179,15 @@ static struct lxc_config_t *get_network_config_ops(const char *key,
 		return log_error_errno(NULL, ENOMEM, "Failed to duplicate string \"%s\"", key);
 
 	/* lxc.net.<n> */
-	if (!isdigit(*(key + 8)))
+	if (!isdigit(*(key + STRLITERALLEN("lxc.net."))))
 		return log_error_errno(NULL, EINVAL, "Failed to detect digit in string \"%s\"", key + 8);
 
 	/* beginning of index string */
-	idx_start = (copy + 7);
+	idx_start = copy + (STRLITERALLEN("lxc.net.") - 1);
 	*idx_start = '\0';
 
 	/* end of index string */
-	idx_end = strchr((copy + 8), '.');
+	idx_end = strchr((copy + STRLITERALLEN("lxc.net.")), '.');
 	if (idx_end)
 		*idx_end = '\0';
 
@@ -5217,7 +5217,7 @@ static struct lxc_config_t *get_network_config_ops(const char *key,
 		if (strlen(idx_end + 1) == 0)
 			return log_error_errno(NULL, EINVAL, "No subkey in network configuration key \"%s\"", key);
 
-		memmove(copy + 8, idx_end + 1, strlen(idx_end + 1));
+		memmove(copy + STRLITERALLEN("lxc.net."), idx_end + 1, strlen(idx_end + 1));
 		copy[strlen(key) - (numstrlen + 1)] = '\0';
 
 		config = lxc_get_config(copy);

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -5202,7 +5202,7 @@ static struct lxc_config_t *get_network_config_ops(const char *key,
 	 * better safe than sorry.
 	 * (Checking for INT_MAX here is intentional.)
 	 */
-	if (tmpidx == INT_MAX)
+	if (tmpidx >= INT_MAX)
 		return log_error_errno(NULL, ERANGE, "Number of configured networks would overflow the counter");
 	*idx = tmpidx;
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -364,11 +364,11 @@ static int set_config_net_flags(const char *key, const char *value,
 {
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_flags(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_flags(key, lxc_conf, data);
 
 	netdev->flags |= IFF_UP;
 
@@ -422,11 +422,11 @@ static int set_config_net_link(const char *key, const char *value,
 	struct lxc_netdev *netdev = data;
 	int ret = 0;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_link(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_link(key, lxc_conf, data);
 
 	if (value[strlen(value) - 1] == '+' && netdev->type == LXC_NET_PHYS)
 		ret = create_matched_ifnames(value, lxc_conf, netdev);
@@ -443,11 +443,11 @@ static int set_config_net_l2proxy(const char *key, const char *value,
 	unsigned int val = 0;
 	int ret;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_l2proxy(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_l2proxy(key, lxc_conf, data);
 
 	ret = lxc_safe_uint(value, &val);
 	if (ret < 0)
@@ -470,11 +470,11 @@ static int set_config_net_name(const char *key, const char *value,
 {
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_name(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_name(key, lxc_conf, data);
 
 	return network_ifname(netdev->name, value, sizeof(netdev->name));
 }
@@ -484,6 +484,12 @@ static int set_config_net_veth_mode(const char *key, const char *value,
 				       struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev = data;
+
+	if (!netdev)
+		return ret_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VETH)
+		return ret_errno(EINVAL);
 
 	if (lxc_config_value_empty(value))
 		return clr_config_net_veth_mode(key, lxc_conf, data);
@@ -499,23 +505,29 @@ static int set_config_net_veth_pair(const char *key, const char *value,
 {
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_veth_pair(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VETH)
+		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_veth_pair(key, lxc_conf, data);
 
 	return network_ifname(netdev->priv.veth_attr.pair, value,
 			      sizeof(netdev->priv.veth_attr.pair));
 }
 
 static int set_config_net_veth_vlan_id(const char *key, const char *value,
-				  struct lxc_conf *lxc_conf, void *data)
+				       struct lxc_conf *lxc_conf, void *data)
 {
 	int ret;
 	struct lxc_netdev *netdev = data;
 
 	if (!netdev)
+		return ret_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VETH)
 		return ret_errno(EINVAL);
 
 	if (lxc_config_value_empty(value))
@@ -541,7 +553,8 @@ static int set_config_net_veth_vlan_id(const char *key, const char *value,
 }
 
 static int set_config_net_veth_vlan_tagged_id(const char *key, const char *value,
-				       struct lxc_conf *lxc_conf, void *data)
+					      struct lxc_conf *lxc_conf,
+					      void *data)
 {
 	__do_free struct lxc_list *list = NULL;
 	int ret;
@@ -549,6 +562,9 @@ static int set_config_net_veth_vlan_tagged_id(const char *key, const char *value
 	struct lxc_netdev *netdev = data;
 
 	if (!netdev)
+		return ret_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VETH)
 		return ret_errno(EINVAL);
 
 	if (lxc_config_value_empty(value))
@@ -577,49 +593,48 @@ static int set_config_net_macvlan_mode(const char *key, const char *value,
 {
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_macvlan_mode(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_MACVLAN)
+		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_macvlan_mode(key, lxc_conf, data);
 
 	return lxc_macvlan_mode_to_flag(&netdev->priv.macvlan_attr.mode, value);
 }
 
 static int set_config_net_ipvlan_mode(const char *key, const char *value,
-				       struct lxc_conf *lxc_conf, void *data)
+				      struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev = data;
-
-	if (lxc_config_value_empty(value))
-		return clr_config_net_ipvlan_mode(key, lxc_conf, data);
 
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_IPVLAN)
-		return log_error_errno(-EINVAL,
-				       EINVAL, "Invalid ipvlan mode \"%s\", can only be used with ipvlan network",
-				       value);
+		return syserror_set(-EINVAL, "Invalid ipvlan mode \"%s\", can only be used with ipvlan network", value);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_ipvlan_mode(key, lxc_conf, data);
 
 	return lxc_ipvlan_mode_to_flag(&netdev->priv.ipvlan_attr.mode, value);
 }
 
 static int set_config_net_ipvlan_isolation(const char *key, const char *value,
-				       struct lxc_conf *lxc_conf, void *data)
+					   struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev = data;
-
-	if (lxc_config_value_empty(value))
-		return clr_config_net_ipvlan_isolation(key, lxc_conf, data);
 
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_IPVLAN)
-		return log_error_errno(-EINVAL,
-				       EINVAL, "Invalid ipvlan isolation \"%s\", can only be used with ipvlan network",
-				       value);
+		return syserror_set(-EINVAL, "Invalid ipvlan isolation \"%s\", can only be used with ipvlan network", value);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_ipvlan_isolation(key, lxc_conf, data);
 
 	return lxc_ipvlan_isolation_to_flag(&netdev->priv.ipvlan_attr.isolation, value);
 }
@@ -630,11 +645,11 @@ static int set_config_net_hwaddr(const char *key, const char *value,
 	__do_free char *new_value = NULL;
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_hwaddr(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_hwaddr(key, lxc_conf, data);
 
 	new_value = strdup(value);
 	if (!new_value)
@@ -656,11 +671,14 @@ static int set_config_net_vlan_id(const char *key, const char *value,
 	int ret;
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_vlan_id(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VLAN)
+		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_vlan_id(key, lxc_conf, data);
 
 	ret = get_u16(&netdev->priv.vlan_attr.vid, value, 0);
 	if (ret < 0)
@@ -674,11 +692,11 @@ static int set_config_net_mtu(const char *key, const char *value,
 {
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_mtu(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_mtu(key, lxc_conf, data);
 
 	return set_config_string_item(&netdev->mtu, value);
 }
@@ -694,11 +712,11 @@ static int set_config_net_ipv4_address(const char *key, const char *value,
 	char *cursor, *slash;
 	char *bcast = NULL, *prefix = NULL;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_ipv4_address(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_ipv4_address(key, lxc_conf, data);
 
 	inetdev = zalloc(sizeof(*inetdev));
 	if (!inetdev)
@@ -765,11 +783,11 @@ static int set_config_net_ipv4_gateway(const char *key, const char *value,
 {
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (lxc_config_value_empty(value))
 		return clr_config_net_ipv4_gateway(key, lxc_conf, data);
-
-	if (!netdev)
-		return -1;
 
 	free(netdev->ipv4_gateway);
 
@@ -800,7 +818,7 @@ static int set_config_net_ipv4_gateway(const char *key, const char *value,
 }
 
 static int set_config_net_veth_ipv4_route(const char *key, const char *value,
-				       struct lxc_conf *lxc_conf, void *data)
+					  struct lxc_conf *lxc_conf, void *data)
 {
 	__do_free char *valdup = NULL;
 	__do_free struct lxc_inetdev *inetdev = NULL;
@@ -809,16 +827,14 @@ static int set_config_net_veth_ipv4_route(const char *key, const char *value,
 	char *netmask, *slash;
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_veth_ipv4_route(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_VETH)
-		return log_error_errno(-EINVAL,
-				       EINVAL, "Invalid ipv4 route \"%s\", can only be used with veth network",
-				       value);
+		return syserror_set(-EINVAL, "Invalid ipv4 route \"%s\", can only be used with veth network", value);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_veth_ipv4_route(key, lxc_conf, data);
 
 	inetdev = zalloc(sizeof(*inetdev));
 	if (!inetdev)
@@ -870,11 +886,11 @@ static int set_config_net_ipv6_address(const char *key, const char *value,
 	struct lxc_netdev *netdev = data;
 	char *slash, *netmask;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_ipv6_address(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_ipv6_address(key, lxc_conf, data);
 
 	inet6dev = zalloc(sizeof(*inet6dev));
 	if (!inet6dev)
@@ -916,11 +932,11 @@ static int set_config_net_ipv6_gateway(const char *key, const char *value,
 {
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_ipv6_gateway(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_ipv6_gateway(key, lxc_conf, data);
 
 	free(netdev->ipv6_gateway);
 
@@ -952,7 +968,7 @@ static int set_config_net_ipv6_gateway(const char *key, const char *value,
 }
 
 static int set_config_net_veth_ipv6_route(const char *key, const char *value,
-				       struct lxc_conf *lxc_conf, void *data)
+					  struct lxc_conf *lxc_conf, void *data)
 {
 	__do_free char *valdup = NULL;
 	__do_free struct lxc_inet6dev *inet6dev = NULL;
@@ -961,16 +977,14 @@ static int set_config_net_veth_ipv6_route(const char *key, const char *value,
 	char *netmask, *slash;
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_veth_ipv6_route(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_VETH)
-		return log_error_errno(-EINVAL,
-				       EINVAL, "Invalid ipv6 route \"%s\", can only be used with veth network",
-				       value);
+		return syserror_set(-EINVAL, "Invalid ipv6 route \"%s\", can only be used with veth network", value);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_veth_ipv6_route(key, lxc_conf, data);
 
 	inet6dev = zalloc(sizeof(*inet6dev));
 	if (!inet6dev)
@@ -1016,11 +1030,11 @@ static int set_config_net_script_up(const char *key, const char *value,
 {
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_script_up(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_script_up(key, lxc_conf, data);
 
 	return set_config_string_item(&netdev->upscript, value);
 }
@@ -1030,11 +1044,11 @@ static int set_config_net_script_down(const char *key, const char *value,
 {
 	struct lxc_netdev *netdev = data;
 
-	if (lxc_config_value_empty(value))
-		return clr_config_net_script_down(key, lxc_conf, data);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (lxc_config_value_empty(value))
+		return clr_config_net_script_down(key, lxc_conf, data);
 
 	return set_config_string_item(&netdev->downscript, value);
 }
@@ -5402,7 +5416,7 @@ static int clr_config_net_ipvlan_mode(const char *key,
 }
 
 static int clr_config_net_ipvlan_isolation(const char *key,
-				       struct lxc_conf *lxc_conf, void *data)
+					   struct lxc_conf *lxc_conf, void *data)
 {
 	struct lxc_netdev *netdev = data;
 
@@ -5441,6 +5455,9 @@ static int clr_config_net_veth_pair(const char *key, struct lxc_conf *lxc_conf,
 	if (!netdev)
 		return ret_errno(EINVAL);
 
+	if (netdev->type != LXC_NET_VETH)
+		return 0;
+
 	netdev->priv.veth_attr.pair[0] = '\0';
 
 	return 0;
@@ -5453,6 +5470,9 @@ static int clr_config_net_veth_vlan_id(const char *key, struct lxc_conf *lxc_con
 
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VETH)
+		return 0;
 
 	netdev->priv.veth_attr.vlan_id = 0;
 	netdev->priv.veth_attr.vlan_id_set = false;
@@ -5468,6 +5488,9 @@ static int clr_config_net_veth_vlan_tagged_id(const char *key,
 
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VETH)
+		return 0;
 
 	lxc_list_for_each_safe(cur, &netdev->priv.veth_attr.vlan_tagged_ids, next) {
 		lxc_list_del(cur);
@@ -5538,6 +5561,9 @@ static int clr_config_net_vlan_id(const char *key, struct lxc_conf *lxc_conf,
 	if (!netdev)
 		return ret_errno(EINVAL);
 
+	if (netdev->type != LXC_NET_VLAN)
+		return 0;
+
 	netdev->priv.vlan_attr.vid = 0;
 
 	return 0;
@@ -5582,6 +5608,9 @@ static int clr_config_net_veth_ipv4_route(const char *key,
 
 	if (!netdev)
 		return ret_errno(EINVAL);
+
+	if (netdev->type != LXC_NET_VETH)
+		return 0;
 
 	lxc_list_for_each_safe(cur, &netdev->priv.veth_attr.ipv4_routes, next) {
 		lxc_list_del(cur);
@@ -5632,6 +5661,9 @@ static int clr_config_net_veth_ipv6_route(const char *key,
 	if (!netdev)
 		return ret_errno(EINVAL);
 
+	if (netdev->type != LXC_NET_VETH)
+		return 0;
+
 	lxc_list_for_each_safe(cur, &netdev->priv.veth_attr.ipv6_routes, next) {
 		lxc_list_del(cur);
 		free(cur->elem);
@@ -5672,13 +5704,13 @@ static int get_config_net_type(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	strprint(retv, inlen, "%s", lxc_net_type_to_str(netdev->type));
 
@@ -5692,13 +5724,13 @@ static int get_config_net_flags(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	if (netdev->flags & IFF_UP)
 		strprint(retv, inlen, "up");
@@ -5713,13 +5745,13 @@ static int get_config_net_link(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	if (netdev->link[0] != '\0')
 		strprint(retv, inlen, "%s", netdev->link);
@@ -5731,6 +5763,10 @@ static int get_config_net_l2proxy(const char *key, char *retv, int inlen,
 				  struct lxc_conf *c, void *data)
 {
 	struct lxc_netdev *netdev = data;
+
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	return lxc_get_conf_bool(c, retv, inlen, netdev->l2proxy);
 }
 
@@ -5741,13 +5777,13 @@ static int get_config_net_name(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	if (netdev->name[0] != '\0')
 		strprint(retv, inlen, "%s", netdev->name);
@@ -5763,16 +5799,16 @@ static int get_config_net_macvlan_mode(const char *key, char *retv, int inlen,
 	const char *mode;
 	struct lxc_netdev *netdev = data;
 
-	if (!retv)
-		inlen = 0;
-	else
-		memset(retv, 0, inlen);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_MACVLAN)
-		return 0;
+		return ret_errno(EINVAL);
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
 
 	switch (netdev->priv.macvlan_attr.mode) {
 	case MACVLAN_MODE_PRIVATE:
@@ -5805,16 +5841,16 @@ static int get_config_net_ipvlan_mode(const char *key, char *retv, int inlen,
 	int len;
 	const char *mode;
 
-	if (!retv)
-		inlen = 0;
-	else
-		memset(retv, 0, inlen);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_IPVLAN)
-		return 0;
+		return ret_errno(EINVAL);
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
 
 	switch (netdev->priv.ipvlan_attr.mode) {
 	case IPVLAN_MODE_L3:
@@ -5844,16 +5880,16 @@ static int get_config_net_ipvlan_isolation(const char *key, char *retv, int inle
 	int len;
 	const char *mode;
 
-	if (!retv)
-		inlen = 0;
-	else
-		memset(retv, 0, inlen);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_IPVLAN)
-		return 0;
+		return ret_errno(EINVAL);
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
 
 	switch (netdev->priv.ipvlan_attr.isolation) {
 	case IPVLAN_ISOLATION_BRIDGE:
@@ -5876,23 +5912,23 @@ static int get_config_net_ipvlan_isolation(const char *key, char *retv, int inle
 }
 
 static int get_config_net_veth_mode(const char *key, char *retv, int inlen,
-				       struct lxc_conf *c, void *data)
+				    struct lxc_conf *c, void *data)
 {
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 	int len;
 	const char *mode;
 
-	if (!retv)
-		inlen = 0;
-	else
-		memset(retv, 0, inlen);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_VETH)
-		return 0;
+		return ret_errno(EINVAL);
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
 
 	switch (netdev->priv.veth_attr.mode) {
 	case VETH_MODE_BRIDGE:
@@ -5918,16 +5954,16 @@ static int get_config_net_veth_pair(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
-	if (!retv)
-		inlen = 0;
-	else
-		memset(retv, 0, inlen);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_VETH)
-		return 0;
+		return ret_errno(EINVAL);
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
 
 	strprint(retv, inlen, "%s",
 		 netdev->priv.veth_attr.pair[0] != '\0'
@@ -5948,7 +5984,7 @@ static int get_config_net_veth_vlan_id(const char *key, char *retv, int inlen,
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_VETH)
-		return 0;
+		return ret_errno(EINVAL);
 
 	if (!retv)
 		inlen = 0;
@@ -5960,8 +5996,9 @@ static int get_config_net_veth_vlan_id(const char *key, char *retv, int inlen,
 	return fulllen;
 }
 
-static int get_config_net_veth_vlan_tagged_id(const char *key, char *retv, int inlen,
-				       struct lxc_conf *c, void *data)
+static int get_config_net_veth_vlan_tagged_id(const char *key, char *retv,
+					      int inlen, struct lxc_conf *c,
+					      void *data)
 {
 	int len;
 	size_t listlen;
@@ -5973,7 +6010,7 @@ static int get_config_net_veth_vlan_tagged_id(const char *key, char *retv, int i
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_VETH)
-		return 0;
+		return ret_errno(EINVAL);
 
 	if (!retv)
 		inlen = 0;
@@ -5984,8 +6021,7 @@ static int get_config_net_veth_vlan_tagged_id(const char *key, char *retv, int i
 
 	lxc_list_for_each(it, &netdev->priv.veth_attr.vlan_tagged_ids) {
 		unsigned short i = PTR_TO_USHORT(it->elem);
-		strprint(retv, inlen, "%u%s", i,
-			 (listlen-- > 1) ? "\n" : "");
+		strprint(retv, inlen, "%u%s", i, (listlen-- > 1) ? "\n" : "");
 	}
 
 	return fulllen;
@@ -5998,13 +6034,13 @@ static int get_config_net_script_up(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	if (netdev->upscript)
 		strprint(retv, inlen, "%s", netdev->upscript);
@@ -6019,13 +6055,13 @@ static int get_config_net_script_down(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	if (netdev->downscript)
 		strprint(retv, inlen, "%s", netdev->downscript);
@@ -6040,13 +6076,13 @@ static int get_config_net_hwaddr(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	if (netdev->hwaddr)
 		strprint(retv, inlen, "%s", netdev->hwaddr);
@@ -6061,13 +6097,13 @@ static int get_config_net_mtu(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	if (netdev->mtu)
 		strprint(retv, inlen, "%s", netdev->mtu);
@@ -6082,16 +6118,16 @@ static int get_config_net_vlan_id(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
-	if (!retv)
-		inlen = 0;
-	else
-		memset(retv, 0, inlen);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_VLAN)
-		return 0;
+		return ret_errno(EINVAL);
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
 
 	strprint(retv, inlen, "%d", netdev->priv.vlan_attr.vid);
 
@@ -6106,13 +6142,13 @@ static int get_config_net_ipv4_gateway(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	if (netdev->ipv4_gateway_auto) {
 		strprint(retv, inlen, "auto");
@@ -6137,13 +6173,13 @@ static int get_config_net_ipv4_address(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	listlen = lxc_list_len(&netdev->ipv4);
 
@@ -6159,7 +6195,7 @@ static int get_config_net_ipv4_address(const char *key, char *retv, int inlen,
 }
 
 static int get_config_net_veth_ipv4_route(const char *key, char *retv, int inlen,
-				       struct lxc_conf *c, void *data)
+					  struct lxc_conf *c, void *data)
 {
 	int len;
 	size_t listlen;
@@ -6168,16 +6204,16 @@ static int get_config_net_veth_ipv4_route(const char *key, char *retv, int inlen
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
-	if (!retv)
-		inlen = 0;
-	else
-		memset(retv, 0, inlen);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_VETH)
-		return 0;
+		return ret_errno(EINVAL);
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
 
 	listlen = lxc_list_len(&netdev->priv.veth_attr.ipv4_routes);
 
@@ -6200,13 +6236,13 @@ static int get_config_net_ipv6_gateway(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	if (netdev->ipv6_gateway_auto) {
 		strprint(retv, inlen, "auto");
@@ -6231,13 +6267,13 @@ static int get_config_net_ipv6_address(const char *key, char *retv, int inlen,
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
+	if (!netdev)
+		return ret_errno(EINVAL);
+
 	if (!retv)
 		inlen = 0;
 	else
 		memset(retv, 0, inlen);
-
-	if (!netdev)
-		return ret_errno(EINVAL);
 
 	listlen = lxc_list_len(&netdev->ipv6);
 
@@ -6262,16 +6298,16 @@ static int get_config_net_veth_ipv6_route(const char *key, char *retv, int inlen
 	int fulllen = 0;
 	struct lxc_netdev *netdev = data;
 
-	if (!retv)
-		inlen = 0;
-	else
-		memset(retv, 0, inlen);
-
 	if (!netdev)
 		return ret_errno(EINVAL);
 
 	if (netdev->type != LXC_NET_VETH)
-		return 0;
+		return ret_errno(EINVAL);
+
+	if (!retv)
+		inlen = 0;
+	else
+		memset(retv, 0, inlen);
 
 	listlen = lxc_list_len(&netdev->priv.veth_attr.ipv6_routes);
 

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -481,6 +481,7 @@ void lxc_free_networks(struct lxc_list *networks)
 
 		lxc_list_del(cur);
 		lxc_free_netdev(netdev);
+		free(cur);
 	}
 
 	/* prevent segfaults */

--- a/src/lxc/string_utils.c
+++ b/src/lxc/string_utils.c
@@ -677,6 +677,8 @@ int lxc_safe_int64_residual(const char *numstr, int64_t *converted, int base, ch
 	if (!residual && residual_len != 0)
 		return ret_errno(EINVAL);
 
+	memset(residual, 0, residual_len);
+
 	while (isspace(*numstr))
 		numstr++;
 
@@ -691,10 +693,8 @@ int lxc_safe_int64_residual(const char *numstr, int64_t *converted, int base, ch
 	if (residual) {
 		size_t len = 0;
 
-		if (*remaining == '\0') {
-			memset(residual, 0, residual_len);
+		if (*remaining == '\0')
 			goto out;
-		}
 
 		len = strlen(remaining);
 		if (len >= residual_len)


### PR DESCRIPTION
It was found by ClusterFuzz in https://oss-fuzz.com/testcase-detail/4747480244813824
but hasn't been reported on Monorail
(https://bugs.chromium.org/p/oss-fuzz/) yet

```
$ cat minimized-from-1a18983c13ce64e8a3bd0f699a97d25beb21481e
lxc.net.0.hwaddr=0
lxc.net.0.hwaddr=4

./out/fuzz-lxc-config-read minimized-from-1a18983c13ce64e8a3bd0f699a97d25beb21481e
INFO: Seed: 1473396311
INFO: Loaded 1 modules   (18821 inline 8-bit counters): 18821 [0x885fa0, 0x88a925),
INFO: Loaded 1 PC tables (18821 PCs): 18821 [0x88a928,0x8d4178),
./out/fuzz-lxc-config-read: Running 1 inputs 1 time(s) each.
Running: minimized-from-1a18983c13ce64e8a3bd0f699a97d25beb21481e

=================================================================
==226185==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x4d25d7 in strdup (/home/vagrant/lxc/out/fuzz-lxc-config-read+0x4d25d7)
    #1 0x58e48f in set_config_net_hwaddr /home/vagrant/lxc/src/lxc/confile.c:654:14
    #2 0x59af3b in set_config_net_nic /home/vagrant/lxc/src/lxc/confile.c:5276:9
    #3 0x571c29 in parse_line /home/vagrant/lxc/src/lxc/confile.c:2958:9
    #4 0x61b0b2 in lxc_file_for_each_line_mmap /home/vagrant/lxc/src/lxc/parse.c:125:9
    #5 0x5710ed in lxc_config_read /home/vagrant/lxc/src/lxc/confile.c:3035:9
    #6 0x542cd6 in LLVMFuzzerTestOneInput /home/vagrant/lxc/src/tests/fuzz-lxc-config-read.c:23:2
    #7 0x449e8c in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/vagrant/lxc/out/fuzz-lxc-config-read+0x449e8c)
    #8 0x42bbad in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/vagrant/lxc/out/fuzz-lxc-config-read+0x42bbad)
    #9 0x432c50 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/vagrant/lxc/out/fuzz-lxc-config-read+0x432c50)
    #10 0x423136 in main (/home/vagrant/lxc/out/fuzz-lxc-config-read+0x423136)
    #11 0x7f2cbb992081 in __libc_start_main (/lib64/libc.so.6+0x27081)

SUMMARY: AddressSanitizer: 2 byte(s) leaked in 1 allocation(s).
```

This PR is based on https://github.com/lxc/lxc/pull/3739. I'm just trying to figure out whether it's the last bug causing CIFuzz to fail as soon as it starts.