### PR TITLE
doc: Adds mention of ability to specify manual IPv4 broadcast address

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -661,6 +661,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
               Specify the ipv4 address to assign to the virtualized interface.
               Several lines specify several ipv4 addresses. The address is in
               format x.y.z.t/m, eg. 192.168.1.123/24.
+              You can optionally specify the broadcast address after the IP adress,
+              e.g. 192.168.1.123/24 255.255.255.255.
+              Otherwise it is automatically calculated from the IP address.
             </para>
           </listitem>
         </varlistentry>


### PR DESCRIPTION
I found this ability when working on https://github.com/lxc/lxd/pull/9103.

But I couldn't find any mention of it in the docs, so am adding it now.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>