### PR TITLE
Improve bash completion - part 2.

### DIFF
--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -39,6 +39,7 @@ __lxc_check_name_present() {
     mapfile -t names < <(command lxc-ls -1)
     local -r shortoptnamexp="^-[0-9A-Za-mo-z]*n[0-9A-Za-mo-z]*$"
     local parsed
+    local -r current="${cur//[\\\"\']}"
     mapfile -t names < <(command lxc-ls -1)
     # If `--name` or `-n` are present, do not complete with container names.
     for param in "${words[@]}"; do
@@ -50,7 +51,9 @@ __lxc_check_name_present() {
             return 0
         fi
         for name in "${names[@]}"; do
-            [[ "${parsed}" == "${name}" ]] && return 0
+            if [[ "${parsed}" == "${name}" ]] && [[ "${current}" != "${parsed}" ]]; then
+                return 0
+            fi
         done
     done
     return 1

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -564,7 +564,6 @@ _lxc_create() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
 }
 complete -F _lxc_create lxc-create
 

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -219,7 +219,13 @@ __lxc_piped_args() {
                 prefix=$(__lxc_concat_array_sep "${sep}" "${current[@]}")
                 for comp in "${completion[@]}"; do
                     [[ "${comp}" == "${lastword}" ]] && continue
-                    extcompletion+=("\"${prefix}${comp}\"")
+                    if [[ "${comp}" != "${sep}" ]]; then
+                        extcompletion+=("\"${prefix}${comp}\"")
+                    else
+                        # Trailing sep.
+                        extcompletion+=("\"${prefix}\"")
+                        [[ "${#completion[@]}" -gt 2 ]] && extcompletion+=("\"${prefix}${comp}\"")
+                    fi
                 done
             fi
         fi
@@ -329,8 +335,7 @@ _lxc_autostart() {
             return
             ;;
         --groups | -g )
-            # @TODO: add NULL group as a leading comma, trailing comma, embedded double comma.
-            __lxc_piped_args "${cur}" ',' $( __lxc_groups )
+            __lxc_piped_args "${cur}" ',' $( __lxc_groups ) ','
             return
             ;;
     esac
@@ -754,8 +759,7 @@ _lxc_ls() {
             return
             ;;
         --groups | -g )
-            # @TODO: add NULL group as a leading comma, trailing comma, embedded double comma.
-            __lxc_piped_args "${cur}" ',' $( __lxc_groups )
+            __lxc_piped_args "${cur}" ',' $( __lxc_groups ) ','
             return
             ;;
         --nesting )

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -1,42 +1,55 @@
 # lxc-* commands completion
 
 _lxc_names() {
+    declare -a names
     case ${words[0]} in
         lxc-attach | lxc-cgroup | lxc-checkpoint | lxc-console | lxc-device | lxc-freeze | lxc-stop )
-            COMPREPLY=( $( compgen -W "$( command lxc-ls --running )" -- "$cur" ) )
+            mapfile -t names < <(command lxc-ls --running -1)
             ;;
         lxc-destroy | lxc-execute | lxc-snapshot | lxc-start )
-            COMPREPLY=( $( compgen -W "$( command lxc-ls --stopped )" -- "$cur" ) )
+            mapfile -t names < <(command lxc-ls --stopped -1)
             ;;
         lxc-copy | lxc-info | lxc-monitor | lxc-wait )
-            COMPREPLY=( $( compgen -W "$( command lxc-ls --defined )" -- "$cur" ) )
+            mapfile -t names < <(command lxc-ls --defined -1)
             ;;
         lxc-autostart | lxc-create | lxc-checkconfig | lxc-config | lxc-ls | \
         lxc-top | lxc-unshare | lxc-update-config | lxc-usernsexec )
             ;;
         lxc-unfreeze )
-            COMPREPLY=( $( compgen -W "$( command lxc-ls --frozen )" -- "$cur" ) )
+            mapfile -t names < <(command lxc-ls --frozen -1)
             ;;
         *)
             # If we are running as an alias or symlink with different name,
             # fallback to old behaviour.
-            COMPREPLY=( $( compgen -W "$( command lxc-ls )" -- "$cur" ) )
+            mapfile -t names < <(command lxc-ls -1)
             ;;
     esac
