### PR TITLE
criu: fix error message

### DIFF
--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -322,7 +322,7 @@ static int exec_criu(struct cgroup_ops *cgroup_ops, struct lxc_conf *conf,
 
 		tmp = path_simplify(cgroup_base_path);
 		if (!tmp)
-			return log_error_errno(-ENOMEM, ENOMEM, "Failed to remove extraneous slashes from \"%s\"", tmp);
+			return log_error_errno(-ENOMEM, ENOMEM, "Failed to remove extraneous slashes from \"%s\"", cgroup_base_path);
 		free_move_ptr(cgroup_base_path, tmp);
 
 		if (controllers_list[0]) {


### PR DESCRIPTION
as of 59d8a539d106 ("criu: massage exec_criu()") I see:

In file included from criu.c:22:
criu.c: In function 'exec_criu':
log.h:376:2: error: '%s' directive argument is null [-Werror=format-overflow=]
  376 |  LXC_ERROR(&locinfo, format, ##__VA_ARGS__);   \
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
log.h:457:3: note: in expansion of macro 'ERROR'
  457 |   ERROR("%s - " format, ptr, ##__VA_ARGS__); \
      |   ^~~~~
log.h:491:3: note: in expansion of macro 'SYSERROR'
  491 |   SYSERROR(format, ##__VA_ARGS__);              \
      |   ^~~~~~~~
criu.c:325:11: note: in expansion of macro 'log_error_errno'
  325 |    return log_error_errno(-ENOMEM, ENOMEM, "Failed to remove extraneous slashes from \"%s\"", tmp);
      |           ^~~~~~~~~~~~~~~

it looks like we should be logging the string that failed, vs. tmp here.

(my log was taken from stable-4.0, but the same issue exists on master it
seems.)

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>