### PR TITLE
lxc-default-cgns apparmor profile: allow overlay mounts

### DIFF
--- a/config/apparmor/profiles/lxc-default-cgns
+++ b/config/apparmor/profiles/lxc-default-cgns
@@ -10,4 +10,5 @@ profile lxc-container-default-cgns flags=(attach_disconnected,mediate_deleted) {
   deny mount fstype=devpts,
   mount fstype=cgroup -> /sys/fs/cgroup/**,
   mount fstype=cgroup2 -> /sys/fs/cgroup/**,
+  mount fstype=overlay,
 }


### PR DESCRIPTION
Signed-off-by: Serge Hallyn <serge@hallyn.com>