### PR TITLE
conf: fix setups where /dev is outside of LXC's control

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3457,12 +3457,6 @@ int lxc_setup(struct lxc_handler *handler)
 			return log_error(-1, "Failed to mount \"/dev\"");
 	}
 
-	lxc_conf->rootfs.dfd_dev = open_at(lxc_conf->rootfs.dfd_mnt, "dev",
-					        PROTECT_OPATH_DIRECTORY,
-						PROTECT_LOOKUP_BENEATH_XDEV, 0);
-	if (lxc_conf->rootfs.dfd_dev < 0 && errno != ENOENT)
-		return log_error_errno(-errno, errno, "Failed to open \"/dev\"");
-
 	/* Do automatic mounts (mainly /proc and /sys), but exclude those that
 	 * need to wait until other stuff has finished.
 	 */
@@ -3480,6 +3474,11 @@ int lxc_setup(struct lxc_handler *handler)
 		if (ret < 0)
 			return log_error(-1, "Failed to setup mount entries");
 	}
+
+	lxc_conf->rootfs.dfd_dev = open_at(lxc_conf->rootfs.dfd_mnt, "dev",
+					   PROTECT_OPATH_DIRECTORY, PROTECT_LOOKUP_BENEATH_XDEV, 0);
+	if (lxc_conf->rootfs.dfd_dev < 0 && errno != ENOENT)
+		return log_error_errno(-errno, errno, "Failed to open \"/dev\"");
 
 	if (lxc_conf->is_execute) {
 		if (execveat_supported()) {

--- a/src/lxc/log.h
+++ b/src/lxc/log.h
@@ -565,7 +565,7 @@ __lxc_unused static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 #define syserror(format, ...)                    \
 	({                                       \
 		SYSERROR(format, ##__VA_ARGS__); \
-		(-errno);                        \
+		(-labs(errno));                  \
 	})
 
 #define syserror_set(__ret__, format, ...)                    \
@@ -586,7 +586,7 @@ __lxc_unused static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 #define syswarn(format, ...)                    \
 	({                                      \
 		SYSWARN(format, ##__VA_ARGS__); \
-		(-errno);                       \
+		(-labs(errno));                 \
 	})
 
 #define syswarn_set(__ret__, format, ...)                     \
@@ -605,16 +605,16 @@ __lxc_unused static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 	})
 
 #define sysinfo(format, ...)                    \
-	({                                       \
+	({                                      \
 		SYSINFO(format, ##__VA_ARGS__); \
-		(-errno);                        \
+		(-labs(errno));                 \
 	})
 
-#define sysinfo_set(__ret__, format, ...)                    \
+#define sysinfo_set(__ret__, format, ...)                     \
 	({                                                    \
 		typeof(__ret__) __internal_ret__ = (__ret__); \
 		errno = labs(__ret__);                        \
-		SYSINFO(format, ##__VA_ARGS__);              \
+		SYSINFO(format, ##__VA_ARGS__);               \
 		__internal_ret__;                             \
 	})
 
@@ -628,7 +628,7 @@ __lxc_unused static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 #define sysdebug(format, ...)                    \
 	({                                       \
 		SYSDEBUG(format, ##__VA_ARGS__); \
-		(-errno);                        \
+		(-labs(errno));                  \
 	})
 
 #define sysdebug_set(__ret__, format, ...)                    \
@@ -649,7 +649,7 @@ __lxc_unused static inline void LXC_##LEVEL(struct lxc_log_locinfo* locinfo,	\
 #define systrace(format, ...)                    \
 	({                                       \
 		SYSTRACE(format, ##__VA_ARGS__); \
-		(-errno);                        \
+		(-labs(errno));                  \
 	})
 
 #define systrace_set(__ret__, format, ...)                    \


### PR DESCRIPTION
Fixes: #3770
Suggested-by: Ruben Jenster <r.jenster@drachenfels.de>
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>