### PR TITLE
ttys: ensure container_ttys= env variable is set correctly

### DIFF
--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -1371,6 +1371,7 @@ void lxc_terminal_info_init(struct lxc_terminal_info *terminal)
 	terminal->ptx = -EBADF;
 	terminal->pty = -EBADF;
 	terminal->busy = -1;
+	terminal->pty_nr = -1;
 }
 
 void lxc_terminal_init(struct lxc_terminal *terminal)

--- a/src/lxc/terminal.h
+++ b/src/lxc/terminal.h
@@ -29,6 +29,9 @@ struct lxc_terminal_info {
 
 	/* whether the terminal is currently used */
 	int busy;
+
+	/* the number of the terminal */
+	int pty_nr;
 };
 
 struct lxc_terminal_state {


### PR DESCRIPTION
Fixes: #4088
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>