### PR TITLE
oss-fuzz: always turn off logging on OSS-Fuzz

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -488,7 +488,11 @@ if test "x$enable_fuzzers" = "xyes"; then
 	if test "x$LIB_FUZZING_ENGINE" = x; then
 		CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[ \
 			-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION \
+			-DRUN_ON_OSS_FUZZ=0 \
 			-fsanitize=fuzzer-no-link])
+	else
+		CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[ \
+			-DRUN_ON_OSS_FUZZ=1])
 	fi
 else
 	CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[-flto=thin])

--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -508,7 +508,7 @@ static int build_dir(const char *name)
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 		ret = lxc_unpriv(mkdir(n, 0755));
 #else
-		if (is_in_comm("fuzz-lxc-") > 0)
+		if (RUN_ON_OSS_FUZZ || is_in_comm("fuzz-lxc-") > 0)
 			ret = errno = EEXIST;
 		else
 			ret = lxc_unpriv(mkdir(n, 0755));
@@ -529,7 +529,7 @@ static int log_open(const char *name)
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 	fd = lxc_unpriv(open(name, O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, 0660));
 #else
-	if (is_in_comm("fuzz-lxc-") <= 0)
+	if (!RUN_ON_OSS_FUZZ && is_in_comm("fuzz-lxc-") <= 0)
 		fd = lxc_unpriv(open(name, O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, 0660));
 #endif /* !FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
 	if (fd < 0)


### PR DESCRIPTION
Apparently /proc/self/comm can't be used (reliably) on OSS-Fuzz to figure out
whether the code is run inside the fuzz targets, which causes the
fuzz targets to fill the filesystem with log files.

Related: https://github.com/google/oss-fuzz/issues/5509
Should address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33835

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>