### PR TITLE
build: add libsystemd to oss fuzz dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -896,6 +896,9 @@ endif
 
 if has_sd_bus
     liblxc_dependencies += [libsystemd]
+    if want_oss_fuzz
+        oss_fuzz_dependencies += [libsystemd]
+    endif
 endif
 
 if have_openpty


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52169
Signed-off-by: Christian Brauner (Microsoft) <christian.brauner@ubuntu.com>