### PR TITLE
Add support for LISTEN_FDS environment variable.

### DIFF
--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -223,7 +223,8 @@ struct lxc_container {
 
 	/*!
 	 * \brief Change whether the container wishes all file descriptors
-	 *  to be closed on startup.
+	 *  to be closed on startup. The LISTEN_FDS environment variable
+	 *  can be set to keep inherited file descriptors open.
 	 *
 	 * \param c Container.
 	 * \param state Value for the close_all_fds bit (0 or 1).


### PR DESCRIPTION
The LISTEN_FDS environment variable defines the number of
file descriptors that should be inherited by the container,
in addition to stdio.
The LISTEN_FDS environment variable is defined in the OCI spec
and used to support socket activation.

Refs #3845

Signed-off-by: Ruben Jenster <r.jenster@drachenfels.de>
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>