### PR TITLE
confile_utils: free list during lxc_remove_nic_by_idx()

### DIFF
--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -466,6 +466,7 @@ bool lxc_remove_nic_by_idx(struct lxc_conf *conf, unsigned int idx)
 
 		lxc_list_del(cur);
 		lxc_free_netdev(netdev);
+		free(cur);
 		return true;
 	}
 


### PR DESCRIPTION
Reported-by: Evgeny Vereshchagin <evvers@ya.ru>
Link: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=32484
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>