+
+    COMPREPLY=()
+    for i in "${!names[@]}"; do
+        # For composed names with spaces escaped by '\'.
+        names[${i}]=$(command printf "%q" "${names[${i}]}")
+        if [[ -n $(compgen -W "${names[${i}]}" -- "$cur") ]]; then
+            COMPREPLY+=("${names[${i}]}")
+        fi
+    done
 }
 
 _lxc_append_name() {
-    local vms=$(command lxc-ls)
+    mapfile -t names < <(command lxc-ls -1)
     local -r shortoptnamexp="^-[0-9A-Za-mo-z]*n[0-9A-Za-mo-z]*$"
+    local parsed
     # If `--name` or `-n` are present, do not complete with container names.
-    for param in ${words[@]}; do
-        if [[ ${param} =~ ^--name(=(.*))?$ ]]; then
+    for param in "${words[@]}"; do
+        # Parse names from command line when space is escaped by backslash.
+        parsed="${param//[\\]}"
+        if [[ ${parsed} =~ ^--name(=(.*))?$ ]]; then
             return
-        elif [[ ${param} =~ ${shortoptnamexp} ]]; then
+        elif [[ ${parsed} =~ ${shortoptnamexp} ]]; then
             return
         fi
-        for vm in ${vms[@]}; do
-            [[ "${param}" = "${vm}" ]] && return
+        for name in "${names[@]}"; do
+            [[ "${parsed}" = "${name}" ]] && return
         done
     done
     _lxc_names

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -35,24 +35,31 @@ __lxc_names() {
     done
 }
 
-__lxc_append_name() {
+__lxc_check_name_present() {
     mapfile -t names < <(command lxc-ls -1)
     local -r shortoptnamexp="^-[0-9A-Za-mo-z]*n[0-9A-Za-mo-z]*$"
     local parsed
+    mapfile -t names < <(command lxc-ls -1)
     # If `--name` or `-n` are present, do not complete with container names.
     for param in "${words[@]}"; do
         # Parse names from command line when space is escaped by backslash.
         parsed="${param//[\\\"\']}"
         if [[ ${parsed} =~ ^--name(=(.*))?$ ]]; then
-            return
+            return 0
         elif [[ ${parsed} =~ ${shortoptnamexp} ]]; then
-            return
+            return 0
         fi
         for name in "${names[@]}"; do
-            [[ "${parsed}" == "${name}" ]] && return
+            [[ "${parsed}" == "${name}" ]] && return 0
         done
     done
-    __lxc_names
+    return 1
+}
+
+__lxc_append_name() {
+    if ! __lxc_check_name_present; then
+        __lxc_names
+    fi
 }
 
 __lxc_get_snapshots() {
@@ -383,6 +390,53 @@ _lxc_autostart() {
 } &&
     complete -F _lxc_autostart lxc-autostart
 
+__lxc_cgroup_v2() {
+    declare -a stateObjects
+    local -r path="${1}"
+    [[ ! -f "${path}/cgroup.controllers" ]] && return
+    for controller in $(<"${path}/cgroup.controllers"); do
+        for so in ${path}/${controller}.*; do
+            [[ ! -f "${so}" ]] && continue
+            stateObjects+=("${so##*/}")
+        done
+    done
+    command printf "%s" "${stateObjects[*]}"
+}
+
+__lxc_cgroup_v1() {
+    declare -a stateObjects
+    local -r path="${1}"
+    local prefix
+    for controller in "${path}"/*; do
+        [[ ! -d "${controller}" ]] && continue
+        prefix="${controller##*/}"
+        for so in "${controller}/${prefix}".*; do
+            [[ ! -f "${so}" ]] && continue
+            stateObjects+=("${so##*/}")
+        done
+    done
+    command printf "%s" "${stateObjects[*]}"
+}
+
+__lxc_cgroup_state_object() {
+    local -r name="${1}"
+    local -r cgroupPath="/sys/fs/cgroup"
+    # cgroup_v2 + user.slice
+    local -r userSlicePath="${cgroupPath}/user.slice"
+    if [[ -d "${userSlicePath}" ]]; then
+        COMPREPLY=( $( compgen -W "$(__lxc_cgroup_v2 "${userSlicePath}")" -- "${cur}" ) )
+        return
+    fi
+    # cgroup_v2 + lxc.payload
+    local -r lxcCgroup="${cgroupPath}/lxc.payload.${name}"
+    if [[ -d "${lxcCgroup}" ]]; then
+        COMPREPLY=( $( compgen -W "$(__lxc_cgroup_v2 "${lxcCgroup}")" -- "${cur}" ) )
+        return
+    fi
+    # cgroup_v1
+    COMPREPLY=( $( compgen -W "$(__lxc_cgroup_v1 "${cgroupPath}")" -- "${cur}" ) )
+}
+
 _lxc_cgroup() {
     local cur prev words cword split
     COMPREPLY=()
@@ -408,7 +462,12 @@ _lxc_cgroup() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    __lxc_append_name
+
+    if __lxc_check_name_present; then
+        __lxc_cgroup_state_object
+    else
+        __lxc_append_name
+    fi
 } &&
     complete -F _lxc_cgroup lxc-cgroup
 

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -27,11 +27,12 @@ _lxc_names() {
 
 _lxc_append_name() {
     local vms=$(command lxc-ls)
+    local -r shortoptnamexp="^-[0-9A-Za-mo-z]*n[0-9A-Za-mo-z]*$"
     # If `--name` or `-n` are present, do not complete with container names.
     for param in ${words[@]}; do
-        if [[ ${param} =~ ^--name=(.*)$ ]]; then
+        if [[ ${param} =~ ^--name(=(.*))?$ ]]; then
             return
-        elif [[ ${param} =~ ^-n$ ]]; then
+        elif [[ ${param} =~ ${shortoptnamexp} ]]; then
             return
         fi
         for vm in ${vms[@]}; do

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -111,6 +111,10 @@ __lxc_piped_args() {
     fi
 
     COMPREPLY=( $( compgen -P '"' -S '"' -W "$(command echo -e ${extended[@]})" -- "${cur}" ) )
+    # If no more words availables for completion, add space after last match.
+    if [[ "${#completion[@]}" -gt 1 ]]; then
+        compopt -o nospace
+    fi
 }
 
 _lxc_attach() {
@@ -140,12 +144,10 @@ _lxc_attach() {
             ;;
         --elevated-privileges | -e )
             __lxc_piped_args "$cur" '|' CGROUP CAP LSM
-            compopt -o nospace
             return
             ;;
         --namespaces | -s )
             __lxc_piped_args "$cur" '|' MOUNT PID UTSNAME IPC USER NETWORK
-            compopt -o nospace
             return
             ;;
         --remount-sys-proc | -R | --keep-env | --clear-env )
@@ -213,7 +215,6 @@ _lxc_autostart() {
         --groups | -g )
             # @TODO: add NULL group as a leading comma, trailing comma, embedded double comma.
             __lxc_piped_args "$cur" ',' $( __lxc_groups )
-            compopt -o nospace
             return
             ;;
     esac
@@ -638,7 +639,6 @@ _lxc_ls() {
         --groups | -g )
             # @TODO: add NULL group as a leading comma, trailing comma, embedded double comma.
             __lxc_piped_args "$cur" ',' $( __lxc_groups )
-            compopt -o nospace
             return
             ;;
         --nesting )
@@ -902,8 +902,7 @@ _lxc_unshare() {
 
     case $prev in
         --namespaces | -s )
-            __lxc_piped_args "$cur" '|' "MOUNT" "PID" "UTSNAME" "IPC" "USER" "NETWORK"
-            compopt -o nospace
+            __lxc_piped_args "$cur" '|' MOUNT PID UTSNAME IPC USER NETWORK
             return
             ;;
         --user | -u )
@@ -1008,7 +1007,6 @@ _lxc_wait() {
             ;;
         --state | -s )
             __lxc_piped_args "$cur" '|' STOPPED STARTING RUNNING STOPPING ABORTING FREEZING FROZEN THAWED
-            compopt -o nospace
             return
             ;;
         --timeout | -t )

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -509,6 +509,21 @@ __lxc_backing_stores() {
     COMPREPLY=( $( compgen -W 'best btrfs dir loop lvm nbd overlay overlayfs rbd zfs' -- "${cur}" ) )
 }
 
+__lxc_size_unit() {
+    if [[ -n "${cur}" ]] && [[ ! "${cur}" =~ ^[0-9]+$ ]]; then
+        return
+    fi
+    # Size.
+    if [[ -z "${cur}" ]]; then
+        COMPREPLY=( $( compgen -P "${cur}" -W "{1..9}" ) )
+    else
+        COMPREPLY=( $( compgen -P "${cur}" -W "{0..9}" ) )
+        # Unit
+        COMPREPLY+=( $( compgen -P "${cur}" -W "$( command echo ${@})" ) )
+    fi
+    compopt -o nospace
+}
+
 _lxc_copy() {
     local cur prev words cword split
     COMPREPLY=()
@@ -540,7 +555,7 @@ _lxc_copy() {
             return
             ;;
         --fssize | -L )
-            # @TODO: return a size suffixed by K,M,G,T
+            __lxc_size_unit K M G T
             return
             ;;
     esac

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -1124,6 +1124,14 @@ _lxc_update_config() {
 } &&
     complete -F _lxc_update_config lxc-update-config
 
+__lxc_id_mapping() {
+    local -r tmp="${cur//[^:]}"
+    if [[ "${#tmp}" -eq 0 ]]; then
+        COMPREPLY=( $( compgen -W "u: g: b:" -- "${cur}" ) )
+    fi
+    compopt -o nospace
+}
+
 _lxc_usernsexec() {
     local cur prev words cword split
     COMPREPLY=()
@@ -1139,7 +1147,8 @@ _lxc_usernsexec() {
             return
             ;;
         -m )
-            # @TODO: ^[ugb]:[0-9]+:[0-9]+(:[0-9]+)?$
+            # ^[ugb]:[0-9]+:[0-9]+(:[0-9]+)?$
+            __lxc_id_mapping
             return
             ;;
         -s )
@@ -1152,7 +1161,6 @@ _lxc_usernsexec() {
     if [[ ${cur} == -* ]]; then
         COMPREPLY=( $( compgen -W '-h -m -s' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
-        return
     fi
 } &&
     complete -F _lxc_usernsexec lxc-usernsexec

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -29,7 +29,7 @@ _lxc_names() {
     for i in "${!names[@]}"; do
         # For composed names with spaces escaped by '\'.
         names[${i}]=$(command printf "%q" "${names[${i}]}")
-        if [[ -n $(compgen -W "${names[${i}]}" -- "$cur") ]]; then
+        if [[ -n $(compgen -W "${names[${i}]}" -- "${cur}") ]]; then
             COMPREPLY+=("${names[${i}]}")
         fi
     done
@@ -49,7 +49,7 @@ _lxc_append_name() {
             return
         fi
         for name in "${names[@]}"; do
-            [[ "${parsed}" = "${name}" ]] && return
+            [[ "${parsed}" == "${name}" ]] && return
         done
     done
     _lxc_names
@@ -57,11 +57,11 @@ _lxc_append_name() {
 
 _lxc_common_opt() {
     # End of options.
-    if [[ "${words[@]}" =~ ' -- ' ]]; then
+    if [[ "${words[*]}" =~ ' -- ' ]]; then
         return 1
     fi
 
-    case $prev in
+    case ${prev} in
         --help | -h | -\? | --usage | --version )
             return 1
             ;;
@@ -74,7 +74,7 @@ _lxc_common_opt() {
             return 1
             ;;
         --logpriority | -l )
-            COMPREPLY=( $(compgen -W 'FATAL CRIT WARN ERROR NOTICE INFO DEBUG' -- "$cur") )
+            COMPREPLY=( $(compgen -W 'FATAL CRIT WARN ERROR NOTICE INFO DEBUG' -- "${cur}") )
             return 1
             ;;
         --quiet | -q )
@@ -138,7 +138,7 @@ _lxc_attach() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -153,15 +153,15 @@ _lxc_attach() {
             ;;
         --arch | -a )
             # https://github.com/lxc/lxc/blob/stable-4.0/src/tests/arch_parse.c#L37
-            COMPREPLY=( $( compgen -W 'arm armel armhf armv7l athlon i386 i486 i586 i686 linux32 mips mipsel ppc powerpc x86 aarch64 amd64 arm64 linux64 mips64 mips64el ppc64 ppc64el ppc64le powerpc64 s390x x86_64' -- "$cur" ) )
+            COMPREPLY=( $( compgen -W 'arm armel armhf armv7l athlon i386 i486 i586 i686 linux32 mips mipsel ppc powerpc x86 aarch64 amd64 arm64 linux64 mips64 mips64el ppc64 ppc64el ppc64le powerpc64 s390x x86_64' -- "${cur}" ) )
             return
             ;;
         --elevated-privileges | -e )
-            __lxc_piped_args "$cur" '|' CGROUP CAP LSM
+            __lxc_piped_args "${cur}" '|' CGROUP CAP LSM
             return
             ;;
         --namespaces | -s )
-            __lxc_piped_args "$cur" '|' MOUNT PID UTSNAME IPC USER NETWORK
+            __lxc_piped_args "${cur}" '|' MOUNT PID UTSNAME IPC USER NETWORK
             return
             ;;
         --remount-sys-proc | -R | --keep-env | --clear-env )
@@ -172,7 +172,7 @@ _lxc_attach() {
             return
             ;;
         --keep-var )
-            COMPREPLY=( $( compgen -A variable -- "$cur" ) )
+            COMPREPLY=( $( compgen -A variable -- "${cur}" ) )
             return
             ;;
         --uid | -u )
@@ -191,8 +191,8 @@ _lxc_attach() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -217,26 +217,26 @@ _lxc_autostart() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --reboot | -r | --shutdown | -s | --kill | -k | --list | -L | --all | -a | --ignore-auto | -A )
             # Only flags.
             ;;
         --timeout | -t )
