### PR TITLE
getsubopt: use correct include

### DIFF
--- a/src/lxc/tools/include/getsubopt.c
+++ b/src/lxc/tools/include/getsubopt.c
@@ -7,7 +7,7 @@
 #include "config.h"
 
 #ifndef HAVE_STRCHRNUL
-#include "include/strchrnul"
+#include "../../../include/strchrnul.h"
 #endif
 
 /* Parse comma separated suboption from *OPTIONP and match against


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>