### PR TITLE
Skip rootfs pinning for read-only file system.

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -573,8 +573,12 @@ int lxc_rootfs_init(struct lxc_conf *conf, bool userns)
 			 PROTECT_OPEN | O_CREAT,
 			 PROTECT_LOOKUP_BENEATH,
 			 S_IWUSR | S_IRUSR);
-	if (fd_pin < 0)
+	if (fd_pin < 0) {
+		if (errno == EROFS) {
+			return log_trace_errno(0, EROFS, "Not pinning on read-only filesystem");
+		}
 		return syserror("Failed to pin rootfs");
+	}
 
 	TRACE("Pinned rootfs %d(.lxc_keep)", fd_pin);
 


### PR DESCRIPTION
Anbox mounts a squashfs image and uses it as the lxc container root. The squashfs image is mounted read-only, hence the rootfs pinning code in newer versions of lxc breaks anbox.

This fixes the issue.

Reference: bug report of anbox: https://github.com/anbox/anbox/issues/1801