-            COMPREPLY=( $( compgen -P "$cur" -W "{0..9}" ) )
+            COMPREPLY=( $( compgen -P "${cur}" -W "{0..9}" ) )
             compopt -o nospace
             return
             ;;
         --groups | -g )
             # @TODO: add NULL group as a leading comma, trailing comma, embedded double comma.
-            __lxc_piped_args "$cur" ',' $( __lxc_groups )
+            __lxc_piped_args "${cur}" ',' $( __lxc_groups )
             return
             ;;
     esac
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -250,7 +250,7 @@ _lxc_cgroup() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -263,8 +263,8 @@ _lxc_cgroup() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -279,7 +279,7 @@ _lxc_checkpoint() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -303,8 +303,8 @@ _lxc_checkpoint() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -318,12 +318,12 @@ _lxc_config() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-l' -- "$cur"))
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=($(compgen -W '-l' -- "${cur}"))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    COMPREPLY=( $( compgen -W "$( command lxc-config -l )" -- "$cur" ) )
+    COMPREPLY=( $( compgen -W "$( command lxc-config -l )" -- "${cur}" ) )
 }
 complete -F _lxc_config lxc-config
 
@@ -334,7 +334,7 @@ _lxc_console() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -344,11 +344,11 @@ _lxc_console() {
             return
             ;;
         --escape | -e )
-            COMPREPLY+=( $( compgen -P "'" -S "'" -W "^{a..z} {a..z}" -- "$cur" ) )
+            COMPREPLY+=( $( compgen -P "'" -S "'" -W "^{a..z} {a..z}" -- "${cur}" ) )
             return
             ;;
         --tty | -t )
-            COMPREPLY=( $( compgen -P "$cur" -W "{0..9}" ) )
+            COMPREPLY=( $( compgen -P "${cur}" -W "{0..9}" ) )
             compopt -o nospace
             return
             ;;
@@ -356,8 +356,8 @@ _lxc_console() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -366,7 +366,7 @@ _lxc_console() {
 complete -F _lxc_console lxc-console
 
 __lxc_backing_stores() {
-    COMPREPLY=( $( compgen -W 'best btrfs dir loop lvm nbd overlay overlayfs rbd zfs' -- "$cur" ) )
+    COMPREPLY=( $( compgen -W 'best btrfs dir loop lvm nbd overlay overlayfs rbd zfs' -- "${cur}" ) )
 }
 
 _lxc_copy() {
@@ -376,7 +376,7 @@ _lxc_copy() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -407,8 +407,8 @@ _lxc_copy() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -417,7 +417,7 @@ _lxc_copy() {
 complete -F _lxc_copy lxc-copy
 
 __lxc_templates() {
-    COMPREPLY=( $( compgen -W "$(command ls @LXCTEMPLATEDIR@/ | command sed -e 's|^lxc-||' )" -- "$cur" ) )
+    COMPREPLY=( $( compgen -W "$(command ls @LXCTEMPLATEDIR@/ | command sed -e 's|^lxc-||' )" -- "${cur}" ) )
 }
 
 _lxc_create() {
@@ -427,7 +427,7 @@ _lxc_create() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -452,8 +452,8 @@ _lxc_create() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -468,7 +468,7 @@ _lxc_destroy() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -484,8 +484,8 @@ _lxc_destroy() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -498,7 +498,7 @@ _lxc_device() {
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    case $prev in
+    case ${prev} in
         -h )
             return
             ;;
@@ -515,8 +515,8 @@ _lxc_device() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -531,7 +531,7 @@ _lxc_execute() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -561,8 +561,8 @@ _lxc_execute() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -577,7 +577,7 @@ _lxc_freeze() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -590,8 +590,8 @@ _lxc_freeze() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -606,7 +606,7 @@ _lxc_info() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -628,8 +628,8 @@ _lxc_info() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -643,7 +643,7 @@ _lxc_ls() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --line | -1 | --fancy | -f | --active | --frozen | --running | --stopped | --defined )
             # Only flags.
             ;;
@@ -653,11 +653,11 @@ _lxc_ls() {
             ;;
         --groups | -g )
             # @TODO: add NULL group as a leading comma, trailing comma, embedded double comma.
-            __lxc_piped_args "$cur" ',' $( __lxc_groups )
+            __lxc_piped_args "${cur}" ',' $( __lxc_groups )
             return
             ;;
         --nesting )
-            COMPREPLY=( $( compgen -P "$cur" -W "{0..9}" ) )
+            COMPREPLY=( $( compgen -P "${cur}" -W "{0..9}" ) )
             compopt -o nospace
             return
             ;;
@@ -669,8 +669,8 @@ _lxc_ls() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -683,7 +683,7 @@ _lxc_monitor() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -695,8 +695,8 @@ _lxc_monitor() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -710,7 +710,7 @@ _lxc_snapshot() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -724,14 +724,14 @@ _lxc_snapshot() {
             return
             ;;
         --destroy | -d )
-            COMPREPLY=( $( compgen -W 'ALL $( lxc-snapshot --list )' -- "$cur" ) )
+            COMPREPLY=( $( compgen -W 'ALL $( lxc-snapshot --list )' -- "${cur}" ) )
             return
             ;;
         --list | -L | --showcomments | -C )
             # Only flags.
             ;;
         --restore | -r )
-            COMPREPLY=( $( compgen -W '$( lxc-snapshot --list )' -- "$cur" ) )
+            COMPREPLY=( $( compgen -W '$( lxc-snapshot --list )' -- "${cur}" ) )
             return
             ;;
         --newname | -N )
