### PR TITLE
utils: add fastpath routine on mkdir_p function

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -218,6 +218,9 @@ int mkdir_p(const char *dir, mode_t mode)
 	const char *tmp = dir;
 	const char *orig = dir;
 
+	if (access(dir, F_OK) != -1)
+		return 0;
+
 	do {
 		__do_free char *makeme = NULL;
 		int ret;


### PR DESCRIPTION
Call 'access' to examine whether 'dir' is already existed or not instead
of directly calling 'mkdir' on each dir name separated by slash '/' even though
'dir' is existed.

Signed-off-by: Leesoo Ahn <lsahn@ooseel.net>