### PR TITLE
tree-wide: only rely on sys/ headers to avoid conflicts with linux/ headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -583,7 +583,6 @@ decl_headers = '''
 #include <linux/fs.h>
 #include <linux/if_link.h>
 #include <linux/openat2.h>
-#include <linux/sched.h>
 #include <linux/types.h>
 '''
 

--- a/meson.build
+++ b/meson.build
@@ -628,7 +628,6 @@ foreach tuple: [
     endif
 endforeach
 
-## Types.
 decl_headers = '''
 #include <sys/mount.h>
 '''
@@ -641,74 +640,61 @@ else
     srcconf.set10('HAVE_' + 'struct mount_attr'.underscorify().to_upper(), false)
     missing_types += 'struct mount_attr (sys/mount.h)' endif
 
-## Types.
-decl_headers = '''
-#include <linux/mount.h>
-'''
-
-# We get -1 if the size cannot be determined
-if cc.sizeof('struct mount_attr', prefix: decl_headers, args: '-D_GNU_SOURCE') > 0
-    srcconf.set10('HAVE_UAPI_' + 'struct mount_attr'.underscorify().to_upper(), true)
-    found_types += 'struct mount_attr (linux/mount.h)'
-else
-    srcconf.set10('HAVE_UAPI_' + 'struct mount_attr'.underscorify().to_upper(), false)
-    missing_types += 'struct mount_attr (linux/mount.h)'
-endif
-
+## Check if sys/mount.h defines the fsconfig commands
 if cc.has_header_symbol('sys/mount.h', 'FSCONFIG_SET_FLAG')
     srcconf.set10('HAVE_' + 'FSCONFIG_SET_FLAG'.underscorify().to_upper(), true)
-    found_types += 'FSCONFIG_SET_FLAG'
+    found_types += 'FSCONFIG_SET_FLAG (sys/mount.h)'
 else
     srcconf.set10('HAVE_' + 'FSCONFIG_SET_FLAG'.underscorify().to_upper(), false)
-    missing_types += 'FSCONFIG_SET_FLAG'
+    missing_types += 'FSCONFIG_SET_FLAG (sys/mount.h)'
 endif
 
 if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_STRING')
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_STRING'.underscorify().to_upper(), true)
-    found_types += 'FS_CONFIG_SET_STRING'
+    found_types += 'FS_CONFIG_SET_STRING (sys/mount.h)'
 else
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_STRING'.underscorify().to_upper(), false)
-    missing_types += 'FS_CONFIG_SET_STRING'
+    missing_types += 'FS_CONFIG_SET_STRING (sys/mount.h)'
 endif
 
 if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_BINARY')
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_BINARY'.underscorify().to_upper(), true)
-    found_types += 'FS_CONFIG_SET_BINARY'
+    found_types += 'FS_CONFIG_SET_BINARY (sys/mount.h)'
 else
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_BINARY'.underscorify().to_upper(), false)
-    missing_types += 'FS_CONFIG_SET_BINARY'
+    missing_types += 'FS_CONFIG_SET_BINARY (sys/mount.h)'
 endif
 
 if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_PATH_EMPTY')
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_EMPTY'.underscorify().to_upper(), true)
-    found_types += 'FS_CONFIG_SET_PATH_EMPTY'
+    found_types += 'FS_CONFIG_SET_PATH_EMPTY (sys/mount.h)'
 else
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_EMPTY'.underscorify().to_upper(), false)
-    missing_types += 'FS_CONFIG_SET_PATH_EMPTY'
+    missing_types += 'FS_CONFIG_SET_PATH_EMPTY (sys/mount.h)'
 endif
 
 if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_PATH_FD')
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_FD'.underscorify().to_upper(), true)
-    found_types += 'FS_CONFIG_SET_PATH_FD'
+    found_types += 'FS_CONFIG_SET_PATH_FD (sys/mount.h)'
 else
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_PATH_FD'.underscorify().to_upper(), false)
-    missing_types += 'FS_CONFIG_SET_PATH_FD'
+    missing_types += 'FS_CONFIG_SET_PATH_FD (sys/mount.h)'
 endif
 
 if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_CMD_CREATE')
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_CREATE'.underscorify().to_upper(), true)
-    found_types += 'FS_CONFIG_SET_CMD_CREATE'
+    found_types += 'FS_CONFIG_SET_CMD_CREAT (sys/mount.h)'
 else
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_CREATE'.underscorify().to_upper(), false)
-    missing_types += 'FS_CONFIG_SET_CMD_CREATE'
+    missing_types += 'FS_CONFIG_SET_CMD_CREATE (sys/mount.h)'
 endif
 
 if cc.has_header_symbol('sys/mount.h', 'FS_CONFIG_SET_CMD_RECONFIGURE')
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_RECONFIGURE'.underscorify().to_upper(), true)
-    found_types += 'FS_CONFIG_SET_CMD_RECONFIGURE'
+    found_types += 'FS_CONFIG_SET_CMD_RECONFIGURE (sys/mount.h)'
 else
     srcconf.set10('HAVE_' + 'FS_CONFIG_SET_CMD_RECONFIGURE'.underscorify().to_upper(), false)
-    missing_types += 'FS_CONFIG_SET_CMD_RECONFIGURE'
+    missing_types += 'FS_CONFIG_SET_CMD_RECONFIGURE (sys/mount.h)'
 endif
 
 ## Headers.

--- a/meson.build
+++ b/meson.build
@@ -580,9 +580,7 @@ decl_headers = '''
 #include <uchar.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
-#include <linux/fs.h>
 #include <linux/if_link.h>
-#include <linux/openat2.h>
 #include <linux/types.h>
 '''
 

--- a/src/lxc/file_utils.c
+++ b/src/lxc/file_utils.c
@@ -652,7 +652,7 @@ int open_at(int dfd, const char *path, unsigned int o_flags,
 	    unsigned int resolve_flags, mode_t mode)
 {
 	__do_close int fd = -EBADF;
-	struct lxc_open_how how = {
+	struct open_how how = {
 		.flags		= o_flags,
 		.mode		= mode,
 		.resolve	= resolve_flags,

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -8,6 +8,7 @@
 #include <asm/types.h>
 #include <limits.h>
 #include <linux/if_link.h>
+#include <linux/ioctl.h>
 #include <linux/loop.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
@@ -811,5 +812,17 @@ static inline bool is_set(__u32 bit, __u32 *bitarr)
 }
 
 #define BIT(nr) (1UL << (nr))
+
+#ifndef FS_IOC_GETFLAGS
+#define FS_IOC_GETFLAGS _IOR('f', 1, long)
+#endif
+
+#ifndef FS_IOC_SETFLAGS
+#define FS_IOC_SETFLAGS _IOW('f', 2, long)
+#endif
+
+#ifndef FS_IMMUTABLE_FL
+#define FS_IMMUTABLE_FL 0x00000010 /* Immutable file */
+#endif
 
 #endif /* __LXC_MACRO_H */

--- a/src/lxc/mount_utils.c
+++ b/src/lxc/mount_utils.c
@@ -186,7 +186,7 @@ int fs_prepare(const char *fs_name,
 	int fd_from;
 
 	if (!is_empty_string(path_from)) {
-		struct lxc_open_how how = {
+		struct open_how how = {
 			.flags		= o_flags_from,
 			.resolve	= resolve_flags_from,
 		};
@@ -237,7 +237,7 @@ int fs_attach(int fd_fs,
 	int fd_to, ret;
 
 	if (!is_empty_string(path_to)) {
-		struct lxc_open_how how = {
+		struct open_how how = {
 			.flags		= o_flags_to,
 			.resolve	= resolve_flags_to,
 		};
@@ -308,7 +308,7 @@ int move_detached_mount(int dfd_from, int dfd_to, const char *path_to,
 	int fd_to, ret;
 
 	if (!is_empty_string(path_to)) {
-		struct lxc_open_how how = {
+		struct open_how how = {
 			.flags		= o_flags_to,
 			.resolve	= resolve_flags_to,
 		};
@@ -348,7 +348,7 @@ int __fd_bind_mount(int dfd_from, const char *path_from, __u64 o_flags_from,
 	set_atime(&attr);
 
 	if (!is_empty_string(path_from)) {
-		struct lxc_open_how how = {
+		struct open_how how = {
 			.flags		= o_flags_from,
 			.resolve	= resolve_flags_from,
 		};

--- a/src/lxc/mount_utils.h
+++ b/src/lxc/mount_utils.h
@@ -124,7 +124,7 @@ struct lxc_rootfs;
 #endif
 #endif
 
-#if !FSCONFIG_CMD_RECONFIGURE
+#if !HAVE_FSCONFIG_CMD_RECONFIGURE
 #ifndef FSCONFIG_CMD_RECONFIGURE
 #define	FSCONFIG_CMD_RECONFIGURE 7	/* Invoke superblock reconfiguration */
 #endif

--- a/src/lxc/process_utils.c
+++ b/src/lxc/process_utils.c
@@ -90,7 +90,7 @@ __returns_twice pid_t lxc_raw_legacy_clone(unsigned long flags, int *pidfd)
 __returns_twice pid_t lxc_raw_clone(unsigned long flags, int *pidfd)
 {
 	pid_t pid;
-	struct lxc_clone_args args = {
+	struct clone_args args = {
 		.flags		= flags,
 		.pidfd		= ptr_to_u64(pidfd),
 	};

--- a/src/lxc/process_utils.h
+++ b/src/lxc/process_utils.h
@@ -5,7 +5,6 @@
 
 #include "config.h"
 
-#include <linux/sched.h>
 #include <sched.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -165,7 +164,8 @@
 #define u64_to_ptr(x) ((void *)(uintptr_t)x)
 #endif
 
-struct lxc_clone_args {
+#if !HAVE_STRUCT_CLONE_ARGS
+struct clone_args {
 	__aligned_u64 flags;
 	__aligned_u64 pidfd;
 	__aligned_u64 child_tid;
@@ -178,8 +178,9 @@ struct lxc_clone_args {
 	__aligned_u64 set_tid_size;
 	__aligned_u64 cgroup;
 };
+#endif
 
-__returns_twice static inline pid_t lxc_clone3(struct lxc_clone_args *args, size_t size)
+__returns_twice static inline pid_t lxc_clone3(struct clone_args *args, size_t size)
 {
 	return syscall(__NR_clone3, args, size);
 }

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1673,7 +1673,7 @@ static int lxc_spawn(struct lxc_handler *handler)
 	} else {
 		int cgroup_fd = -EBADF;
 
-		struct lxc_clone_args clone_args = {
+		struct clone_args clone_args = {
 			.flags = handler->clone_flags,
 			.pidfd = ptr_to_u64(&handler->pidfd),
 			.exit_signal = SIGCHLD,

--- a/src/lxc/start.h
+++ b/src/lxc/start.h
@@ -5,7 +5,6 @@
 
 #include "config.h"
 
-#include <linux/sched.h>
 #include <sched.h>
 #include <signal.h>
 #include <stdbool.h>

--- a/src/lxc/syscall_wrappers.h
+++ b/src/lxc/syscall_wrappers.h
@@ -10,6 +10,7 @@
 #include <linux/keyctl.h>
 #include <sched.h>
 #include <stdint.h>
+#include <sys/mount.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
@@ -17,12 +18,6 @@
 
 #include "macro.h"
 #include "syscall_numbers.h"
-
-#if HAVE_STRUCT_MOUNT_ATTR
-#include <sys/mount.h>
-#elif HAVE_UAPI_STRUCT_MOUNT_ATTR
-#include <linux/mount.h>
-#endif
 
 #ifdef HAVE_LINUX_MEMFD_H
 #include <linux/memfd.h>
@@ -216,7 +211,7 @@ extern int fsmount(int fs_fd, unsigned int flags, unsigned int attr_flags);
 /*
  * mount_setattr()
  */
-#if !HAVE_STRUCT_MOUNT_ATTR && !HAVE_UAPI_STRUCT_MOUNT_ATTR
+#if !HAVE_STRUCT_MOUNT_ATTR
 struct mount_attr {
 	__u64 attr_set;
 	__u64 attr_clr;

--- a/src/lxc/syscall_wrappers.h
+++ b/src/lxc/syscall_wrappers.h
@@ -240,11 +240,13 @@ static inline int mount_setattr(int dfd, const char *path, unsigned int flags,
  * @mode: O_CREAT/O_TMPFILE file mode.
  * @resolve: RESOLVE_* flags.
  */
-struct lxc_open_how {
+#if !HAVE_STRUCT_OPEN_HOW
+struct open_how {
 	__u64 flags;
 	__u64 mode;
 	__u64 resolve;
 };
+#endif
 
 /* how->resolve flags for openat2(2). */
 #ifndef RESOLVE_NO_XDEV
@@ -296,7 +298,7 @@ struct lxc_open_how {
 #define PROTECT_OPEN_RW (O_CLOEXEC | O_NOCTTY | O_RDWR | O_NOFOLLOW)
 
 #if !HAVE_OPENAT2
-static inline int openat2(int dfd, const char *filename, struct lxc_open_how *how, size_t size)
+static inline int openat2(int dfd, const char *filename, struct open_how *how, size_t size)
 {
 	return syscall(__NR_openat2, dfd, filename, how, size);
 }

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1095,7 +1095,7 @@ int __safe_mount_beneath_at(int beneath_fd, const char *src, const char *dst, co
 			    unsigned int flags, const void *data)
 {
 	__do_close int source_fd = -EBADF, target_fd = -EBADF;
-	struct lxc_open_how how = {
+	struct open_how how = {
 		.flags		= PROTECT_OPATH_DIRECTORY,
 		.resolve	= PROTECT_LOOKUP_BENEATH_WITH_MAGICLINKS,
 	};

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -19,8 +19,6 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/mount.h>
-/* Needs to be after sys/mount.h header */
-#include <linux/fs.h>
 #include <sys/param.h>
 #include <sys/prctl.h>
 #include <sys/stat.h>

--- a/src/tests/reboot.c
+++ b/src/tests/reboot.c
@@ -32,8 +32,6 @@
 
 #include "namespace.h"
 
-#include <sched.h>
-#include <linux/sched.h>
 #include <linux/reboot.h>
 
 int clone(int (*fn)(void *), void *child_stack, int flags, void *arg, ...);


### PR DESCRIPTION
Signed-off-by: Christian Brauner (Microsoft) <christian.brauner@ubuntu.com>