### PR TITLE
RFC: conf: userns.conf: include userns.conf.d

### DIFF
--- a/config/templates/userns.conf.in
+++ b/config/templates/userns.conf.in
@@ -19,3 +19,6 @@ lxc.tty.dir =
 
 # Setup the default mounts
 lxc.mount.auto = sys:rw
+
+# Lastly, include all the configs from @LXCTEMPLATECONFIG@/userns.conf.d/
+lxc.include = @LXCTEMPLATECONFIG@/userns.conf.d/

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -2689,7 +2689,7 @@ static int do_includedir(const char *dirp, struct lxc_conf *lxc_conf)
 
 	dir = opendir(dirp);
 	if (!dir)
-		return -errno;
+		return errno == ENOENT ? 0 : -errno;
 
 	while ((direntp = readdir(dir))) {
 		const char *fnam;
@@ -2726,7 +2726,7 @@ static int set_config_includefiles(const char *key, const char *value,
 		return 0;
 	}
 
-	if (is_dir(value))
+	if (value[strlen(value)-1] == '/' || is_dir(value))
 		return do_includedir(value, lxc_conf);
 
 	return lxc_config_read(value, lxc_conf, true);


### PR DESCRIPTION
With `common.conf` including `common.conf.d/` I find it would make sense to have the "common" `userns.conf` include `userns.conf.d/`.

The only downside is that it some people might already be doing this and possibly end up double-including those files...