### PR TITLE
Don't include internal headers in external library headers

### DIFF
--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -3,8 +3,6 @@
 #ifndef __LXC_CONTAINER_H
 #define __LXC_CONTAINER_H
 
-#include "config.h"
-
 #include <malloc.h>
 #include <semaphore.h>
 #include <stdbool.h>


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>