### PR TITLE
Fix off-by-one error constructing mount options

### DIFF
--- a/src/lxc/storage/overlay.c
+++ b/src/lxc/storage/overlay.c
@@ -445,7 +445,7 @@ int ovl_mount(struct lxc_storage *bdev)
 			       upper, lower, mntdata);
 
 		len2 = strlen(lower) + strlen(upper) + strlen(work) +
-		       strlen("upperdir=,lowerdir=,workdir=") +
+		       strlen("upperdir=,lowerdir=,workdir=,") +
 		       strlen(mntdata) + 1;
 		options_work = must_realloc(NULL, len2);
 		ret2 = snprintf(options, len2,


### PR DESCRIPTION
This fixes a really subtle off-by-one error constructing overlay mount options if rootfs options are provided and modern overlayfs (i.e. requiring a workdir) is used. We need to allow for the extra "," required to separate the extra options when computing the length!

Signed-off-by: srd424 <srd424@users.noreply.github.com>
(cherry picked from commit df3301046fc5f31881a2d4736cc5c381342ecc3d)