### PR TITLE
string_utils: cast __s64 to long long signed int

### DIFF
--- a/src/lxc/string_utils.h
+++ b/src/lxc/string_utils.h
@@ -173,7 +173,7 @@ static inline const char *fdstr(__s64 fd)
 	static const char *fdstr_invalid = "-EBADF";
 	static char buf[INTTYPE_TO_STRLEN(__s64)];
 
-	if (strnprintf(buf, sizeof(buf), "%lld", fd) < 0)
+	if (strnprintf(buf, sizeof(buf), "%lld", (long long signed int)fd) < 0)
 		return fdstr_invalid;
 
 	return buf;


### PR DESCRIPTION
Link: https://launchpadlibrarian.net/550723147/buildlog_snap_ubuntu_focal_ppc64el_lxd-latest-edge_BUILDING.txt.gz
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>