### PR TITLE
confile: make lxc_get_config() and lxc_get_config_net() always return…

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -1005,9 +1005,6 @@ static int lxc_cmd_get_config_item_callback(int fd, struct lxc_cmd_req *req,
 
 	memset(&rsp, 0, sizeof(rsp));
 	item = lxc_get_config(req->data);
-	if (!item)
-		goto err1;
-
 	cilen = item->get(req->data, NULL, 0, handler->conf, NULL);
 	if (cilen <= 0)
 		goto err1;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -82,6 +82,7 @@ lxc_config_define(console_logfile);
 lxc_config_define(console_path);
 lxc_config_define(console_rotate);
 lxc_config_define(console_size);
+lxc_config_define(unsupported_key);
 lxc_config_define(environment);
 lxc_config_define(ephemeral);
 lxc_config_define(execute_cmd);
@@ -157,6 +158,24 @@ lxc_config_define(tty_dir);
 lxc_config_define(uts_name);
 lxc_config_define(sysctl);
 lxc_config_define(proc);
+
+static int set_config_unsupported_key(const char *key, const char *value,
+				      struct lxc_conf *lxc_conf, void *data)
+{
+	return syserror_set(-EINVAL, "Unsupported config key \"%s\"", key);
+}
+
+static int get_config_unsupported_key(const char *key, char *retv, int inlen,
+				      struct lxc_conf *c, void *data)
+{
+	return syserror_set(-EINVAL, "Unsupported config key \"%s\"", key);
+}
+
+static int clr_config_unsupported_key(const char *key,
+				      struct lxc_conf *lxc_conf, void *data)
+{
+	return syserror_set(-EINVAL, "Unsupported config key \"%s\"", key);
+}
 
 /*
  * Important Note:
@@ -257,6 +276,14 @@ static struct lxc_config_t config_jump_table[] = {
 	{ "lxc.proc",                       false, set_config_proc,                       get_config_proc,                       clr_config_proc,                       },
 };
 
+static struct lxc_config_t unsupported_config_key = {
+	NULL,
+	false,
+	set_config_unsupported_key,
+	get_config_unsupported_key,
+	clr_config_unsupported_key,
+};
+
 struct lxc_config_net_t {
 	LXC_CONFIG_MEMBERS;
 };
@@ -287,6 +314,14 @@ static struct lxc_config_net_t config_jump_table_net[] = {
 	{ "veth.ipv6.route",        true,  set_config_net_veth_ipv6_route,        get_config_net_veth_ipv6_route,        clr_config_net_veth_ipv6_route,        },
 	{ "veth.vlan.id",           true,  set_config_net_veth_vlan_id,           get_config_net_veth_vlan_id,           clr_config_net_veth_vlan_id,           },
 	{ "veth.vlan.tagged.id",    true,  set_config_net_veth_vlan_tagged_id,    get_config_net_veth_vlan_tagged_id,    clr_config_net_veth_vlan_tagged_id,    },
+};
+
+static struct lxc_config_net_t unsupported_config_net_key = {
+	NULL,
+	false,
+	set_config_unsupported_key,
+	get_config_unsupported_key,
+	clr_config_unsupported_key,
 };
 
 struct lxc_config_t *lxc_get_config_exact(const char *key)
@@ -327,13 +362,13 @@ struct lxc_config_t *lxc_get_config(const char *key)
 		case 0:
 			continue;
 		case -E2BIG:
-			return NULL;
+			return &unsupported_config_key;
 		}
 
 		return cur;
 	}
 
-	return NULL;
+	return &unsupported_config_key;
 }
 
 static inline bool match_config_net_item(const struct lxc_config_net_t *entry,
@@ -355,7 +390,7 @@ static struct lxc_config_net_t *lxc_get_config_net(const char *key)
 		return cur;
 	}
 
-	return NULL;
+	return &unsupported_config_net_key;
 }
 
 static int set_config_net(const char *key, const char *value,
@@ -3037,9 +3072,6 @@ static int parse_line(char *buffer, void *data)
 	}
 
 	config = lxc_get_config(key);
-	if (!config)
-		return log_error_errno(-EINVAL, EINVAL, "Unknown configuration key \"%s\"", key);
-
 	return config->set(key, value, plc->conf, NULL);
 }
 
@@ -5363,7 +5395,7 @@ static int get_network_config_ops(const char *key, struct lxc_conf *lxc_conf,
 
 	/* lxc.net.<idx>.<subkey> */
 	info->ops = lxc_get_config_net(info->subkey);
-	if (!info->ops)
+	if (info->ops == &unsupported_config_net_key)
 		return syserror_set(-ENOENT, "Unknown network configuration key \"%s\"", key);
 
 	return 0;

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2230,12 +2230,8 @@ static bool do_lxcapi_clear_config_item(struct lxc_container *c,
 		return false;
 
 	config = lxc_get_config(key);
-	/* Verify that the config key exists and that it has a callback
-	 * implemented.
-	 */
-	if (config && config->clr)
-		ret = config->clr(key, c->lxc_conf, NULL);
 
+	ret = config->clr(key, c->lxc_conf, NULL);
 	if (!ret)
 		do_clear_unexp_config_line(c->lxc_conf, key);
 
@@ -2571,11 +2567,8 @@ static int do_lxcapi_get_config_item(struct lxc_container *c, const char *key, c
 		return -1;
 
 	config = lxc_get_config(key);
-	/* Verify that the config key exists and that it has a callback
-	 * implemented.
-	 */
-	if (config && config->get)
-		ret = config->get(key, retv, inlen, c->lxc_conf, NULL);
+
+	ret = config->get(key, retv, inlen, c->lxc_conf, NULL);
 
 	container_mem_unlock(c);
 	return ret;
@@ -3138,8 +3131,6 @@ int lxc_set_config_item_locked(struct lxc_conf *conf, const char *key,
 	bool bret = true;
 
 	config = lxc_get_config(key);
-	if (!config)
-		return -EINVAL;
 
 	ret = config->set(key, v, conf, NULL);
 	if (ret < 0)


### PR DESCRIPTION
… non-NULL

Introduce the concept of an unsupported config item.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>