### PR TITLE
tests: fix a memory leak in cgpath

### DIFF
--- a/src/tests/cgpath.c
+++ b/src/tests/cgpath.c
@@ -60,7 +60,7 @@ static int test_running_container(const char *lxcpath, const char *name)
 	char *cgrelpath;
 	char  relpath[PATH_MAX+1];
 	char  value[NAME_MAX], value_save[NAME_MAX];
-	struct cgroup_ops *cgroup_ops;
+	call_cleaner(cgroup_exit) struct cgroup_ops *cgroup_ops = NULL;
 
 	(void)strlcpy(template, P_tmpdir"/attach_XXXXXX", sizeof(template));
 


### PR DESCRIPTION
```
$ sudo ./src/tests/lxc-test-cgpath
Container creation tests...Passed
Container creation with LXCPATH tests...Passed

=================================================================
==57206==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 296 byte(s) in 1 object(s) allocated from:
    #0 0x7fef22c27dc6 in calloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10ddc6)
    #1 0x557c6e3ce3d9 in cgroup_ops_init cgroups/cgfsng.c:3347
    #2 0x557c6e3d6516 in cgroup_init cgroups/cgroup.c:33
    #3 0x557c6e3788e2 in test_running_container /home/vagrant/lxc/src/tests/cgpath.c:102
    #4 0x557c6e379c69 in test_container /home/vagrant/lxc/src/tests/cgpath.c:197
    #5 0x557c6e379e37 in main /home/vagrant/lxc/src/tests/cgpath.c:233
    #6 0x7fef2136c0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

Direct leak of 296 byte(s) in 1 object(s) allocated from:
    #0 0x7fef22c27dc6 in calloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10ddc6)
    #1 0x557c6e3ce3d9 in cgroup_ops_init cgroups/cgfsng.c:3347
    #2 0x557c6e3d6516 in cgroup_init cgroups/cgroup.c:33
    #3 0x557c6e3788e2 in test_running_container /home/vagrant/lxc/src/tests/cgpath.c:102
    #4 0x557c6e379c69 in test_container /home/vagrant/lxc/src/tests/cgpath.c:197
    #5 0x557c6e379e61 in main /home/vagrant/lxc/src/tests/cgpath.c:237
    #6 0x7fef2136c0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
```

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>