### PR TITLE
src/lxc/meson.build: fix the static library path

### DIFF
--- a/src/lxc/meson.build
+++ b/src/lxc/meson.build
@@ -149,7 +149,7 @@ if want_selinux and libselinux.found()
 endif
 
 liblxc_static = static_library(
-    'lxc_static',
+    'lxc',
     liblxc_sources + include_sources + netns_ifaddrs_sources,
     install: true,
     include_directories: liblxc_includes,


### PR DESCRIPTION
Since switching to meson, liblxc.a is being shipped as liblxc_static.a. Change it back to liblxc.a.

Signed-off-by: Serge Hallyn <serge@hallyn.com>