### PR TITLE
lxc-net.in: fix failure executing dnsmasq

### DIFF
--- a/config/init/common/lxc-net.in
+++ b/config/init/common/lxc-net.in
@@ -179,12 +179,17 @@ start() {
         LXC_DHCP_PING_ARG="--no-ping"
     fi
 
+    DNSMASQ_MISC_DIR="$varlib/misc"
+    if [ ! -d "$DNSMASQ_MISC_DIR" ]; then
+        mkdir -p "$DNSMASQ_MISC_DIR"
+    fi
+
     dnsmasq $LXC_DHCP_CONFILE_ARG $LXC_DOMAIN_ARG $LXC_DHCP_PING_ARG -u ${DNSMASQ_USER} \
             --strict-order --bind-interfaces --pid-file="${varrun}"/dnsmasq.pid \
             --listen-address ${LXC_ADDR} --dhcp-range ${LXC_DHCP_RANGE} \
             --dhcp-lease-max=${LXC_DHCP_MAX} --dhcp-no-override \
             --except-interface=lo --interface=${LXC_BRIDGE} \
-            --dhcp-leasefile="${varlib}"/misc/dnsmasq.${LXC_BRIDGE}.leases \
+            --dhcp-leasefile="${DNSMASQ_MISC_DIR}"/dnsmasq.${LXC_BRIDGE}.leases \
             --dhcp-authoritative $LXC_IPV6_ARG || cleanup
 
     touch "${varrun}"/network_up


### PR DESCRIPTION
Failure executing dnsmasq happens if misc dir is not existed as the
following error messages.

localhost.localdomain systemd[1]: Starting LXC network bridge setup...
localhost.localdomain lxc-net[5754]: dnsmasq: cannot open or create lease file /usr/local/var/lib/misc/dnsmasq.lxcbr0.leases: No such file or directory
localhost.localdomain dnsmasq[5754]: cannot open or create lease file /usr/local/var/lib/misc/dnsmasq.lxcbr0.leases: No such file or directory
localhost.localdomain dnsmasq[5754]: FAILED to start up
localhost.localdomain lxc-net[5727]: Failed to setup lxc-net.
localhost.localdomain lxc-net[5727]: Failed to setup lxc-net.
localhost.localdomain systemd[1]: lxc-net.service: Main process exited, code=exited, status=1/FAILURE
localhost.localdomain systemd[1]: lxc-net.service: Failed with result 'exit-code'.
localhost.localdomain systemd[1]: Failed to start LXC network bridge setup.

Modify 'lxc-net' script to call 'mkdir -p' command if the directory is not
existed before executing dnsmasq daemon.
