### PR TITLE
use sd_bus_call_method_async to replace the asyncv one

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -295,9 +295,9 @@ if not want_sd_bus.disabled()
         has_sd_bus = false
     endif
 
-    if not cc.has_function('sd_bus_call_method_asyncv', prefix: '#include <systemd/sd-bus.h>', dependencies: libsystemd) 
+    if not cc.has_function('sd_bus_call_method_async', prefix: '#include <systemd/sd-bus.h>', dependencies: libsystemd) 
         if not sd_bus_optional
-            error('libsystemd misses required sd_bus_call_method_asyncv function')
+            error('libsystemd misses required sd_bus_call_method_async function')
         endif
 
         has_sd_bus = false

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1232,7 +1232,7 @@ static int unpriv_systemd_create_scope(struct cgroup_ops *ops, struct lxc_conf *
 	if (r < 0)
 		return log_error(SYSTEMD_SCOPE_FAILED, "Failed to connect to user bus: %s", strerror(-r));
 
-	r = sd_bus_call_method_asyncv(bus, NULL, DESTINATION, PATH, INTERFACE, "Subscribe", NULL, NULL, NULL, NULL);
+	r = sd_bus_call_method_async(bus, NULL, DESTINATION, PATH, INTERFACE, "Subscribe", NULL, NULL, NULL);
 	if (r < 0)
 		return log_error(SYSTEMD_SCOPE_FAILED, "Failed to subscribe to signals: %s", strerror(-r));
 


### PR DESCRIPTION
The sd_bus_call_method_asyncv's 10th parameter is of type
va_list and supplying NULL when invoking it causes compilation
error. Just replace it with the async one.

Signed-off-by: Chen Qi <Qi.Chen@windriver.com>