### PR TITLE
bpf: simplify detection if BPF is supported

### DIFF
--- a/src/lxc/cgroups/cgroup2_devices.c
+++ b/src/lxc/cgroups/cgroup2_devices.c
@@ -538,6 +538,10 @@ bool bpf_devices_cgroup_supported(void)
 		return log_trace(false,
 				 "The bpf device cgroup requires real root");
 
+	ret = bpf(BPF_PROG_LOAD, NULL, sizeof(union bpf_attr));
+	if (ret < 0 && errno == ENOSYS)
+		return log_trace(false, "The bpf syscall is not available");
+
 	prog = bpf_program_new(BPF_PROG_TYPE_CGROUP_DEVICE);
 	if (!prog)
 		return log_trace(false, "Failed to allocate new bpf device cgroup program");


### PR DESCRIPTION
bpf_devices_cgroup_supported() tries to load a simple BPF program to test
if BPF works. This is problematic because the function used to load the
program - bpf_program_load_kernel() - emits an error to the log if BPF is
not enabled in the kernel although device controller is not requested in
the configuration.

To detect if BPF is supported we need to check if the BPF syscall is
available. We can do it by passing a NULL pointer instead of the syscall
argument as the kernel returns either ENOSYS, when the sysall is not
implemented or EFAULT, when it is implemented.