### PR TITLE
use systemd dbus StartTransientUnit for unpriv cgroup2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq gcc clang meson llvm
-          sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev libselinux1-dev linux-libc-dev libpam0g-dev docbook2x
+          sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev libselinux1-dev linux-libc-dev libpam0g-dev docbook2x libsystemd-dev
 
       - name: Compiler version
         env:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq gcc clang
-          sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev libselinux1-dev linux-libc-dev docbook2x
+          sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev libselinux1-dev linux-libc-dev docbook2x libsystemd-dev
 
       - name: Compiler version
         run: |

--- a/.github/workflows/sanitizers.sh
+++ b/.github/workflows/sanitizers.sh
@@ -18,7 +18,7 @@ apt-get install --yes --no-install-recommends \
     libpam0g-dev libseccomp-dev libselinux1-dev libtool linux-libc-dev \
     llvm lsb-release make openssl pkg-config python3-all-dev \
     python3-setuptools rsync squashfs-tools uidmap unzip uuid-runtime \
-    wget xz-utils systemd-coredump
+    wget xz-utils systemd-coredump libsystemd-dev
 apt-get remove --yes lxc-utils liblxc-common liblxc1 liblxc-dev
 
 ARGS="-Dprefix=/usr -Dtests=true -Dpam-cgroup=false -Dwerror=true -Dio-uring-event-loop=false -Db_lto_mode=default -Db_lundef=false"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq gcc clang meson llvm
-          sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev libselinux1-dev linux-libc-dev libpam0g-dev docbook2x
+          sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev libselinux1-dev linux-libc-dev libpam0g-dev docbook2x libsystemd-dev
 
       - name: Compiler version
         env:

--- a/meson.build
+++ b/meson.build
@@ -151,6 +151,7 @@ want_oss_fuzz = get_option('oss-fuzz')
 want_seccomp = get_option('seccomp')
 want_thread_safety = get_option('thread-safety')
 want_memfd_rexec = get_option('memfd-rexec')
+want_sd_bus = get_option('sd-bus')
 
 srcconf.set_quoted('DEFAULT_CGROUP_PATTERN', cgrouppattern)
 if coverity
@@ -254,6 +255,49 @@ if want_io_uring
     srcconf.set10('HAVE_LIBURING', true)
 else
     srcconf.set10('HAVE_LIBURING', false)
+endif
+
+if not want_sd_bus.disabled()
+    has_sd_bus = true
+    sd_bus_optional = want_sd_bus.auto()
+
+    libsystemd = dependency('libsystemd', required: not sd_bus_optional)
+    if not libsystemd.found()
+        if not sd_bus_optional
+            error('missing required libsystemd dependency')
+        endif
+
+        has_sd_bus = false
+    endif
+
+    if not cc.has_header('systemd/sd-bus.h')
+        if not sd_bus_optional
+            error('libsystemd misses required systemd/sd-bus.h header')
+        endif
+
+        has_sd_bus = false
+    endif
+
+    if not cc.has_header('systemd/sd-event.h')
+        if not sd_bus_optional
+            error('libsystemd misses required systemd/sd-event.h header')
+        endif
+
+        has_sd_bus = false
+    endif
+
+    if not cc.has_function('sd_bus_call_method_asyncv', prefix: '#include <systemd/sd-bus.h>', dependencies: libsystemd) 
+        if not sd_bus_optional
+            error('libsystemd misses required sd_bus_call_method_asyncv function')
+        endif
+
+        has_sd_bus = false
+    endif
+
+    srcconf.set10('HAVE_LIBSYSTEMD', has_sd_bus)
+else
+    has_sd_bus = false
+    srcconf.set10('HAVE_LIBSYSTEMD', false)
 endif
 
 ## Time EPOCH.
