### PR TITLE
memory_utils: make cleanup handler as unused

### DIFF
--- a/src/lxc/mainloop.c
+++ b/src/lxc/mainloop.c
@@ -315,11 +315,10 @@ static int __lxc_mainloop_io_uring(struct lxc_async_descr *descr, int timeout_ms
 
 static int __lxc_mainloop_epoll(struct lxc_async_descr *descr, int timeout_ms)
 {
-	int i, nfds, ret;
-	struct mainloop_handler *handler;
-	struct epoll_event events[MAX_EVENTS];
-
 	for (;;) {
+		int nfds;
+		struct epoll_event events[MAX_EVENTS];
+
 		nfds = epoll_wait(descr->epfd, events, MAX_EVENTS, timeout_ms);
 		if (nfds < 0) {
 			if (errno == EINTR)
@@ -328,8 +327,9 @@ static int __lxc_mainloop_epoll(struct lxc_async_descr *descr, int timeout_ms)
 			return -errno;
 		}
 
-		for (i = 0; i < nfds; i++) {
-			handler = events[i].data.ptr;
+		for (int i = 0; i < nfds; i++) {
+			int ret;
+			struct mainloop_handler *handler = events[i].data.ptr;
 
 			/* If the handler returns a positive value, exit the
 			 * mainloop.

--- a/src/lxc/memory_utils.h
+++ b/src/lxc/memory_utils.h
@@ -20,7 +20,8 @@
 			cleaner(*ptr);                   \
 	}
 
-#define call_cleaner(cleaner) __attribute__((__cleanup__(cleaner##_function)))
+#define call_cleaner(cleaner) \
+	__attribute__((__cleanup__(cleaner##_function))) __attribute__((unused))
 
 #define close_prot_errno_disarm(fd) \
 	if (fd >= 0) {              \


### PR DESCRIPTION
They are sometimes used to just clean something up automatically at end
of scope but the variables themselves might not be actually used.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>