### PR TITLE
oss-fuzz.sh: put the "lxc.net" keys to the seed corpus as well

### DIFF
--- a/src/tests/oss-fuzz.sh
+++ b/src/tests/oss-fuzz.sh
@@ -49,6 +49,10 @@ make -j$(nproc)
 $CC -c -o fuzz-lxc-config-read.o $CFLAGS -Isrc -Isrc/lxc src/tests/fuzz-lxc-config-read.c
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzz-lxc-config-read.o src/lxc/.libs/liblxc.a -o $OUT/fuzz-lxc-config-read
 
-perl -lne 'if (/config_jump_table\[\]\s*=/../^}/) { /"([^"]+)"/ && print "$1=" }' src/lxc/confile.c >doc/examples/all-keys.conf
-[[ -s doc/examples/all-keys.conf ]]
+perl -lne 'if (/config_jump_table\[\]\s*=/../^}/) { /"([^"]+)"/ && print "$1=" }' src/lxc/confile.c >doc/examples/keys.conf
+[[ -s doc/examples/keys.conf ]]
+
+perl -lne 'if (/config_jump_table_net\[\]\s*=/../^}/) { /"([^"]+)"/ && print "lxc.net.$1=" }' src/lxc/confile.c >doc/examples/lxc-net-keys.conf
+[[ -s doc/examples/lxc-net-keys.conf ]]
+
 zip -r $OUT/fuzz-lxc-config-read_seed_corpus.zip doc/examples


### PR DESCRIPTION
It's just a follow-up to 0abcc213e2291d71 (where the "lxc.net" keys
were moved from config_jump_table to config_jump_table_net)