### PR TITLE
templates/*.in: fixed PATH handling with spaces

### DIFF
--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -26,7 +26,7 @@ LXC_MAPPED_GID=
 BUSYBOX_EXE=`which busybox`
 
 # Make sure the usual locations are in PATH
-export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH="$PATH:/usr/sbin:/usr/bin:/sbin:/bin"
 
 in_userns() {
   [ -e /proc/self/uid_map ] || { echo no; return; }

--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -66,7 +66,7 @@ if [ -z "${DOWNLOAD_KEYSERVER:-}" ]; then
 fi
 
 # Make sure the usual locations are in PATH
-export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH="$PATH:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Some useful functions
 cleanup() {

--- a/templates/lxc-local.in
+++ b/templates/lxc-local.in
@@ -33,7 +33,7 @@ MODE="system"
 COMPAT_LEVEL=5
 
 # Make sure the usual locations are in PATH
-export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH="$PATH:/usr/sbin:/usr/bin:/sbin:/bin"
 
 in_userns() {
   [ -e /proc/self/uid_map ] || { echo no; return; }

--- a/templates/lxc-oci.in
+++ b/templates/lxc-oci.in
@@ -23,7 +23,7 @@
 set -eu
 
 # Make sure the usual locations are in PATH
-export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH="$PATH:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Check for required binaries
 for bin in skopeo umoci jq; do


### PR DESCRIPTION
if $PATH already contains a path with a space the append of the
default directories in all template scripts fails with an error
like the following:

/usr/share/lxc/templates/lxc-download: 69: export: (x86)/NVIDIA: bad
variable name