### PR TITLE
CIFuzz: turn on MSan

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           oss-fuzz-project-name: 'lxc'
           fuzz-seconds: 180
-          dry-run: ${{ matrix.sanitizer == 'memory' }}
+          dry-run: false
           sanitizer: ${{ matrix.sanitizer }}
       - name: Upload Crash
         uses: actions/upload-artifact@v1

--- a/src/lxc/string_utils.c
+++ b/src/lxc/string_utils.c
@@ -902,7 +902,7 @@ int parse_byte_size_string(const char *s, long long int *converted)
 	int ret, suffix_len;
 	long long int conv, mltpl;
 	char *end;
-	char dup[INTTYPE_TO_STRLEN(long long int)];
+	char dup[INTTYPE_TO_STRLEN(long long int)] = {0};
 	char suffix[3] = {0};
 
 	if (is_empty_string(s))


### PR DESCRIPTION
MSan doesn't instrument stpncpy (https://github.com/google/sanitizers/issues/926),
which causes the fuzzer to fail with:
```
$ cat ../minimized-from-740f56329efc60eab59b8194132b712a873e88a3
lxc.console.size=123

$ ./out/fuzz-lxc-config-read ../minimized-from-740f56329efc60eab59b8194132b712a873e88a3
INFO: Seed: 3561494591
INFO: Loaded 1 modules   (18795 inline 8-bit counters): 18795 [0x866b98, 0x86b503),
INFO: Loaded 1 PC tables (18795 PCs): 18795 [0x86b508,0x8b4bb8),
./out/fuzz-lxc-config-read: Running 1 inputs 1 time(s) each.
Running: ../minimized-from-740f56329efc60eab59b8194132b712a873e88a3
==850885==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x6b3e7f in parse_byte_size_string /home/vagrant/lxc/src/lxc/string_utils.c:912:6
    #1 0x550991 in set_config_console_size /home/vagrant/lxc/src/lxc/confile.c:2483:8
    #2 0x5346e2 in parse_line /home/vagrant/lxc/src/lxc/confile.c:2962:9
    #3 0x64b3cd in lxc_file_for_each_line_mmap /home/vagrant/lxc/src/lxc/parse.c:125:9
    #4 0x53340c in lxc_config_read /home/vagrant/lxc/src/lxc/confile.c:3039:9
    #5 0x4e7ec2 in LLVMFuzzerTestOneInput /home/vagrant/lxc/src/tests/fuzz-lxc-config-read.c:23:2
    #6 0x44ad2c in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/vagrant/lxc/out/fuzz-lxc-config-read+0x44ad2c)
    #7 0x42ca4d in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/vagrant/lxc/out/fuzz-lxc-config-read+0x42ca4d)
    #8 0x433af0 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/vagrant/lxc/out/fuzz-lxc-config-read+0x433af0)
    #9 0x423ff6 in main (/home/vagrant/lxc/out/fuzz-lxc-config-read+0x423ff6)
    #10 0x7f79bdc89081 in __libc_start_main (/lib64/libc.so.6+0x27081)
    #11 0x42402d in _start (/home/vagrant/lxc/out/fuzz-lxc-config-read+0x42402d)

  Uninitialized value was created by an allocation of 'dup' in the stack frame of function 'parse_byte_size_string'
    #0 0x6b3330 in parse_byte_size_string /home/vagrant/lxc/src/lxc/string_utils.c:901

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/vagrant/lxc/src/lxc/string_utils.c:912:6 in parse_byte_size_string
Exiting
```

Closes https://oss-fuzz.com/testcase-detail/5829890470445056

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>