### PR TITLE
lxc-ls: list names with whitespaces in `--active`.

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -5400,6 +5400,17 @@ int lxc_get_wait_states(const char **states)
 	return MAX_STATE;
 }
 
+static char *get_socket_entry(char *line)
+{
+    char *p = line, *entry = NULL;
+    const char start[3] = {' ', 0x40};
+    while ((p = strstr(p, start))) {
+        p += 2;
+        entry = p;
+    }
+    return entry;
+}
+
 /*
  * These next two could probably be done smarter with reusing a common function
  * with different iterators and tests...
@@ -5514,14 +5525,9 @@ int list_active_containers(const char *lxcpath, char ***nret,
 		return -1;
 
 	while (getline(&line, &len, f) != -1) {
-		char *p = strrchr(line, ' '), *p2;
+		char *p = get_socket_entry(line), *p2;
 		if (!p)
 			continue;
-		p++;
-
-		if (*p != 0x40)
-			continue;
-		p++;
 
 		is_hashed = false;
 


### PR DESCRIPTION
Hello,

while working on the bash completion file, I found out about #3970. This is my workaround for this issue.

As far as testing goes, I noticed the test `src/tests/list.c`, which partially covers this.  Not sure if it needs another test case file. In case  the pr seems reasonable and you want a test, I can provide one for CI/CD in the same style as others in the tests dir.

Feel free to close this if not needed.