### PR TITLE
api-extensions: don't advertise seccomp notify support if it's not co…

### DIFF
--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -27,7 +27,9 @@ static char *api_extensions[] = {
 	"cgroup_relative",
 	"mount_injection_file",
 	"seccomp_allow_nesting",
+#ifdef HAVE_SECCOMP_NOTIFY
 	"seccomp_notify",
+#endif /* HAVE_SECCOMP_NOTIFY */
 	"network_veth_routes",
 	"network_ipvlan",
 	"network_l2proxy",
@@ -42,8 +44,10 @@ static char *api_extensions[] = {
 	"time_namespace",
 	"seccomp_allow_deny_syntax",
 	"devpts_fd",
+#ifdef HAVE_SECCOMP_NOTIFY
 	"seccomp_notify_fd_active",
 	"seccomp_proxy_send_notify_fd",
+#endif /* HAVE_SECCOMP_NOTIFY */
 	"idmapped_mounts",
 	"idmapped_mounts_v2",
 	"core_scheduling",


### PR DESCRIPTION
…mpiled in

Link: https://discuss.linuxcontainers.org/t/runtimeerror-failed-to-read-zi-bytes-from-dev-urandom
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>