### PR TITLE
oss-fuzz: reject giant configs early

### DIFF
--- a/src/tests/fuzz-lxc-config-read.c
+++ b/src/tests/fuzz-lxc-config-read.c
@@ -13,6 +13,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	char tmpf[] = "/tmp/fuzz-lxc-config-read-XXXXXX";
 	struct lxc_conf *conf = NULL;
 
+	/*
+	 * 100Kb should probably be enough to trigger all the issues
+	 * we're interested in without any timeouts
+	 */
+	if (size > 102400)
+		return 0;
+
 	fd = lxc_make_tmpfile(tmpf, false);
 	lxc_test_assert_abort(fd >= 0);
 	lxc_write_nointr(fd, data, size);


### PR DESCRIPTION
It should help the fuzzer to avoid running into timeouts
like https://oss-fuzz.com/testcase-detail/5132999948632064.
Hopefully, once this is merged OSS-Fuzz will report only
infinite loops as timeouts.

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>