### PR TITLE
Fix attach c

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1430,6 +1430,11 @@ int lxc_attach(struct lxc_container *container, lxc_attach_exec_t exec_function,
 		return log_error(-1, "Failed to get attach context");
 	}
 
+	if (options->lsm_label) {
+		free(ctx->lsm_label);
+		ctx->lsm_label = strdup(options->lsm_label);
+	}
+
 	conf = ctx->container->lxc_conf;
 
 	if (!fetch_seccomp(ctx->container, options))

--- a/src/lxc/confile.h
+++ b/src/lxc/confile.h
@@ -89,7 +89,7 @@ __hidden extern void lxc_config_define_free(struct lxc_list *defines);
  */
 __hidden extern int lxc_config_parse_arch(const char *arch, signed long *persona);
 
-__hidden extern int lxc_fill_elevated_privileges(char *flaglist, int *flags);
+__hidden extern int lxc_fill_elevated_privileges(char *flaglist, int *flags, const char *selinux_context);
 
 __hidden extern int lxc_clear_config_item(struct lxc_conf *c, const char *key);
 


### PR DESCRIPTION
Currently, the -c command (to set the selinux context) seems to be
broken because lxc-attach expects that also a new mount namespace
is specified via command line. This commit remove the check for the new
mount namespace to fix this issue. Please note that the
--elevated-privileges option is not affected by this issue.

Current situation:
```
~ # lxc-attach -n container --elevated-privileges=LSM
~ # id
uid=0(root) gid=0(root) context=u:r:unconfined_t:s0
# can not enter container
~ # lxc-attach -n container -c u:r:unconfined_t:s0
lxc-attach: node1: attach.c: lxc_attach_run_shell: 1860 Permission denied - Failed to execute shell
```

Expected:
```
~ # lxc-attach -n container --elevated-privileges=LSM
~ # id
uid=0(root) gid=0(root) context=u:r:unconfined_t:s0
# works
~ # lxc-attach -n container -c u:r:unconfined_t:s0
# in container now
~ # id
uid=0(root) gid=0(root) context=u:r:unconfined_t:s0
```

Please also note that when --elevated-privileges=LSM and -c are specified the -c context is silently ignored. This was pretty confusing to me since `-c u:r:unconfined_t:s0` didn't work (due to the bug) but `-c u:r:init_t:s0 -e` did work but transited into the `unconfined_t` context. Thus, i've added a patch to make the -c and the lsm privileges option exclusive.