### PR TITLE
Mount propagation fixes

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -111,7 +111,7 @@ https://www.kernel.org/doc/html/latest/process/coding-style.html
   punctuation sign.
 - They should be descriptive, without being needlessly long. It is best to just
   use already existing error messages as examples.
-- The commit message itself is not subject to rule 4), i.e. it should not be
+- The error message itself is not subject to rule 4), i.e. it should not be
   wrapped at 80chars. This is to make it easy to grep for it.
 - Examples of acceptable error messages are:
   ```C

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2217,6 +2217,12 @@ static int parse_mntopt(char *opt, unsigned long *flags, char **data, size_t siz
 {
 	size_t ret;
 
+	/* Propagation opts are parsed separately and must not go into data. */
+	for (struct mount_opt *mo = &propagation_opt[0]; mo->name != NULL; mo++) {
+		if (strnequal(opt, mo->name, strlen(mo->name)))
+			return 0;
+	}
+
 	/* If '=' is contained in opt, the option must go into data. */
 	if (!strchr(opt, '=')) {
 		/*


### PR DESCRIPTION
Hi there,

I made some changes to allow shared mount propagation and to fix mount option parsing.
As shared mount propagation is considered dangerous and  I'm quite new to it please
review carefully.

There is a pending issue #2477  that may be closed if this is merged.

###  background (mount propgation fixes):
I tried out several CSI (Container Storage Interface) providers to add persistent 
storage for my lxcri/lxc backed kubernetes cluster and noticed that it did not work.
CSI requires`Bidirectional` (shared) mount propagation to work.

See also:
* https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
* https://kubernetes-csi.github.io/docs/deploying.html#enabling-mount-propagation