### PR TITLE
Skip rootfs pinning for ZFS roots.

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -543,16 +543,13 @@ int lxc_rootfs_init(struct lxc_conf *conf, bool userns)
 			return syserror_set(-EINVAL, "Idmapped rootfs currently only supports the \"dir\" storage driver");
 	}
 
-	if (rootfs->bdev_type && strequal(rootfs->bdev_type, "zfs")) {
-		TRACE("Not pinning because container uses ZFS");
-		goto out;
-	}
-
 	if (rootfs->path) {
-		if (rootfs->bdev_type &&
-		    (strequal(rootfs->bdev_type, "overlay") ||
-		     strequal(rootfs->bdev_type, "overlayfs")))
-			return log_trace_errno(0, EINVAL, "Not pinning on stacking filesystem");
+		if (rootfs->bdev_type) {
+			if (strequal(rootfs->bdev_type, "overlay") || strequal(rootfs->bdev_type, "overlayfs"))
+				return log_trace_errno(0, EINVAL, "Not pinning on stacking filesystem");
+			if (strequal(rootfs->bdev_type, "zfs"))
+				return log_trace_errno(0, EINVAL, "Not pinning on ZFS filesystem");
+		}
 
 		dfd_path = open_at(-EBADF, rootfs->path, PROTECT_OPATH_FILE, 0, 0);
 	} else {

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -543,6 +543,11 @@ int lxc_rootfs_init(struct lxc_conf *conf, bool userns)
 			return syserror_set(-EINVAL, "Idmapped rootfs currently only supports the \"dir\" storage driver");
 	}
 
+	if (rootfs->bdev_type && strequal(rootfs->bdev_type, "zfs")) {
+		TRACE("Not pinning because container uses ZFS");
+		goto out;
+	}
+
 	if (rootfs->path) {
 		if (rootfs->bdev_type &&
 		    (strequal(rootfs->bdev_type, "overlay") ||


### PR DESCRIPTION
Hello! This is definitely a drive-by contribution, only tested through to "Works For Me" status, but it fixes a predicament for me. The last couple versions of LXC failed to start my containers, so I pinned to 4.0.6, but was bitten by the bug discussed at https://github.com/lxc/lxc/issues/3828 after upgrading the kernel to 5.12.1, so couldn't start any unprivileged containers that had ZFS roots.

It seems that the recently-rewritten code for rootfs pinning in conf.c (see https://github.com/lxc/lxc/commit/79ff643d24593a1b77bb39233219d55d20efa4bc) is not considering the case of ZFS roots. The old version reads like it would return -2, i.e., "nothing needed to be pinned", for ZFS roots since the paths would fail to canonicalize. In the new version, containers with ZFS roots fail to start with an error that reads `Bad file descriptor - Failed to open "pool/dataset"`.

This commit checks if `rootfs->bdev_type` is ZFS before the path is analyzed and simply does `goto out`, following the pattern established a few lines later. I'm not sure whether it's correct, but it lets me start my containers again on 5.12.1. :)