### PR TITLE
confile_utils: fix a signed integer overflow

### DIFF
--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -1047,13 +1047,13 @@ static int rt_sig_num(const char *signame)
 		return ret_errno(EINVAL);
 
 	sig_n = sig_num(signame);
+	if (sig_n < 0 || sig_n > SIGRTMAX - SIGRTMIN)
+		return ret_errno(EINVAL);
+
 	if (rtmax)
 		sig_n = SIGRTMAX - sig_n;
 	else
 		sig_n = SIGRTMIN + sig_n;
-
-	if (sig_n > SIGRTMAX || sig_n < SIGRTMIN)
-		return ret_errno(EINVAL);
 
 	return sig_n;
 }


### PR DESCRIPTION
This was triggered by the following chain of conversions:
```
lxc_safe_uint("020000000020") -> 2147483664 (uint)
sig_num(2147483664 (uint)) -> -2147483632 (int)

64 - -2147483632 cannot be represented in type 'int'
```
Closes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=32596

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>

@brauner could you take a look?