### PR TITLE
oss-fuzz: build the fuzzers without -PIE -pie

### DIFF
--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -797,16 +797,16 @@ LIB_FUZZING_ENGINE ?= -fsanitize=fuzzer
 # https://google.github.io/oss-fuzz/getting-started/new-project-guide/#Requirements
 nodist_EXTRA_fuzz_lxc_config_read_SOURCES = dummy.cxx
 fuzz_lxc_config_read_SOURCES = fuzz-lxc-config-read.c
-fuzz_lxc_config_read_CFLAGS = $(AM_CFLAGS)
-fuzz_lxc_config_read_CXXFLAGS = $(AM_CFLAGS)
-fuzz_lxc_config_read_LDFLAGS = $(AM_LDFLAGS) -static
+fuzz_lxc_config_read_CFLAGS = $(AM_CFLAGS) -fno-PIE
+fuzz_lxc_config_read_CXXFLAGS = $(AM_CFLAGS) -fno-PIE
+fuzz_lxc_config_read_LDFLAGS = $(AM_LDFLAGS) -no-pie -static
 fuzz_lxc_config_read_LDADD = $(LDADD) $(LIB_FUZZING_ENGINE)
 
 nodist_EXTRA_fuzz_lxc_define_load_SOURCES = dummy.cxx
 fuzz_lxc_define_load_SOURCES = fuzz-lxc-define-load.c
-fuzz_lxc_define_load_CFLAGS = $(AM_CFLAGS)
-fuzz_lxc_define_load_CXXFLAGS = $(AM_CFLAGS)
-fuzz_lxc_define_load_LDFLAGS = $(AM_LDFLAGS) -static
+fuzz_lxc_define_load_CFLAGS = $(AM_CFLAGS) -fno-PIE
+fuzz_lxc_define_load_CXXFLAGS = $(AM_CFLAGS) -fno-PIE
+fuzz_lxc_define_load_LDFLAGS = $(AM_LDFLAGS) -no-pie -static
 fuzz_lxc_define_load_LDADD = $(LDADD) $(LIB_FUZZING_ENGINE)
 
 bin_PROGRAMS += fuzz-lxc-config-read \


### PR DESCRIPTION
to make them compatible with non-PIC fuzzing engines
```
Step #32: libtool: link: /src/aflplusplus/afl-clang-fast++ -fPIE -Wvla -std=gnu11 -fms-extensions -fdiagnostics-color -Wcast-align -Wstrict-prototypes -fno-strict-aliasing -fstack-clash-protection -fstack-protector-strong --param=ssp-buffer-size=4 -g -fcf-protection -Werror=implicit-function-declaration -Wmissing-include-dirs -Wold-style-definition -Winit-self -Wfloat-equal -Werror=return-type -Werror=incompatible-pointer-types -Wformat=2 -Wshadow -Wendif-labels -Werror=overflow -fdiagnostics-show-option -Werror=shift-count-overflow -Wdate-time -Wnested-externs -fasynchronous-unwind-tables -pipe -fexceptions -Warray-bounds -DLXCROOTFSMOUNT=\"/usr/local/lib/lxc/rootfs\" -DLXCPATH=\"/usr/local/var/lib/lxc\" -DLXC_GLOBAL_CONF=\"/usr/local/etc/lxc/lxc.conf\" -DLXCINITDIR=\"/usr/local/libexec\" -DLIBEXECDIR=\"/usr/local/libexec\" -DLOGPATH=\"/usr/local/var/log/lxc\" -DLXCTEMPLATEDIR=\"/usr/local/share/lxc/templates\" -DLXC_DEFAULT_CONFIG=\"/usr/local/etc/lxc/default.conf\" -DDEFAULT_CGROUP_PATTERN=\"\" -DRUNTIME_PATH=\"/run\" -DSBINDIR=\"/usr/local/sbin\" -I ../../src -I ../../src/lxc -I ../../src/lxc/cgroups -I ../../src/lxc/tools -I ../../src/lxc/storage -pthread -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -stdlib=libc++ -Wl,--as-needed -Wl,--gc-sections -Wl,-z -Wl,relro -Wl,-z -Wl,now -pie -Wl,-fuse-ld=gold -o fuzz-lxc-define-load fuzz_lxc_define_load-fuzz-lxc-define-load.o  ../lxc/.libs/liblxc.a /usr/lib/libFuzzingEngine.a -lpthread -pthread
Step #32: /usr/bin/ld: /usr/lib/libFuzzingEngine.a(aflpp_driver.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
Step #32: /usr/lib/libFuzzingEngine.a: error adding symbols: Bad value
```

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>