### PR TITLE
seccomp: close seccomp notifier fd in cleanup handler

### DIFF
--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1373,6 +1373,7 @@ int seccomp_notify_cleanup_handler(int fd, void *data)
 	 * seccomp notify handler through the command socket (e.g. for attach)
 	 * and so we won't touch the container's config.
 	 */
+	close(fd);
 #endif
 	return 0;
 }


### PR DESCRIPTION
Reported-by: Wolfgang Bumiller <w.bumiller@proxmox.com>
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>