### PR TITLE
tests: switch to the "busybox" template in lxc-test-checkpoint-restore

### DIFF
--- a/src/tests/lxc-test-checkpoint-restore
+++ b/src/tests/lxc-test-checkpoint-restore
@@ -27,7 +27,7 @@ if verlte "$criu_version" "1.3.1"; then
 fi
 
 name=lxc-test-criu
-lxc-create -t ubuntu -n $name || FAIL "creating container"
+lxc-create -t busybox -n $name || FAIL "creating container"
 
 cat >> "$(lxc-config lxc.lxcpath)/$name/config" <<EOF
 # hax for criu


### PR DESCRIPTION
criu can't seem to dump systemd-logind used in Ubuntu due to what appears to be
checkpoint-restore/criu#1430.
Let's switch to busybox where all the processes hopefully can be dumped.

Closes https://github.com/lxc/lxc/issues/3792

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>