@@ -639,6 +683,8 @@ endforeach
 found_headers = []
 missing_headers = []
 foreach tuple: [
+    ['systemd/sd-bus.h'],
+    ['systemd/sd-event.h'],
     ['sys/resource.h'],
     ['sys/memfd.h'],
     ['sys/personality.h'],
@@ -676,6 +722,7 @@ foreach tuple: [
     ['pam'],
     ['openssl'],
     ['liburing'],
+    ['libsystemd'],
 ]
 
     if tuple.length() >= 2
@@ -748,6 +795,10 @@ endif
 
 if want_io_uring
     liblxc_dependencies += [liburing]
+endif
+
+if has_sd_bus
+    liblxc_dependencies += [libsystemd]
 endif
 
 liblxc_link_whole = [liblxc_static]

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,6 +22,9 @@ option('init-script', type : 'array',
 option('io-uring-event-loop', type: 'boolean', value: 'false',
        description: 'Enable io-uring based event loop')
 
+option('sd-bus', type: 'feature', value: 'auto',
+       description: 'Enable linking against sd-bus')
+
 # was --{disable,enable}-doc in autotools
 option('man', type: 'boolean', value: 'true',
        description: 'build and install manpages')

--- a/src/lxc/commands.h
+++ b/src/lxc/commands.h
@@ -52,6 +52,7 @@ typedef enum {
 	LXC_CMD_GET_CGROUP_CTX			= 23,
 	LXC_CMD_GET_CGROUP_FD			= 24,
 	LXC_CMD_GET_LIMIT_CGROUP_FD		= 25,
+	LXC_CMD_GET_SYSTEMD_SCOPE		= 26,
 	LXC_CMD_MAX,
 } lxc_cmd_t;
 
@@ -115,6 +116,7 @@ __hidden extern char *lxc_cmd_get_config_item(const char *name, const char *item
 					      const char *lxcpath);
 __hidden extern char *lxc_cmd_get_name(const char *hashed_sock);
 __hidden extern char *lxc_cmd_get_lxcpath(const char *hashed_sock);
+__hidden extern char *lxc_cmd_get_systemd_scope(const char *name, const char *lxcpath);
 __hidden extern pid_t lxc_cmd_get_init_pid(const char *name, const char *lxcpath);
 __hidden extern int lxc_cmd_get_init_pidfd(const char *name, const char *lxcpath);
 __hidden extern int lxc_cmd_get_state(const char *name, const char *lxcpath);

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4831,6 +4831,7 @@ void lxc_conf_free(struct lxc_conf *conf)
 	free(conf->cgroup_meta.container_dir);
 	free(conf->cgroup_meta.namespace_dir);
 	free(conf->cgroup_meta.controllers);
+	free(conf->cgroup_meta.systemd_scope);
 	free(conf->shmount.path_host);
 	free(conf->shmount.path_cont);
 	free(conf);

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -74,6 +74,13 @@ struct lxc_cgroup {
 			char *container_dir;
 			char *namespace_dir;
 			bool relative;
+			/* If an unpriv user in pure unified-only hierarchy
+			 * starts a container, then we ask systemd to create
+			 * a scope for us, and create the monitor and container
+			 * cgroups under that.
+			 * This will ignore the above things like monitor_dir
+			 */
+			char *systemd_scope;
 		};
 	};
 

--- a/src/tests/oss-fuzz.sh
+++ b/src/tests/oss-fuzz.sh
@@ -24,7 +24,7 @@ mkdir -p $OUT
 apt-get update -qq
 apt-get install --yes --no-install-recommends \
     build-essential docbook2x doxygen git \
-    wget xz-utils systemd-coredump pkgconf
+    wget xz-utils systemd-coredump pkgconf libsystemd-dev
 apt-get remove --yes lxc-utils liblxc-common liblxc1 liblxc-dev
 
 # make sure we have a new enough meson version


### PR DESCRIPTION
If, when init'ing cgroups for a container start, we detect that we
are an unprivileged user on a unified-hierarchy-only system, then we
try to request systemd, through dbus api, to create a new scope for
us with delegation.  Call the cgroup it creates for us P1.  We then
create P1/init, move ourselves into there, so we can enable the
controllers for delegation to P1's children through P1/cgroup.subtree_control.

On attach, we try to request systemd attach us to the container's
scope.  We can't do that ourselves in the normal case, as root owns
our login cgroups.

Create a new command api for the lxc monitor to tell lxc-attach the
systemd scope to which to attach.

Changelog:
 * free cgroup_meta.systemd_scope in lxc_conf_free (Thanks Tycho)
 * fix some indent
 * address some (not all) of brauner's feedback

Signed-off-by: Serge Hallyn <serge@hallyn.com>