### PR TITLE
Revert "initutils: use vfork() in lxc_container_init()"

### DIFF
--- a/src/lxc/initutils.c
+++ b/src/lxc/initutils.c
@@ -551,7 +551,7 @@ __noreturn int lxc_container_init(int argc, char *const *argv, bool quiet)
 
 	remove_self();
 
-	pid = vfork();
+	pid = fork();
 	if (pid < 0)
 		exit(EXIT_FAILURE);
 


### PR DESCRIPTION
This reverts commit d65e5e492f740bbb50e3005f97420c3ddae3d595.

With vfork the child process modifies the parent's memory,
so the calls to `signal`, `fprintf` and regular `exit` may
be dangerous and might cause conflicting states in the
parent.

---

While I haven't actually run into issues, from what the manpage says I think it's better to stick with `fork` for this one.
(Though from the code I think we would mostly see issues in the error cases, if any, not sure about the state of the signal handlers and whether the functions we're calling here actually cause any changes under the hood that would affect the parent process.)