### PR TITLE
tests: fix a memory leak in lxcpath

### DIFF
--- a/src/tests/lxcpath.c
+++ b/src/tests/lxcpath.c
@@ -27,6 +27,8 @@
 #include <string.h>
 #include <errno.h>
 
+#include "memory_utils.h"
+
 #define MYNAME "lxctest1"
 
 #define TSTERR(x) do { \
@@ -36,7 +38,8 @@
 int main(int argc, char *argv[])
 {
 	struct lxc_container *c;
-	const char *p1, *p2;
+	const char *p1;
+	__do_free char *p2 = NULL;
 	int retval = -1;
 
 	c = lxc_container_new(MYNAME, NULL);
@@ -60,6 +63,7 @@ int main(int argc, char *argv[])
 	}
 
 	p1 = c->get_config_path(c);
+	free(p2);
 	p2 = c->config_file_name(c);
 	if (strcmp(p1, CPATH) || strcmp(p2, FPATH)) {
 		TSTERR("Bad result for path names after set_config_path()");
@@ -74,6 +78,7 @@ int main(int argc, char *argv[])
 	}
 
 	p1 = c->get_config_path(c);
+	free(p2);
 	p2 = c->config_file_name(c);
 	if (strcmp(p1, CPATH) || strcmp(p2, FPATH)) {
 		TSTERR("Bad result for path names after create with custom path");


### PR DESCRIPTION
```
$ sudo ./src/tests/lxc-test-lxcpath

=================================================================
==95911==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 39 byte(s) in 1 object(s) allocated from:
    #0 0x7effafc8d3dd in strdup (/lib/x86_64-linux-gnu/libasan.so.5+0x963dd)
    #1 0x7effaf5a2de6 in lxcapi_config_file_name /home/vagrant/lxc/src/lxc/lxccontainer.c:3190
    #2 0x562961680c30 in main /home/vagrant/lxc/src/tests/lxcpath.c:49
    #3 0x7effae5150b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

Direct leak of 21 byte(s) in 1 object(s) allocated from:
    #0 0x7effafc8d3dd in strdup (/lib/x86_64-linux-gnu/libasan.so.5+0x963dd)
    #1 0x7effaf5a2de6 in lxcapi_config_file_name /home/vagrant/lxc/src/lxc/lxccontainer.c:3190
    #2 0x56296168115e in main /home/vagrant/lxc/src/tests/lxcpath.c:77
    #3 0x7effae5150b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

Direct leak of 21 byte(s) in 1 object(s) allocated from:
    #0 0x7effafc8d3dd in strdup (/lib/x86_64-linux-gnu/libasan.so.5+0x963dd)
    #1 0x7effaf5a2de6 in lxcapi_config_file_name /home/vagrant/lxc/src/lxc/lxccontainer.c:3190
    #2 0x562961680f0a in main /home/vagrant/lxc/src/tests/lxcpath.c:63
    #3 0x7effae5150b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

SUMMARY: AddressSanitizer: 81 byte(s) leaked in 3 allocation(s).
```

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>