### PR TITLE
apparmor: turn bytes into null-terminated strings before calling strcspn

### DIFF
--- a/src/lxc/lsm/apparmor.c
+++ b/src/lxc/lsm/apparmor.c
@@ -431,6 +431,7 @@ error:
 static char *apparmor_process_label_get(struct lsm_ops *ops, pid_t pid)
 {
 	__do_close int fd_label = -EBADF;
+	__do_free char *buf = NULL;
 	__do_free char *label = NULL;
 	int ret;
 	size_t len;
@@ -439,12 +440,18 @@ static char *apparmor_process_label_get(struct lsm_ops *ops, pid_t pid)
 	if (fd_label < 0)
 		return NULL;
 
-	ret = fd_to_buf(fd_label, &label, &len);
+	ret = fd_to_buf(fd_label, &buf, &len);
 	if (ret < 0)
 		return NULL;
 
 	if (len == 0)
 		return NULL;
+
+	label = malloc(len + 1);
+	if (!label)
+		return NULL;
+	memcpy(label, buf, len);
+	label[len] = '\0';
 
 	len = strcspn(label, "\n \t");
 	if (len)


### PR DESCRIPTION
It's extracted from https://github.com/lxc/lxc/pull/3787

```
==70349==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020000009fb at pc 0x000000433b70 bp 0x7ffcde087810 sp 0x7ffcde086fd0
READ of size 12 at 0x6020000009fb thread T0
    #0 0x433b6f in strcspn (/usr/bin/lxc-execute+0x433b6f)
    #1 0x7f720413a5cb in apparmor_process_label_get /home/runner/work/lxc/lxc/src/lxc/lsm/apparmor.c:449:8
    #2 0x7f720413bc2a in apparmor_prepare /home/runner/work/lxc/lxc/src/lxc/lsm/apparmor.c:1104:13
    #3 0x7f720409b6e9 in lxc_init /home/runner/work/lxc/lxc/src/lxc/start.c:848:8
    #4 0x7f72040a395a in __lxc_start /home/runner/work/lxc/lxc/src/lxc/start.c:2009:8
    #5 0x7f7203fc7186 in lxc_execute /home/runner/work/lxc/lxc/src/lxc/execute.c:99:9
    #6 0x7f7204000e44 in do_lxcapi_start /home/runner/work/lxc/lxc/src/lxc/lxccontainer.c:1112:9
    #7 0x7f7203ff0c07 in lxcapi_start /home/runner/work/lxc/lxc/src/lxc/lxccontainer.c:1149:8
    #8 0x4c6912 in main /home/runner/work/lxc/lxc/src/lxc/tools/lxc_execute.c:224:9
    #9 0x7f72034ac0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #10 0x41d93d in _start (/usr/bin/lxc-execute+0x41d93d)
+ echo ---

0x6020000009fb is located 0 bytes to the right of 11-byte region [0x6020000009f0,0x6020000009fb)
allocated by thread T0 here:
    #0 0x496399 in realloc (/usr/bin/lxc-execute+0x496399)
    #1 0x7f7203fcf85c in fd_to_buf /home/runner/work/lxc/lxc/src/lxc/file_utils.c:463:10
    #2 0x7f720413a52b in apparmor_process_label_get /home/runner/work/lxc/lxc/src/lxc/lsm/apparmor.c:442:8
    #3 0x7f720413bc2a in apparmor_prepare /home/runner/work/lxc/lxc/src/lxc/lsm/apparmor.c:1104:13
    #4 0x7f720409b6e9 in lxc_init /home/runner/work/lxc/lxc/src/lxc/start.c:848:8
    #5 0x7f72040a395a in __lxc_start /home/runner/work/lxc/lxc/src/lxc/start.c:2009:8
    #6 0x7f7203fc7186 in lxc_execute /home/runner/work/lxc/lxc/src/lxc/execute.c:99:9
    #7 0x7f7204000e44 in do_lxcapi_start /home/runner/work/lxc/lxc/src/lxc/lxccontainer.c:1112:9
    #8 0x7f7203ff0c07 in lxcapi_start /home/runner/work/lxc/lxc/src/lxc/lxccontainer.c:1149:8
    #9 0x4c6912 in main /home/runner/work/lxc/lxc/src/lxc/tools/lxc_execute.c:224:9
```

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>