### PR TITLE
terminal: log TIOCGPTPEER failure less alarmingly

### DIFF
--- a/src/lxc/af_unix.c
+++ b/src/lxc/af_unix.c
@@ -121,6 +121,9 @@ int lxc_abstract_unix_send_fds_iov(int fd, const int *sendfds, int num_sendfds,
 	struct cmsghdr *cmsg = NULL;
 	size_t cmsgbufsize = CMSG_SPACE(num_sendfds * sizeof(int));
 
+	if (num_sendfds <= 0)
+		return ret_errno(EINVAL);
+
 	cmsgbuf = malloc(cmsgbufsize);
 	if (!cmsgbuf)
 		return ret_errno(-ENOMEM);

--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -931,7 +931,17 @@ static int lxc_terminal_create_native(const char *name, const char *lxcpath, str
 
 	terminal->pty = ioctl(terminal->ptx, TIOCGPTPEER, O_RDWR | O_NOCTTY | O_CLOEXEC);
 	if (terminal->pty < 0) {
-		SYSWARN("Failed to allocate new pty device");
+		switch (errno) {
+		case ENOTTY:
+			SYSTRACE("Pure fd-based terminal allocation not possible");
+			break;
+		case ENOSPC:
+			SYSTRACE("Exceeding number of allocatable terminals");
+			break;
+		default:
+			SYSWARN("Failed to allocate new pty device");
+			break;
+		}
 		goto err;
 	}
 


### PR DESCRIPTION
This is not a fatal error and the fallback codepath is equally safe.
When we use TIOCGPTPEER we're using a stashed fd to the container's
devpts mount's ptmx device and allocating a new fd non-path based
through this ioctl. If this ioctl can't be used we're falling back to
allocating a pts device from the host's devpts mount's ptmx device which
is path-based but is not under control of the container and so that's
safe. The difference is just that the first method gets you a nice
native terminal with all the pleasantries of having tty and friends
working whereas the latter method does not.

Fixes: #3625
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>