### PR TITLE
tools: lxc-destroy: update help message for --force

### DIFF
--- a/src/lxc/tools/lxc_destroy.c
+++ b/src/lxc/tools/lxc_destroy.c
@@ -38,7 +38,7 @@ lxc-destroy destroys a container with the identifier NAME\n\
 Options :\n\
   -n, --name=NAME   NAME of the container\n\
   -s, --snapshots   destroy including all snapshots\n\
-  -f, --force       wait for the container to shut down\n\
+  -f, --force       stop and destroy the container if it's still running\n\
   --rcfile=FILE     Load configuration file FILE\n",
 	.options      = my_longopts,
 	.parser       = my_parser,


### PR DESCRIPTION
Looks like the --force is a flag to stop a running container before destroying it.

Update the help message accordingly.

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>