### PR TITLE
lxc-checkconfig: Only check probed modules if /proc/modules exists

### DIFF
--- a/src/lxc/cmd/lxc-checkconfig.in
+++ b/src/lxc/cmd/lxc-checkconfig.in
@@ -58,6 +58,9 @@ has_cgroup_ns() {
 }
 
 is_probed() {
+    if [ ! -f /proc/modules ]; then
+        return
+    fi
     lsmod | grep $1 > /dev/null
     if [ $? -eq 0 ]; then
         echo -n ", loaded"


### PR DESCRIPTION
Kernels can be built with `CONFIG_MODULES=n` which results in `is_probed()` telling the module isn't probed and `lsmod` spamming the following to stderr each time it's called:
```
libkmod: kmod_module_new_from_loaded: could not open /proc/modules: No such file or directory
Error: could not get list of modules: No such file or directory
```
Fix this by "stubbing" `is_probed()` when `/proc/modules` doesn't exist as it's always called after a `is_enabled()` anyway.