### PR TITLE
Make number of rx and tx queues configurable for veths

### DIFF
--- a/src/lxc/cmd/lxc_user_nic.c
+++ b/src/lxc/cmd/lxc_user_nic.c
@@ -469,7 +469,7 @@ static int instantiate_veth(char *veth1, char *veth2, pid_t pid, unsigned int mt
 {
 	int ret;
 
-	ret = lxc_veth_create(veth1, veth2, pid, mtu);
+	ret = lxc_veth_create(veth1, veth2, pid, mtu, -1, -1);
 	if (ret < 0) {
 		CMD_SYSERROR("Failed to create %s-%s\n", veth1, veth2);
 		return ret_errno(-ret);

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -77,6 +77,8 @@ struct ifla_veth {
 	struct list_head ipv4_routes;
 	struct list_head ipv6_routes;
 	int mode; /* bridge, router */
+	int n_rxqueues;
+	int n_txqueues;
 	short vlan_id;
 	bool vlan_id_set;
 	struct lxc_list vlan_tagged_ids;
@@ -207,7 +209,7 @@ __hidden extern int lxc_netdev_set_mtu(const char *name, int mtu);
 
 /* Create a virtual network devices. */
 __hidden extern int lxc_veth_create(const char *name1, const char *name2, pid_t pid,
-				    unsigned int mtu);
+				    unsigned int mtu, int n_rxqueues, int n_txqueues);
 __hidden extern int lxc_macvlan_create(const char *parent, const char *name, int mode);
 __hidden extern int lxc_vlan_create(const char *parent, const char *name, unsigned short vid);
 


### PR DESCRIPTION
Distribute traffic over cpu cores of container by configuring more
than 1 tx/rx queue.

Signed-off-by: Cole Dishington <Cole.Dishington@alliedtelesis.co.nz>