@@ -741,8 +741,8 @@ _lxc_snapshot() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -757,7 +757,7 @@ _lxc_start() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -790,18 +790,18 @@ _lxc_start() {
             ;;
         --share-net | --share-ipc | --share-uts )
             _pids
-            COMPREPLY+=( $( compgen -W "$( command lxc-ls --active )" -- "$cur" ) )
+            COMPREPLY+=( $( compgen -W "$( command lxc-ls --active )" -- "${cur}" ) )
             return
             ;;
     esac
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
 
         # Needed due to weird `_parse_help` output for the `--share-*` options.
-	COMPREPLY=( $( compgen -W '${COMPREPLY[@]/--share-} --share-net --share-ipc --share-uts' -- "$cur" ) )
+	COMPREPLY=( $( compgen -W '${COMPREPLY[@]/--share-} --share-net --share-ipc --share-uts' -- "${cur}" ) )
 
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
@@ -817,7 +817,7 @@ _lxc_stop() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -830,7 +830,7 @@ _lxc_stop() {
             # Only flags.
             ;;
         --timeout | -t )
-            COMPREPLY=( $( compgen -P "$cur" -W "{0..9}" ) )
+            COMPREPLY=( $( compgen -P "${cur}" -W "{0..9}" ) )
             compopt -o nospace
             return
             ;;
@@ -838,8 +838,8 @@ _lxc_stop() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -854,25 +854,25 @@ _lxc_top() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --batch | -b | --reverse | -r )
             # Only flags.
             ;;
         --delay | -d )
-            COMPREPLY=( $( compgen -P "$cur" -W "{0..9}" ) )
+            COMPREPLY=( $( compgen -P "${cur}" -W "{0..9}" ) )
             compopt -o nospace
             return
             ;;
         --sort | -s )
-            COMPREPLY=( $( compgen -W 'n c b m k' -- "$cur" ) )
+            COMPREPLY=( $( compgen -W 'n c b m k' -- "${cur}" ) )
             return
             ;;
     esac
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -886,7 +886,7 @@ _lxc_unfreeze() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -899,8 +899,8 @@ _lxc_unfreeze() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -915,9 +915,9 @@ _lxc_unshare() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --namespaces | -s )
-            __lxc_piped_args "$cur" '|' MOUNT PID UTSNAME IPC USER NETWORK
+            __lxc_piped_args "${cur}" '|' MOUNT PID UTSNAME IPC USER NETWORK
             return
             ;;
         --user | -u )
@@ -938,8 +938,8 @@ _lxc_unshare() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -951,7 +951,7 @@ _lxc_update_config() {
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    case $prev in
+    case ${prev} in
         --help | -h )
             return
             ;;
@@ -963,8 +963,8 @@ _lxc_update_config() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -978,11 +978,11 @@ _lxc_usernsexec() {
     _init_completion -s -n : || return
 
     # End of options.
-    if [[ "${words[@]}" =~ ' -- ' ]]; then
+    if [[ "${words[*]}" =~ ' -- ' ]]; then
         return
     fi
 
-    case $prev in
+    case ${prev} in
         -h )
             return
             ;;
@@ -997,8 +997,8 @@ _lxc_usernsexec() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '-h -m -s' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '-h -m -s' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
@@ -1011,7 +1011,7 @@ _lxc_wait() {
 
     _lxc_common_opt || return
 
-    case $prev in
+    case ${prev} in
         --name | -n )
             _lxc_names
             return
@@ -1021,11 +1021,11 @@ _lxc_wait() {
             return
             ;;
         --state | -s )
-            __lxc_piped_args "$cur" '|' STOPPED STARTING RUNNING STOPPING ABORTING FREEZING FROZEN THAWED
+            __lxc_piped_args "${cur}" '|' STOPPED STARTING RUNNING STOPPING ABORTING FREEZING FROZEN THAWED
             return
             ;;
         --timeout | -t )
-            COMPREPLY=( $( compgen -P "$cur" -W "{0..9}" ) )
+            COMPREPLY=( $( compgen -P "${cur}" -W "{0..9}" ) )
             compopt -o nospace
             return
             ;;
