### PR TITLE
Replace backticks with $() construct

### DIFF
--- a/coccinelle/run-coccinelle.sh
+++ b/coccinelle/run-coccinelle.sh
@@ -18,7 +18,7 @@ fi
 
 for SCRIPT in ${@-$top/coccinelle/*.cocci} ; do
         echo "--x-- Processing $SCRIPT --x--"
-        TMPFILE=`mktemp`
+        TMPFILE=$(mktemp)
         echo "+ spatch --sp-file $SCRIPT $args ..."
         parallel --halt now,fail=1 --keep-order --noswap --max-args=20 \
                  spatch --sp-file $SCRIPT $args ::: $files \

--- a/config/init/common/lxc-containers.in
+++ b/config/init/common/lxc-containers.in
@@ -56,12 +56,12 @@ wait_for_bridge()
     local BRNAME try flags br
     [ -f "$sysconfdir"/lxc/default.conf ] || { return 0; }
 
-    BRNAME=`grep '^[ 	]*lxc.net.0.link' "$sysconfdir"/lxc/default.conf | sed 's/^.*=[ 	]*//'`
+    BRNAME=$(grep '^[ 	]*lxc.net.0.link' "$sysconfdir"/lxc/default.conf | sed 's/^.*=[ 	]*//')
     if [ -z "$BRNAME" ]; then
         return 0
     fi
 
-    for try in `seq 1 30`; do
+    for try in $(seq 1 30); do
         for br in ${BRNAME}; do
              [ -r /sys/class/net/${br}/flags ] || { sleep 1; continue 2; }
              read flags < /sys/class/net/${br}/flags

--- a/config/init/common/lxc-net.in
+++ b/config/init/common/lxc-net.in
@@ -52,7 +52,7 @@ _ifdown() {
 }
 
 _ifup() {
-    MASK=`_netmask2cidr ${LXC_NETMASK}`
+    MASK=$(_netmask2cidr ${LXC_NETMASK})
     CIDR_ADDR="${LXC_ADDR}/${MASK}"
     ip addr add ${CIDR_ADDR} broadcast + dev ${LXC_BRIDGE}
     ip link set dev ${LXC_BRIDGE} address $LXC_BRIDGE_MAC
@@ -234,7 +234,7 @@ stop() {
             stop_iptables
         fi
 
-        pid=`cat "${varrun}"/dnsmasq.pid 2>/dev/null` && kill -9 $pid
+        pid=$(cat "${varrun}"/dnsmasq.pid 2>/dev/null) && kill -9 $pid
         rm -f "${varrun}"/dnsmasq.pid
         # if $LXC_BRIDGE has attached interfaces, don't destroy the bridge
         ls /sys/class/net/${LXC_BRIDGE}/brif/* > /dev/null 2>&1 || ip link delete ${LXC_BRIDGE}

--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,7 @@ AC_SUBST([LIBTOOL_DEPS])
 AC_MSG_CHECKING([host distribution])
 AC_ARG_WITH(distro, AS_HELP_STRING([--with-distro=DISTRO], [Specify the Linux distribution to target: One of redhat, redhatenterpriseserver, oracle, centos, fedora, suse, gentoo, debian, arch, slackware, plamo, paldo, openmandriva, pardus, sparclinux, altlinux.]))
 if type lsb_release >/dev/null 2>&1 && test "z$with_distro" = "z"; then
-	with_distro=`lsb_release -is`
+	with_distro=$(lsb_release -is)
 fi
 if test "z$with_distro" = "z"; then
 	AC_CHECK_FILE(/etc/redhat-release,with_distro="redhat")
@@ -105,7 +105,7 @@ if test "z$with_distro" = "z"; then
 	AC_CHECK_FILE(/etc/altlinux-release,with_distro="altlinux")
 	AC_CHECK_FILE(/etc/pld-release,with_distro="pld")
 fi
-with_distro=`echo ${with_distro} | tr '[[:upper:]]' '[[:lower:]]'`
+with_distro=$(echo ${with_distro} | tr '[[:upper:]]' '[[:lower:]]')
 
 if test "z$with_distro" = "zforsparc"; then
 	with_distro="sparclinux"

--- a/hooks/mountecryptfsroot
+++ b/hooks/mountecryptfsroot
@@ -28,7 +28,7 @@
 #     a. c=q1
 #     b. mv /var/lib/lxc/$c/rootfs /var/lib/lxc/$c/rootfs.plain
 #     c. mkdir /var/lib/lxc/$c/rootfs{,.crypt}
-#     d. sig=`echo none | ecryptfs-add-passphrase | grep -v Passphrase | cut -d[ -f 2 | cut -d] -f 1`
+#     d. sig=$(echo none | ecryptfs-add-passphrase | grep -v Passphrase | cut -d[ -f 2 | cut -d] -f 1)
 #     e. echo $sig > /var/lib/lxc/$c/sig
 #     f. mount -t ecryptfs -o ecryptfs_cipher=aes,ecryptfs_key_bytes=16,ecryptfs_passthrough=n,ecryptfs_enable_filename_crypto=n,ecryptfs_sig=${sig},sig=${sig},verbosity=0 /var/lib/lxc/$c/rootfs.crypt /var/lib/lxc/$c/rootfs
 #     g. rsync -va /var/lib/lxc/$c/rootfs.plain/ /var/lib/lxc/$c/rootfs/
@@ -45,6 +45,6 @@ set -e
 ecryptfs_crypt=$(echo $LXC_ROOTFS_PATH | sed 's/rootfs$/rootfs.crypt/')
 sigfile=$(echo $LXC_CONFIG_FILE | sed 's/config$/sig/')
 
-sig=`cat $sigfile`
+sig=$(cat $sigfile)
 mount -n -t ecryptfs -o ecryptfs_cipher=aes,ecryptfs_key_bytes=16,ecryptfs_passthrough=n,ecryptfs_enable_filename_crypto=n,ecryptfs_sig=${sig},sig=${sig},verbosity=0 $ecryptfs_crypt $LXC_ROOTFS_PATH
 exit 0

--- a/src/lxc/cmd/lxc-checkconfig.in
+++ b/src/lxc/cmd/lxc-checkconfig.in
@@ -70,7 +70,7 @@ echo "LXC version $(lxc-start --version)"
 
 if [ ! -f $CONFIG ]; then
     echo "Kernel configuration not found at $CONFIG; searching..."
-    KVER="`uname -r`"
+    KVER="$(uname -r)"
     HEADERS_CONFIG="/lib/modules/$KVER/build/.config"
     BOOT_CONFIG="/boot/config-$KVER"
     [ -f "${HEADERS_CONFIG}" ] && CONFIG=${HEADERS_CONFIG}
@@ -166,32 +166,32 @@ print_cgroups() {
   awk '$1 !~ /#/ && $3 == mp { print $2; } ; END { exit(0); } '  "mp=$1" "$2" ;
 }
 
-CGROUP_V1_MNTS=`print_cgroups cgroup /proc/self/mounts`
+CGROUP_V1_MNTS=$(print_cgroups cgroup /proc/self/mounts)
 echo
 echo "Cgroup v1 mount points: "
 echo "$CGROUP_V1_MNTS"
 echo
 
-CGROUP_V2_MNTS=`print_cgroups cgroup2 /proc/self/mounts`
+CGROUP_V2_MNTS=$(print_cgroups cgroup2 /proc/self/mounts)
 echo "Cgroup v2 mount points: "
 echo "$CGROUP_V2_MNTS"
 echo
 
-CGROUP_SYSTEMD_MNTPT=`echo "$CGROUP_V1_MNTS" | grep "/systemd"`
+CGROUP_SYSTEMD_MNTPT=$(echo "$CGROUP_V1_MNTS" | grep "/systemd")
 if [ -z "$CGROUP_SYSTEMD_MNTPT" ]; then
     echo -n "Cgroup v1 systemd controller: "
     $SETCOLOR_FAILURE && echo -n "missing" && $SETCOLOR_NORMAL
     echo
 fi
 
-CGROUP_FREEZER_MNTPT=`echo "$CGROUP_V1_MNTS" | grep "/freezer"`
+CGROUP_FREEZER_MNTPT=$(echo "$CGROUP_V1_MNTS" | grep "/freezer")
 if [ -z "$CGROUP_FREEZER_MNTPT" ]; then
     echo -n "Cgroup v1 freezer controller: "
     $SETCOLOR_FAILURE && echo -n "missing" && $SETCOLOR_NORMAL
     echo
 fi
 
-CGROUP_MNT_PATH=`echo "$CGROUP_V1_MNTS" | head -n 1`
+CGROUP_MNT_PATH=$(echo "$CGROUP_V1_MNTS" | head -n 1)
 if [ -f $CGROUP_MNT_PATH/cgroup.clone_children ]; then
     echo -n "Cgroup v1 clone_children flag: " &&
     $SETCOLOR_SUCCESS && echo "enabled" && $SETCOLOR_NORMAL

--- a/src/lxc/lxc.functions.in
+++ b/src/lxc/lxc.functions.in
@@ -7,6 +7,6 @@ bindir=@BINDIR@
 templatedir=@LXCTEMPLATEDIR@
 lxcinitdir=@LXCINITDIR@
 
-lxc_path=`lxc-config lxc.lxcpath`
-lxc_vg=`lxc-config lxc.bdev.lvm.vg`
-lxc_zfsroot=`lxc-config lxc.bdev.zfs.root`
+lxc_path=$(lxc-config lxc.lxcpath)
+lxc_vg=$(lxc-config lxc.bdev.lvm.vg)
+lxc_zfsroot=$(lxc-config lxc.bdev.zfs.root)

--- a/src/tests/lxc-test-apparmor-generated
+++ b/src/tests/lxc-test-apparmor-generated
@@ -54,8 +54,8 @@ echo "lxc.apparmor.profile = generated" >> $CONTAINER_PATH/config
 # Start it
 lxc-start -n $CONTAINER_NAME -lDEBUG -o "$LOGFILE"
 lxc-wait -n $CONTAINER_NAME -t 5 -s RUNNING || (echo "Container didn't start" && exit 1)
-pid=`lxc-info -p -H -n $CONTAINER_NAME`
-profile=`cat /proc/$pid/attr/current`
+pid=$(lxc-info -p -H -n $CONTAINER_NAME)
+profile=$(cat /proc/$pid/attr/current)
 expected_profile="lxc-${CONTAINER_NAME}_</var/lib/lxc>//&:lxc-${CONTAINER_NAME}_<-var-lib-lxc>:unconfined (enforce)"
 lxc-stop -n $CONTAINER_NAME -k
 if [ "x$profile" != "x$expected_profile" ]; then

--- a/src/tests/lxc-test-apparmor-mount
+++ b/src/tests/lxc-test-apparmor-mount
@@ -54,9 +54,9 @@ run_cmd() {
 
 DONE=0
 MOUNTSR=/sys/kernel/security/apparmor/features/mount
-dnam=`mktemp -d`
-logfile=`mktemp`
-cname=`basename $dnam`
+dnam=$(mktemp -d)
+logfile=$(mktemp)
+cname=$(basename $dnam)
 cleanup() {
 	run_cmd lxc-destroy -f -n $cname || true
 	umount -l $MOUNTSR || true
@@ -153,8 +153,8 @@ run_cmd lxc-create -t busybox -n $cname
 echo "test default confined container"
 run_cmd lxc-start -n $cname -d -lDEBUG -o "$logfile"
 run_cmd lxc-wait -n $cname -s RUNNING
-pid=`run_cmd lxc-info -p -H -n $cname`
-profile=`cat /proc/$pid/attr/current`
+pid=$(run_cmd lxc-info -p -H -n $cname)
+profile=$(cat /proc/$pid/attr/current)
 if [ "x$profile" != "x${default_profile}" ]; then
 	echo "FAIL: confined container was in profile $profile"
 	exit 1
@@ -166,8 +166,8 @@ echo "test regular unconfined container"
 echo "lxc.apparmor.profile = unconfined" >> $HDIR/.local/share/lxc/$cname/config
 run_cmd lxc-start -n $cname -d -lDEBUG -o "$logfile"
 run_cmd lxc-wait -n $cname -s RUNNING
-pid=`run_cmd lxc-info -p -H -n $cname`
-profile=`cat /proc/$pid/attr/current`
+pid=$(run_cmd lxc-info -p -H -n $cname)
+profile=$(cat /proc/$pid/attr/current)
 if [ "x$profile" != "xunconfined" ]; then
 	echo "FAIL: unconfined container was in profile $profile"
 	exit 1
@@ -182,7 +182,7 @@ echo "test default confined container"
 sed -i '/apparmor.profile/d' $HDIR/.local/share/lxc/$cname/config
 run_cmd lxc-start -n $cname -d || true
 sleep 3
-pid=`run_cmd lxc-info -p -H -n $cname` || true
+pid=$(run_cmd lxc-info -p -H -n $cname) || true
 if [ -n "$pid" -a "$pid" != "-1" ]; then
 	echo "FAIL: confined container started without mount restrictions"
 	echo "pid was $pid"
@@ -193,12 +193,12 @@ echo "test regular unconfined container"
 echo "lxc.apparmor.profile = unconfined" >> $HDIR/.local/share/lxc/$cname/config
 run_cmd lxc-start -n $cname -d -lDEBUG -o "$logfile"
 run_cmd lxc-wait -n $cname -s RUNNING
-pid=`run_cmd lxc-info -p -H -n $cname`
+pid=$(run_cmd lxc-info -p -H -n $cname)
 if [ "$pid" = "-1" ]; then
 	echo "FAIL: unconfined container failed to start without mount restrictions"
 	exit 1
 fi
-profile=`cat /proc/$pid/attr/current`
+profile=$(cat /proc/$pid/attr/current)
 if [ "x$profile" != "xunconfined" ]; then
 	echo "FAIL: confined container was in profile $profile"
 	exit 1
@@ -211,12 +211,12 @@ sed -i '/apparmor.profile/d' $HDIR/.local/share/lxc/$cname/config
 echo "lxc.apparmor.allow_incomplete = 1" >> $HDIR/.local/share/lxc/$cname/config
 run_cmd lxc-start -n $cname -d -lDEBUG -o "$logfile"
 run_cmd lxc-wait -n $cname -s RUNNING
-pid=`run_cmd lxc-info -p -H -n $cname`
+pid=$(run_cmd lxc-info -p -H -n $cname)
 if [ "$pid" = "-1" ]; then
 	echo "FAIL: excepted container failed to start without mount restrictions"
 	exit 1
 fi
-profile=`cat /proc/$pid/attr/current`
+profile=$(cat /proc/$pid/attr/current)
 if [ "x$profile" != "x${default_profile}" ]; then
 	echo "FAIL: confined container was in profile $profile"
 	exit 1

--- a/src/tests/lxc-test-automount
+++ b/src/tests/lxc-test-automount
@@ -55,8 +55,8 @@ sed -i '/lxc.mount.auto/d' $config
 echo "lxc.mount.auto = proc:mixed sys:mixed" >> $config
 
 lxc-start -n lxc-test-automount
-pid=`lxc-info -n lxc-test-automount -p -H`
-cg=`awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup`
+pid=$(lxc-info -n lxc-test-automount -p -H)
+cg=$(awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup)
 notfound=0
 stat /proc/$pid/root/sys/fs/cgroup/freezer || notfound=1
 [ $notfound -ne 0 ]
@@ -75,7 +75,7 @@ echo "Starting phase $PHASE"
 sed -i '/lxc.mount.auto/d' $config
 echo "lxc.mount.auto = cgroup:mixed proc:mixed sys:mixed" >> $config
 lxc-start -n lxc-test-automount
-pid=`lxc-info -n lxc-test-automount -p -H`
+pid=$(lxc-info -n lxc-test-automount -p -H)
 notfound=0
 stat /proc/$pid/root/sys/fs/cgroup/freezer || notfound=1
 [ $notfound -ne 1 ]
@@ -98,8 +98,8 @@ echo "Starting phase $PHASE"
 sed -i '/lxc.mount.auto/d' $config
 echo "lxc.mount.auto = cgroup:ro proc:mixed sys:mixed" >> $config
 lxc-start -n lxc-test-automount
-pid=`lxc-info -n lxc-test-automount -p -H`
-cg=`awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup`
+pid=$(lxc-info -n lxc-test-automount -p -H)
+cg=$(awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup)
 notfound=0
 stat /proc/$pid/root/sys/fs/cgroup/freezer || notfound=1
 [ $notfound -ne 1 ]
@@ -122,8 +122,8 @@ echo "Starting phase $PHASE"
 sed -i '/lxc.mount.auto/d' $config
 echo "lxc.mount.auto = cgroup:rw proc:mixed sys:mixed" >> $config
 lxc-start -n lxc-test-automount
-pid=`lxc-info -n lxc-test-automount -p -H`
-cg=`awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup`
+pid=$(lxc-info -n lxc-test-automount -p -H)
+cg=$(awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup)
 notfound=0
 stat /proc/$pid/root/sys/fs/cgroup/freezer || notfound=1
 [ $notfound -ne 1 ]
@@ -149,8 +149,8 @@ echo "Starting phase $PHASE"
 sed -i '/lxc.mount.auto/d' $config
 echo "lxc.mount.auto = cgroup-full:mixed  proc:mixed sys:mixed" >> $config
 lxc-start -n lxc-test-automount
-pid=`lxc-info -n lxc-test-automount -p -H`
-cg=`awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup`
+pid=$(lxc-info -n lxc-test-automount -p -H)
+cg=$(awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup)
 notfound=0
 stat /proc/$pid/root/sys/fs/cgroup/freezer || notfound=1
 [ $notfound -ne 1 ]
@@ -174,8 +174,8 @@ echo "Starting phase $PHASE"
 sed -i '/lxc.mount.auto/d' $config
 echo "lxc.mount.auto = cgroup-full:ro proc:mixed sys:mixed" >> $config
 lxc-start -n lxc-test-automount
-pid=`lxc-info -n lxc-test-automount -p -H`
-cg=`awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup`
+pid=$(lxc-info -n lxc-test-automount -p -H)
+cg=$(awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup)
 notfound=0
 stat /proc/$pid/root/sys/fs/cgroup/freezer || notfound=1
 [ $notfound -ne 1 ]
@@ -198,8 +198,8 @@ echo "Starting phase $PHASE"
 sed -i '/lxc.mount.auto/d' $config
 echo "lxc.mount.auto = cgroup-full:rw proc:mixed sys:mixed" >> $config
 lxc-start -n lxc-test-automount
-pid=`lxc-info -n lxc-test-automount -p -H`
-cg=`awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup`
+pid=$(lxc-info -n lxc-test-automount -p -H)
+cg=$(awk -F: '/freezer/ { print $3 }' /proc/$pid/cgroup)
 notfound=0
 stat /proc/$pid/root/sys/fs/cgroup/freezer || notfound=1
 [ $notfound -ne 1 ]

--- a/src/tests/lxc-test-cloneconfig
+++ b/src/tests/lxc-test-cloneconfig
@@ -23,15 +23,15 @@
 
 set -e
 
-s=`mktemp -d /tmp/lxctest-XXXXXX`
+s=$(mktemp -d /tmp/lxctest-XXXXXX)
 
 DONE=0
 
 verify_unchanged_number() {
 	key=$1
 	desc=$2
-	n1=`grep ^$key $CONTAINER_PATH/config | wc -l`
-	n2=`grep ^$key $CONTAINER2_PATH/config | wc -l`
+	n1=$(grep ^$key $CONTAINER_PATH/config | wc -l)
+	n2=$(grep ^$key $CONTAINER2_PATH/config | wc -l)
 	if [ $n1 -ne $n2 ]; then
 		echo "Test $testnum failed"
 		echo "unequal number of $desc"
@@ -54,7 +54,7 @@ verify_numnics() {
 verify_hwaddr() {
 	verify_unchanged_number lxc.net.0.hwaddr "hwaddr defs"
 	grep ^lxc.net.0.hwaddr $CONTAINER_PATH/config | while read line; do
-		addr=`echo $line | awk -F= { print $2 }`
+		addr=$(echo $line | awk -F= { print $2 })
 		echo "looking for $addr in $CONTAINER2_PATH/config"
 		if grep -q $addr $CONTAINER2_PATH/config; then
 			echo "Test $testnum failed"

--- a/src/tests/lxc-test-createconfig
+++ b/src/tests/lxc-test-createconfig
@@ -23,7 +23,7 @@
 
 set -e
 
-s=`mktemp -d /tmp/lxctest-XXXXXX`
+s=$(mktemp -d /tmp/lxctest-XXXXXX)
 f="$s/in.conf"
 
 cleanup() {

--- a/src/tests/lxc-test-fuzzers
+++ b/src/tests/lxc-test-fuzzers
@@ -3,7 +3,7 @@
 set -eux
 set -o pipefail
 
-TMP_DIR=`mktemp -d`
+TMP_DIR=$(mktemp -d)
 export ASAN_OPTIONS=${ASAN_OPTIONS:-detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:strict_string_checks=1}
 export UBSAN_OPTIONS=${UBSAN_OPTIONS:-print_stacktrace=1:print_summary=1:halt_on_error=1}
 

--- a/src/tests/lxc-test-lxc-attach
+++ b/src/tests/lxc-test-lxc-attach
@@ -71,7 +71,7 @@ fi
 # stdin  --> attached to pty
 # stdout --> attached to pty
 # stderr --> attached to pty
-for i in `seq 1 100`; do
+for i in $(seq 1 100); do
 	attach=$(lxc-attach -n busy -l trace -o "${ATTACH_LOG}" -- hostname || FAIL "to allocate or setup pty")
 	if [ "$attach" != "busy" ]; then
 		FAIL "lxc-attach -n busy -- hostname"

--- a/src/tests/lxc-test-rootfs
+++ b/src/tests/lxc-test-rootfs
@@ -45,7 +45,7 @@ sed -i '/lxc.rootfs.options/d' $config
 echo "lxc.rootfs.options = ro" >> $config
 
 lxc-start -n lxc-test-rootfs
-pid=`lxc-info -n lxc-test-rootfs -p -H`
+pid=$(lxc-info -n lxc-test-rootfs -p -H)
 ro=0
 mkdir /proc/$pid/root/rotest || ro=1
 [ $ro -ne 0 ]
@@ -56,7 +56,7 @@ echo "Starting phase $PHASE"
 sed -i '/lxc.rootfs.options/d' $config
 echo "lxc.rootfs.options = rw" >> $config
 lxc-start -n lxc-test-rootfs
-pid=`lxc-info -n lxc-test-rootfs -p -H`
+pid=$(lxc-info -n lxc-test-rootfs -p -H)
 ro=0
 mkdir /proc/$pid/root/rwtest || ro=1
 [ $ro -ne 1 ]

--- a/src/tests/lxc-test-snapdeps
+++ b/src/tests/lxc-test-snapdeps
@@ -35,7 +35,7 @@ if ! grep -q overlay /proc/filesystems; then
 fi
 
 cleanup() {
-	for i in `seq 1 20`; do
+	for i in $(seq 1 20); do
 		lxc-destroy -n snapdeptest$i > /dev/null 2>&1 || true
 	done
 	lxc-destroy -n snapdeptest > /dev/null 2>&1 || true
@@ -43,7 +43,7 @@ cleanup() {
 
 verify_deps() {
 	n=$1
-	m=`wc -l /var/lib/lxc/snapdeptest/lxc_snapshots | awk '{ print $1 }'`
+	m=$(wc -l /var/lib/lxc/snapdeptest/lxc_snapshots | awk '{ print $1 }')
 	[ $((n*2)) -eq $m ]
 }
 
@@ -60,7 +60,7 @@ if [ $fail -eq 0 ]; then
 	false
 fi
 
-for i in `seq 2 20`; do
+for i in $(seq 2 20); do
 	lxc-copy -s -n snapdeptest -N snapdeptest$i
 done
 
@@ -74,7 +74,7 @@ lxc-destroy -n snapdeptest20
 
 verify_deps 18
 
-for i in `seq 2 19`; do
+for i in $(seq 2 19); do
 	lxc-destroy -n snapdeptest$i
 done
 

--- a/src/tests/lxc-test-symlink
+++ b/src/tests/lxc-test-symlink
@@ -9,9 +9,9 @@ set -ex
 #
 # This is a regression test for symbolic links
 
-dirname=`mktemp -d`
-fname=`mktemp`
-fname2=`mktemp`
+dirname=$(mktemp -d)
+fname=$(mktemp)
+fname2=$(mktemp)
 
 lxcpath=/var/lib/lxcsym1
 

--- a/src/tests/lxc-test-unpriv
+++ b/src/tests/lxc-test-unpriv
@@ -162,7 +162,7 @@ run_cmd lxc-create -t busybox -n c1 -l trace -o "${UNPRIV_LOG}"
 
 # Make sure we can start it - twice
 
-for count in `seq 1 2`; do
+for count in $(seq 1 2); do
     run_cmd lxc-start -n c1 -d -l trace -o "${UNPRIV_LOG}"
 
     p1=$(run_cmd lxc-info -n c1 -p -H -l trace -o "${UNPRIV_LOG}")

--- a/templates/lxc-busybox.in
+++ b/templates/lxc-busybox.in
@@ -121,8 +121,8 @@ EOF
   chmod 644 "${rootfs}/etc/inittab" || return 1
 
   # Look for the pathname of "default.script" from the help of udhcpc
-  DEF_SCRIPT=`${BUSYBOX_EXE} udhcpc --help 2>&1 | egrep -- '-s.*Run PROG' | cut -d'/' -f2- | cut -d')' -f1`
-  DEF_SCRIPT_DIR=`dirname /${DEF_SCRIPT}`
+  DEF_SCRIPT=$(${BUSYBOX_EXE} udhcpc --help 2>&1 | egrep -- '-s.*Run PROG' | cut -d'/' -f2- | cut -d')' -f1)
+  DEF_SCRIPT_DIR=$(dirname /${DEF_SCRIPT})
   mkdir -p ${rootfs}/${DEF_SCRIPT_DIR}
   chmod 644 ${rootfs}/${DEF_SCRIPT_DIR} || return 1
 


### PR DESCRIPTION
See https://github.com/koalaman/shellcheck/wiki/SC2006 for details.

Signed-off-by: Diederik de Haas <didi.debian@cknow.org>

---
I'm not 100% sure whether the change should also be applied to `src/lxc/lxc.functions.in`, but I have included it.