### PR TITLE
tree-wide: cast to core scheduling cookie to llu

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -414,7 +414,7 @@ static int get_attach_context(struct attach_context *ctx,
 		INFO("Container does not run in a separate core scheduling domain");
 	else
 		INFO("Container runs in separate core scheduling domain %llu",
-		     (long long unsigned int)ctx->core_sched_cookie);
+		     (llu)ctx->core_sched_cookie);
 
 	ret = strnprintf(path, sizeof(path), "/proc/%d", ctx->init_pid);
 	if (ret < 0)
@@ -1158,13 +1158,13 @@ __noreturn static void do_attach(struct attach_payload *ap)
 		if (!core_scheduling_cookie_valid(core_sched_cookie) &&
 		    ctx->core_sched_cookie != core_sched_cookie) {
 			SYSERROR("Invalid core scheduling domain cookie %llu != %llu",
-				 (long long unsigned int)core_sched_cookie,
-				 (long long unsigned int)ctx->core_sched_cookie);
+				 (llu)core_sched_cookie,
+				 (llu)ctx->core_sched_cookie);
 			goto on_error;
 		}
 
 		INFO("Joined core scheduling domain of %d with cookie %lld",
-		     ctx->init_pid, core_sched_cookie);
+		     ctx->init_pid, (llu)core_sched_cookie);
 	}
 
 	/* A description of the purpose of this functionality is provided in the

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -763,4 +763,6 @@ static inline bool has_exact_flags(__u32 flags, __u32 mask)
 			 "pointer type mismatch in container_of()");	\
 	((type *)(__mptr - offsetof(type, member))); })
 
+typedef long long unsigned int llu;
+
 #endif /* __LXC_MACRO_H */

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1577,7 +1577,7 @@ static int core_scheduling(struct lxc_handler *handler)
 		return syserror("Failed to retrieve core scheduling domain cookie");
 
 	TRACE("Created new core scheduling domain with cookie %llu",
-	      (long long unsigned int)conf->sched_core_cookie);
+	      (llu)conf->sched_core_cookie);
 
 	return 0;
 }


### PR DESCRIPTION
Link: https://launchpadlibrarian.net/561086365/buildlog_ubuntu-focal-ppc64el.lxc_1%3A4.0.10+master~20210930-1812-0ubuntu1~focal_BUILDING.txt.gz
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>