### PR TITLE
conf: handle kernels without or not using SMT

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -409,8 +409,8 @@ static int get_attach_context(struct attach_context *ctx,
 		SYSERROR("Failed to retrieve namespace flags");
 	ctx->ns_clone_flags = ret;
 
-	ctx->core_sched_cookie = core_scheduling_cookie_get(ctx->init_pid);
-	if (!core_scheduling_cookie_valid(ctx->core_sched_cookie))
+	ret = core_scheduling_cookie_get(ctx->init_pid, &ctx->core_sched_cookie);
+	if (ret || !core_scheduling_cookie_valid(ctx->core_sched_cookie))
 		INFO("Container does not run in a separate core scheduling domain");
 	else
 		INFO("Container runs in separate core scheduling domain %llu",
@@ -1155,9 +1155,9 @@ __noreturn static void do_attach(struct attach_payload *ap)
 			goto on_error;
 		}
 
-		core_sched_cookie = core_scheduling_cookie_get(getpid());
-		if (!core_scheduling_cookie_valid(core_sched_cookie) &&
-		    ctx->core_sched_cookie != core_sched_cookie) {
+		ret = core_scheduling_cookie_get(getpid(), &core_sched_cookie);
+		if (ret || !core_scheduling_cookie_valid(core_sched_cookie) ||
+		    (ctx->core_sched_cookie != core_sched_cookie)) {
 			SYSERROR("Invalid core scheduling domain cookie %llu != %llu",
 				 (llu)core_sched_cookie,
 				 (llu)ctx->core_sched_cookie);

--- a/src/lxc/syscall_wrappers.h
+++ b/src/lxc/syscall_wrappers.h
@@ -367,17 +367,21 @@ static inline bool core_scheduling_cookie_valid(__u64 cookie)
 	return (cookie > 0) && (cookie != INVALID_SCHED_CORE_COOKIE);
 }
 
-static inline __u64 core_scheduling_cookie_get(pid_t pid)
+static inline int core_scheduling_cookie_get(pid_t pid, __u64 *cookie)
 {
-	__u64 cookie;
 	int ret;
 
-	ret = prctl(PR_SCHED_CORE, PR_SCHED_CORE_GET, pid,
-		    PR_SCHED_CORE_SCOPE_THREAD, (unsigned long)&cookie);
-	if (ret)
-		return INVALID_SCHED_CORE_COOKIE;
+	if (!cookie)
+		return ret_errno(EINVAL);
 
-	return cookie;
+	ret = prctl(PR_SCHED_CORE, PR_SCHED_CORE_GET, pid,
+		    PR_SCHED_CORE_SCOPE_THREAD, (unsigned long)cookie);
+	if (ret) {
+		*cookie = INVALID_SCHED_CORE_COOKIE;
+		return -errno;
+	}
+
+	return 0;
 }
 
 static inline int core_scheduling_cookie_create_threadgroup(pid_t pid)


### PR DESCRIPTION
On kernel not enabling or not using SMT core scheduling will return with
ENODEV. Handle such kernels.

Link: https://github.com/lxc/lxd/issues/9419
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>