### PR TITLE
lxc/attach: Detect EACCES from execvp and convert to 126 exit status

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1828,6 +1828,7 @@ int lxc_attach_run_command(void *payload)
 	ret = execvp(cmd->program, cmd->argv);
 	if (ret < 0) {
 		switch (errno) {
+		case EACCES:
 		case ENOEXEC:
 			ret = 126;
 			break;


### PR DESCRIPTION
Before:

```
sudo lxc-attach -n test /etc/passwd ; echo $?
lxc-attach: test: ../src/lxc/attach.c: lxc_attach_run_command: 1841 Permission denied - Failed to exec "/etc/passwd"
255
```

After:

```
sudo lxc-attach -n test /etc/passwd ; echo $?
lxc-attach: test: ../src/lxc/attach.c: lxc_attach_run_command: 1841 Permission denied - Failed to exec "/etc/passwd"
126
```

Which better aligns with bash:

```
/etc/passwd; echo $?
bash: /etc/passwd: Permission denied
126
```

Related to https://github.com/lxc/lxd/issues/10534

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>