### PR TITLE
mainloop: s,sys/poll,poll

### DIFF
--- a/src/lxc/mainloop.c
+++ b/src/lxc/mainloop.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/epoll.h>
 #include <unistd.h>
 


### PR DESCRIPTION
I get the following warning (which then fails the build because of
-Werror):

In file included from mainloop.c:11:
/usr/include/sys/poll.h:1:2: error: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Werror=cpp]
    1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
      |  ^~~~~~~

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>