### PR TITLE
lxc_can_use_pidfd: don't log error if pidfds not supported, trace

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1792,7 +1792,7 @@ bool lxc_can_use_pidfd(int pidfd)
 	int ret;
 
 	if (pidfd < 0)
-		return log_error(false, "Kernel does not support pidfds");
+		return log_trace(false, "Kernel does not support pidfds");
 
 	/*
 	 * We don't care whether or not children were in a waitable state. We


### PR DESCRIPTION
My kernel is old enough not to have pidfds but I spawn containers regularly and don't want to see this err.
I need it in stable-4.0 actually. but master first.
