### PR TITLE
Fix errors constructing mount string when extra mount options supplied

### DIFF
--- a/src/lxc/storage/overlay.c
+++ b/src/lxc/storage/overlay.c
@@ -445,7 +445,7 @@ int ovl_mount(struct lxc_storage *bdev)
 			       upper, lower, mntdata);
 
 		len2 = strlen(lower) + strlen(upper) + strlen(work) +
-		       strlen("upperdir=,lowerdir=,workdir=") +
+		       strlen("upperdir=,lowerdir=,workdir=,") +
 		       strlen(mntdata) + 1;
 		options_work = must_realloc(NULL, len2);
 		ret2 = snprintf(options, len2,

--- a/src/lxc/storage/overlay.c
+++ b/src/lxc/storage/overlay.c
@@ -448,7 +448,7 @@ int ovl_mount(struct lxc_storage *bdev)
 		       strlen("upperdir=,lowerdir=,workdir=,") +
 		       strlen(mntdata) + 1;
 		options_work = must_realloc(NULL, len2);
-		ret2 = snprintf(options, len2,
+		ret2 = snprintf(options_work, len2,
 				"upperdir=%s,lowerdir=%s,workdir=%s,%s", upper,
 				lower, work, mntdata);
 	} else {


### PR DESCRIPTION
This fixes a really subtle off-by-one error constructing overlay mount options if rootfs options are provided and modern overlayfs (i.e. requiring a workdir) is used. We need to allow for the extra "," required to separate the extra options when computing the length!

Without the fix container creation fails with a "Failed to create string" error in the debug log.
