### PR TITLE
Replace 'which' with 'command -v'

### DIFF
--- a/config/init/common/lxc-net.in
+++ b/config/init/common/lxc-net.in
@@ -31,7 +31,7 @@ use_nft() {
     [ -n "$NFT" ] && nft list ruleset > /dev/null 2>&1 && [ "$LXC_USE_NFT" = "true" ]
 }
 
-NFT="$(which nft)"
+NFT="$(command -v nft)"
 if ! use_nft; then
     use_iptables_lock="-w"
     iptables -w -L -n > /dev/null 2>&1 || use_iptables_lock=""
@@ -144,7 +144,7 @@ start() {
     # can't write its pid into, so we restorecon it (to var_run_t)
     if [ ! -d "${varrun}" ]; then
         mkdir -p "${varrun}"
-        if which restorecon >/dev/null 2>&1; then
+        if command -v restorecon >/dev/null 2>&1; then
             restorecon "${varrun}"
         fi
     fi

--- a/hooks/dhclient.in
+++ b/hooks/dhclient.in
@@ -29,7 +29,7 @@ usage() {
 # Wrap the dhclient command with "aa-exec -p unconfined" if AppArmor is enabled.
 dhclient() {
     bin="/sbin/dhclient"
-    if [ -d "/sys/kernel/security/apparmor" ] && which aa-exec >/dev/null; then
+    if [ -d "/sys/kernel/security/apparmor" ] && command -v aa-exec >/dev/null; then
         bin="aa-exec -p unconfined ${bin}"
     fi
     echo $bin

--- a/hooks/nvidia
+++ b/hooks/nvidia
@@ -45,7 +45,7 @@ else
 fi
 
 export PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
-if ! which nvidia-container-cli >/dev/null; then
+if ! command -v nvidia-container-cli >/dev/null; then
     echo "ERROR: Missing tool nvidia-container-cli, see https://github.com/NVIDIA/libnvidia-container" >&2
     exit 1
 fi

--- a/src/lxc/cmd/lxc-checkconfig.in
+++ b/src/lxc/cmd/lxc-checkconfig.in
@@ -128,16 +128,16 @@ echo
 echo -n "User namespace: " && is_enabled CONFIG_USER_NS
 echo
 if is_set CONFIG_USER_NS; then
-	if which newuidmap > /dev/null 2>&1; then
-		f=`which newuidmap`
+	if command -v newuidmap >/dev/null 2>&1; then
+		f=$(command -v newuidmap)
 		if [ ! -u "${f}" ]; then
 			echo "Warning: newuidmap is not setuid-root"
 		fi
 	else
 		echo "newuidmap is not installed"
 	fi
-	if which newgidmap > /dev/null 2>&1; then
-		f=`which newgidmap`
+	if command -v newgidmap >/dev/null 2>&1; then
+		f=$(command -v newgidmap)
 		if [ ! -u "${f}" ]; then
 			echo "Warning: newgidmap is not setuid-root"
 		fi

--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -23,7 +23,7 @@
 LXC_MAPPED_UID=
 LXC_MAPPED_GID=
 
-BUSYBOX_EXE=`which busybox`
+BUSYBOX_EXE=$(command -v busybox)
 
 # Make sure the usual locations are in PATH
 export PATH="$PATH:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/templates/lxc-oci.in
+++ b/templates/lxc-oci.in
@@ -27,7 +27,7 @@ export PATH="$PATH:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Check for required binaries
 for bin in skopeo umoci jq; do
-  if ! which $bin >/dev/null 2>&1; then
+  if ! command -v $bin >/dev/null 2>&1; then
     echo "ERROR: Missing required tool: $bin" 1>&2
     exit 1
   fi
@@ -303,7 +303,7 @@ mkdir -p "${DOWNLOAD_BASE}"
 # Trap all exit signals
 trap cleanup EXIT HUP INT TERM
 
-if ! which mktemp >/dev/null 2>&1; then
+if ! command -v mktemp >/dev/null 2>&1; then
   DOWNLOAD_TEMP="${DOWNLOAD_BASE}/lxc-oci.$$"
   mkdir -p "${DOWNLOAD_TEMP}"
 else


### PR DESCRIPTION
The 'which' command is deprecated on Debian Sid as it is not POSIX
compliant and it's behavior is therefor not consistent, so replace it
with 'command -v' which is POSIX compliant.
See https://stackoverflow.com/a/677212 for details.

Also replaced a use of backticks (`) as that is deprecated as well.
See https://github.com/koalaman/shellcheck/wiki/SC2006 for details.

Signed-off-by: Diederik de Haas <didi.debian@cknow.org>