@@ -1033,8 +1033,8 @@ _lxc_wait() {
 
     $split && return
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -166,9 +166,11 @@ __lxc_check_word_in_array() {
 }
 
 __lxc_piped_args() {
+    local -r currentWord="${1}"
     local -r sep="${2}"
+    declare -a completionWords=("${@:3}")
     # Remove double/single quote and backslash from current completion parameter.
-    IFS=$"${sep}" read -r -e -a current <<< "${1//[\\\"\']}"
+    IFS=$"${sep}" read -r -e -a current <<< "${currentWord//[\\\"\']}"
 
     # Add separator back to current in case it is part of completion list.
     for i in "${!current[@]}"; do
@@ -179,7 +181,7 @@ __lxc_piped_args() {
 
     # Remove words from completion already added to argument.
     declare -a minuslast=("${current[@]::${#current[@]}-1}")
-    declare -a completion=("${@:3}")
+    declare -a completion=("${completionWords[@]}")
     for i in "${!completion[@]}"; do
         if __lxc_check_word_in_array "${completion[${i}]}" "${minuslast[@]}"; then
             command unset -v 'completion[${i}]'
@@ -191,7 +193,7 @@ __lxc_piped_args() {
     if __lxc_array_has_duplicates "${minuslast[@]}"; then
         return
     fi
-    declare -a allcomps=("${@:3}")
+    declare -a allcomps=("${completionWords[@]}")
     for i in "${!minuslast[@]}"; do
         if ! __lxc_check_word_in_array "${minuslast[${i}]}" "${allcomps[@]}"; then
             return
@@ -212,7 +214,7 @@ __lxc_piped_args() {
         fi
         # TAB after quotes to complete for next value.
         if ! __lxc_array_has_duplicates "${current[@]}" && __lxc_check_word_in_array "${lastword}" "${allcomps[@]}"; then
-            if ! __lxc_check_completion_avail "${lastword}" "${completion[@]}" || [[ "${#1}" -lt "${#sep}" ]] || [[ "${1: -${#sep}}" == "${sep}" ]]; then
+            if ! __lxc_check_completion_avail "${lastword}" "${completion[@]}" || [[ "${#currentWord}" -lt "${#sep}" ]] || [[ "${currentWord: -${#sep}}" == "${sep}" ]]; then
                 prefix=$(__lxc_concat_array_sep "${sep}" "${current[@]}")
                 for comp in "${completion[@]}"; do
                     [[ "${comp}" == "${lastword}" ]] && continue
@@ -340,7 +342,7 @@ __lxc_get_groups() {
         line=$(command echo -e "${line}" | command sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
         IFS=$',' read -r -e -a linegroups <<< "${line}"
         for entry in "${linegroups[@]}"; do
-            key=$(printf "%q" "${entry}")
+            key=$(command printf "%q" "${entry}")
             groups+=(["${key}"]=1)
         done
     done
@@ -385,7 +387,7 @@ __lxc_cgroup_v2() {
     local -r path="${1}"
     [[ ! -f "${path}/cgroup.controllers" ]] && return
     for controller in $(<"${path}/cgroup.controllers"); do
-        for so in ${path}/${controller}.*; do
+        for so in "${path}/${controller}".*; do
             [[ ! -f "${so}" ]] && continue
             stateObjects+=("${so##*/}")
         done
@@ -411,20 +413,30 @@ __lxc_cgroup_v1() {
 __lxc_cgroup_state_object() {
     local -r name="${1}"
     local -r cgroupPath="/sys/fs/cgroup"
-    # cgroup_v2 + user.slice
+    local output
     local -r userSlicePath="${cgroupPath}/user.slice"
+    local -r lxcPayloadPath="${cgroupPath}/lxc.payload.${name}"
     if [[ -d "${userSlicePath}" ]]; then
-        COMPREPLY=( $( compgen -W "$(__lxc_cgroup_v2 "${userSlicePath}")" -- "${cur}" ) )
-        return
+        # cgroup_v2 + user.slice
+        read -r -e -a output <<< $(__lxc_cgroup_v2 "${userSlicePath}")
+    elif [[ -d "${lxcPayloadPath}" ]]; then
+        # cgroup_v2 + lxc.payload
+        read -r -e -a output <<< $(__lxc_cgroup_v2 "${lxcPayloadPath}")
+    else
+        # cgroup_v1
+        read -r -e -a output <<< $(__lxc_cgroup_v1 "${cgroupPath}")
     fi
-    # cgroup_v2 + lxc.payload
-    local -r lxcCgroup="${cgroupPath}/lxc.payload.${name}"
-    if [[ -d "${lxcCgroup}" ]]; then
-        COMPREPLY=( $( compgen -W "$(__lxc_cgroup_v2 "${lxcCgroup}")" -- "${cur}" ) )
-        return
-    fi
-    # cgroup_v1
-    COMPREPLY=( $( compgen -W "$(__lxc_cgroup_v1 "${cgroupPath}")" -- "${cur}" ) )
+
+    # Check if state-object is present already.
+    for w in "${words[@]}"; do
+        if [[ "${cur}" != "${w}" ]] && __lxc_check_word_in_array "${w}" "${output[@]}"; then
+            return
+        elif [[ "${cur}" == "${w}" ]] && ! __lxc_check_completion_avail "${w}" "${output[@]}"; then
+            return
+        fi
+    done
+
+    COMPREPLY=( $( compgen -W "${output[*]}" -- "${cur}" ) )
 }
 
 _lxc_cgroup() {
@@ -453,8 +465,9 @@ _lxc_cgroup() {
         return
     fi
 
-    if __lxc_check_name_present; then
-        __lxc_cgroup_state_object
+    local -r custom=$(__lxc_check_name_present)
+    if [[ -n "${custom}" ]]; then
+        __lxc_cgroup_state_object "${custom}"
     else
         __lxc_append_name
     fi

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -42,7 +42,7 @@ _lxc_append_name() {
     # If `--name` or `-n` are present, do not complete with container names.
     for param in "${words[@]}"; do
         # Parse names from command line when space is escaped by backslash.
-        parsed="${param//[\\]}"
+        parsed="${param//[\\\"\']}"
         if [[ ${parsed} =~ ^--name(=(.*))?$ ]]; then
             return
         elif [[ ${parsed} =~ ${shortoptnamexp} ]]; then
@@ -53,6 +53,44 @@ _lxc_append_name() {
         done
     done
     _lxc_names
+}
+
+_lxc_get_snapshots() {
+    mapfile -t names < <(command lxc-ls -1)
+    local -r shortoptnamexp="^-[0-9A-Za-mo-z]*n[0-9A-Za-mo-z]*$"
+    local container
+    local param
+    for i in "${!words[@]}"; do
+        param="${words[${i}]}"
+        parsed="${param//[\\\"\']}"
+        if [[ ${param} =~ ^--name(=(.*))?$ ]]; then
+            if [[ -n "${BASH_REMATCH[2]}" ]]; then
+                container="${BASH_REMATCH[2]}"
+            else
+                container="${words[${i}+1]}"
+            fi
+            break
+        elif [[ ${param} =~ ${shortoptnamexp} ]]; then
+            container="${words[${i}+1]}"
+            break
+        fi
+        for name in "${names[@]}"; do
+            if [[ "${parsed}" == "${name}" ]]; then
+                container="${name}"
+                break
+            fi
+        done
+        [[ -n "${container}" ]] && break
+    done
+    container="${container//[\\\"\']}"
+    mapfile -t snaps < <(command lxc-snapshot --name="${container}" --list)
+    local -r nosnapxp="^No snapshots$"
+    if [[ ! "${snaps[*]}" =~ ${nosnapxp} ]]; then
+        for i in "${!snaps[@]}"; do
+            read -r -e -a line <<< "${snaps[${i}]}"
+            printf "%s " "${line[0]}"
+        done
+    fi
 }
 
 _lxc_common_opt() {
@@ -724,14 +762,14 @@ _lxc_snapshot() {
             return
             ;;
         --destroy | -d )
-            COMPREPLY=( $( compgen -W 'ALL $( lxc-snapshot --list )' -- "${cur}" ) )
+            COMPREPLY=( $( compgen -W 'ALL $( _lxc_get_snapshots )' -- "${cur}" ) )
             return
             ;;
         --list | -L | --showcomments | -C )
             # Only flags.
             ;;
         --restore | -r )
-            COMPREPLY=( $( compgen -W '$( lxc-snapshot --list )' -- "${cur}" ) )
+            COMPREPLY=( $( compgen -W '$( _lxc_get_snapshots )' -- "${cur}" ) )
             return
             ;;
         --newname | -N )

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -3,7 +3,7 @@
 _lxc_names() {
     case ${words[0]} in
         lxc-attach | lxc-cgroup | lxc-checkpoint | lxc-console | lxc-device | lxc-freeze | lxc-stop )
-            COMPREPLY=( $( compgen -W "$( command lxc-ls --active )" -- "$cur" ) )
+            COMPREPLY=( $( compgen -W "$( command lxc-ls --running )" -- "$cur" ) )
             ;;
         lxc-destroy | lxc-execute | lxc-snapshot | lxc-start )
             COMPREPLY=( $( compgen -W "$( command lxc-ls --stopped )" -- "$cur" ) )

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -122,51 +122,115 @@ _lxc_common_opt() {
     esac
 }
 
+__lxc_concat_array_sep() {
+    local -r sep="${1}"
+    local concat
+    for word in "${@:2}"; do
+	if [[ "${word}" == "${sep}" ]]; then
+	    concat+="${word}"
+	else
+	    concat+="${word}${sep}"
+	fi
+    done
+    printf "%s" "${concat}"
+}
+
+__lxc_check_completion_avail() {
+    local -r word="${1}"
+    local -r pattern="^${word}"
+    for w in "${@:2}"; do
+        if [[ "${w}" =~ ${pattern} ]] && [[ "${w}" != "${word}" ]]; then
+           return 0
+        fi
+    done
+    return 1
+}
+
+__lxc_array_has_duplicates() {
+    declare -A unique
+    for word in "${@}"; do
+	if [[ -z "${unique[${word}]}" ]]; then
+	    unique[${word}]="${word}"
+	else
+	    return 0
+	fi
+    done
+    return 1
+}
+
+__lxc_check_word_in_array() {
+    local -r word="${1}"
+    for w in "${@:2}"; do
+        if [[ "${w}" == "${word}" ]]; then
+           return 0
+        fi
+    done
+    return 1
+}
+
 __lxc_piped_args() {
-    read -e -a current <<< "${1//\\}"
-    local sep="${2}"
-    read -e -a completion <<< ${@:3}
+    local -r sep="${2}"
+    # Remove double/single quote and backslash from current completion parameter.
+    IFS=$"${sep}" read -r -e -a current <<< "${1//[\\\"\']}"
 
-    IFS=$"${sep}" read -e -a current <<< "${current[@]//\"}"
+    # Add separator back to current in case it is part of completion list.
+    for i in "${!current[@]}"; do
+        if [[ -z "${current[${i}]}" ]]; then
+	    current["${i}"]="${sep}"
+        fi
+    done
 
-    for index in "${!completion[@]}"; do
-        for value in ${current[@]}; do
-            if [[ "${completion[$index]}" == "$value" ]]; then
-                command unset -v 'completion[$index]'
-            fi
-        done
+    # Remove words from completion already added to argument.
+    declare -a minuslast=("${current[@]::${#current[@]}-1}")
+    declare -a completion=("${@:3}")
+    for i in "${!completion[@]}"; do
+        if __lxc_check_word_in_array "${completion[${i}]}" "${minuslast[@]}"; then
+            command unset -v 'completion[${i}]'
+        fi
     done
     completion=("${completion[@]}")
 
-    declare -a extended=("${completion[@]}")
-    local nparts="${#current[@]}"
-    if [[ $nparts -gt 1 ]]; then
-        prefix=$(command printf "%s${sep}" "${current[@]::$nparts-1}")
-        extended=()
-        for comp in ${completion[@]}; do
-            extended+=("\"${prefix}${comp}\"")
-        done
+    # Check if words from argument are uniquely part of completion.
+    if __lxc_array_has_duplicates "${minuslast[@]}"; then
+        return
     fi
+    declare -a allcomps=("${@:3}")
+    for i in "${!minuslast[@]}"; do
+        if ! __lxc_check_word_in_array "${minuslast[${i}]}" "${allcomps[@]}"; then
+            return
+        fi
+    done
 
-    # TAB after quotes to complete for next value.
-    if [[ $nparts -gt 0 ]]; then
-        local allcomps=("${@:3}")
-        for index in "${!allcomps[@]}"; do
-            if [[ "${allcomps[$index]}" == "${current[$nparts-1]}" ]]; then
-                prefix=$(command printf "%s${sep}" "${current[@]}")
+    # Actual completion array.
+    declare -a extcompletion
+    local -r nparts="${#current[@]}"
+
+    if [[ "${nparts}" -gt 0 ]]; then
+        local prefix=$(__lxc_concat_array_sep "${sep}" "${current[@]::${nparts}-1}")
+        local -r lastword="${current[${nparts}-1]}"
+        if __lxc_check_completion_avail "${lastword}" "${completion[@]}"; then
+            for comp in "${completion[@]}"; do
+                extcompletion+=("\"${prefix}${comp}\"")
+            done
+        fi
+        # TAB after quotes to complete for next value.
+        if ! __lxc_array_has_duplicates "${current[@]}" && __lxc_check_word_in_array "${lastword}" "${allcomps[@]}"; then
+            if ! __lxc_check_completion_avail "${lastword}" "${completion[@]}" || [[ "${#1}" -lt "${#sep}" ]] || [[ "${1: -${#sep}}" == "${sep}" ]]; then
+                prefix=$(__lxc_concat_array_sep "${sep}" "${current[@]}")
                 for comp in "${completion[@]}"; do
-                    extended+=("\"${prefix}${comp}\"")
+                    [[ "${comp}" == "${lastword}" ]] && continue
+                    extcompletion+=("\"${prefix}${comp}\"")
                 done
-                break
             fi
+        fi
+    else # [[ "${nparts}" -eq 0 ]]
+        for word in "${allcomps[@]}"; do
+            extcompletion+=("${word}")
         done
     fi
 
-    COMPREPLY=( $( compgen -P '"' -S '"' -W "$(command echo -e ${extended[@]})" -- "${cur}" ) )
-    # If no more words availables for completion, add space after last match.
-    if [[ "${#completion[@]}" -gt 1 ]]; then
-        compopt -o nospace
-    fi
+    COMPREPLY=( $( compgen -P '"' -S '"' -W "$(command echo -e ${extcompletion[@]})" -- "${cur}" ) )
+    [[ "${#extcompletion[@]}" -gt 1 ]] && compopt -o nospace
 }
 
 _lxc_attach() {

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -5,12 +5,13 @@ _lxc_names() {
         lxc-attach | lxc-cgroup | lxc-checkpoint | lxc-console | lxc-device | lxc-freeze | lxc-stop )
             COMPREPLY=( $( compgen -W "$( command lxc-ls --active )" -- "$cur" ) )
             ;;
-        lxc-start | lxc-destroy | lxc-execute | lxc-snapshot | lxc-start )
+        lxc-destroy | lxc-execute | lxc-snapshot | lxc-start )
             COMPREPLY=( $( compgen -W "$( command lxc-ls --stopped )" -- "$cur" ) )
             ;;
         lxc-copy | lxc-info | lxc-monitor | lxc-wait )
             COMPREPLY=( $( compgen -W "$( command lxc-ls --defined )" -- "$cur" ) )
             ;;
+        lxc-autostart | lxc-create | lxc-checkconfig | lxc-config | lxc-ls | \
         lxc-top | lxc-unshare | lxc-update-config | lxc-usernsexec )
             ;;
         lxc-unfreeze )

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -88,7 +88,7 @@ __lxc_get_snapshots() {
     if [[ ! "${snaps[*]}" =~ ${nosnapxp} ]]; then
         for i in "${!snaps[@]}"; do
             read -r -e -a line <<< "${snaps[${i}]}"
-            printf "%s " "${line[0]}"
+            command printf "%s " "${line[0]}"
         done
     fi
 }
@@ -132,7 +132,7 @@ __lxc_concat_array_sep() {
 	    concat+="${word}${sep}"
 	fi
     done
-    printf "%s" "${concat}"
+    command printf "%s" "${concat}"
 }
 
 __lxc_check_completion_avail() {
@@ -308,14 +308,22 @@ _lxc_attach() {
 } &&
     complete -F _lxc_attach lxc-attach
 
-__lxc_groups() {
+__lxc_get_groups() {
     declare -A groups
-    for line in "$(command lxc-ls -f --fancy-format GROUPS | command sed -e '/^-/d' -e '1d' -e 's/,/ /g')"; do
-	for grp in $line; do
-            groups+=([${grp}]=1)
+    local key
+    declare -a linegroups
+    # Discard "GROUPS" header and lines without any groups (with only '-').
+    mapfile -s 1 -t lines < <(command lxc-ls -f --fancy-format GROUPS | command sed -e '/^-/d')
+    for line in "${lines[@]}"; do
+        line=$(command echo -e "${line}" | command sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        IFS=$',' read -r -e -a linegroups <<< "${line}"
+        for entry in "${linegroups[@]}"; do
+            key=$(printf "%q" "${entry}")
+            groups+=(["${key}"]=1)
         done
     done
-    printf "%s " "${!groups[@]}"
+    declare -a output=("${!groups[@]}")
+    command printf "%s" "${output[*]}"
 }
 
 _lxc_autostart() {
@@ -335,7 +343,7 @@ _lxc_autostart() {
             return
             ;;
         --groups | -g )
-            __lxc_piped_args "${cur}" ',' $( __lxc_groups ) ','
+            __lxc_piped_args "${cur}" ',' $( __lxc_get_groups ) ','
             return
             ;;
     esac
@@ -758,7 +766,7 @@ _lxc_ls() {
             return
             ;;
         --groups | -g )
-            __lxc_piped_args "${cur}" ',' $( __lxc_groups ) ','
+            __lxc_piped_args "${cur}" ',' $( __lxc_get_groups ) ','
             return
             ;;
         --nesting )

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -239,6 +239,31 @@ __lxc_piped_args() {
     [[ "${#extcompletion[@]}" -gt 1 ]] && compopt -o nospace
 }
 
+__lxc_get_selinux_contexts() {
+    declare -a sepolicies=()
+    local sepolicy
+    # Check for SElinux tool.
+    if ! command -v semanage > /dev/null 2>&1; then
+        return
+    fi
+    # Skip header + following empty line.
+    mapfile -s 2 -t output < <(command semanage fcontext -l 2>/dev/null)
+    local -r none="<<None>>"
+    for line in "${output[@]}"; do
+        if [[ "${line}" =~ "SELinux Distribution fcontext Equivalence" ]]; then
+            break
+        fi
+        read -r -e -a current <<< "${line}"
+        if [[ "${#current[@]}" -gt 0 ]]; then
+            sepolicy="${current[${#current[@]}-1]}"
+            [[ ! "${sepolicy}" =~ ${none} ]] && sepolicies+=("${sepolicy}")
+        fi
+    done
+    # Default context.
+    sepolicies+=("unconfined_u:object_r:default_t:s0")
+    COMPREPLY=( $( compgen -P'"' -S'"' -W "${sepolicies[*]}" -- "${cur}" ) )
+}
+
 _lxc_attach() {
     local cur prev words cword split
     COMPREPLY=()
@@ -292,7 +317,7 @@ _lxc_attach() {
             return
             ;;
         --context | -c )
-            # @TODO: list all SElinux contexts available.
+            __lxc_get_selinux_contexts
             return
             ;;
     esac

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -1,6 +1,6 @@
 # lxc-* commands completion
 
-_lxc_names() {
+__lxc_names() {
     declare -a names
     case ${words[0]} in
         lxc-attach | lxc-cgroup | lxc-checkpoint | lxc-console | lxc-device | lxc-freeze | lxc-stop )
@@ -35,7 +35,7 @@ _lxc_names() {
     done
 }
 
-_lxc_append_name() {
+__lxc_append_name() {
     mapfile -t names < <(command lxc-ls -1)
     local -r shortoptnamexp="^-[0-9A-Za-mo-z]*n[0-9A-Za-mo-z]*$"
     local parsed
@@ -52,10 +52,10 @@ _lxc_append_name() {
             [[ "${parsed}" == "${name}" ]] && return
         done
     done
-    _lxc_names
+    __lxc_names
 }
 
-_lxc_get_snapshots() {
+__lxc_get_snapshots() {
     mapfile -t names < <(command lxc-ls -1)
     local -r shortoptnamexp="^-[0-9A-Za-mo-z]*n[0-9A-Za-mo-z]*$"
     local container
@@ -93,7 +93,7 @@ _lxc_get_snapshots() {
     fi
 }
 
-_lxc_common_opt() {
+__lxc_common_opt() {
     # End of options.
     if [[ "${words[*]}" =~ ' -- ' ]]; then
         return 1
@@ -112,7 +112,7 @@ _lxc_common_opt() {
             return 1
             ;;
         --logpriority | -l )
-            COMPREPLY=( $(compgen -W 'FATAL CRIT WARN ERROR NOTICE INFO DEBUG' -- "${cur}") )
+            COMPREPLY=( $( compgen -W 'FATAL CRIT WARN ERROR NOTICE INFO DEBUG' -- "${cur}" ) )
             return 1
             ;;
         --quiet | -q )
@@ -150,7 +150,7 @@ __lxc_array_has_duplicates() {
     declare -A unique
     for word in "${@}"; do
 	if [[ -z "${unique[${word}]}" ]]; then
-	    unique[${word}]="${word}"
+	    unique["${word}"]="${word}"
 	else
 	    return 0
 	fi
@@ -244,11 +244,11 @@ _lxc_attach() {
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile | -f )
@@ -304,9 +304,9 @@ _lxc_attach() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_attach lxc-attach
+    __lxc_append_name
+} &&
+    complete -F _lxc_attach lxc-attach
 
 __lxc_groups() {
     declare -A groups
@@ -323,7 +323,7 @@ _lxc_autostart() {
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --reboot | -r | --shutdown | -s | --kill | -k | --list | -L | --all | -a | --ignore-auto | -A )
@@ -347,19 +347,19 @@ _lxc_autostart() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-}
-complete -F _lxc_autostart lxc-autostart
+} &&
+    complete -F _lxc_autostart lxc-autostart
 
 _lxc_cgroup() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile )
@@ -375,20 +375,20 @@ _lxc_cgroup() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_cgroup lxc-cgroup
+    __lxc_append_name
+} &&
+    complete -F _lxc_cgroup lxc-cgroup
 
 _lxc_checkpoint() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile )
@@ -415,9 +415,9 @@ _lxc_checkpoint() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_checkpoint lxc-checkpoint
+    __lxc_append_name
+} &&
+    complete -F _lxc_checkpoint lxc-checkpoint
 
 _lxc_config() {
     local cur prev words cword split
@@ -426,24 +426,24 @@ _lxc_config() {
     $split && return
 
     if [[ ${cur} == -* ]]; then
-        COMPREPLY=($(compgen -W '-l' -- "${cur}"))
+        COMPREPLY=( $( compgen -W '-l' -- "${cur}" ) )
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
     COMPREPLY=( $( compgen -W "$( command lxc-config -l )" -- "${cur}" ) )
-}
-complete -F _lxc_config lxc-config
+} &&
+    complete -F _lxc_config lxc-config
 
 _lxc_console() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile )
@@ -468,9 +468,9 @@ _lxc_console() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_console lxc-console
+    __lxc_append_name
+} &&
+    complete -F _lxc_console lxc-console
 
 __lxc_backing_stores() {
     COMPREPLY=( $( compgen -W 'best btrfs dir loop lvm nbd overlay overlayfs rbd zfs' -- "${cur}" ) )
@@ -481,11 +481,11 @@ _lxc_copy() {
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile )
@@ -519,9 +519,9 @@ _lxc_copy() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_copy lxc-copy
+    __lxc_append_name
+} &&
+    complete -F _lxc_copy lxc-copy
 
 __lxc_templates() {
     COMPREPLY=( $( compgen -W "$(command ls @LXCTEMPLATEDIR@/ | command sed -e 's|^lxc-||' )" -- "${cur}" ) )
@@ -532,11 +532,11 @@ _lxc_create() {
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile )
@@ -564,19 +564,19 @@ _lxc_create() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-}
-complete -F _lxc_create lxc-create
+} &&
+    complete -F _lxc_create lxc-create
 
 _lxc_destroy() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile )
@@ -595,9 +595,9 @@ _lxc_destroy() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_destroy lxc-destroy
+    __lxc_append_name
+} &&
+    complete -F _lxc_destroy lxc-destroy
 
 _lxc_device() {
     local cur prev words cword split
@@ -609,12 +609,12 @@ _lxc_device() {
             return
             ;;
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         add )
             _available_interfaces
-            COMPREPLY+=( $(compgen -f -d -X "!*/?*" -- "${cur:-/dev/}") )
+            COMPREPLY+=( $( compgen -f -d -X "!*/?*" -- "${cur:-/dev/}" ) )
             return
             ;;
     esac
@@ -626,20 +626,20 @@ _lxc_device() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_device lxc-device
+    __lxc_append_name
+} &&
+    complete -F _lxc_device lxc-device
 
 _lxc_execute() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile | -f )
@@ -672,20 +672,20 @@ _lxc_execute() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_execute lxc-execute
+    __lxc_append_name
+} &&
+    complete -F _lxc_execute lxc-execute
 
 _lxc_freeze() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile | -f )
@@ -701,20 +701,20 @@ _lxc_freeze() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_freeze lxc-freeze
+    __lxc_append_name
+} &&
+    complete -F _lxc_freeze lxc-freeze
 
 _lxc_info() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile )
