### PR TITLE
meson.build: fix build without stack-protector

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -177,7 +177,6 @@ possible_cc_flags = [
     '-Wstrict-prototypes',
     '-fno-strict-aliasing',
     '-fstack-clash-protection',
-    '-fstack-protector-strong',
     '--param=ssp-buffer-size=4',
     '--mcet -fcf-protection',
     '-Werror=implicit-function-declaration',
@@ -215,6 +214,7 @@ possible_link_flags = [
     '-Wl,-z,now',
     '-Wl,-fuse-ld=gold',
     '-fstack-protector',
+    '-fstack-protector-strong',
 ]
 
 if sanitize == 'none'


### PR DESCRIPTION
Move `-fstack-protector-strong` from `possible_cc_flags` to `possible_link_flags` to avoid a build failure on toolchains without ssp

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>