### PR TITLE
initutils: include pthread.h

### DIFF
--- a/src/lxc/cmd/lxc_init.c
+++ b/src/lxc/cmd/lxc_init.c
@@ -9,7 +9,6 @@
 #include <getopt.h>
 #include <libgen.h>
 #include <limits.h>
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/lxc/initutils.c
+++ b/src/lxc/initutils.c
@@ -3,11 +3,12 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
 #endif
+#include <pthread.h>
+#include <signal.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <signal.h>
 
 #include "compiler.h"
 #include "config.h"


### PR DESCRIPTION
Otherwise we might end up with implicit function declaration warnings.

Link: https://jenkins.linuxcontainers.org/job/lxc-build-android/8915/console
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>