### PR TITLE
lxc: remove CLONE_PIDFD flag from fallback clone() syscall

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1692,9 +1692,10 @@ static int lxc_spawn(struct lxc_handler *handler)
 			TRACE("Spawned container directly into target cgroup via cgroup2 fd %d", cgroup_fd);
 		}
 
-		/* Kernel might be too old for clone3(). */
+		/* Kernel might be too old for clone3() and CLONE_PIDFD. */
 		if (handler->pid < 0) {
 			SYSTRACE("Failed to spawn container via clone3()");
+			handler->clone_flags &= ~CLONE_PIDFD;
 
 		/*
 		 * In contrast to all other architectures arm64 verifies that


### PR DESCRIPTION
It doesn't work with kernels older than 5.2.

https://man7.org/linux/man-pages/man2/clone.2.html

"       CLONE_PIDFD (since Linux 5.2)"

Fix lxc container startup error:

clone3({flags=CLONE_PIDFD|CLONE_NEWNS|CLONE_NEWUTS|CLONE_NEWIPC|CLONE_NEWPID|0x200000000, pidfd=0x55904a09a0, exit_signal=SIGCHLD, stack=NULL, stack_size=0, /* bytes 80..87 */ "\x17\x00\x00\x00\x00\x00\x00\x00"}, 88) = -1 ENOSYS (Function not implemented)
clone3({flags=CLONE_PIDFD|CLONE_NEWNS|CLONE_NEWUTS|CLONE_NEWIPC|CLONE_NEWPID, pidfd=0x55904a09a0, exit_signal=SIGCHLD, stack=NULL, stack_size=0}, 64) = -1 ENOSYS (Function not implemented)
clone(child_stack=NULL, flags=CLONE_PIDFD|CLONE_NEWNS|CLONE_NEWUTS|CLONE_NEWIPC|CLONE_NEWPID|SIGCHLD, parent_tid=0x55904a09a0) = -1 EINVAL (Invalid argument)

Signed-off-by: Saloni.Jain <jainsaloni0918@gmail.com>