### PR TITLE
seccomp: only guard seccomp notify behind HAVE_DECL_SECCOMP_NOTIFY_FD

### DIFF
--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -27,9 +27,9 @@ static char *api_extensions[] = {
 	"cgroup_relative",
 	"mount_injection_file",
 	"seccomp_allow_nesting",
-#ifdef HAVE_SECCOMP_NOTIFY
+#ifdef HAVE_DECL_SECCOMP_NOTIFY_FD
 	"seccomp_notify",
-#endif /* HAVE_SECCOMP_NOTIFY */
+#endif /* HAVE_DECL_SECCOMP_NOTIFY_FD */
 	"network_veth_routes",
 	"network_ipvlan",
 	"network_l2proxy",
@@ -44,10 +44,10 @@ static char *api_extensions[] = {
 	"time_namespace",
 	"seccomp_allow_deny_syntax",
 	"devpts_fd",
-#ifdef HAVE_SECCOMP_NOTIFY
+#ifdef HAVE_DECL_SECCOMP_NOTIFY_FD
 	"seccomp_notify_fd_active",
 	"seccomp_proxy_send_notify_fd",
-#endif /* HAVE_SECCOMP_NOTIFY */
+#endif /* HAVE_DECL_SECCOMP_NOTIFY_FD */
 	"idmapped_mounts",
 	"idmapped_mounts_v2",
 	"core_scheduling",

--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -701,7 +701,7 @@ static int lxc_cmd_get_devpts_fd_callback(int fd, struct lxc_cmd_req *req,
 
 int lxc_cmd_get_seccomp_notify_fd(const char *name, const char *lxcpath)
 {
-#ifdef HAVE_SECCOMP_NOTIFY
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	bool stopped = false;
 	int fd;
 	ssize_t ret;
@@ -732,7 +732,7 @@ static int lxc_cmd_get_seccomp_notify_fd_callback(int fd, struct lxc_cmd_req *re
 						  struct lxc_handler *handler,
 						  struct lxc_async_descr *descr)
 {
-#ifdef HAVE_SECCOMP_NOTIFY
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	struct lxc_cmd_rsp rsp = {
 		.ret = -EBADF,
 	};
@@ -1543,7 +1543,7 @@ int lxc_cmd_seccomp_notify_add_listener(const char *name, const char *lxcpath,
 					/* unused */ unsigned int flags)
 {
 
-#ifdef HAVE_SECCOMP_NOTIFY
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	bool stopped = false;
 	ssize_t ret;
 	struct lxc_cmd_rr cmd;
@@ -1568,7 +1568,7 @@ static int lxc_cmd_seccomp_notify_add_listener_callback(int fd,
 {
 	struct lxc_cmd_rsp rsp = {0};
 
-#ifdef HAVE_SECCOMP_NOTIFY
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	int ret;
 	__do_close int recv_fd = -EBADF;
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1204,7 +1204,7 @@ static int set_config_seccomp_allow_nesting(const char *key, const char *value,
 static int set_config_seccomp_notify_cookie(const char *key, const char *value,
 					    struct lxc_conf *lxc_conf, void *data)
 {
-#ifdef HAVE_SECCOMP_NOTIFY
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	return set_config_string_item(&lxc_conf->seccomp.notifier.cookie, value);
 #else
 	return ret_errno(ENOSYS);
@@ -1214,7 +1214,7 @@ static int set_config_seccomp_notify_cookie(const char *key, const char *value,
 static int set_config_seccomp_notify_proxy(const char *key, const char *value,
 					   struct lxc_conf *lxc_conf, void *data)
 {
-#ifdef HAVE_SECCOMP_NOTIFY
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	const char *offset;
 
 	if (lxc_config_value_empty(value))
@@ -4399,7 +4399,7 @@ static int get_config_seccomp_allow_nesting(const char *key, char *retv,
 static int get_config_seccomp_notify_cookie(const char *key, char *retv, int inlen,
 					    struct lxc_conf *c, void *data)
 {
-#ifdef HAVE_SECCOMP_NOTIFY
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	return lxc_get_conf_str(retv, inlen, c->seccomp.notifier.cookie);
 #else
 	return ret_errno(ENOSYS);
@@ -4409,7 +4409,7 @@ static int get_config_seccomp_notify_cookie(const char *key, char *retv, int inl
 static int get_config_seccomp_notify_proxy(const char *key, char *retv, int inlen,
 					   struct lxc_conf *c, void *data)
 {
-#ifdef HAVE_SECCOMP_NOTIFY
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	return lxc_get_conf_str(retv, inlen,
 				(c->seccomp.notifier.proxy_addr.sun_path[0]) == '/'
 				    ? &c->seccomp.notifier.proxy_addr.sun_path[0]
@@ -5142,7 +5142,7 @@ static inline int clr_config_seccomp_allow_nesting(const char *key,
 static inline int clr_config_seccomp_notify_cookie(const char *key,
 						   struct lxc_conf *c, void *data)
 {
-#ifdef HAVE_SECCOMP_NOTIFY
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	free_disarm(c->seccomp.notifier.cookie);
 	return 0;
 #else
@@ -5153,7 +5153,7 @@ static inline int clr_config_seccomp_notify_cookie(const char *key,
 static inline int clr_config_seccomp_notify_proxy(const char *key,
 						   struct lxc_conf *c, void *data)
 {
-#ifdef HAVE_SECCOMP_NOTIFY
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	memset(&c->seccomp.notifier.proxy_addr, 0,
 	       sizeof(c->seccomp.notifier.proxy_addr));
 	return 0;

--- a/src/lxc/lxcseccomp.h
+++ b/src/lxc/lxcseccomp.h
@@ -6,10 +6,12 @@
 #include "config.h"
 
 #include <errno.h>
+
 #ifdef HAVE_SECCOMP
 #include <linux/seccomp.h>
 #include <seccomp.h>
 #endif
+
 #if HAVE_DECL_SECCOMP_NOTIFY_FD
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -59,8 +61,6 @@ struct seccomp_notify {
 	struct seccomp_notif_resp *rsp_buf;
 	char *cookie;
 };
-
-#define HAVE_SECCOMP_NOTIFY 1
 
 #endif /* HAVE_DECL_SECCOMP_NOTIFY_FD */
 


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>