### PR TITLE
lxc-net: don't start by default inside lxc

### DIFF
--- a/config/init/systemd/lxc-net.service.in
+++ b/config/init/systemd/lxc-net.service.in
@@ -3,6 +3,7 @@ Description=LXC network bridge setup
 After=network-online.target
 Before=lxc.service
 Documentation=man:lxc
+ConditionVirtualization=!lxc
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
When lxc is installed inside an lxc container, trying to bring up
lxc-net with the default parameters will conflict with the networking
setup for lxc on the host. This breaks all networking inside the
container where lxc is installed.

Signed-off-by: Antonio Terceiro <terceiro@debian.org>