### PR TITLE
src/lxc/meson.build: fix build without apparmor

### DIFF
--- a/src/lxc/meson.build
+++ b/src/lxc/meson.build
@@ -32,7 +32,6 @@ liblxc_sources = files(
     'cgroups/cgroup2_devices.h',
     'cgroups/cgroup_utils.c',
     'cgroups/cgroup_utils.h',
-    'lsm/apparmor.c',
     'lsm/lsm.c',
     'lsm/lsm.h',
     'lsm/nop.c',
@@ -139,6 +138,10 @@ liblxc_sources = files(
     'utils.h',
     'uuid.c',
     'uuid.h')
+
+if want_apparmor and libapparmor.found()
+    liblxc_sources += files('lsm/apparmor.c')
+endif
 
 if want_seccomp and libseccomp.found()
     liblxc_sources += files('seccomp.c')


### PR DESCRIPTION
Don't build `lsm/apparmor.c` if apparmor is explicitly disabled by the user to avoid the following build failure with gcc 4.8:

```
/home/buildroot/autobuild/run/instance-3/output-1/host/arm-buildroot-linux-gnueabi/sysroot/usr/include/bits/fcntl2.h: In function '__apparmor_process_label_open.isra.0': /home/buildroot/autobuild/run/instance-3/output-1/host/arm-buildroot-linux-gnueabi/sysroot/usr/include/bits/fcntl2.h:50:24: error: call to '__open_missing_mode' declared with attribute error: open with O_CREAT in second argument needs 3 arguments
    __open_missing_mode ();
                        ^
```

Fixes:
 - http://autobuild.buildroot.org/results/c9f05ad264543adf429badb99310905427092772

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>