### PR TITLE
Update lxc-checkconfig.in

### DIFF
--- a/src/lxc/cmd/lxc-checkconfig.in
+++ b/src/lxc/cmd/lxc-checkconfig.in
@@ -66,7 +66,13 @@ is_probed() {
     fi
 }
 
-echo "LXC version $(lxc-start --version)"
+# Fallback to using 'lxc info' to parse LXC version (for lxd compatability)
+if [ -x lxc-start ]; then
+  LXCVER="$(lxc-start --version)"
+elif [ -x lxc ]; then
+  LXCVER="$(lxc info | awk '$1 ~ /driver_version/ {print $2}')"
+fi
+echo "LXC version ${LXCVER-not found}"
 
 if [ ! -f $CONFIG ]; then
     echo "Kernel configuration not found at $CONFIG; searching..."


### PR DESCRIPTION
This script is pulled by lxd's `lxd.check-kernel` script, but produces this trivial error when run:

```
/snap/lxd/21260/bin/lxc-checkconfig: 69: lxc-start: not found
LXC version 
```

because lxd does not have an lxc-start binary (at least the snap version doesn't).

So this script falls back to using `lxc --version` if `lxc-start` command is not found which should fix it.

I think the only way to fix this from lxd itself is to symlink lxc-start to lxc, but that seems kludgy and potentially problematic.