### PR TITLE
fixes

### DIFF
--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -1886,7 +1886,8 @@ static int netdev_get_flag(const char *name, int *flag)
  */
 int lxc_netdev_isup(const char *name)
 {
-	int err, flag;
+	int err;
+	int flag = 0;
 
 	err = netdev_get_flag(name, &flag);
 	if (err)


### PR DESCRIPTION
Some users report that compilation fails because of reports that this
variable can be used uninitialized. Initialize it to silence the
compiler.

Fixes: https://github.com/lxc/lxc/issues/3850
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>