### PR TITLE
confile: re-add aarch64 architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ src/lxc/cmd/lxc-update-config
 src/tests/lxc-test-device-add-remove
 src/tests/lxc-test-attach
 src/tests/lxc-test-apparmor
+src/tests/lxc-test-arch-parse
 src/tests/lxc-test-cgpath
 src/tests/lxc-test-clonetest
 src/tests/lxc-test-concurrent

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -3230,6 +3230,7 @@ int lxc_config_parse_arch(const char *arch, signed long *persona)
 		{ "ppc",       PER_LINUX32 },
 		{ "powerpc",   PER_LINUX32 },
 		{ "x86",       PER_LINUX32 },
+		{ "aarch64",   PER_LINUX   },
 		{ "amd64",     PER_LINUX   },
 		{ "arm64",     PER_LINUX   },
 		{ "linux64",   PER_LINUX   },

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -19,6 +19,11 @@ if ENABLE_SELINUX
 LSM_SOURCES += ../lxc/lsm/selinux.c
 endif
 
+lxc_test_arch_parse_SOURCES = arch_parse.c \
+			      lxc.h \
+			      lxctest.h \
+			      memory_utils.h
+
 lxc_test_api_reboot_SOURCES = api_reboot.c \
 			      ../lxc/af_unix.c ../lxc/af_unix.h \
 			      ../lxc/caps.c ../lxc/caps.h \
@@ -734,6 +739,7 @@ endif
 
 bin_PROGRAMS = lxc-test-api-reboot \
 	       lxc-test-apparmor \
+	       lxc-test-arch-parse \
 	       lxc-test-attach \
 	       lxc-test-basic \
 	       lxc-test-cgpath \

--- a/src/tests/arch_parse.c
+++ b/src/tests/arch_parse.c
@@ -1,0 +1,72 @@
+/* liblxcapi
+ *
+ * Copyright © 2021 Christian Brauner <christian.brauner@ubuntu.com>.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "lxc/lxccontainer.h"
+
+#include "lxctest.h"
+#include "../lxc/log.h"
+#include "../lxc/lxc.h"
+#include "../lxc/memory_utils.h"
+
+#ifndef HAVE_STRLCPY
+#include "include/strlcpy.h"
+#endif
+
+static const char *const arches[] = {
+    "arm",   "armel",	"armhf",   "armv7l",	"athlon",  "i386",   "i486",
+    "i586",  "i686",	"linux32", "mips",	"mipsel",  "ppc",    "powerpc",
+    "x86",   "aarch64", "amd64",   "arm64",	"linux64", "mips64", "mips64el",
+    "ppc64", "ppc64el", "ppc64le", "powerpc64", "s390x",   "x86_64",
+};
+
+static bool parse_valid_architectures(void)
+{
+	__put_lxc_container struct lxc_container *c = NULL;
+
+	c = lxc_container_new("parse-arch", NULL);
+	if (!c)
+		return test_error_ret(false, "Failed to create container \"parse_arch\"");
+
+	for (size_t i = 0; i < ARRAY_SIZE(arches); i++) {
+		const char *arch = arches[i];
+
+		if (!c->set_config_item(c, "lxc.arch", arch))
+			return test_error_ret(false, "Failed to set \"lxc.arch=%s\"", arch);
+
+		if (!c->clear_config_item(c, "lxc.arch"))
+			return test_error_ret(false, "Failed to clear \"lxc.arch=%s\"", arch);
+	}
+
+	return true;
+}
+
+int main(int argc, char *argv[])
+{
+	if (!parse_valid_architectures())
+		exit(EXIT_FAILURE);
+
+	exit(EXIT_SUCCESS);
+}

--- a/src/tests/lxctest.h
+++ b/src/tests/lxctest.h
@@ -30,7 +30,7 @@
 
 #define lxc_debug_stream(stream, format, ...)                                  \
 	do {                                                                   \
-		fprintf(stream, "%s: %d: %s: " format, __FILE__, __LINE__,     \
+		fprintf(stream, "%s: %d: %s: " format "\n", __FILE__, __LINE__,     \
 			__func__, __VA_ARGS__);                                \
 	} while (false)
 
@@ -47,5 +47,12 @@
 	} while (false)
 
 #define lxc_test_assert_abort(expression) lxc_test_assert_stringify(expression, #expression)
+
+#define test_error_ret(__ret__, format, ...)                  \
+	({                                                    \
+		typeof(__ret__) __internal_ret__ = (__ret__); \
+		fprintf(stderr, format, ##__VA_ARGS__);       \
+		__internal_ret__;                             \
+	})
 
 #endif /* __LXC_TEST_H */


### PR DESCRIPTION
Apparenty we dropped this when we cleaned up architecture handling.

Fixes: #3832
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>