### PR TITLE
mainloop: io_uring support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -671,6 +671,22 @@ AC_CHECK_HEADER([ifaddrs.h],
 	AC_DEFINE(HAVE_IFADDRS_H, 1, [Have ifaddrs.h]),
 	AM_CONDITIONAL(HAVE_IFADDRS_H, false))
 
+AC_ARG_ENABLE([liburing],
+	[AS_HELP_STRING([--enable-liburing], [enable liburing support [default=auto]])],
+	[enable_liburing=$enableval], [enable_liburing=auto])
+
+if test "x$enable_liburing" = "auto"; then
+	AC_CHECK_LIB([uring],[__io_uring_sqring_wait],[enable_liburing=yes],[enable_liburing=no])
+fi
+
+AM_CONDITIONAL([ENABLE_LIBURING], [test "x$enable_liburing" = "xyes"])
+
+AM_COND_IF([ENABLE_LIBURING],
+	[AC_CHECK_HEADER([liburing.h],[],[AC_MSG_ERROR([You must install the liburing development package in order to compile lxc])])
+	# We use __io_uring_sqring_wait as an indicator whether liburing is new enough to support poll.
+	AC_CHECK_LIB([uring],[__io_uring_sqring_wait],[],[AC_MSG_ERROR([The liburing development package in order to compile lxc])])
+        AC_SUBST([LIBURING_LIBS], [-luring])])
+
 # lookup major()/minor()/makedev()
 AC_HEADER_MAJOR
 

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -274,7 +274,8 @@ liblxc_la_LIBADD = $(CAP_LIBS) \
 		   $(OPENSSL_LIBS) \
 		   $(SELINUX_LIBS) \
 		   $(SECCOMP_LIBS) \
-		   $(DLOG_LIBS)
+		   $(DLOG_LIBS) \
+		   $(LIBURING_LIBS)
 
 bin_SCRIPTS=
 
@@ -333,7 +334,8 @@ LDADD = liblxc.la \
 	@OPENSSL_LIBS@ \
 	@SECCOMP_LIBS@ \
 	@SELINUX_LIBS@ \
