### PR TITLE
meson.build: allow explicit distrosysconfdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -117,14 +117,18 @@ conf.set('SYSCONFDIR', sysconfdir)
 
 # Set sysconfdir
 fs = import('fs')
-if fs.is_dir('/etc/sysconfig')
+distrosysconfdir = get_option('distrosysconfdir')
+if distrosysconfdir != ''
+    distrosysconfdir = join_paths(sysconfdir, distrosysconfdir)
+    conf.set('LXC_DISTRO_SYSCONF', distrosysconfdir)
+elif fs.is_dir('/etc/sysconfig')
     distrosysconfdir = join_paths(sysconfdir, 'sysconfig')
     conf.set('LXC_DISTRO_SYSCONF', distrosysconfdir)
 elif fs.is_dir('/etc/default')
     distrosysconfdir = join_paths(sysconfdir, 'default')
     conf.set('LXC_DISTRO_SYSCONF', distrosysconfdir)
 else
-    distrosysconfdir = ''
+    error('"distrosysconfdir" is not set')
 endif
 
 # Cross-compile on Android.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -115,3 +115,6 @@ option('thread-safety', type : 'boolean', value : 'true',
 # was --{disable,enable}-memfd-rexec in autotools
 option('memfd-rexec', type : 'boolean', value : 'true',
        description : 'whether to rexec the lxc-attach binary when attaching to a container')
+
+option('distrosysconfdir', type : 'string', value: '',
+       description: 'relative path to sysconfdir for distro default configuration')


### PR DESCRIPTION
Allows either:

- Build inside minimal-and-clean chroot without neither
  /etc/sysconfdir nor /etc/default.
- Cross Compile lxc from foreign distro,
  let's say host distro uses /etc/sysconfdir and build distro
  uses /etc/default and vice versus.

Fix #4178 