### PR TITLE
fix error message when use tools with -? option

### DIFF
--- a/src/lxc/tools/arguments.h
+++ b/src/lxc/tools/arguments.h
@@ -137,6 +137,7 @@ struct lxc_arguments {
 #define LXC_COMMON_OPTIONS                                                     \
 	    { "name",        required_argument, 0, 'n'         },              \
 	    { "help",        no_argument,       0, 'h'         },              \
+	    { "help",        no_argument,       0, '?'         },              \
 	    { "usage",       no_argument,       0, OPT_USAGE   },              \
 	    { "version",     no_argument,       0, OPT_VERSION },              \
 	    { "quiet",       no_argument,       0, 'q'         },              \


### PR DESCRIPTION
Signed-off-by: Neil.wrz <wangrunze13@huawei.com>

### bugfix: 
using all the commands from lxc tools with -? option to get the help list gives an error message:

For example:
lxc-info -? gives an error message lxc-info: invalid option -- '?'

fix this by adding one entry for `-?` option 

[my issues here](https://github.com/lxc/lxc/issues/4191)