@@ -739,15 +739,15 @@ _lxc_info() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_info lxc-info
+    __lxc_append_name
+} &&
+    complete -F _lxc_info lxc-info
 
 _lxc_ls() {
     local cur prev words cword split
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --line | -1 | --fancy | -f | --active | --frozen | --running | --stopped | --defined )
@@ -779,18 +779,18 @@ _lxc_ls() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-}
-complete -F _lxc_ls lxc-ls
+} &&
+    complete -F _lxc_ls lxc-ls
 
 _lxc_monitor() {
     local cur prev words cword split
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --quit | -Q )
@@ -805,19 +805,19 @@ _lxc_monitor() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_monitor lxc-monitor
+    __lxc_append_name
+} &&
+    complete -F _lxc_monitor lxc-monitor
 
 _lxc_snapshot() {
     local cur prev words cword split
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile )
@@ -829,14 +829,14 @@ _lxc_snapshot() {
             return
             ;;
         --destroy | -d )
-            COMPREPLY=( $( compgen -W 'ALL $( _lxc_get_snapshots )' -- "${cur}" ) )
+            COMPREPLY=( $( compgen -W 'ALL $( __lxc_get_snapshots )' -- "${cur}" ) )
             return
             ;;
         --list | -L | --showcomments | -C )
             # Only flags.
             ;;
         --restore | -r )
