### PR TITLE
meson.build: strip newline for variable assignments

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -330,7 +330,7 @@ endif
 
 # Fallback to current epoch.
 if time_epoch == ''
-    time_epoch = run_command(date, '+%s', check: true).stdout()
+    time_epoch = run_command(date, '+%s', check: true).stdout().strip()
 endif
 generate_date = run_command(date, '--utc', '--date=@' + time_epoch, '+%Y-%m-%d', check: true).stdout().strip()
 


### PR DESCRIPTION
Unfortunately, builds using alpine:edge still break! Apparently, run_command(...).stdout() must be strip()'ed for variable assignments

Addendum to d5600cf76a4d932a03ea75aea6dd6c997a4e2f35 Fixes issue #4223

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>