### PR TITLE
remove_from_array() causes a crash

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2326,7 +2326,7 @@ static bool remove_from_array(char ***names, char *cname, int size)
 		char **newnames = (char**)realloc(*names, (size-1) * sizeof(char *));
 		if (!newnames) {
 			ERROR("Out of memory");
-			return false;
+			return true;
 		}
 
 		*names = newnames;

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2270,8 +2270,10 @@ static bool add_to_array(char ***names, char *cname, int pos)
 
 	*names = newnames;
 	newnames[pos] = strdup(cname);
-	if (!newnames[pos])
+	if (!newnames[pos]) {
+		*names = (char**)realloc(*names, (pos) * sizeof(char *));
 		return false;
+	}
 
 	/* Sort the array as we will use binary search on it. */
 	qsort(newnames, pos + 1, sizeof(char *),
@@ -2320,7 +2322,12 @@ static bool remove_from_array(char ***names, char *cname, int size)
 {
 	char **result = get_from_array(names, cname, size);
 	if (result != NULL) {
-		free(result);
+		int i;
+		for (i = 0; (*names)[i] != *result && i < size; i++) {
+		}
+		free(*result);
+		memmove(*names+i, *names+i+1, (size-i-1) * sizeof(char*));
+		*names = (char**)realloc(*names, (size-1) * sizeof(char *));
 		return true;
 	}
 
@@ -5659,7 +5666,7 @@ int list_all_containers(const char *lxcpath, char ***nret,
 {
 	int i, ret, active_cnt, ct_cnt, ct_list_cnt;
 	char **active_name;
-	char **ct_name;
+	char **ct_name = NULL;
 	struct lxc_container **ct_list = NULL;
 
 	ct_cnt = list_defined_containers(lxcpath, &ct_name, NULL);


### PR DESCRIPTION
Fix for #3876.

When an item is added to an array, then the array is realloc()ed (to size+1),
and the item is copied (strdup()) to the array.
Thus, when an item is removed from an array, memory allocated for that item
should be freed, successive items should be left-shifted and the array
realloc()ed again (size-1).

Additional changes:
- If strdup() fails in add_to_array(), then an array should be
  realloc()ed again to original size.
- Initialize an array in list_all_containers().

Valgrind summary on the patched version:
```
==476062==
==476062== HEAP SUMMARY:
==476062==     in use at exit: 0 bytes in 0 blocks
==476062==   total heap usage: 13 allocs, 13 frees, 73,880 bytes allocated
==476062==
==476062== All heap blocks were freed -- no leaks are possible
==476062==
==476062== For lists of detected and suppressed errors, rerun with: -s
==476062== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

static inline int string_cmp(char **first, char **second)
{
    return strcmp(*first, *second);
}

static char** get_from_array(char ***names, char *cname, int size)
{
    return (char **)bsearch(&cname, *names, size, sizeof(char *), (int (*)(const void *, const void *))string_cmp);
}

static bool add_to_array(char ***names, char *cname, int pos)
{
    char **newnames = (char**)realloc(*names, (pos+1) * sizeof(char *));
    if (!newnames) {
        fprintf(stderr, "Out of memory\n");
        return false;
    }

    *names = newnames;
    newnames[pos] = strdup(cname);
    if (!newnames[pos]) {
        *names = (char**)realloc(*names, (pos) * sizeof(char *));
        return false;
    }

    // sort the arrray as we will use binary search on it
    qsort(newnames, pos + 1, sizeof(char *), (int (*)(const void *,const void *))string_cmp);

    return true;
}

static bool remove_from_array(char ***names, char *cname, int size)
{
    char **result = get_from_array(names, cname, size);
    if (result != NULL) {
        int i;
        for (i = 0; (*names)[i] != *result && i < size; i++) {
        }
        free(*result);
        memmove(*names+i, *names+i+1, (size-i-1) * sizeof(char*));
        *names = (char**)realloc(*names, (size-1) * sizeof(char *));
        return true;
    }
    return false;
}

void test_realloc()
{
  char **ct_name = NULL;
  int i, ct_name_cnt = 0;
  add_to_array(&ct_name, "Item#01", ct_name_cnt++);
  remove_from_array(&ct_name, "Item#01", ct_name_cnt--);
  add_to_array(&ct_name, "Item#01", ct_name_cnt++);
  add_to_array(&ct_name, "Item#02", ct_name_cnt++);
  add_to_array(&ct_name, "Item#03", ct_name_cnt++);
  add_to_array(&ct_name, "Item#04", ct_name_cnt++);
  for (i = 0; i < ct_name_cnt; i++) {
      printf("i[%d]='%s'\n", i, ct_name[i]);
  }
  remove_from_array(&ct_name, "Item#03", ct_name_cnt--);
  for (i = 0; i < ct_name_cnt; i++) {
      printf("i[%d]='%s'\n", i, ct_name[i]);
  }
  for (i = 0; i < ct_name_cnt; i++) {
      free(ct_name[i]);
  }
  free(ct_name);
}

int main() {
    test_realloc();
    return 0;
}
```