-            COMPREPLY=( $( compgen -W '$( _lxc_get_snapshots )' -- "${cur}" ) )
+            COMPREPLY=( $( compgen -W '$( __lxc_get_snapshots )' -- "${cur}" ) )
             return
             ;;
         --newname | -N )
@@ -851,20 +851,20 @@ _lxc_snapshot() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_snapshot lxc-snapshot
+    __lxc_append_name
+} &&
+    complete -F _lxc_snapshot lxc-snapshot
 
 _lxc_start() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --daemon | -d | --foreground | -F | --close-all-fds | -C )
@@ -911,20 +911,20 @@ _lxc_start() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_start lxc-start
+    __lxc_append_name
+} &&
+    complete -F _lxc_start lxc-start
 
 _lxc_stop() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile )
@@ -948,16 +948,16 @@ _lxc_stop() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_stop lxc-stop
+    __lxc_append_name
+} &&
+    complete -F _lxc_stop lxc-stop
 
 _lxc_top() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --batch | -b | --reverse | -r )
@@ -981,19 +981,19 @@ _lxc_top() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-}
-complete -F _lxc_top lxc-top
+} &&
+    complete -F _lxc_top lxc-top
 
 _lxc_unfreeze() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile )
@@ -1009,16 +1009,16 @@ _lxc_unfreeze() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_unfreeze lxc-unfreeze
+    __lxc_append_name
+} &&
+    complete -F _lxc_unfreeze lxc-unfreeze
 
 _lxc_unshare() {
     local cur prev words cword split
     COMPREPLY=()
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --namespaces | -s )
@@ -1048,8 +1048,8 @@ _lxc_unshare() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-}
-complete -F _lxc_unshare lxc-unshare
+} &&
+    complete -F _lxc_unshare lxc-unshare
 
 _lxc_update_config() {
     local cur prev words cword split
@@ -1073,9 +1073,8 @@ _lxc_update_config() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-
-}
-complete -F _lxc_update_config lxc-update-config
+} &&
+    complete -F _lxc_update_config lxc-update-config
 
 _lxc_usernsexec() {
     local cur prev words cword split
@@ -1107,18 +1106,18 @@ _lxc_usernsexec() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-}
-complete -F _lxc_usernsexec lxc-usernsexec
+} &&
+    complete -F _lxc_usernsexec lxc-usernsexec
 
 _lxc_wait() {
     local cur prev words cword split
     _init_completion -s -n : || return
 
-    _lxc_common_opt || return
+    __lxc_common_opt || return
 
     case ${prev} in
         --name | -n )
