### PR TITLE
autotools: remove --enable-{asan,ubsan} in favor of --enable-sanitizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ inside the Linux kernel.
 ## Status
 Type            | Service               | Status
 ---             | ---                   | ---
+CI (Linux)      | GitHub                | [![Build Status](https://github.com/lxc/lxc/actions/workflows/build.yml/badge.svg)](https://github.com/lxc/lxc/actions)
 CI (Linux)      | Jenkins               | [![Build Status](https://jenkins.linuxcontainers.org/job/lxc-github-commit/badge/icon)](https://jenkins.linuxcontainers.org/job/lxc-github-commit/)
-CI (Linux)      | Travis                | [![Build Status](https://travis-ci.org/lxc/lxc.svg?branch=master)](https://travis-ci.org/lxc/lxc/)
 Project status  | CII Best Practices    | [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1087/badge)](https://bestpractices.coreinfrastructure.org/projects/1087)
 Code Quality    | LGTM                  | [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/lxc/lxc.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/lxc/lxc/context:cpp)
 Fuzzing         | OSS-Fuzz              | [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/lxc.svg)](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#lxc)

--- a/configure.ac
+++ b/configure.ac
@@ -452,17 +452,24 @@ AC_ARG_ENABLE([static-binaries],
 	[enable_static_binaries=$enableval], [enable_static_binaries=no])
 AM_CONDITIONAL([ENABLE_STATIC_BINARIES], [test "x$enable_static_binaries" = "xyes"])
 
-# Build with ASAN commands
-AC_ARG_ENABLE([asan],
-	[AS_HELP_STRING([--enable-asan], [build with address sanitizer enabled [default=no]])],
-	[enable_asan=$enableval], [enable_asan=no])
-AM_CONDITIONAL([ENABLE_ASAN], [test "x$enable_asan" = "xyes"])
+AC_ARG_ENABLE([sanitizers],
+	[AS_HELP_STRING([--enable-sanitizers], [build with sanitizers enabled [default=no]])],
+	[enable_sanitizers=$enableval], [enable_sanitizers=no])
+AM_CONDITIONAL([ENABLE_SANITIZERS], [test "x$enable_sanitizers" = "xyes"])
+if test "x$enable_sanitizers" = "xyes"; then
+	AC_DEFINE([ENABLE_SANITIZERS], 1, [build with sanitizers enabled])
 
-# Build with UBSAN commands
-AC_ARG_ENABLE([ubsan],
-	[AS_HELP_STRING([--enable-ubsan], [build with ubsan sanitizer enabled [default=no]])],
-	[enable_asan=$enableval], [enable_ubsan=no])
-AM_CONDITIONAL([ENABLE_UBSAN], [test "x$enable_ubsan" = "xyes"])
+	CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[ \
+		-fsanitize=address \
+		-fsanitize=undefined \
+		-fsanitize=memory \
+		-fno-omit-frame-pointer])
+	AC_SUBST(AM_CFLAGS)
+
+	AC_MSG_RESULT([yes])
+else
+	AC_MSG_RESULT([no])
+fi
 
 # Optional test binaries
 AC_ARG_ENABLE([tests],
@@ -1104,7 +1111,7 @@ Documentation:
  - user documentation: $enable_doc
 
 Debugging:
- - ASAN: $enable_asan
+ - Sanitizers: $enable_sanitizers
  - Coverity: $enable_coverity_build
  - mutex debugging: $enable_mutex_debugging
  - tests: $enable_tests

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -260,14 +260,6 @@ liblxc_la_CFLAGS = -fPIC \
 		   $(AM_CFLAGS) \
 		   $(LIBLXC_SANITIZER) \
 		   -pthread
-if ENABLE_ASAN
-liblxc_la_CFLAGS += -fsanitize=address \
-		    -fno-omit-frame-pointer
-endif
-
-if ENABLE_UBSAN
-liblxc_la_CFLAGS += -fsanitize=undefined
-endif
 
 liblxc_la_LDFLAGS = -pthread \
 		    -Wl,-no-undefined \


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>