### PR TITLE
Fix build error on sparc64 caused by using the gold linker

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -225,10 +225,14 @@ possible_link_flags = [
     '-Wl,--gc-sections',
     '-Wl,-z,relro',
     '-Wl,-z,now',
-    '-Wl,-fuse-ld=gold',
     '-fstack-protector',
     '-fstack-protector-strong',
 ]
+
+# The gold linker fails with a bus error on sparc64
+if build_machine.cpu_family() != 'sparc64'
+    possible_link_flags += '-Wl,-fuse-ld=gold'
+endif
 
 if sanitize == 'none'
     possible_link_flags += '-Wl,--warn-common'


### PR DESCRIPTION
When building on a sparc64 machine running Debian sid with gcc 12.2.0, linking fails with the following error:

`collect2: fatal error: ld terminated with signal 10 [Bus error]` ([build log](https://buildd.debian.org/status/fetch.php?pkg=lxc&arch=sparc64&ver=1%3A5.0.1-2&stamp=1672947476&raw=0))

It appears to be caused by using the gold linker, although I'm not exactly sure why. None of the other Linux-based Debian architectures exhibit this issue with the gold linker.

I made the proposed change and tested it on one of the GCC Compile Farm sparc64 machines (gcc202), which was then able to successfully compile lxc.