### PR TITLE
seccomp: fix complication when !HAVE_DECL_SECCOMP_NOTIFY_FD

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1360,6 +1360,7 @@ static void seccomp_notify_default_answer(int fd, struct seccomp_notif *req,
 
 int seccomp_notify_cleanup_handler(int fd, void *data)
 {
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	struct lxc_handler *hdlr = data;
 	struct lxc_conf *conf = hdlr->conf;
 
@@ -1372,6 +1373,7 @@ int seccomp_notify_cleanup_handler(int fd, void *data)
 	 * seccomp notify handler through the command socket (e.g. for attach)
 	 * and so we won't touch the container's config.
 	 */
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
```
[2021-08-18 05:48:26] [build-stdout] mv -f $depbase.Tpo $depbase.Po
[2021-08-18 05:48:26] [build-stderr] seccomp.c: In function ‘seccomp_notify_cleanup_handler’:
[2021-08-18 05:48:26] [build-stderr] seccomp.c:1367:25: error: ‘struct lxc_seccomp’ has no member named ‘notifier’
[2021-08-18 05:48:26] [build-stderr]  1367 |  if (fd == conf->seccomp.notifier.notify_fd)
[2021-08-18 05:48:26] [build-stderr]       |                         ^
[2021-08-18 05:48:26] [build-stderr] In file included from af_unix.h:12,
[2021-08-18 05:48:26] [build-stderr]                  from seccomp.c:14:
[2021-08-18 05:48:26] [build-stderr] seccomp.c:1368:29: error: ‘struct lxc_seccomp’ has no member named ‘notifier’
[2021-08-18 05:48:26] [build-stderr]  1368 |   fd = move_fd(conf->seccomp.notifier.notify_fd);
[2021-08-18 05:48:26] [build-stderr]       |                             ^
[2021-08-18 05:48:26] [build-stderr] macro.h:655:26: note: in definition of macro ‘move_fd’
[2021-08-18 05:48:26] [build-stderr]   655 |   int __internal_fd__ = (fd); \
[2021-08-18 05:48:26] [build-stderr]       |                          ^~
[2021-08-18 05:48:26] [build-stderr] seccomp.c:1368:29: error: ‘struct lxc_seccomp’ has no member named ‘notifier’
[2021-08-18 05:48:26] [build-stderr]  1368 |   fd = move_fd(conf->seccomp.notifier.notify_fd);
[2021-08-18 05:48:26] [build-stderr]       |                             ^
[2021-08-18 05:48:26] [build-stderr] macro.h:656:4: note: in definition of macro ‘move_fd’
[2021-08-18 05:48:26] [build-stderr]   656 |   (fd) = -EBADF;              \
[2021-08-18 05:48:26] [build-stderr]       |    ^~
[2021-08-18 05:48:26] [build-stderr] make[3]: *** [Makefile:4496: seccomp.o] Error 1
[2021-08-18 05:48:26] [build-stdout] make[3]: Leaving directory '/opt/src/src/lxc'
[2021-08-18 05:48:26] [build-stdout] make[2]: Leaving directory '/opt/src/src'
[2021-08-18 05:48:26] [build-stdout] make[1]: Leaving directory '/opt/src/src'
[2021-08-18 05:48:26] [build-stderr] make[2]: *** [Makefile:440: all-recursive] Error 1
[2021-08-18 05:48:26] [build-stderr] make[1]: *** [Makefile:379: all] Error 2
[2021-08-18 05:48:26] [build-stderr] make: *** [Makefile:537: all-recursive] Error 1
[2021-08-18 05:48:26] [build-stderr] + '[' -f build.ninja ']'
[2021-08-18 05:48:26] [build-stdout] Semmle autobuild: no supported build system detected.
[2021-08-18 05:48:26] [build-stderr] + '[' -d ../_lgtm_build_dir ']'
[2021-08-18 05:48:26] [build-stderr] + for f in build build.sh
[2021-08-18 05:48:26] [build-stderr] + '[' -x build ']'
[2021-08-18 05:48:26] [build-stderr] + for f in build build.sh
[2021-08-18 05:48:26] [build-stderr] + '[' -x build.sh ']'
[2021-08-18 05:48:26] [build-stderr] + '[' -f setup.py ']'
[2021-08-18 05:48:26] [build-stderr] + echo 'Semmle autobuild: no supported build system detected.'
[2021-08-18 05:48:26] [build-stderr] + exit 1
[2021-08-18 05:48:26] [ERROR] Spawned process exited abnormally (code 1; tried to run: [/opt/dist/tools/linux64/preload_tracer, /opt/dist/cpp/tools/do-build])
[2021-08-18 05:48:26] [build-stderr] A fatal error occurred: Exit status 1 from command: [/opt/dist/cpp/tools/do-build]
[2021-08-18 05:48:26] [build-stderr] deptrace-server: received exit command
[2021-08-18 05:48:27] [ERROR] Spawned process exited abnormally (code 2; tried to run: [/opt/work/lgtm-workspace/lgtm/extract.sh])
A fatal error occurred: Exit status 2 from command: [/opt/work/lgtm-workspace/lgtm/extract.sh]
```

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>