### PR TITLE
tests: fix a memory leak in cgpath

### DIFF
--- a/src/tests/cgpath.c
+++ b/src/tests/cgpath.c
@@ -180,6 +180,7 @@ static int test_container(const char *lxcpath, const char *name,
 	if (c->is_defined(c)) {
 		c->stop(c);
 		c->destroy(c);
+		lxc_container_put(c);
 		c = lxc_container_new(name, lxcpath);
 	}
 	c->set_config_item(c, "lxc.net.0.type", "empty");


### PR DESCRIPTION
```
==131188==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 568 byte(s) in 1 object(s) allocated from:
    #0 0x7f8918943bc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
    #1 0x7f89181ee5a3 in lxc_container_new /home/vagrant/lxc/src/lxc/lxccontainer.c:5264
    #2 0x55ffc5022869 in test_container /home/vagrant/lxc/src/tests/cgpath.c:176
    #3 0x55ffc5023023 in main /home/vagrant/lxc/src/tests/cgpath.c:233
    #4 0x7f891709e0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
```

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>