### PR TITLE
terminal: log at warning message

### DIFF
--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -967,17 +967,17 @@ int lxc_devpts_terminal(int devpts_fd, int *ret_ptx, int *ret_pty,
 		if (errno == ENOSPC)
 			return systrace("Exceeded number of allocatable terminals");
 
-		return syserror("Failed to open terminal multiplexer device");
+		return syswarn("Failed to open terminal multiplexer device");
 	}
 
 	if (devpts_fd < 0) {
 		fd_devpts = open_at(-EBADF, "/dev/pts", PROTECT_OPATH_DIRECTORY,
 				    PROTECT_LOOKUP_ABSOLUTE_XDEV, 0);
 		if (fd_devpts < 0)
-			return syserror("Failed to open devpts instance");
+			return syswarn("Failed to open devpts instance");
 
 		if (!same_device(fd_devpts, "ptmx", fd_ptx, ""))
-			return syserror("The acquired ptmx devices don't match");
+			return syswarn("The acquired ptmx devices don't match");
 		devpts_fd = fd_devpts;
 	}
 


### PR DESCRIPTION
The lxc_devpts_terminal() helper is called in contexts where it can fail
due to various reasons but where we safely fallback to allocating
terminal devices on the host. Logging error messages irritates users so
just log warning messages.

Link: https://discuss.linuxcontainers.org/t/lxc-attach-error-failed-to-open-terminal-multiplexer-device
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>