### PR TITLE
Replace remaining occurences of 'which' with 'command -v'

### DIFF
--- a/hooks/nvidia
+++ b/hooks/nvidia
@@ -68,7 +68,7 @@ in_userns() {
 }
 
 get_ldconfig() {
-    which "ldconfig.real" || which "ldconfig"
+    command -v "ldconfig.real" || command -v "ldconfig"
     return $?
 }
 


### PR DESCRIPTION
The later is builtin and POSIX compliant.

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>