### PR TITLE
api_extensions: introduce idmapped_mounts_v2 api extension

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -147,4 +147,9 @@ Whether the seccomp notify proxy sends a long a notify fd file descriptor.
 
 ## idmapped\_mounts
 
-Whether this LXC instance can handle idmapped mounts.
+Whether this LXC instance can handle idmapped mounts for the rootfs.
+
+## idmapped\_mounts\_v2
+
+Whether this LXC instance can handle idmapped mounts for lxc.mount.entry
+entries.

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -45,6 +45,7 @@ static char *api_extensions[] = {
 	"seccomp_notify_fd_active",
 	"seccomp_proxy_send_notify_fd",
 	"idmapped_mounts",
+	"idmapped_mounts_v2",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);


### PR DESCRIPTION
This indicates that LXC supports idmapping the rootfs and
idmapped lxc.mount.entry entries.

Link: https://github.com/lxc/lxd/issues/8870
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>