### PR TITLE
add check for statvfs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -538,6 +538,7 @@ foreach tuple: [
     ['sigdescr_np'],
     ['signalfd'],
     ['statx'],
+    ['statvfs'],
     ['strlcat'],
     ['strlcpy'],
     ['unshare'],
@@ -667,6 +668,7 @@ foreach ident: [
     ['setns',             '''#include <sched.h>'''],
     ['sigdescr_np',       '''#include <string.h>'''],
     ['signalfd',          '''#include <sys/signalfd.h>'''],
+    ['statvfs',           '''#include <sys/statvfs.h>'''],
     ['statx',             '''#include <sys/types.h>
                              #include <sys/stat.h>
                              #include <unistd.h>'''],


### PR DESCRIPTION
we use HAVE_STATVFS in the code but with meson the check got
lost causing mount_entry to fail to remount some things such
as a bind mount of /dev/fuse via

    lxc.mount.entry = /dev/fuse dev/fuse none bind,create=file 0 0

which would cause the following log messages:

    DEBUG    conf - ../src/lxc/conf.c:mount_entry:2416 - Remounting "/dev/fuse" on "/usr/lib/x86_64-linux-gnu/lxc/rootfs/dev/fuse" to respect bind or remount options
    ERROR    conf - ../src/lxc/conf.c:mount_entry:2459 - Operation not permitted - Failed to mount "/dev/fuse" on "/usr/lib/x86_64-linux-gnu/lxc/rootfs/dev/fuse"

note that the `Flags for ... were ...` line is not showing
up there, which depends on HAVE_STATVFS

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>