### PR TITLE
build: force linking against liblxc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
         'b_lto=true',
         'b_lto_mode=thin',
         'b_colorout=always',
-        'b_asneeded=true',
+        'b_asneeded=false',
         'b_pie=true',
         'b_staticpic=true',
         'c_std=gnu11',
@@ -221,6 +221,7 @@ possible_cc_flags = [
 ]
 
 possible_link_flags = [
+    '-Wl,--no-as-needed',
     '-Wl,--gc-sections',
     '-Wl,-z,relro',
     '-Wl,-z,now',


### PR DESCRIPTION
We really need to split up our code into better chunks so we avoid all of this duplicated compilation.

Fixes: https://github.com/lxc/lxc/issues/4249
Signed-off-by: Christian Brauner (Microsoft) <christian.brauner@ubuntu.com>