### PR TITLE
ci: make use of --enable-sanitizers instead of CFLAGS

### DIFF
--- a/.github/workflows/sanitizers.sh
+++ b/.github/workflows/sanitizers.sh
@@ -31,7 +31,7 @@ if [[ "$CC" == "gcc" ]]; then
 fi
 
 ./autogen.sh
-CFLAGS="-Wall -Werror -fsanitize=address,undefined" ./configure --enable-tests --prefix=/usr/ --sysconfdir=/etc/ --localstatedir=/var/ --disable-no-undefined
+CFLAGS="-Wall -Werror" ./configure --enable-sanitizers --enable-tests --prefix=/usr/ --sysconfdir=/etc/ --localstatedir=/var/ --disable-no-undefined
 make
 make install
 

--- a/.github/workflows/sanitizers.sh
+++ b/.github/workflows/sanitizers.sh
@@ -20,16 +20,6 @@ apt-get install --yes --no-install-recommends \
     python3-setuptools rsync squashfs-tools uidmap unzip uuid-runtime \
     wget xz-utils
 
-# init.lxc.static is run in arbitrary containers where the libasan library lxc has been built with
-# isn't always installed. To make it work let's override GCC's default and link both libasan
-# and libubsan statically. It should help to fix issues like
-# ...
-# ++ lxc-execute -n c1 -- sudo -u ubuntu /nnptest
-# lxc-init: error while loading shared libraries: libasan.so.5: cannot open shared object file: No such file or directory
-if [[ "$CC" == "gcc" ]]; then
-    sed -i '/init_lxc_static_LDFLAGS/s/$/ -static-libasan -static-libubsan/' src/lxc/Makefile.am
-fi
-
 ./autogen.sh
 CFLAGS="-Wall -Werror" ./configure --enable-sanitizers --enable-tests --prefix=/usr/ --sysconfdir=/etc/ --localstatedir=/var/ --disable-no-undefined
 make

--- a/config/attributes.m4
+++ b/config/attributes.m4
@@ -70,7 +70,7 @@ AC_DEFUN([CC_CHECK_LDFLAGS], [
     AS_TR_SH([cc_cv_ldflags_$1]),
     [ac_save_LDFLAGS="$LDFLAGS"
      LDFLAGS="$LDFLAGS $1"
-     AC_LINK_IFELSE([int main() { return 1; }],
+     AC_LINK_IFELSE([AC_LANG_SOURCE([int main() { return 1; }])],
        [eval "AS_TR_SH([cc_cv_ldflags_$1])='yes'"],
        [eval "AS_TR_SH([cc_cv_ldflags_$1])="])
      LDFLAGS="$ac_save_LDFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -471,11 +471,6 @@ if test "x$enable_sanitizers" = "xyes"; then
 		-fno-omit-frame-pointer])
 	AC_SUBST(AM_CFLAGS)
 
-	CC_CHECK_FLAGS_APPEND([AM_LDFLAGS],[LDFLAGS],[ \
-		-fsanitize=address])
-
-	AC_SUBST(AM_LDFLAGS)
-
 	AC_MSG_RESULT([yes])
 else
 	AC_MSG_RESULT([no])

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -1827,6 +1827,9 @@ endif
 init_lxc_static_LDFLAGS = -all-static -pthread
 init_lxc_static_LDADD = @CAP_LIBS@
 init_lxc_static_CFLAGS = $(AM_CFLAGS) -DNO_LXC_CONF
+if ENABLE_SANITIZERS
+init_lxc_static_CFLAGS += -fno-sanitize=address,undefined
+endif
 endif
 endif
 


### PR DESCRIPTION
Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>