### PR TITLE
meson.build: strip newlines from git output

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -330,7 +330,7 @@ if time_epoch == '' and git.found() and run_command('test', '-e', '.git', check:
     # If we're in a git repository, use the creation time of the latest git tag.
     latest_tag = run_command(git, 'describe', '--abbrev=0', '--tags', check: false).stdout().strip()
     if latest_tag != ''
-      time_epoch = run_command(git, 'log', '--no-show-signature', '-1', '--format=%at', latest_tag, check: true).stdout()
+      time_epoch = run_command(git, 'log', '--no-show-signature', '-1', '--format=%at', latest_tag, check: true).stdout().strip()
     endif
 endif
 


### PR DESCRIPTION
Fixes issue #4223

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

Same PR as https://github.com/lxc/lxc/pull/4224 but posted to `master` branch.