-	@DLOG_LIBS@
+	@DLOG_LIBS@ \
+	@LIBURING_LIBS@
 
 if ENABLE_TOOLS
 lxc_attach_SOURCES = tools/lxc_attach.c \

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1353,7 +1353,7 @@ static int lxc_attach_terminal(const char *name, const char *lxcpath, struct lxc
 }
 
 static int lxc_attach_terminal_mainloop_init(struct lxc_terminal *terminal,
-					     struct lxc_epoll_descr *descr)
+					     struct lxc_async_descr *descr)
 {
 	int ret;
 
@@ -1395,7 +1395,7 @@ int lxc_attach(struct lxc_container *container, lxc_attach_exec_t exec_function,
 	       pid_t *attached_process)
 {
 	int ret_parent = -1;
-	struct lxc_epoll_descr descr = {};
+	struct lxc_async_descr descr = {};
 	int ret;
 	char *name, *lxcpath;
 	int ipc_sockets[2];

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1987,7 +1987,11 @@ static int cg_unified_freeze_do(struct cgroup_ops *ops, int timeout,
 		/* automatically cleaned up now */
 		descr_ptr = &descr;
 
-		ret = lxc_mainloop_add_handler_events(&descr, fd, EPOLLPRI, freezer_cgroup_events_cb, INT_TO_PTR(state_num));
+		ret = lxc_mainloop_add_handler_events(&descr, fd, EPOLLPRI,
+						      freezer_cgroup_events_cb,
+						      default_cleanup_handler,
+						      INT_TO_PTR(state_num),
+						      "freezer_cgroup_events_cb");
 		if (ret < 0)
 			return log_error_errno(-1, errno, "Failed to add cgroup.events fd handler to mainloop");
 	}
@@ -3669,7 +3673,11 @@ static int do_cgroup_freeze(int unified_fd,
 		if (events_fd < 0)
 			return log_error_errno(-errno, errno, "Failed to open cgroup.events file");
 
-		ret = lxc_mainloop_add_handler_events(&descr, events_fd, EPOLLPRI, freezer_cgroup_events_cb, INT_TO_PTR(state_num));
+		ret = lxc_mainloop_add_handler_events(&descr, events_fd, EPOLLPRI,
+						      freezer_cgroup_events_cb,
+						      default_cleanup_handler,
+						      INT_TO_PTR(state_num),
+						      "freezer_cgroup_events_cb");
 		if (ret < 0)
 			return log_error_errno(-1, errno, "Failed to add cgroup.events fd handler to mainloop");
 	}

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -768,7 +768,7 @@ static int __cgroup_tree_create(int dfd_base, const char *path, mode_t mode,
 	/* The final cgroup must be succesfully creatd by us. */
 	if (ret) {
 		if (ret != -EEXIST || !eexist_ignore)
-			return syserror_set(ret, "Creating the final cgroup %d(%s) failed", dfd_base, path);
+			return syswarn_set(ret, "Creating the final cgroup %d(%s) failed", dfd_base, path);
 	}
 
 	return move_fd(dfd_final);
@@ -791,7 +791,7 @@ static bool cgroup_tree_create(struct cgroup_ops *ops, struct lxc_conf *conf,
 		/* With isolation both parts need to not already exist. */
 		fd_limit = __cgroup_tree_create(h->dfd_base, cgroup_limit_dir, 0755, cpuset_v1, false);
 		if (fd_limit < 0)
-			return syserror_ret(false, "Failed to create limiting cgroup %d(%s)", h->dfd_base, cgroup_limit_dir);
+			return syswarn_ret(false, "Failed to create limiting cgroup %d(%s)", h->dfd_base, cgroup_limit_dir);
 
 		h->path_lim = make_cgroup_path(h, h->at_base, cgroup_limit_dir, NULL);
 		h->dfd_lim = move_fd(fd_limit);
@@ -807,7 +807,7 @@ static bool cgroup_tree_create(struct cgroup_ops *ops, struct lxc_conf *conf,
 		 */
 		if (string_in_list(h->controllers, "devices") &&
 		    !ops->setup_limits_legacy(ops, conf, true))
-			return log_error(false, "Failed to setup legacy device limits");
+			return log_warn(false, "Failed to setup legacy device limits");
 
 		/*
 		 * If we use a separate limit cgroup, the leaf cgroup, i.e. the
@@ -820,7 +820,7 @@ static bool cgroup_tree_create(struct cgroup_ops *ops, struct lxc_conf *conf,
 				SYSWARN("Failed to destroy %d(%s)", h->dfd_base, cgroup_limit_dir);
 			else
 				TRACE("Removed cgroup tree %d(%s)", h->dfd_base, cgroup_limit_dir);
-			return syserror_ret(false, "Failed to create %s cgroup %d(%s)", payload ? "payload" : "monitor", h->dfd_base, cgroup_limit_dir);
+			return syswarn_ret(false, "Failed to create %s cgroup %d(%s)", payload ? "payload" : "monitor", h->dfd_base, cgroup_limit_dir);
 		}
 		h->dfd_con = move_fd(fd_final);
 		h->path_con = must_make_path(h->path_lim, cgroup_leaf, NULL);
@@ -828,7 +828,7 @@ static bool cgroup_tree_create(struct cgroup_ops *ops, struct lxc_conf *conf,
 	} else {
 		fd_final = __cgroup_tree_create(h->dfd_base, cgroup_limit_dir, 0755, cpuset_v1, false);
 		if (fd_final < 0)
-			return syserror_ret(false, "Failed to create %s cgroup %d(%s)", payload ? "payload" : "monitor", h->dfd_base, cgroup_limit_dir);
+			return syswarn_ret(false, "Failed to create %s cgroup %d(%s)", payload ? "payload" : "monitor", h->dfd_base, cgroup_limit_dir);
 
 		if (payload) {
 			h->dfd_con = move_fd(fd_final);

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1927,7 +1927,7 @@ static int cg_legacy_freeze(struct cgroup_ops *ops)
 }
 
 static int freezer_cgroup_events_cb(int fd, uint32_t events, void *cbdata,
-				    struct lxc_epoll_descr *descr)
+				    struct lxc_async_descr *descr)
 {
 	__do_free char *line = NULL;
 	__do_fclose FILE *f = NULL;
@@ -1960,9 +1960,9 @@ static int cg_unified_freeze_do(struct cgroup_ops *ops, int timeout,
 				const char *wait_error)
 {
 	__do_close int fd = -EBADF;
-	call_cleaner(lxc_mainloop_close) struct lxc_epoll_descr *descr_ptr = NULL;
+	call_cleaner(lxc_mainloop_close) struct lxc_async_descr *descr_ptr = NULL;
 	int ret;
-	struct lxc_epoll_descr descr;
+	struct lxc_async_descr descr;
 	struct hierarchy *h;
 
 	h = ops->unified;
@@ -3653,9 +3653,9 @@ static int do_cgroup_freeze(int unified_fd,
 			    const char *wait_error)
 {
 	__do_close int events_fd = -EBADF;
-	call_cleaner(lxc_mainloop_close) struct lxc_epoll_descr *descr_ptr = NULL;
+	call_cleaner(lxc_mainloop_close) struct lxc_async_descr *descr_ptr = NULL;
 	int ret;
-	struct lxc_epoll_descr descr = {};
+	struct lxc_async_descr descr = {};
 
 	if (timeout != 0) {
 		ret = lxc_mainloop_open(&descr);

--- a/src/lxc/cmd/lxc_monitord.c
+++ b/src/lxc/cmd/lxc_monitord.c
@@ -56,7 +56,7 @@ struct lxc_monitor {
 	int *clientfds;
 	int clientfds_size;
 	int clientfds_cnt;
-	struct lxc_epoll_descr descr;
+	struct lxc_async_descr descr;
 };
 
 static struct lxc_monitor monitor;
@@ -137,7 +137,7 @@ static void lxc_monitord_sockfd_remove(struct lxc_monitor *mon, int fd)
 }
 
 static int lxc_monitord_sock_handler(int fd, uint32_t events, void *data,
-				     struct lxc_epoll_descr *descr)
+				     struct lxc_async_descr *descr)
 {
 	struct lxc_monitor *mon = data;
 
@@ -157,7 +157,7 @@ static int lxc_monitord_sock_handler(int fd, uint32_t events, void *data,
 }
 
 static int lxc_monitord_sock_accept(int fd, uint32_t events, void *data,
-				    struct lxc_epoll_descr *descr)
+				    struct lxc_async_descr *descr)
 {
 	int ret, clientfd;
 	struct lxc_monitor *mon = data;
@@ -283,7 +283,7 @@ static void lxc_monitord_delete(struct lxc_monitor *mon)
 }
 
 static int lxc_monitord_fifo_handler(int fd, uint32_t events, void *data,
-				     struct lxc_epoll_descr *descr)
+				     struct lxc_async_descr *descr)
 {
 	int ret, i;
 	struct lxc_msg msglxc;

--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -611,7 +611,7 @@ pid_t lxc_cmd_get_init_pid(const char *name, const char *lxcpath)
 
 static int lxc_cmd_get_init_pid_callback(int fd, struct lxc_cmd_req *req,
 					 struct lxc_handler *handler,
-					 struct lxc_epoll_descr *descr)
+					 struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp = {
 		.data = PID_TO_PTR(handler->pid),
@@ -648,7 +648,7 @@ int lxc_cmd_get_init_pidfd(const char *name, const char *lxcpath)
 
 static int lxc_cmd_get_init_pidfd_callback(int fd, struct lxc_cmd_req *req,
 					   struct lxc_handler *handler,
-					   struct lxc_epoll_descr *descr)
+					   struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp = {
 		.ret = -EBADF,
@@ -688,7 +688,7 @@ int lxc_cmd_get_devpts_fd(const char *name, const char *lxcpath)
 
 static int lxc_cmd_get_devpts_fd_callback(int fd, struct lxc_cmd_req *req,
 					  struct lxc_handler *handler,
-					  struct lxc_epoll_descr *descr)
+					  struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp = {
 		.ret = -EBADF,
@@ -732,7 +732,7 @@ int lxc_cmd_get_seccomp_notify_fd(const char *name, const char *lxcpath)
 
 static int lxc_cmd_get_seccomp_notify_fd_callback(int fd, struct lxc_cmd_req *req,
 						  struct lxc_handler *handler,
-						  struct lxc_epoll_descr *descr)
+						  struct lxc_async_descr *descr)
 {
 #ifdef HAVE_SECCOMP_NOTIFY
 	struct lxc_cmd_rsp rsp = {
@@ -773,7 +773,7 @@ int lxc_cmd_get_cgroup_ctx(const char *name, const char *lxcpath,
 
 static int lxc_cmd_get_cgroup_ctx_callback(int fd, struct lxc_cmd_req *req,
 					   struct lxc_handler *handler,
-					   struct lxc_epoll_descr *descr)
+					   struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp = {
 		.ret = EINVAL,
@@ -824,7 +824,7 @@ int lxc_cmd_get_clone_flags(const char *name, const char *lxcpath)
 
 static int lxc_cmd_get_clone_flags_callback(int fd, struct lxc_cmd_req *req,
 					    struct lxc_handler *handler,
-					    struct lxc_epoll_descr *descr)
+					    struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp = {
 		.data = INT_TO_PTR(handler->ns_clone_flags),
@@ -914,7 +914,7 @@ char *lxc_cmd_get_limit_cgroup_path(const char *name, const char *lxcpath,
 
 static int __lxc_cmd_get_cgroup_callback(int fd, struct lxc_cmd_req *req,
 					 struct lxc_handler *handler,
-					 struct lxc_epoll_descr *descr,
+					 struct lxc_async_descr *descr,
 					 bool limiting_cgroup)
 {
 	ssize_t ret;
@@ -950,14 +950,14 @@ static int __lxc_cmd_get_cgroup_callback(int fd, struct lxc_cmd_req *req,
 
 static int lxc_cmd_get_cgroup_callback(int fd, struct lxc_cmd_req *req,
 				       struct lxc_handler *handler,
-				       struct lxc_epoll_descr *descr)
+				       struct lxc_async_descr *descr)
 {
 	return __lxc_cmd_get_cgroup_callback(fd, req, handler, descr, false);
 }
 
 static int lxc_cmd_get_limit_cgroup_callback(int fd, struct lxc_cmd_req *req,
 					     struct lxc_handler *handler,
-					     struct lxc_epoll_descr *descr)
+					     struct lxc_async_descr *descr)
 {
 	return __lxc_cmd_get_cgroup_callback(fd, req, handler, descr, true);
 }
@@ -997,7 +997,7 @@ char *lxc_cmd_get_config_item(const char *name, const char *item,
 
 static int lxc_cmd_get_config_item_callback(int fd, struct lxc_cmd_req *req,
 					    struct lxc_handler *handler,
-					    struct lxc_epoll_descr *descr)
+					    struct lxc_async_descr *descr)
 {
 	__do_free char *cidata = NULL;
 	int cilen;
@@ -1059,7 +1059,7 @@ int lxc_cmd_get_state(const char *name, const char *lxcpath)
 
 static int lxc_cmd_get_state_callback(int fd, struct lxc_cmd_req *req,
 				      struct lxc_handler *handler,
-				      struct lxc_epoll_descr *descr)
+				      struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp = {
 		.data = INT_TO_PTR(handler->state),
@@ -1104,7 +1104,7 @@ int lxc_cmd_stop(const char *name, const char *lxcpath)
 
 static int lxc_cmd_stop_callback(int fd, struct lxc_cmd_req *req,
 				 struct lxc_handler *handler,
-				 struct lxc_epoll_descr *descr)
+				 struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp;
 	int stopsignal = SIGKILL;
@@ -1155,7 +1155,7 @@ int lxc_cmd_terminal_winch(const char *name, const char *lxcpath)
 
 static int lxc_cmd_terminal_winch_callback(int fd, struct lxc_cmd_req *req,
 					   struct lxc_handler *handler,
-					   struct lxc_epoll_descr *descr)
+					   struct lxc_async_descr *descr)
 {
 	/* should never be called */
 	return syserror_set(-ENOSYS, "Called lxc_cmd_terminal_winch_callback()");
@@ -1207,7 +1207,7 @@ int lxc_cmd_get_tty_fd(const char *name, int *ttynum, int *fd, const char *lxcpa
 
 static int lxc_cmd_get_tty_fd_callback(int fd, struct lxc_cmd_req *req,
 				       struct lxc_handler *handler,
-				       struct lxc_epoll_descr *descr)
+				       struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp = {
 		.ret = -EBADF,
@@ -1258,7 +1258,7 @@ char *lxc_cmd_get_name(const char *hashed_sock_name)
 
 static int lxc_cmd_get_name_callback(int fd, struct lxc_cmd_req *req,
 				     struct lxc_handler *handler,
-				     struct lxc_epoll_descr *descr)
+				     struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp;
 
@@ -1298,7 +1298,7 @@ char *lxc_cmd_get_lxcpath(const char *hashed_sock_name)
 
 static int lxc_cmd_get_lxcpath_callback(int fd, struct lxc_cmd_req *req,
 					struct lxc_handler *handler,
-					struct lxc_epoll_descr *descr)
+					struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp = {
 		.ret		= 0,
@@ -1351,7 +1351,7 @@ int lxc_cmd_add_state_client(const char *name, const char *lxcpath,
 
 static int lxc_cmd_add_state_client_callback(__owns int fd, struct lxc_cmd_req *req,
 					     struct lxc_handler *handler,
-					     struct lxc_epoll_descr *descr)
+					     struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp = {
 		.ret = -EINVAL,
@@ -1403,7 +1403,7 @@ int lxc_cmd_add_bpf_device_cgroup(const char *name, const char *lxcpath,
 
 static int lxc_cmd_add_bpf_device_cgroup_callback(int fd, struct lxc_cmd_req *req,
 						  struct lxc_handler *handler,
-						  struct lxc_epoll_descr *descr)
+						  struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp = {
 		.ret = -EINVAL,
@@ -1470,7 +1470,7 @@ int lxc_cmd_console_log(const char *name, const char *lxcpath,
 
 static int lxc_cmd_console_log_callback(int fd, struct lxc_cmd_req *req,
 					struct lxc_handler *handler,
-					struct lxc_epoll_descr *descr)
+					struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp;
 	uint64_t buffer_size = handler->conf->console.buffer_size;
@@ -1526,7 +1526,7 @@ int lxc_cmd_serve_state_clients(const char *name, const char *lxcpath,
 
 static int lxc_cmd_serve_state_clients_callback(int fd, struct lxc_cmd_req *req,
 						struct lxc_handler *handler,
-						struct lxc_epoll_descr *descr)
+						struct lxc_async_descr *descr)
 {
 	int ret;
 	lxc_state_t state = PTR_TO_INT(req->data);
@@ -1566,7 +1566,7 @@ int lxc_cmd_seccomp_notify_add_listener(const char *name, const char *lxcpath,
 static int lxc_cmd_seccomp_notify_add_listener_callback(int fd,
 							struct lxc_cmd_req *req,
 							struct lxc_handler *handler,
-							struct lxc_epoll_descr *descr)
+							struct lxc_async_descr *descr)
 {
 	struct lxc_cmd_rsp rsp = {0};
 
@@ -1621,7 +1621,7 @@ int lxc_cmd_freeze(const char *name, const char *lxcpath, int timeout)
 
 static int lxc_cmd_freeze_callback(int fd, struct lxc_cmd_req *req,
 				   struct lxc_handler *handler,
-				   struct lxc_epoll_descr *descr)
+				   struct lxc_async_descr *descr)
 {
 	int timeout = PTR_TO_INT(req->data);
 	struct lxc_cmd_rsp rsp = {
@@ -1653,7 +1653,7 @@ int lxc_cmd_unfreeze(const char *name, const char *lxcpath, int timeout)
 
 static int lxc_cmd_unfreeze_callback(int fd, struct lxc_cmd_req *req,
 				   struct lxc_handler *handler,
-				   struct lxc_epoll_descr *descr)
+				   struct lxc_async_descr *descr)
 {
 	int timeout = PTR_TO_INT(req->data);
 	struct lxc_cmd_rsp rsp = {
@@ -1713,7 +1713,7 @@ int lxc_cmd_get_limit_cgroup_fd(const char *name, const char *lxcpath,
 
 static int __lxc_cmd_get_cgroup_fd_callback(int fd, struct lxc_cmd_req *req,
 					    struct lxc_handler *handler,
-					    struct lxc_epoll_descr *descr,
+					    struct lxc_async_descr *descr,
 					    bool limit)
 {
 	struct lxc_cmd_rsp rsp = {
@@ -1745,14 +1745,14 @@ static int __lxc_cmd_get_cgroup_fd_callback(int fd, struct lxc_cmd_req *req,
 
 static int lxc_cmd_get_cgroup_fd_callback(int fd, struct lxc_cmd_req *req,
 					  struct lxc_handler *handler,
-					  struct lxc_epoll_descr *descr)
+					  struct lxc_async_descr *descr)
 {
 	return __lxc_cmd_get_cgroup_fd_callback(fd, req, handler, descr, false);
 }
 
 static int lxc_cmd_get_limit_cgroup_fd_callback(int fd, struct lxc_cmd_req *req,
 						struct lxc_handler *handler,
-						struct lxc_epoll_descr *descr)
+						struct lxc_async_descr *descr)
 {
 	return __lxc_cmd_get_cgroup_fd_callback(fd, req, handler, descr, true);
 }
@@ -1809,7 +1809,7 @@ int lxc_cmd_get_limit_cgroup2_fd(const char *name, const char *lxcpath)
 
 static int __lxc_cmd_get_cgroup2_fd_callback(int fd, struct lxc_cmd_req *req,
 					     struct lxc_handler *handler,
-					     struct lxc_epoll_descr *descr,
+					     struct lxc_async_descr *descr,
 					     bool limiting_cgroup)
 {
 	struct lxc_cmd_rsp rsp = {
@@ -1835,14 +1835,14 @@ static int __lxc_cmd_get_cgroup2_fd_callback(int fd, struct lxc_cmd_req *req,
 
 static int lxc_cmd_get_cgroup2_fd_callback(int fd, struct lxc_cmd_req *req,
 					   struct lxc_handler *handler,
-					   struct lxc_epoll_descr *descr)
+					   struct lxc_async_descr *descr)
 {
 	return __lxc_cmd_get_cgroup2_fd_callback(fd, req, handler, descr, false);
 }
 
 static int lxc_cmd_get_limit_cgroup2_fd_callback(int fd, struct lxc_cmd_req *req,
 						 struct lxc_handler *handler,
-						 struct lxc_epoll_descr *descr)
+						 struct lxc_async_descr *descr)
 {
 	return __lxc_cmd_get_cgroup2_fd_callback(fd, req, handler, descr, true);
 }
@@ -1859,10 +1859,10 @@ static int lxc_cmd_rsp_send_enosys(int fd, int id)
 
 static int lxc_cmd_process(int fd, struct lxc_cmd_req *req,
 			   struct lxc_handler *handler,
-			   struct lxc_epoll_descr *descr)
+			   struct lxc_async_descr *descr)
 {
 	typedef int (*callback)(int, struct lxc_cmd_req *, struct lxc_handler *,
-				struct lxc_epoll_descr *);
+				struct lxc_async_descr *);
 
 	callback cb[LXC_CMD_MAX] = {
 		[LXC_CMD_GET_TTY_FD]			= lxc_cmd_get_tty_fd_callback,
@@ -1900,7 +1900,7 @@ static int lxc_cmd_process(int fd, struct lxc_cmd_req *req,
 }
 
 static void lxc_cmd_fd_cleanup(int fd, struct lxc_handler *handler,
-			       struct lxc_epoll_descr *descr, const lxc_cmd_t cmd)
+			       struct lxc_async_descr *descr, const lxc_cmd_t cmd)
 {
 	lxc_terminal_free(handler->conf, fd);
 	lxc_mainloop_del_handler(descr, fd);
@@ -1945,7 +1945,7 @@ static void lxc_cmd_fd_cleanup(int fd, struct lxc_handler *handler,
 }
 
 static int lxc_cmd_handler(int fd, uint32_t events, void *data,
-			   struct lxc_epoll_descr *descr)
+			   struct lxc_async_descr *descr)
 {
 	__do_free void *reqdata = NULL;
 	int ret;
@@ -2012,7 +2012,7 @@ out_close:
 }
 
 static int lxc_cmd_accept(int fd, uint32_t events, void *data,
-			  struct lxc_epoll_descr *descr)
+			  struct lxc_async_descr *descr)
 {
 	__do_close int connection = -EBADF;
 	int opt = 1, ret = -1;
@@ -2063,7 +2063,7 @@ int lxc_server_init(const char *name, const char *lxcpath, const char *suffix)
 	return log_trace(move_fd(fd), "Created abstract unix socket \"%s\"", &path[1]);
 }
 
-int lxc_cmd_mainloop_add(const char *name, struct lxc_epoll_descr *descr,
+int lxc_cmd_mainloop_add(const char *name, struct lxc_async_descr *descr,
 			 struct lxc_handler *handler)
 {
 	int ret;

--- a/src/lxc/commands.h
+++ b/src/lxc/commands.h
@@ -137,11 +137,11 @@ __hidden __access_r_nosize(3) extern int lxc_cmd_add_state_client(const char *na
 __hidden extern int lxc_cmd_serve_state_clients(const char *name, const char *lxcpath,
 						lxc_state_t state);
 
-struct lxc_epoll_descr;
+struct lxc_async_descr;
 struct lxc_handler;
 
 __hidden extern int lxc_server_init(const char *name, const char *lxcpath, const char *suffix);
-__hidden extern int lxc_cmd_mainloop_add(const char *name, struct lxc_epoll_descr *descr,
+__hidden extern int lxc_cmd_mainloop_add(const char *name, struct lxc_async_descr *descr,
 					 struct lxc_handler *handler);
 __hidden extern int lxc_try_cmd(const char *name, const char *lxcpath);
 __hidden extern int lxc_cmd_console_log(const char *name, const char *lxcpath,

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3991,7 +3991,7 @@ static int lxc_setup_keyring(struct lsm_ops *lsm_ops, const struct lxc_conf *con
 	else if (conf->lsm_se_context)
 		ret = lsm_ops->keyring_label_set(lsm_ops, conf->lsm_se_context);
 	if (ret < 0)
-		return log_error_errno(-1, errno, "Failed to set keyring context");
+		return syserror("Failed to set keyring context");
 
 	/*
 	 * Try to allocate a new session keyring for the container to prevent
@@ -4010,7 +4010,7 @@ static int lxc_setup_keyring(struct lsm_ops *lsm_ops, const struct lxc_conf *con
 			DEBUG("Failed to access kernel keyring. Continuing...");
 			break;
 		default:
-			SYSERROR("Failed to create kernel keyring");
+			SYSWARN("Failed to create kernel keyring");
 			break;
 		}
 	}

--- a/src/lxc/lxcseccomp.h
+++ b/src/lxc/lxcseccomp.h
@@ -22,7 +22,7 @@
 #include "memory_utils.h"
 
 struct lxc_conf;
-struct lxc_epoll_descr;
+struct lxc_async_descr;
 struct lxc_handler;
 
 #ifndef SECCOMP_FILTER_FLAG_NEW_LISTENER
@@ -82,10 +82,10 @@ __hidden extern int lxc_seccomp_load(struct lxc_conf *conf);
 __hidden extern int lxc_read_seccomp_config(struct lxc_conf *conf);
 __hidden extern void lxc_seccomp_free(struct lxc_seccomp *seccomp);
 __hidden extern int seccomp_notify_handler(int fd, uint32_t events, void *data,
-					   struct lxc_epoll_descr *descr);
+					   struct lxc_async_descr *descr);
 __hidden extern void seccomp_conf_init(struct lxc_conf *conf);
 __hidden extern int lxc_seccomp_setup_proxy(struct lxc_seccomp *seccomp,
-					    struct lxc_epoll_descr *descr,
+					    struct lxc_async_descr *descr,
 					    struct lxc_handler *handler);
 __hidden extern int lxc_seccomp_send_notifier_fd(struct lxc_seccomp *seccomp, int socket_fd);
 __hidden extern int lxc_seccomp_recv_notifier_fd(struct lxc_seccomp *seccomp, int socket_fd);
@@ -131,7 +131,7 @@ static inline void lxc_seccomp_free(struct lxc_seccomp *seccomp)
 }
 
 static inline int seccomp_notify_handler(int fd, uint32_t events, void *data,
-				  struct lxc_epoll_descr *descr)
+				  struct lxc_async_descr *descr)
 {
 	return -ENOSYS;
 }
@@ -141,7 +141,7 @@ static inline void seccomp_conf_init(struct lxc_conf *conf)
 }
 
 static inline int lxc_seccomp_setup_proxy(struct lxc_seccomp *seccomp,
-					  struct lxc_epoll_descr *descr,
+					  struct lxc_async_descr *descr,
 					  struct lxc_handler *handler)
 {
 	return 0;

--- a/src/lxc/lxcseccomp.h
+++ b/src/lxc/lxcseccomp.h
@@ -81,6 +81,7 @@ struct lxc_seccomp {
 __hidden extern int lxc_seccomp_load(struct lxc_conf *conf);
 __hidden extern int lxc_read_seccomp_config(struct lxc_conf *conf);
 __hidden extern void lxc_seccomp_free(struct lxc_seccomp *seccomp);
+__hidden extern int seccomp_notify_cleanup_handler(int fd, void *data);
 __hidden extern int seccomp_notify_handler(int fd, uint32_t events, void *data,
 					   struct lxc_async_descr *descr);
 __hidden extern void seccomp_conf_init(struct lxc_conf *conf);
@@ -133,7 +134,12 @@ static inline void lxc_seccomp_free(struct lxc_seccomp *seccomp)
 static inline int seccomp_notify_handler(int fd, uint32_t events, void *data,
 				  struct lxc_async_descr *descr)
 {
-	return -ENOSYS;
+	return ret_errno(ENOSYS);
+}
+
+static inline int seccomp_notify_cleanup_handler(void *data)
+{
+	return ret_errno(ENOSYS);
 }
 
 static inline void seccomp_conf_init(struct lxc_conf *conf)

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -747,4 +747,9 @@ enum {
 #define PER_LINUX32	0x0008
 #endif
 
+static inline bool has_exact_flags(__u32 flags, __u32 mask)
+{
+	return (flags & mask) == mask;
+}
+
 #endif /* __LXC_MACRO_H */

--- a/src/lxc/mainloop.c
+++ b/src/lxc/mainloop.c
@@ -22,7 +22,7 @@ struct mainloop_handler {
 
 #define MAX_EVENTS 10
 
-int lxc_mainloop(struct lxc_epoll_descr *descr, int timeout_ms)
+int lxc_mainloop(struct lxc_async_descr *descr, int timeout_ms)
 {
 	int i, nfds, ret;
 	struct mainloop_handler *handler;
@@ -59,7 +59,7 @@ int lxc_mainloop(struct lxc_epoll_descr *descr, int timeout_ms)
 	}
 }
 
-int lxc_mainloop_add_handler_events(struct lxc_epoll_descr *descr, int fd,
+int lxc_mainloop_add_handler_events(struct lxc_async_descr *descr, int fd,
 				    int events,
 				    lxc_mainloop_callback_t callback,
 				    void *data)
@@ -94,14 +94,14 @@ int lxc_mainloop_add_handler_events(struct lxc_epoll_descr *descr, int fd,
 	return 0;
 }
 
-int lxc_mainloop_add_handler(struct lxc_epoll_descr *descr, int fd,
+int lxc_mainloop_add_handler(struct lxc_async_descr *descr, int fd,
 			     lxc_mainloop_callback_t callback, void *data)
 {
 	return lxc_mainloop_add_handler_events(descr, fd, EPOLLIN, callback,
 					       data);
 }
 
-int lxc_mainloop_del_handler(struct lxc_epoll_descr *descr, int fd)
+int lxc_mainloop_del_handler(struct lxc_async_descr *descr, int fd)
 {
 	struct mainloop_handler *handler;
 	struct lxc_list *iterator;
@@ -124,7 +124,7 @@ int lxc_mainloop_del_handler(struct lxc_epoll_descr *descr, int fd)
 	return ret_errno(EINVAL);
 }
 
-int lxc_mainloop_open(struct lxc_epoll_descr *descr)
+int lxc_mainloop_open(struct lxc_async_descr *descr)
 {
 	descr->epfd = epoll_create1(EPOLL_CLOEXEC);
 	if (descr->epfd < 0)
@@ -134,7 +134,7 @@ int lxc_mainloop_open(struct lxc_epoll_descr *descr)
 	return 0;
 }
 
-void lxc_mainloop_close(struct lxc_epoll_descr *descr)
+void lxc_mainloop_close(struct lxc_async_descr *descr)
 {
 	struct lxc_list *iterator, *next;
 

--- a/src/lxc/mainloop.c
+++ b/src/lxc/mainloop.c
@@ -8,21 +8,292 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/poll.h>
 #include <sys/epoll.h>
 #include <unistd.h>
 
 #include "config.h"
+#include "log.h"
+#include "macro.h"
 #include "mainloop.h"
 
+lxc_log_define(mainloop, lxc);
+
+#define CANCEL_RAISED	(1 << 0)
+#define CANCEL_RECEIVED (1 << 1)
+#define CANCEL_SUCCESS (1 << 2)
+
 struct mainloop_handler {
-	lxc_mainloop_callback_t callback;
+	struct lxc_list *list;
 	int fd;
 	void *data;
+	lxc_mainloop_callback_t callback;
+	lxc_mainloop_cleanup_t cleanup;
+	const char *handler_name;
+	unsigned int flags;
 };
 
 #define MAX_EVENTS 10
 
-int lxc_mainloop(struct lxc_async_descr *descr, int timeout_ms)
+static int __io_uring_disarm(struct lxc_async_descr *descr,
+			     struct mainloop_handler *handler);
+
+static void delete_handler(struct lxc_async_descr *descr,
+			   struct mainloop_handler *handler, bool oneshot)
+{
+	int ret = 0;
+	struct lxc_list *list;
+
+	if (descr->type == LXC_MAINLOOP_IO_URING) {
+		/*
+		 * For a oneshot handler we don't have to do anything. If we
+		 * end up here we know that an event for this handler has been
+		 * generated before and since this is a oneshot handler it
+		 * means that it has been deactivated. So the only thing we
+		 * need to do is to call the registered cleanup handler and
+		 * remove the handlerfrom the list.
+		 */
+		if (!oneshot)
+			ret = __io_uring_disarm(descr, handler);
+	} else {
+		ret = epoll_ctl(descr->epfd, EPOLL_CTL_DEL, handler->fd, NULL);
+	}
+	if (ret < 0)
+		SYSWARN("Failed to delete \"%d\" for \"%s\"", handler->fd, handler->handler_name);
+
+	if (handler->cleanup) {
+		ret = handler->cleanup(handler->fd, handler->data);
+		if (ret < 0)
+			SYSWARN("Failed to call cleanup \"%s\" handler", handler->handler_name);
+	}
+
+	list = move_ptr(handler->list);
+	lxc_list_del(list);
+	free(list->elem);
+	free(list);
+}
+
+#ifndef HAVE_LIBURING
+static inline int __lxc_mainloop_io_uring(struct lxc_async_descr *descr,
+					  int timeout_ms)
+{
+	return ret_errno(ENOSYS);
+}
+
+static int __io_uring_arm(struct lxc_async_descr *descr,
+			  struct mainloop_handler *handler, bool oneshot)
+{
+	return ret_errno(ENOSYS);
+}
+
+static int __io_uring_disarm(struct lxc_async_descr *descr,
+			     struct mainloop_handler *handler)
+{
+	return ret_errno(ENOSYS);
+}
+
+static inline int __io_uring_open(struct lxc_async_descr *descr)
+{
+	return ret_errno(ENOSYS);
+}
+
+#else
+
+static inline int __io_uring_open(struct lxc_async_descr *descr)
+{
+	int ret;
+	*descr = (struct lxc_async_descr){
+		.epfd = -EBADF,
+	};
+
+	descr->ring = mmap(NULL, sizeof(struct io_uring), PROT_READ | PROT_WRITE,
+			   MAP_SHARED | MAP_POPULATE | MAP_ANONYMOUS, -1, 0);
+	if (descr->ring == MAP_FAILED)
+		return syserror("Failed to mmap io_uring memory");
+
+	ret = io_uring_queue_init(512, descr->ring, IORING_SETUP_SQPOLL);
+	if (ret) {
+		SYSERROR("Failed to initialize io_uring instance");
+		goto on_error;
+	}
+
+	ret = io_uring_ring_dontfork(descr->ring);
+	if (ret) {
+		SYSERROR("Failed to prevent inheritance of io_uring mmaped region");
+		goto on_error;
+	}
+
+	descr->type = LXC_MAINLOOP_IO_URING;
+	TRACE("Created io-uring instance");
+	return 0;
+
+on_error:
+	ret = munmap(descr->ring, sizeof(struct io_uring));
+	if (ret < 0)
+		SYSWARN("Failed to unmap io_uring mmaped memory");
+
+	return ret_errno(ENOSYS);
+}
+
+static int __io_uring_arm(struct lxc_async_descr *descr,
+			  struct mainloop_handler *handler, bool oneshot)
+{
+	int ret;
+	struct io_uring_sqe *sqe;
+
+	sqe = io_uring_get_sqe(descr->ring);
+	if (!sqe)
+		return syserror_set(ENOENT, "Failed to get submission queue entry");
+
+	io_uring_prep_poll_add(sqe, handler->fd, EPOLLIN);
+
+	/*
+	 * Raise IORING_POLL_ADD_MULTI to set up a multishot poll. The same sqe
+	 * will now produce multiple cqes. A cqe produced from a multishot sqe
+	 * will raise IORING_CQE_F_MORE in cqe->flags.
+	 * Some devices can't be used with IORING_POLL_ADD_MULTI. This can only
+	 * be detected at completion time. The IORING_CQE_F_MORE flag will not
+	 * raised in cqe->flags. This includes terminal devices. So
+	 * unfortunately we can't use multishot for them although we really
+	 * would like to. But instead we will need to resubmit them. The
+	 * io_uring based mainloop will deal cases whwere multishot doesn't
+	 * work and resubmit the request. The handler just needs to inform the
+	 * mainloop that it wants to keep the handler.
+	 */
+	if (!oneshot)
+		sqe->len |= IORING_POLL_ADD_MULTI;
+
+	io_uring_sqe_set_data(sqe, handler);
+	ret = io_uring_submit(descr->ring);
+	if (ret < 0) {
+		if (!oneshot && ret == -EINVAL) {
+			/* The kernel might not yet support multishot. */
+			sqe->len &= ~IORING_POLL_ADD_MULTI;
+			ret = io_uring_submit(descr->ring);
+		}
+	}
+	if (ret < 0)
+		return syserror_ret(ret, "Failed to add \"%s\" handler", handler->handler_name);
+
+	TRACE("Added \"%s\" handler", handler->handler_name);
+	return 0;
+}
+
+static int __io_uring_disarm(struct lxc_async_descr *descr,
+			     struct mainloop_handler *handler)
+{
+	int ret;
+	struct io_uring_sqe *sqe;
+
+	sqe = io_uring_get_sqe(descr->ring);
+	if (!sqe)
+		return syserror_set(ENOENT,
+				    "Failed to get submission queue entry");
+
+	io_uring_prep_poll_remove(sqe, handler);
+	handler->flags |= CANCEL_RAISED;
+	io_uring_sqe_set_data(sqe, handler);
+	ret = io_uring_submit(descr->ring);
+	if (ret < 0) {
+		handler->flags &= ~CANCEL_RAISED;
+		return syserror_ret(ret, "Failed to remove \"%s\" handler",
+				    handler->handler_name);
+	}
+
+	TRACE("Removed handler \"%s\"", handler->handler_name);
+	return ret;
+}
+
+static void msec_to_ts(struct __kernel_timespec *ts, unsigned int timeout_ms)
+{
+	ts->tv_sec = timeout_ms / 1000;
+	ts->tv_nsec = (timeout_ms % 1000) * 1000000;
+}
+
+static int __lxc_mainloop_io_uring(struct lxc_async_descr *descr, int timeout_ms)
+{
+	struct __kernel_timespec ts;
+
+	if (timeout_ms >= 0)
+		msec_to_ts(&ts, timeout_ms);
+
+	for (;;) {
+		int ret;
+		__s32 mask = 0;
+		bool oneshot = false;
+		struct io_uring_cqe *cqe = NULL;
+		struct mainloop_handler *handler = NULL;
+
+		if (timeout_ms >= 0)
+			ret = io_uring_wait_cqe_timeout(descr->ring, &cqe, &ts);
+		else
+			ret = io_uring_wait_cqe(descr->ring, &cqe);
+		if (ret < 0) {
+			if (ret == -EINTR)
+				continue;
+
+			if (ret == -ETIME)
+				return 0;
+
+			return syserror_ret(ret, "Failed to wait for completion");
+		}
+
+		ret	= LXC_MAINLOOP_CONTINUE;
+		oneshot = !(cqe->flags & IORING_CQE_F_MORE);
+		mask	= cqe->res;
+		handler = io_uring_cqe_get_data(cqe);
+		io_uring_cqe_seen(descr->ring, cqe);
+
+		switch (mask) {
+		case -ECANCELED:
+			handler->flags |= CANCEL_RECEIVED;
+			TRACE("Canceled \"%s\" handler", handler->handler_name);
+			goto out;
+		case -ENOENT:
+			handler->flags = CANCEL_SUCCESS | CANCEL_RECEIVED;
+			TRACE("No sqe for \"%s\" handler", handler->handler_name);
+			goto out;
+		case -EALREADY:
+			TRACE("Repeat sqe remove request for \"%s\" handler", handler->handler_name);
+			goto out;
+		case 0:
+			handler->flags |= CANCEL_SUCCESS;
+			TRACE("Removed \"%s\" handler", handler->handler_name);
+			goto out;
+		default:
+			/*
+			 * We need to always remove the handler for a
+			 * successful oneshot request.
+			 */
+			if (oneshot)
+				handler->flags = CANCEL_SUCCESS | CANCEL_RECEIVED;
+		}
+
+		ret = handler->callback(handler->fd, mask, handler->data, descr);
+		switch (ret) {
+		case LXC_MAINLOOP_CONTINUE:
+			/* We're operating in oneshot mode so we need to rearm. */
+			if (oneshot && __io_uring_arm(descr, handler, true))
+				return -1;
+			break;
+		case LXC_MAINLOOP_DISARM:
+			if (has_exact_flags(handler->flags, (CANCEL_SUCCESS | CANCEL_RECEIVED)))
+				delete_handler(descr, handler, oneshot);
+			break;
+		case LXC_MAINLOOP_CLOSE:
+			return log_trace(0, "Closing from \"%s\"", handler->handler_name);
+		case LXC_MAINLOOP_ERROR:
+			return syserror_ret(-1, "Closing with error from \"%s\"", handler->handler_name);
+		}
+
+	out:
+		if (lxc_list_empty(&descr->handlers))
+			return error_ret(0, "Closing because there are no more handlers");
+	}
+}
+#endif
+
+static int __lxc_mainloop_epoll(struct lxc_async_descr *descr, int timeout_ms)
 {
 	int i, nfds, ret;
 	struct mainloop_handler *handler;
@@ -45,10 +316,17 @@ int lxc_mainloop(struct lxc_async_descr *descr, int timeout_ms)
 			 */
 			ret = handler->callback(handler->fd, events[i].events,
 						handler->data, descr);
-			if (ret == LXC_MAINLOOP_ERROR)
-				return -1;
-			if (ret == LXC_MAINLOOP_CLOSE)
+			switch (ret) {
+			case LXC_MAINLOOP_DISARM:
+				delete_handler(descr, handler, false);
+				__fallthrough;
+			case LXC_MAINLOOP_CONTINUE:
+				break;
+			case LXC_MAINLOOP_CLOSE:
 				return 0;
+			case LXC_MAINLOOP_ERROR:
+				return -1;
+			}
 		}
 
 		if (nfds == 0)
@@ -59,76 +337,153 @@ int lxc_mainloop(struct lxc_async_descr *descr, int timeout_ms)
 	}
 }
 
-int lxc_mainloop_add_handler_events(struct lxc_async_descr *descr, int fd,
-				    int events,
-				    lxc_mainloop_callback_t callback,
-				    void *data)
+int lxc_mainloop(struct lxc_async_descr *descr, int timeout_ms)
+{
+	if (descr->type == LXC_MAINLOOP_IO_URING)
+		return __lxc_mainloop_io_uring(descr, timeout_ms);
+
+	return __lxc_mainloop_epoll(descr, timeout_ms);
+}
+
+static int __lxc_mainloop_add_handler_events(struct lxc_async_descr *descr,
+					     int fd, int events,
+					     lxc_mainloop_callback_t callback,
+					     lxc_mainloop_cleanup_t cleanup,
+					     void *data, bool oneshot,
+					     const char *handler_name)
 {
 	__do_free struct mainloop_handler *handler = NULL;
-	__do_free struct lxc_list *item = NULL;
+	__do_free struct lxc_list *list = NULL;
+	int ret;
 	struct epoll_event ev;
 
 	if (fd < 0)
-		return -1;
+		return ret_errno(EBADF);
 
-	handler = malloc(sizeof(*handler));
+	if (!callback || !cleanup || !events || !handler_name)
+		return ret_errno(EINVAL);
+
+	handler = zalloc(sizeof(*handler));
 	if (!handler)
-		return -1;
-
-	handler->callback = callback;
-	handler->fd = fd;
-	handler->data = data;
-
-	ev.events = events;
-	ev.data.ptr = handler;
-
-	if (epoll_ctl(descr->epfd, EPOLL_CTL_ADD, fd, &ev) < 0)
-		return -errno;
-
-	item = malloc(sizeof(*item));
-	if (!item)
 		return ret_errno(ENOMEM);
 
-	item->elem = move_ptr(handler);
-	lxc_list_add(&descr->handlers, move_ptr(item));
+	handler->callback	= callback;
+	handler->cleanup	= cleanup;
+	handler->fd		= fd;
+	handler->data		= data;
+	handler->handler_name	= handler_name;
+
+	if (descr->type == LXC_MAINLOOP_IO_URING) {
+		ret = __io_uring_arm(descr, handler, oneshot);
+	} else {
+		ev.events = events;
+		ev.data.ptr = handler;
+		ret = epoll_ctl(descr->epfd, EPOLL_CTL_ADD, fd, &ev);
+	}
+	if (ret < 0)
+		return -errno;
+
+	list = lxc_list_new();
+	if (!list)
+		return ret_errno(ENOMEM);
+
+	handler->list = list;
+	lxc_list_add_elem(list, move_ptr(handler));;
+	lxc_list_add_tail(&descr->handlers, move_ptr(list));
 	return 0;
 }
 
-int lxc_mainloop_add_handler(struct lxc_async_descr *descr, int fd,
-			     lxc_mainloop_callback_t callback, void *data)
+int lxc_mainloop_add_handler_events(struct lxc_async_descr *descr, int fd,
+				    int events,
+				    lxc_mainloop_callback_t callback,
+				    lxc_mainloop_cleanup_t cleanup,
+				    void *data, const char *handler_name)
 {
-	return lxc_mainloop_add_handler_events(descr, fd, EPOLLIN, callback,
-					       data);
+	return __lxc_mainloop_add_handler_events(descr, fd, events,
+						 callback, cleanup,
+						 data, false, handler_name);
+}
+
+int lxc_mainloop_add_handler(struct lxc_async_descr *descr, int fd,
+			     lxc_mainloop_callback_t callback,
+			     lxc_mainloop_cleanup_t cleanup,
+			     void *data, const char *handler_name)
+{
+	return __lxc_mainloop_add_handler_events(descr, fd, EPOLLIN,
+						 callback, cleanup,
+						 data, false, handler_name);
+}
+
+int lxc_mainloop_add_oneshot_handler(struct lxc_async_descr *descr, int fd,
+				     lxc_mainloop_callback_t callback,
+				     lxc_mainloop_cleanup_t cleanup,
+				     void *data, const char *handler_name)
+{
+	return __lxc_mainloop_add_handler_events(descr, fd, EPOLLIN,
+						 callback, cleanup,
+						 data, true, handler_name);
 }
 
 int lxc_mainloop_del_handler(struct lxc_async_descr *descr, int fd)
 {
-	struct mainloop_handler *handler;
-	struct lxc_list *iterator;
+	int ret;
+	struct lxc_list *iterator = NULL;
 
 	lxc_list_for_each(iterator, &descr->handlers) {
-		handler = iterator->elem;
+		struct mainloop_handler *handler = iterator->elem;
 
-		if (handler->fd == fd) {
-			/* found */
-			if (epoll_ctl(descr->epfd, EPOLL_CTL_DEL, fd, NULL))
-				return -errno;
+		if (handler->fd != fd)
+			continue;
 
+		if (descr->type == LXC_MAINLOOP_IO_URING)
+			ret = __io_uring_disarm(descr, handler);
+		else
+			ret = epoll_ctl(descr->epfd, EPOLL_CTL_DEL, fd, NULL);
+		if (ret < 0)
+			return syserror("Failed to disarm \"%s\"", handler->handler_name);
+
+		/*
+		 * For io_uring the deletion happens at completion time. Either
+		 * we get ENOENT if the request was oneshot and it had already
+		 * triggered or we get ECANCELED for the original sqe and 0 for
+		 * the cancellation request.
+		 */
+		if (descr->type == LXC_MAINLOOP_EPOLL) {
 			lxc_list_del(iterator);
 			free(iterator->elem);
 			free(iterator);
-			return 0;
 		}
+
+		return 0;
 	}
 
 	return ret_errno(EINVAL);
 }
 
-int lxc_mainloop_open(struct lxc_async_descr *descr)
+static inline int __epoll_open(struct lxc_async_descr *descr)
 {
+	*descr = (struct lxc_async_descr){
+		.epfd = -EBADF,
+	};
+
 	descr->epfd = epoll_create1(EPOLL_CLOEXEC);
 	if (descr->epfd < 0)
-		return -errno;
+		return syserror("Failed to create epoll instance");
+
+	descr->type = LXC_MAINLOOP_EPOLL;
+	TRACE("Created epoll instance");
+	return 0;
+}
+
+int lxc_mainloop_open(struct lxc_async_descr *descr)
+{
+	int ret;
+
+	ret = __io_uring_open(descr);
+	if (ret == -ENOSYS)
+		ret = __epoll_open(descr);
+	if (ret < 0)
+		return syserror("Failed to create mainloop instance");
 
 	lxc_list_init(&descr->handlers);
 	return 0;
@@ -148,5 +503,14 @@ void lxc_mainloop_close(struct lxc_async_descr *descr)
 		iterator = next;
 	}
 
-	close_prot_errno_disarm(descr->epfd);
+	if (descr->type == LXC_MAINLOOP_IO_URING) {
+#ifdef HAVE_LIBURING
+		io_uring_queue_exit(descr->ring);
+		munmap(descr->ring, sizeof(struct io_uring));
+#else
+		ERROR("Unsupported io_uring mainloop");
+#endif
+	} else {
+		close_prot_errno_disarm(descr->epfd);
+	}
 }

--- a/src/lxc/mainloop.h
+++ b/src/lxc/mainloop.h
@@ -13,27 +13,27 @@
 #define LXC_MAINLOOP_CONTINUE 0
 #define LXC_MAINLOOP_CLOSE 1
 
-struct lxc_epoll_descr {
+struct lxc_async_descr {
 	int epfd;
 	struct lxc_list handlers;
 };
 
 typedef int (*lxc_mainloop_callback_t)(int fd, uint32_t event, void *data,
-				       struct lxc_epoll_descr *descr);
+				       struct lxc_async_descr *descr);
 
-__hidden extern int lxc_mainloop(struct lxc_epoll_descr *descr, int timeout_ms);
+__hidden extern int lxc_mainloop(struct lxc_async_descr *descr, int timeout_ms);
 
-__hidden extern int lxc_mainloop_add_handler_events(struct lxc_epoll_descr *descr, int fd, int events,
+__hidden extern int lxc_mainloop_add_handler_events(struct lxc_async_descr *descr, int fd, int events,
 						    lxc_mainloop_callback_t callback, void *data);
-__hidden extern int lxc_mainloop_add_handler(struct lxc_epoll_descr *descr, int fd,
+__hidden extern int lxc_mainloop_add_handler(struct lxc_async_descr *descr, int fd,
 					     lxc_mainloop_callback_t callback, void *data);
 
-__hidden extern int lxc_mainloop_del_handler(struct lxc_epoll_descr *descr, int fd);
+__hidden extern int lxc_mainloop_del_handler(struct lxc_async_descr *descr, int fd);
 
-__hidden extern int lxc_mainloop_open(struct lxc_epoll_descr *descr);
+__hidden extern int lxc_mainloop_open(struct lxc_async_descr *descr);
 
-__hidden extern void lxc_mainloop_close(struct lxc_epoll_descr *descr);
+__hidden extern void lxc_mainloop_close(struct lxc_async_descr *descr);
 
-define_cleanup_function(struct lxc_epoll_descr *, lxc_mainloop_close);
+define_cleanup_function(struct lxc_async_descr *, lxc_mainloop_close);
 
 #endif

--- a/src/lxc/mainloop.h
+++ b/src/lxc/mainloop.h
@@ -9,24 +9,55 @@
 #include "list.h"
 #include "memory_utils.h"
 
+#ifdef HAVE_LIBURING
+#include <liburing.h>
+#endif
+
 #define LXC_MAINLOOP_ERROR -1
 #define LXC_MAINLOOP_CONTINUE 0
 #define LXC_MAINLOOP_CLOSE 1
+#define LXC_MAINLOOP_DISARM 2
+
+typedef enum {
+	LXC_MAINLOOP_EPOLL	= 1,
+	LXC_MAINLOOP_IO_URING	= 2,
+} async_descr_t;
 
 struct lxc_async_descr {
-	int epfd;
+	async_descr_t type;
+	union {
+		int epfd;
+#ifdef HAVE_LIBURING
+		struct io_uring *ring;
+#endif
+	};
 	struct lxc_list handlers;
 };
+
+static inline int default_cleanup_handler(int fd, void *data)
+{
+	return 0;
+}
 
 typedef int (*lxc_mainloop_callback_t)(int fd, uint32_t event, void *data,
 				       struct lxc_async_descr *descr);
 
+typedef int (*lxc_mainloop_cleanup_t)(int fd, void *data);
+
 __hidden extern int lxc_mainloop(struct lxc_async_descr *descr, int timeout_ms);
 
 __hidden extern int lxc_mainloop_add_handler_events(struct lxc_async_descr *descr, int fd, int events,
-						    lxc_mainloop_callback_t callback, void *data);
+						    lxc_mainloop_callback_t callback,
+						    lxc_mainloop_cleanup_t cleanup,
+						    void *data, const char *handler_name);
 __hidden extern int lxc_mainloop_add_handler(struct lxc_async_descr *descr, int fd,
-					     lxc_mainloop_callback_t callback, void *data);
+					     lxc_mainloop_callback_t callback,
+					     lxc_mainloop_cleanup_t cleanup,
+					     void *data, const char *handler_name);
+__hidden extern int lxc_mainloop_add_oneshot_handler(struct lxc_async_descr *descr, int fd,
+						     lxc_mainloop_callback_t callback,
+						     lxc_mainloop_cleanup_t cleanup,
+						     void *data, const char *handler_name);
 
 __hidden extern int lxc_mainloop_del_handler(struct lxc_async_descr *descr, int fd);
 

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1359,7 +1359,7 @@ static void seccomp_notify_default_answer(int fd, struct seccomp_notif *req,
 #endif
 
 int seccomp_notify_handler(int fd, uint32_t events, void *data,
-			   struct lxc_epoll_descr *descr)
+			   struct lxc_async_descr *descr)
 {
 
 #if HAVE_DECL_SECCOMP_NOTIFY_FD
@@ -1566,7 +1566,7 @@ void seccomp_conf_init(struct lxc_conf *conf)
 }
 
 int lxc_seccomp_setup_proxy(struct lxc_seccomp *seccomp,
-			    struct lxc_epoll_descr *descr,
+			    struct lxc_async_descr *descr,
 			    struct lxc_handler *handler)
 {
 #if HAVE_DECL_SECCOMP_NOTIFY_FD

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -378,7 +378,7 @@ static int setup_signal_fd(sigset_t *oldmask)
 }
 
 static int signal_handler(int fd, uint32_t events, void *data,
-			  struct lxc_epoll_descr *descr)
+			  struct lxc_async_descr *descr)
 {
 	int ret;
 	siginfo_t info;
@@ -577,7 +577,7 @@ int lxc_poll(const char *name, struct lxc_handler *handler)
 {
 	int ret;
 	bool has_console = true;
-	struct lxc_epoll_descr descr, descr_console;
+	struct lxc_async_descr descr, descr_console;
 
 	if (handler->conf->console.path &&
 	    strequal(handler->conf->console.path, "none"))

--- a/src/lxc/syscall_wrappers.h
+++ b/src/lxc/syscall_wrappers.h
@@ -27,10 +27,6 @@
 #include <sys/signalfd.h>
 #endif
 
-#ifdef HAVE_STRUCT_OPEN_HOW
-#include <linux/openat2.h>
-#endif
-
 #if HAVE_SYS_PERSONALITY_H
 #include <sys/personality.h>
 #endif
@@ -299,11 +295,7 @@ struct lxc_open_how {
 #ifndef HAVE_OPENAT2
 static inline int openat2(int dfd, const char *filename, struct lxc_open_how *how, size_t size)
 {
-	/* When struct open_how is updated we should update lxc as well. */
-#ifdef HAVE_STRUCT_OPEN_HOW
-	BUILD_BUG_ON(sizeof(struct lxc_open_how) != sizeof(struct open_how));
-#endif
-	return syscall(__NR_openat2, dfd, filename, (struct open_how *)how, size);
+	return syscall(__NR_openat2, dfd, filename, how, size);
 }
 #endif /* HAVE_OPENAT2 */
 

--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -69,7 +69,7 @@ static void lxc_terminal_winch(struct lxc_terminal_state *ts)
 }
 
 int lxc_terminal_signalfd_cb(int fd, uint32_t events, void *cbdata,
-			     struct lxc_epoll_descr *descr)
+			     struct lxc_async_descr *descr)
 {
 	ssize_t ret;
 	struct signalfd_siginfo siginfo;
@@ -329,7 +329,7 @@ static int lxc_terminal_write_log_file(struct lxc_terminal *terminal, char *buf,
 }
 
 int lxc_terminal_io_cb(int fd, uint32_t events, void *data,
-		       struct lxc_epoll_descr *descr)
+		       struct lxc_async_descr *descr)
 {
 	struct lxc_terminal *terminal = data;
 	char buf[LXC_TERMINAL_BUFFER_SIZE];
@@ -411,7 +411,7 @@ static int lxc_terminal_mainloop_add_peer(struct lxc_terminal *terminal)
 	return 0;
 }
 
-int lxc_terminal_mainloop_add(struct lxc_epoll_descr *descr,
+int lxc_terminal_mainloop_add(struct lxc_async_descr *descr,
 			      struct lxc_terminal *terminal)
 {
 	int ret;
@@ -1116,7 +1116,7 @@ int lxc_terminal_set_stdfds(int fd)
 }
 
 int lxc_terminal_stdin_cb(int fd, uint32_t events, void *cbdata,
-			  struct lxc_epoll_descr *descr)
+			  struct lxc_async_descr *descr)
 {
 	int ret;
 	char c;
@@ -1150,7 +1150,7 @@ int lxc_terminal_stdin_cb(int fd, uint32_t events, void *cbdata,
 }
 
 int lxc_terminal_ptx_cb(int fd, uint32_t events, void *cbdata,
-			   struct lxc_epoll_descr *descr)
+			   struct lxc_async_descr *descr)
 {
 	int r, w;
 	char buf[LXC_TERMINAL_BUFFER_SIZE];
@@ -1180,7 +1180,7 @@ int lxc_console(struct lxc_container *c, int ttynum,
 		int escape)
 {
 	int ptxfd, ret, ttyfd;
-	struct lxc_epoll_descr descr;
+	struct lxc_async_descr descr;
 	struct termios oldtios;
 	struct lxc_terminal_state *ts;
 	struct lxc_terminal terminal = {

--- a/src/lxc/terminal.h
+++ b/src/lxc/terminal.h
@@ -13,7 +13,7 @@
 
 struct lxc_container;
 struct lxc_conf;
-struct lxc_epoll_descr;
+struct lxc_async_descr;
 
 struct lxc_terminal_info {
 	/* the path name of the pty side */
@@ -63,7 +63,7 @@ struct lxc_terminal {
 	int ptx;
 	int peer;
 	struct lxc_terminal_info proxy;
-	struct lxc_epoll_descr *descr;
+	struct lxc_async_descr *descr;
 	char *path;
 	char name[PATH_MAX];
 	struct termios *tios;
@@ -141,7 +141,7 @@ __hidden extern void lxc_terminal_free(struct lxc_conf *conf, int fd);
 /**
  * Register terminal event handlers in an open mainloop.
  */
-__hidden extern int lxc_terminal_mainloop_add(struct lxc_epoll_descr *, struct lxc_terminal *);
+__hidden extern int lxc_terminal_mainloop_add(struct lxc_async_descr *, struct lxc_terminal *);
 
 /**
  * Handle SIGWINCH events on the allocated terminals.
@@ -182,7 +182,7 @@ __hidden extern int lxc_terminal_set_stdfds(int fd);
  * This function exits the loop cleanly when an EPOLLHUP event is received.
  */
 __hidden extern int lxc_terminal_stdin_cb(int fd, uint32_t events, void *cbdata,
-					  struct lxc_epoll_descr *descr);
+					  struct lxc_async_descr *descr);
 
 /**
  * Handler for events on the ptx fd of the terminal. To be registered via
@@ -191,7 +191,7 @@ __hidden extern int lxc_terminal_stdin_cb(int fd, uint32_t events, void *cbdata,
  * This function exits the loop cleanly when an EPOLLHUP event is received.
  */
 __hidden extern int lxc_terminal_ptx_cb(int fd, uint32_t events, void *cbdata,
-					struct lxc_epoll_descr *descr);
+					struct lxc_async_descr *descr);
 
 /**
  * Setup new terminal properties. The old terminal settings are stored in
@@ -240,12 +240,12 @@ __hidden extern struct lxc_terminal_state *lxc_terminal_signal_init(int srcfd, i
  * declared and defined in mainloop.{c,h} or lxc_terminal_mainloop_add().
  */
 __hidden extern int lxc_terminal_signalfd_cb(int fd, uint32_t events, void *cbdata,
-					     struct lxc_epoll_descr *descr);
+					     struct lxc_async_descr *descr);
 
 __hidden extern int lxc_terminal_write_ringbuffer(struct lxc_terminal *terminal);
 __hidden extern int lxc_terminal_create_log_file(struct lxc_terminal *terminal);
 __hidden extern int lxc_terminal_io_cb(int fd, uint32_t events, void *data,
-				       struct lxc_epoll_descr *descr);
+				       struct lxc_async_descr *descr);
 
 __hidden extern int lxc_make_controlling_terminal(int fd);
 __hidden extern int lxc_terminal_prepare_login(int fd);

--- a/src/lxc/terminal.h
+++ b/src/lxc/terminal.h
@@ -244,8 +244,6 @@ __hidden extern int lxc_terminal_signalfd_cb(int fd, uint32_t events, void *cbda
 
 __hidden extern int lxc_terminal_write_ringbuffer(struct lxc_terminal *terminal);
 __hidden extern int lxc_terminal_create_log_file(struct lxc_terminal *terminal);
-__hidden extern int lxc_terminal_io_cb(int fd, uint32_t events, void *data,
-				       struct lxc_async_descr *descr);
 
 __hidden extern int lxc_make_controlling_terminal(int fd);
 __hidden extern int lxc_terminal_prepare_login(int fd);

--- a/src/lxc/tools/lxc_top.c
+++ b/src/lxc/tools/lxc_top.c
@@ -594,7 +594,10 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	ret = lxc_mainloop_add_handler(&descr, 0, stdin_handler, &in_char);
+	ret = lxc_mainloop_add_handler(&descr, 0,
+				       stdin_handler,
+				       default_cleanup_handler,
+				       &in_char, "stdin_handler");
 	if (ret) {
 		fprintf(stderr, "Failed to add stdin handler\n");
 		ret = EXIT_FAILURE;

--- a/src/lxc/tools/lxc_top.c
+++ b/src/lxc/tools/lxc_top.c
@@ -549,7 +549,7 @@ static void ct_realloc(int active_cnt)
 }
 
 static int stdin_handler(int fd, uint32_t events, void *data,
-			 struct lxc_epoll_descr *descr)
+			 struct lxc_async_descr *descr)
 {
 	char *in_char = data;
 
@@ -569,7 +569,7 @@ static int stdin_handler(int fd, uint32_t events, void *data,
 
 int main(int argc, char *argv[])
 {
-	struct lxc_epoll_descr descr;
+	struct lxc_async_descr descr;
 	int ret, ct_print_cnt;
 	char in_char;
 

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -5,7 +5,8 @@ LDADD = ../lxc/liblxc.la \
 	@OPENSSL_LIBS@ \
 	@SECCOMP_LIBS@ \
 	@SELINUX_LIBS@ \
-	@DLOG_LIBS@
+	@DLOG_LIBS@ \
+	@LIBURING_LIBS@
 
 LSM_SOURCES = ../lxc/lsm/lsm.c \
 	      ../lxc/lsm/lsm.h \


### PR DESCRIPTION
Users can choose to compile liblxc with io_uring support. This will
cause LXC to use io_uring instead of epoll.
We're using both, io_uring's one-shot and multi-shot poll mode depending
on the type of handler.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>