### PR TITLE
oss-fuzz/cifuzz: a couple of follow-up commits

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           oss-fuzz-project-name: 'lxc'
           fuzz-seconds: 180
-          dry-run: ${{ matrix.sanitizer != 'address' }}
+          dry-run: ${{ matrix.sanitizer == 'memory' }}
           sanitizer: ${{ matrix.sanitizer }}
       - name: Upload Crash
         uses: actions/upload-artifact@v1

--- a/src/tests/oss-fuzz.sh
+++ b/src/tests/oss-fuzz.sh
@@ -4,8 +4,14 @@ set -ex
 
 export SANITIZER=${SANITIZER:-address}
 flags="-O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
-sanitizer_flags="-fsanitize=address -fsanitize-address-use-after-scope"
 coverage_flags="-fsanitize=fuzzer-no-link"
+
+sanitizer_flags="-fsanitize=address -fsanitize-address-use-after-scope"
+if [[ "$SANITIZER" == "undefined" ]]; then
+    sanitizer_flags="-fsanitize=undefined"
+elif [[ "$SANITIZER" == "memory" ]]; then
+    sanitizer_flags="-fsanitize=memory -fsanitize-memory-track-origins"
+fi
 
 export CC=${CC:-clang}
 export CFLAGS=${CFLAGS:-$flags $sanitizer_flags $coverage_flags}


### PR DESCRIPTION
* cifuzz: turn on UBsan

* oss-fuzz.sh: take SANITIZER into account
to make it possible to build the fuzzer with UBSan and MSan locally
```
$ SANITIZER=undefined ./src/tests/oss-fuzz.sh
$ printf 'lxc.signal.stop=sigrtmax-020000000020' >oss-fuzz-32596
$ UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1 ./out/fuzz-lxc-config-read oss-fuzz-32596
INFO: Seed: 595864277
INFO: Loaded 1 modules   (61553 inline 8-bit counters): 61553 [0x80a1b0, 0x819221),
INFO: Loaded 1 PC tables (61553 PCs): 61553 [0x819228,0x909938),
./out/fuzz-lxc-config-read: Running 1 inputs 1 time(s) each.
Running: oss-fuzz-32596
confile_utils.c:1051:20: runtime error: signed integer overflow: 64 - -2147483632 cannot be represented in type 'int'
    #0 0x51799a in rt_sig_num /home/vagrant/lxc/src/lxc/confile_utils.c:1051:20
    #1 0x517268 in sig_parse /home/vagrant/lxc/src/lxc/confile_utils.c:1069:11
    #2 0x500ca4 in set_config_signal_stop /home/vagrant/lxc/src/lxc/confile.c:1738:10
    #3 0x4b8c7c in parse_line /home/vagrant/lxc/src/lxc/confile.c:2962:9
    #4 0x5a5eb0 in lxc_file_for_each_line_mmap /home/vagrant/lxc/src/lxc/parse.c:125:9

```