-            _lxc_names
+            __lxc_names
             return
             ;;
         --rcfile )
@@ -1143,8 +1142,8 @@ _lxc_wait() {
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi
-    _lxc_append_name
-}
-complete -F _lxc_wait lxc-wait
+    __lxc_append_name
+} &&
+    complete -F _lxc_wait lxc-wait
 
 # ex: filetype=sh

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -635,6 +635,7 @@ _lxc_ls() {
             # Only flags.
             ;;
         --fancy-format | -F )
+            __lxc_piped_args "${cur}" ',' NAME STATE PID RAM SWAP AUTOSTART GROUPS INTERFACE IPV4 IPV6 UNPRIVILEGED
             return
             ;;
         --groups | -g )

--- a/config/bash/lxc.in
+++ b/config/bash/lxc.in
@@ -38,20 +38,31 @@ __lxc_names() {
 __lxc_check_name_present() {
     mapfile -t names < <(command lxc-ls -1)
     local -r shortoptnamexp="^-[0-9A-Za-mo-z]*n[0-9A-Za-mo-z]*$"
+    local container
+    local param
     local parsed
+    # Current word on command line, minus double/single quote and backslash.
     local -r current="${cur//[\\\"\']}"
-    mapfile -t names < <(command lxc-ls -1)
-    # If `--name` or `-n` are present, do not complete with container names.
-    for param in "${words[@]}"; do
+    # If `--name` or `-n` are present, then a container name should be available.
+    for i in "${!words[@]}"; do
+        param="${words[${i}]}"
         # Parse names from command line when space is escaped by backslash.
         parsed="${param//[\\\"\']}"
         if [[ ${parsed} =~ ^--name(=(.*))?$ ]]; then
+            if [[ -n "${BASH_REMATCH[2]}" ]]; then
+                container="${BASH_REMATCH[2]}"
+            else
+                container="${words[${i}+1]}"
+            fi
+            command printf "%q" "${container}"
             return 0
         elif [[ ${parsed} =~ ${shortoptnamexp} ]]; then
+            command printf "%q" "${words[${i}+1]}"
             return 0
         fi
         for name in "${names[@]}"; do
             if [[ "${parsed}" == "${name}" ]] && [[ "${current}" != "${parsed}" ]]; then
+                command printf "%q" "${name}"
                 return 0
             fi
         done
@@ -60,39 +71,15 @@ __lxc_check_name_present() {
 }
 
 __lxc_append_name() {
-    if ! __lxc_check_name_present; then
+    local -r name=$(__lxc_check_name_present)
+    if [[ -z "${name}" ]]; then
         __lxc_names
     fi
 }
 
 __lxc_get_snapshots() {
-    mapfile -t names < <(command lxc-ls -1)
-    local -r shortoptnamexp="^-[0-9A-Za-mo-z]*n[0-9A-Za-mo-z]*$"
-    local container
-    local param
-    for i in "${!words[@]}"; do
-        param="${words[${i}]}"
-        parsed="${param//[\\\"\']}"
-        if [[ ${param} =~ ^--name(=(.*))?$ ]]; then
-            if [[ -n "${BASH_REMATCH[2]}" ]]; then
-                container="${BASH_REMATCH[2]}"
-            else
-                container="${words[${i}+1]}"
-            fi
-            break
-        elif [[ ${param} =~ ${shortoptnamexp} ]]; then
-            container="${words[${i}+1]}"
-            break
-        fi
-        for name in "${names[@]}"; do
-            if [[ "${parsed}" == "${name}" ]]; then
-                container="${name}"
-                break
-            fi
-        done
-        [[ -n "${container}" ]] && break
-    done
-    container="${container//[\\\"\']}"
+    local -r container=$(__lxc_check_name_present)
+    [[ -z "${container}" ]] && return
     mapfile -t snaps < <(command lxc-snapshot --name="${container}" --list)
     local -r nosnapxp="^No snapshots$"
     if [[ ! "${snaps[*]}" =~ ${nosnapxp} ]]; then


### PR DESCRIPTION
Hi,

this is a follow-up to #3899. It includes some ideas discussed there, as well as a couple of fixes for stuff my tests did not catch at the time.

However, I would like to have feedback about some changes I did, mostly on design:

1. **Names with spaces**: when you create a container like `lxc-create -t download -n "arch linux"`, you can autocomplete the name as `'arch linux'`, `"arch linux"`or `arch\ linux`. I choose the one with backslash because it felt natural to me. However, you may be able to tell this is a bad idea if there is an edge case that I am unaware of.
2. **cgroup completion**: I am using the entry `lxc.payload.${name}`, where `name` is the container name. Not sure if this is correct. I try first the `user.slice` entry and the payload is my fallback for `cgroups_v2`. I tried to not use external tools to check if I have v1 or v2 by checking dir availability.
3. **Bash version 4**: I use associative arrays and some variable operations that  are available for `bash>=4`. I did not disclose that on my previous pr, but I am always assuming `bash>=4`.
4. **Missing completion for `lxc-info --config` and `lxc-{start,execute} --define`**: I did not find a way to reliable list these values unless I hard-code them into completion. Therefore, they will remain out of this work scope.

In case the commit history looks all over the place, I can later squash/fix-up/force-push for a cleaner history. All the changes I wanted to do are here.

I will await for your word before rewriting anything.