### PR TITLE
config: enable seccomp profile only when compiled with libseccomp

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1211,7 +1211,11 @@ static int set_config_seccomp_notify_proxy(const char *key, const char *value,
 static int set_config_seccomp_profile(const char *key, const char *value,
 				      struct lxc_conf *lxc_conf, void *data)
 {
+#ifdef HAVE_SECCOMP
 	return set_config_path_item(&lxc_conf->seccomp.seccomp, value);
+#else
+	return ret_set_errno(-1, ENOSYS);
+#endif
 }
 
 static int set_config_execute_cmd(const char *key, const char *value,
@@ -4383,7 +4387,11 @@ static int get_config_seccomp_notify_proxy(const char *key, char *retv, int inle
 static int get_config_seccomp_profile(const char *key, char *retv, int inlen,
 				      struct lxc_conf *c, void *data)
 {
+#ifdef HAVE_SECCOMP
 	return lxc_get_conf_str(retv, inlen, c->seccomp.seccomp);
+#else
+	return ret_errno(ENOSYS);
+#endif
 }
 
 static int get_config_autodev(const char *key, char *retv, int inlen,


### PR DESCRIPTION
Make lxc fail if seccomp.profile is specified but lxc is compiled without seccomp support. Currently, seccomp.profile is silently ignored if is specified in such a scenario. This could lead to the false impression that the seccomp filter is applied while it actually isn't.

With this patch make the behavior of lxc.seccomp.profile compliant to the other lxc.seccomp,* options and will thus prevent a situation as described above.

Signed-off-by: Maximilian Blenk <Maximilian.Blenk@bmw.de>