### PR TITLE
github: fix coverity (add libpam-dev)

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq gcc clang meson
-          sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev libselinux1-dev linux-libc-dev docbook2x libsystemd-dev
+          sudo apt-get install -qq libapparmor-dev libcap-dev libseccomp-dev libselinux1-dev linux-libc-dev libpam0g-dev docbook2x libsystemd-dev
 
       - name: Compiler version
         run: |


### PR DESCRIPTION
Should fix
meson.build:494:0: ERROR: C header 'security/pam_modules.h' not found

Signed-off-by: Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>