### PR TITLE
lxc-attach: Fix lost return codes of spawned processes that are killed

### DIFF
--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -399,6 +399,8 @@ int lxc_attach_main(int argc, char *argv[])
 	}
 	if (WIFEXITED(ret))
 		wexit = WEXITSTATUS(ret);
+	else if (WIFSIGNALED(ret))
+		wexit = WTERMSIG(ret) + 128;
 
 out:
 	lxc_container_put(c);


### PR DESCRIPTION
Closes #4203. 

lxc-attach swallows the return codes of processes that are terminated via a signal, and by default exits with a return code of 0 (i.e. indicating success) even if the command it tried to execute was terminated.

This patch fixes it by explicitly checking if the process was terminated via a signal, and returning an appropriate exit code.

Note that we add 128 to the signal value to generate the exit code because by convention the exit code is 128 + signal number. e.g. if a process is killed via signal 9, then the error code is 9 + 128 = 137.

Signed-off-by: Mohammed Ajmal Siddiqui <ajmalsiddiqui21@gmail.com>