### PR TITLE
github: stop installing gnupg now that it's unused

### DIFF
--- a/.github/workflows/sanitizers.sh
+++ b/.github/workflows/sanitizers.sh
@@ -13,7 +13,7 @@ apt-get update -qq
 apt-get install --yes --no-install-recommends \
     apparmor automake autoconf bash-completion bridge-utils build-essential \
     busybox-static clang cloud-image-utils curl dbus debhelper debootstrap \
-    devscripts dnsmasq-base docbook2x doxygen ed fakeroot file gcc gnupg graphviz \
+    devscripts dnsmasq-base docbook2x doxygen ed fakeroot file gcc graphviz \
     git iptables net-tools libapparmor-dev libcap-dev libgnutls28-dev liblua5.2-dev \
     libpam0g-dev libseccomp-dev libselinux1-dev libtool linux-libc-dev \
     llvm lsb-release make openssl pkg-config python3-all-dev \


### PR DESCRIPTION
GPG is not used since #4062