### PR TITLE
Fix regressions in dir_mount

### DIFF
--- a/src/lxc/storage/dir.c
+++ b/src/lxc/storage/dir.c
@@ -180,14 +180,14 @@ int dir_mount(struct lxc_storage *bdev)
 			ret = mount(src, bdev->dest, "bind", mflags, mntdata);
 			if (ret < 0)
 				return log_error_errno(-errno, errno, "Failed to remount \"%s\" on \"%s\" read-only with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
-						       src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, mnt_opts->prop_flags);
+						       src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata ? mntdata : "(none)" , mflags, mnt_opts->prop_flags);
 			else
 				DEBUG("Remounted \"%s\" on \"%s\" read-only with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
-				      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, mnt_opts->prop_flags);
+				      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata ? mntdata : "(none)", mflags, mnt_opts->prop_flags);
 		}
 
 		TRACE("Mounted \"%s\" on \"%s\" with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
-		      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, mnt_opts->prop_flags);
+		      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata ? mntdata : "(none)", mflags, mnt_opts->prop_flags);
 	}
 
 	TRACE("Mounted \"%s\" onto \"%s\"", src, bdev->dest);

--- a/src/lxc/storage/dir.c
+++ b/src/lxc/storage/dir.c
@@ -175,19 +175,19 @@ int dir_mount(struct lxc_storage *bdev)
 			return log_error_errno(-errno, errno, "Failed to mount \"%s\" on \"%s\"", src, bdev->dest);
 
 		if (ret == 0 && (mnt_opts->mnt_flags & MS_RDONLY)) {
-			mflags = add_required_remount_flags(src, bdev->dest, MS_BIND | MS_REC | mnt_opts->mnt_flags | mnt_opts->mnt_flags | MS_REMOUNT);
+			mflags = add_required_remount_flags(src, bdev->dest, MS_BIND | MS_REC | mnt_opts->mnt_flags | mnt_opts->prop_flags | MS_REMOUNT);
 
 			ret = mount(src, bdev->dest, "bind", mflags, mntdata);
 			if (ret < 0)
 				return log_error_errno(-errno, errno, "Failed to remount \"%s\" on \"%s\" read-only with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
-						       src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, mnt_opts->mnt_flags);
+						       src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, mnt_opts->prop_flags);
 			else
 				DEBUG("Remounted \"%s\" on \"%s\" read-only with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
-				      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, mnt_opts->mnt_flags);
+				      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, mnt_opts->prop_flags);
 		}
 
 		TRACE("Mounted \"%s\" on \"%s\" with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
-		      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, mnt_opts->mnt_flags);
+		      src ? src : "(none)", bdev->dest ? bdev->dest : "(none)", mntdata, mflags, mnt_opts->prop_flags);
 	}
 
 	TRACE("Mounted \"%s\" onto \"%s\"", src, bdev->dest);


### PR DESCRIPTION
Hi @brauner,

I noticed that lxc master doesn't compile when building the image for lxcri.
The relevant changes were introduced in 423374e95314ceac9a6d5e1ddaaa1c438de85056
It seems to me that by accident mount options were used in place of the propagation flags.
This pull request should fix both.

```
rage/dir.c  -fPIC -DPIC -o storage/.libs/liblxc_la-dir.o
In file included from storage/dir.c:11:
storage/dir.c: In function 'dir_mount':
./log.h:358:2: error: '%s' directive argument is null [-Werror=format-overflow=]
  358 |  LXC_DEBUG(&locinfo, format, ##__VA_ARGS__);   \
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
storage/dir.c:185:5: note: in expansion of macro 'DEBUG'
  185 |     DEBUG("Remounted \"%s\" on \"%s\" read-only with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
      |     ^~~~~
storage/dir.c:185:64: note: format string is defined here
  185 |     DEBUG("Remounted \"%s\" on \"%s\" read-only with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
      |                                                                ^~
In file included from storage/dir.c:11:
./log.h:353:2: error: '%s' directive argument is null [-Werror=format-overflow=]
  353 |  LXC_TRACE(&locinfo, format, ##__VA_ARGS__);   \
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
storage/dir.c:189:3: note: in expansion of macro 'TRACE'
  189 |   TRACE("Mounted \"%s\" on \"%s\" with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
      |   ^~~~~
storage/dir.c:189:50: note: format string is defined here
  189 |   TRACE("Mounted \"%s\" on \"%s\" with options \"%s\", mount flags \"%lu\", and propagation flags \"%lu\"",
      |                                                  ^~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:4755: storage/liblxc_la-dir.lo] Error 1
make[2]: Leaving directory '/tmp/lxcri-build/lxc/src/lxc'
make[1]: Leaving directory '/tmp/lxcri-build/lxc/src'
make[1]: *** [Makefile:434: install-recursive] Error 1
make: *** [Makefile:531: install-recursive] Error 1
```