### PR TITLE
lsm/apparmor: actually report an error when we fail to wire AppArmor …

### DIFF
--- a/src/lxc/lsm/apparmor.c
+++ b/src/lxc/lsm/apparmor.c
@@ -1184,7 +1184,7 @@ static int apparmor_process_label_set_at(struct lsm_ops *ops, int label_fd, cons
 	ret = lxc_write_nointr(label_fd, command, len - 1);
 
 	INFO("Set AppArmor label to \"%s\"", label);
-	return 0;
+	return ret;
 }
 
 /*


### PR DESCRIPTION
…profile

Link: https://bugs.launchpad.net/ubuntu-kernel-tests/+bug/1931064
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>