### PR TITLE
confile: improve config key/value line parser

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -3050,6 +3050,7 @@ static int parse_line(char *buffer, void *data)
 	bool empty_line;
 	struct lxc_config_t *config;
 	int ret;
+	size_t len;
 	char *dup = buffer;
 	struct parse_line_conf *plc = data;
 
@@ -3101,15 +3102,12 @@ static int parse_line(char *buffer, void *data)
 	value += lxc_char_left_gc(value, strlen(value));
 	value[lxc_char_right_gc(value, strlen(value))] = '\0';
 
-	if (*value == '\'' || *value == '\"') {
-		size_t len;
+	if (*value == '\'' || *value == '\"')
+		value++;
 
-		len = strlen(value);
-		if (len > 1 && value[len - 1] == *value) {
-			value[len - 1] = '\0';
-			value++;
-		}
-	}
+	len = strlen(value);
+	if (len > 1 && (value[len - 1] == '\'' || value[len - 1] == '\"'))
+		value[len - 1] = '\0';
 
 	config = lxc_get_config(key);
 	return config->set(key, value, plc->conf, NULL);


### PR DESCRIPTION
trim quote marks ('/") in head and tail of the value of each line in container
config file.

This change takes care of the following cases.
1. Both marks are in head and tail of value part.
    lxc...='path/to/something'
2. Both marks are in head of value part.
    lxc...='path/to/something
3. Both marks are in tail of value part.
    lxc...=path/to/something'
