### PR TITLE
cgroups: fix compiler warning

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -574,7 +574,7 @@ __cgfsng_ops static void cgfsng_payload_destroy(struct cgroup_ops *ops,
 static bool cpuset1_cpus_initialize(int dfd_parent, int dfd_child,
 				    bool am_initialized)
 {
-	__do_free char *cpulist = NULL, *fpath = NULL, *isolcpus = NULL,
+	__do_free char *cpulist = NULL, *isolcpus = NULL,
 		       *offlinecpus = NULL, *posscpus = NULL;
 	__do_free __u32 *possmask = NULL;
 	int ret;
@@ -582,7 +582,7 @@ static bool cpuset1_cpus_initialize(int dfd_parent, int dfd_child,
 
 	posscpus = read_file_at(dfd_parent, "cpuset.cpus", PROTECT_OPEN, 0);
 	if (!posscpus)
-		return log_error_errno(false, errno, "Failed to read file \"%s\"", fpath);
+		return log_error_errno(false, errno, "Failed to read file %d/cpuset.cpus", dfd_parent);
 
 	if (file_exists(__ISOL_CPUS)) {
 		isolcpus = read_file_at(-EBADF, __ISOL_CPUS, PROTECT_OPEN, 0);


### PR DESCRIPTION
I get:

In file included from cgroups/cgfsng.c:42:
In function 'cpuset1_cpus_initialize',
    inlined from 'cpuset1_initialize' at cgroups/cgfsng.c:658:7,
    inlined from '__cgroup_tree_create.constprop' at cgroups/cgfsng.c:723:26:
./log.h:376:9: error: '%s' directive argument is null [-Werror=format-overflow=]
  376 |         LXC_ERROR(&locinfo, format, ##__VA_ARGS__);                     \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./log.h:457:17: note: in expansion of macro 'ERROR'
  457 |                 ERROR("%s - " format, ptr, ##__VA_ARGS__); \
      |                 ^~~~~
./log.h:491:17: note: in expansion of macro 'SYSERROR'
  491 |                 SYSERROR(format, ##__VA_ARGS__);              \
      |                 ^~~~~~~~
cgroups/cgfsng.c:585:24: note: in expansion of macro 'log_error_errno'
  585 |                 return log_error_errno(false, errno, "Failed to read file \"%s\"", fpath);
      |                        ^~~~~~~~~~~~~~~

it turns out here that fpath is not used, so let's get rid of it and just
render the dfd+pathname directly.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>