### PR TITLE
CODING_STYLE: add forgotten fallthrough

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -689,6 +689,8 @@ int lxc_attach_run_command(void *payload)
 		case ENOEXEC:
 			ret = 126;
 			break;
+		case ENOTDIR:
+			__fallthrough;
 		case ENOENT:
 			ret = 127;
 			break;


### PR DESCRIPTION
Hi,

it seems to me that your example in the coding style markdown file is lacking the `fallthrough` statement it is intended to demonstrate.

I created this example based on the way you do it in `src/lxc/commands.c`. I don't know what exactly the markdown-example is supposed to do. I just assumed that you might want to treat ENOENT and ENOTDIR identically, for example.

In your code you use `__fallthrough`, whereas the markdown suggests `__fallthrough__`. Before pulling this, that should be made congruent, probably. I can not decide what version the document intents to instruct the programmer to do. Take my PR just a suggestion.

Cheers