### PR TITLE
meson.build: fix build with -Dcapabilities=false

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -443,6 +443,7 @@ int main(int argc, char *argv[]) { return 0; };
         srcconf.set10('HAVE_STATIC_LIBCAP', false)
     endif
 else
+    libcap_static = []
     srcconf.set10('HAVE_LIBCAP', false)
     srcconf.set10('HAVE_STATIC_LIBCAP', false)
 endif


### PR DESCRIPTION
Define `libcap_static` to an empty array to avoid the following build failure with `-Dcapabilities=false`:

```
output/build/lxc-5.0.0/src/lxc/cmd/meson.build:64:4: ERROR: Unknown variable "libcap_static".
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>