### PR TITLE
use non-raw selinux api replace raws

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -320,12 +320,12 @@ AC_ARG_ENABLE([selinux],
 	[enable_selinux=$enableval], [enable_selinux=auto])
 
 if test "x$enable_selinux" = xauto; then
-	AC_CHECK_LIB([selinux],[setexeccon_raw],[enable_selinux=yes],[enable_selinux=no])
+	AC_CHECK_LIB([selinux],[setexeccon],[enable_selinux=yes],[enable_selinux=no])
 fi
 AM_CONDITIONAL([ENABLE_SELINUX], [test "x$enable_selinux" = "xyes"])
 AM_COND_IF([ENABLE_SELINUX],
 	[AC_CHECK_HEADER([selinux/selinux.h],[],[AC_MSG_ERROR([You must install the SELinux development package in order to compile lxc])])
-	AC_CHECK_LIB([selinux], [setexeccon_raw],[true],[AC_MSG_ERROR([You must install the SELinux development package in order to compile lxc])])
+	AC_CHECK_LIB([selinux], [setexeccon],[true],[AC_MSG_ERROR([You must install the SELinux development package in order to compile lxc])])
 	AC_SUBST([SELINUX_LIBS], [-lselinux])])
 
 # Seccomp syscall filter


### PR DESCRIPTION
new vesion selinux on android, hidden some raw-function:  https://android.googlesource.com/platform/external/selinux/+/refs/heads/master/libselinux/exported.map.txt

like: setexeccon_raw, getpidcon_raw, setcon_raw, setkeycreatecon_raw  and so on.

also, difference between raw and non-raw is  `getexeccon_raw() and setexeccon_raw() behave identically to their non-raw counterparts but do not perform context translation.` (https://www.systutorials.com/docs/linux/man/3-setexeccon_raw/)

raw functions will ignore context translation maybe not good ideas.

so, i think we need use non-raw functions to replace raws.

Signed-off-by: duguhaotian <duguhaotian@gmail.com>