### PR TITLE
string utils: Make sure don't return uninitialized memory.

### DIFF
--- a/src/lxc/string_utils.c
+++ b/src/lxc/string_utils.c
@@ -404,6 +404,9 @@ char **lxc_string_split_quoted(char *string)
 	if (state == 'a')
 		complete_word(&result, nextword, p, &result_capacity, &result_count);
 
+	if (result == NULL)
+		return calloc(1, sizeof(char *));
+
 	return realloc(result, (result_count + 1) * sizeof(char *));
 }
 
@@ -442,6 +445,9 @@ char **lxc_string_split_and_trim(const char *string, char _sep)
 
 		result_count++;
 	}
+
+	if (result == NULL)
+		return calloc(1, sizeof(char *));
 
 	/* if we allocated too much, reduce it */
 	return realloc(result, (result_count + 1) * sizeof(char *));


### PR DESCRIPTION
The function lxc_string_split_quoted and lxc_string_split_and_trim use
realloc to reduce the memory. But the result may be NULL, then the
returned memory will be uninitialized

Signed-off-by: LiFeng <lifeng68@huawei.com>