### PR TITLE
cgroups: verify that hierarchies are non-empty

### DIFF
--- a/src/lxc/cgroups/cgroup.h
+++ b/src/lxc/cgroups/cgroup.h
@@ -326,6 +326,9 @@ static inline int prepare_cgroup_ctx(struct cgroup_ops *ops,
 {
 	__u32 idx;
 
+	if (!ops || !ops->hierarchies)
+		return ret_errno(ENOENT);
+
 	for (idx = 0; ops->hierarchies[idx]; idx++) {
 		if (idx >= CGROUP_CTX_MAX_FD)
 			return ret_errno(E2BIG);


### PR DESCRIPTION
Fixes: #3881
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>