### PR TITLE
cgroups: clean up cgroup_ops on initialization error

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -3342,14 +3342,14 @@ __cgfsng_ops static int cgfsng_data_init(struct cgroup_ops *ops)
 
 struct cgroup_ops *cgroup_ops_init(struct lxc_conf *conf)
 {
-	__do_free struct cgroup_ops *cgfsng_ops = NULL;
+	__cleanup_cgroup_ops struct cgroup_ops *cgfsng_ops = NULL;
 
 	cgfsng_ops = zalloc(sizeof(struct cgroup_ops));
 	if (!cgfsng_ops)
 		return ret_set_errno(NULL, ENOMEM);
 
-	cgfsng_ops->cgroup_layout = CGROUP_LAYOUT_UNKNOWN;
-	cgfsng_ops->dfd_mnt = -EBADF;
+	cgfsng_ops->cgroup_layout	= CGROUP_LAYOUT_UNKNOWN;
+	cgfsng_ops->dfd_mnt		= -EBADF;
 
 	if (initialize_cgroups(cgfsng_ops, conf))
 		return NULL;

--- a/src/lxc/cgroups/cgroup.h
+++ b/src/lxc/cgroups/cgroup.h
@@ -280,6 +280,7 @@ __hidden extern struct cgroup_ops *cgroup_init(struct lxc_conf *conf);
 
 __hidden extern void cgroup_exit(struct cgroup_ops *ops);
 define_cleanup_function(struct cgroup_ops *, cgroup_exit);
+#define __cleanup_cgroup_ops call_cleaner(cgroup_exit)
 
 __hidden extern int cgroup_attach(const struct lxc_conf *conf, const char *name,
 				  const char *lxcpath, pid_t pid);


### PR DESCRIPTION
Fixes: #3836
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>