### PR TITLE
autotools: Avoid multiple liblxc.so with --enable-pam

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -636,19 +636,19 @@ AM_COND_IF([ENABLE_PAM],
 		[pamdir],
 		[AS_HELP_STRING([--with-pamdir=PATH],[Specify the directory where PAM modules are stored,
 							or "none" if PAM modules are not to be built])],
-		[pamdir=$withval],
+		[exec_pamdir=$withval],
 		[
 			if test "${prefix}" = "/usr"; then
-				pamdir="/lib${libdir##*/lib}/security"
+				exec_pamdir="/lib${libdir##*/lib}/security"
 			else
-				pamdir="\$(libdir)/security"
+				exec_pamdir="\$(libdir)/security"
 			fi
 		]
 	)])
 
-AM_CONDITIONAL([HAVE_PAM], [test x"$pamdir" != "xnone"])
+AM_CONDITIONAL([HAVE_PAM], [test x"$exec_pamdir" != "xnone"])
 AM_COND_IF([ENABLE_PAM],
-	[if test "z$pamdir" != "znone"; then
+	[if test "z$exec_pamdir" != "znone"; then
 		AC_ARG_VAR([PAM_CFLAGS], [C compiler flags for pam])
 		AC_ARG_VAR([PAM_LIBS], [linker flags for pam])
 		AC_CHECK_LIB(
@@ -659,7 +659,7 @@ AM_COND_IF([ENABLE_PAM],
 			])
 
 		AC_SUBST(PAM_LIBS)
-		AC_SUBST([pamdir])
+		AC_SUBST([exec_pamdir])
 	fi])
 
 # Some systems lack PR_CAPBSET_DROP definition => HAVE_DECL_PR_CAPBSET_DROP
@@ -1130,7 +1130,7 @@ Security features:
 
 PAM:
  - PAM module: $enable_pam
- - cgroup PAM module: $pamdir
+ - cgroup PAM module: $exec_pamdir
 
 Documentation:
  - examples: $enable_examples

--- a/src/lxc/Makefile.am
+++ b/src/lxc/Makefile.am
@@ -2631,7 +2631,7 @@ endif
 
 if ENABLE_PAM
 if HAVE_PAM
-pam_LTLIBRARIES = pam_cgfs.la
+exec_pam_LTLIBRARIES = pam_cgfs.la
 
 pam_cgfs_la_SOURCES = pam/pam_cgfs.c \
 		      file_utils.c file_utils.h \
@@ -2661,7 +2661,7 @@ pam_cgfs_la_LDFLAGS = $(AM_LDFLAGS) \
 endif
 endif
 
-install-exec-local: install-libLTLIBRARIES
+install-exec-hook:
 	mkdir -p $(DESTDIR)$(datadir)/lxc
 	install -c -m 644 lxc.functions $(DESTDIR)$(datadir)/lxc
 	mv $(shell readlink -f $(DESTDIR)$(libdir)/liblxc.so) $(DESTDIR)$(libdir)/liblxc.so.@LXC_ABI@
@@ -2669,10 +2669,15 @@ install-exec-local: install-libLTLIBRARIES
 	cd $(DESTDIR)$(libdir); \
 	ln -sf liblxc.so.@LXC_ABI@ liblxc.so.$(firstword $(subst ., ,@LXC_ABI@)); \
 	ln -sf liblxc.so.$(firstword $(subst ., ,@LXC_ABI@)) liblxc.so
-
+if ENABLE_PAM
+if HAVE_PAM
+	$(RM) "$(DESTDIR)$(exec_pamdir)/pam_cgfs.la"
+	$(RM) "$(DESTDIR)$(exec_pamdir)/pam_cgfs.a"
+endif
+endif
 if ENABLE_COMMANDS
-install-exec-hook:
 	chmod u+s $(DESTDIR)$(libexecdir)/lxc/lxc-user-nic
+
 if ENABLE_BASH
 install-data-local:
 	cd $(DESTDIR)$(bashcompdir); \
@@ -2693,10 +2698,6 @@ endif
 
 if ENABLE_PAM
 if HAVE_PAM
-	$(RM) $(DESTDIR)$(pamdir)/pam_cgfs.so*
-
-install-data-hook: install-pamLTLIBRARIES
-	$(RM) "$(DESTDIR)$(pamdir)/pam_cgfs.la"
-	$(RM) "$(DESTDIR)$(pamdir)/pam_cgfs.a"
+	$(RM) $(DESTDIR)$(exec_pamdir)/pam_cgfs.so*
 endif
 endif


### PR DESCRIPTION
When installing LXC with the default options, a single non-symlink liblxc.so* (e.g. liblxc.so.1.7.0) file is created:

```
    $ ./autogen.sh && ./configure && make && \
    rm -rf "$HOME/lxci" && make DESTDIR="$HOME/lxci" install && \
    stat -c%N "$HOME/lxci/usr/local/lib/liblxc.so"*
    [...]
    '/home/someone/lxci/usr/local/lib/liblxc.so' -> 'liblxc.so.1'
    '/home/someone/lxci/usr/local/lib/liblxc.so.1' -> 'liblxc.so.1.7.0'
    '/home/someone/lxci/usr/local/lib/liblxc.so.1.7.0'
```

However, when automake>=1.16.5, and the `--enable-pam` option is used, two non-symlink liblxc.so* (e.g. liblxc.so.1.0.0 and liblxc.so.1.7.0) are erroneously created:

```
    $ ./autogen.sh && ./configure --enable-pam && make && \
    rm -rf "$HOME/lxci" && make DESTDIR="$HOME/lxci" install && \
    stat -c%N "$HOME/lxci/usr/local/lib/liblxc.so"*
    [...]
    '/home/someone/lxci/usr/local/lib/liblxc.so' -> 'liblxc.so.1.0.0'
    '/home/someone/lxci/usr/local/lib/liblxc.so.1' -> 'liblxc.so.1.0.0'
    '/home/someone/lxci/usr/local/lib/liblxc.so.1.0.0'
    '/home/someone/lxci/usr/local/lib/liblxc.so.1.7.0'
```

This is due to infighting between libtool's and LXC's versioning: libtool creates liblxc.so.1.0.0, then LXC's `install-exec-local` hook in `Makefile.am` moves it to liblxc.so.1.7.0. However, with `--enable-pam`, the `install-libLTLIBRARIES` target is re-triggered after `install-pamLTLIBRARIES`, which will create liblxc.so.1.0.0 again.

The bigger problem here is that the install for the pam_cgfs library is done on the `data` phase of the automake install process instead of the `exec` phase (https://www.gnu.org/software/automake/manual/html_node/The-Two-Parts-of-Install.html), which gives `install-libLTLIBRARIES` a chance to run again after the `install-exec-local` / `install-exec-hook` targets have already run.

To fix this, we add an "exec_" prefix to the pam_cgfs library to make it run during the `exec` phase (see link above). We also consolidate the various hooks in the `install-exec-hook` target, which runs after the whole install, avoiding needing to manually specify the dependencies like in `install-exec-local`.
