### PR TITLE
oss-fuzz: add basic cgroup_init()/cgroup_exit() fuzzing

### DIFF
--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -809,8 +809,16 @@ fuzz_lxc_define_load_CXXFLAGS = $(AM_CFLAGS)
 fuzz_lxc_define_load_LDFLAGS = $(AM_LDFLAGS) -static
 fuzz_lxc_define_load_LDADD = $(LDADD) $(LIB_FUZZING_ENGINE)
 
-bin_PROGRAMS += fuzz-lxc-config-read \
-	        fuzz-lxc-define-load
+nodist_EXTRA_fuzz_lxc_cgroup_init_SOURCES = dummy.cxx
+fuzz_lxc_cgroup_init_SOURCES = fuzz-lxc-cgroup-init.c
+fuzz_lxc_cgroup_init_CFLAGS = $(AM_CFLAGS)
+fuzz_lxc_cgroup_init_CXXFLAGS = $(AM_CFLAGS)
+fuzz_lxc_cgroup_init_LDFLAGS = $(AM_LDFLAGS) -static
+fuzz_lxc_cgroup_init_LDADD = $(LDADD) $(LIB_FUZZING_ENGINE)
+
+bin_PROGRAMS += fuzz-lxc-cgroup-init \
+		fuzz-lxc-config-read \
+		fuzz-lxc-define-load
 
 bin_SCRIPTS += lxc-test-fuzzers
 endif

--- a/src/tests/fuzz-lxc-cgroup-init.c
+++ b/src/tests/fuzz-lxc-cgroup-init.c
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "cgroups/cgroup.h"
+#include "conf.h"
+#include "confile.h"
+#include "lxctest.h"
+#include "utils.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	int fd = -1;
+	char tmpf[] = "/tmp/fuzz-lxc-cgroup-init-XXXXXX";
+	struct lxc_conf *conf = NULL;
+	int ret;
+	struct cgroup_ops *ops;
+
+	/*
+	 * 100Kb should probably be enough to trigger all the issues
+	 * we're interested in without any timeouts
+	 */
+	if (size > 102400)
+		return 0;
+
+	fd = lxc_make_tmpfile(tmpf, false);
+	lxc_test_assert_abort(fd >= 0);
+	lxc_write_nointr(fd, data, size);
+	close(fd);
+
+	conf = lxc_conf_init();
+	lxc_test_assert_abort(conf);
+
+	/* Test cgroup_init() with valid config. */
+	ops = cgroup_init(conf);
+	cgroup_exit(ops);
+
+	ret = lxc_config_read(tmpf, conf, false);
+	if (ret == 0) {
+		/* Test cgroup_init() with likely garbage config. */
+		ops = cgroup_init(conf);
+		cgroup_exit(ops);
+	}
+	lxc_conf_free(conf);
+
+	(void) unlink(tmpf);
+
+	return 0;
+}
+


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>