### PR TITLE
LXC API extension: set_timeout

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -1059,7 +1059,7 @@ out:
  *
  * Returns the state on success, < 0 on failure
  */
-int lxc_cmd_get_state(const char *name, const char *lxcpath)
+int lxc_cmd_get_state(const char *name, const char *lxcpath, int timeout)
 {
 	bool stopped = false;
 	ssize_t ret;
@@ -1067,7 +1067,7 @@ int lxc_cmd_get_state(const char *name, const char *lxcpath)
 
 	lxc_cmd_init(&cmd, LXC_CMD_GET_STATE);
 
-	ret = lxc_cmd(name, &cmd, &stopped, lxcpath, NULL);
+	ret = lxc_cmd_timeout(name, &cmd, &stopped, lxcpath, NULL, timeout);
 	if (ret < 0 && stopped)
 		return STOPPED;
 

--- a/src/lxc/commands.h
+++ b/src/lxc/commands.h
@@ -119,7 +119,7 @@ __hidden extern char *lxc_cmd_get_lxcpath(const char *hashed_sock);
 __hidden extern char *lxc_cmd_get_systemd_scope(const char *name, const char *lxcpath);
 __hidden extern pid_t lxc_cmd_get_init_pid(const char *name, const char *lxcpath);
 __hidden extern int lxc_cmd_get_init_pidfd(const char *name, const char *lxcpath);
-__hidden extern int lxc_cmd_get_state(const char *name, const char *lxcpath);
+__hidden extern int lxc_cmd_get_state(const char *name, const char *lxcpath, int timeout);
 __hidden extern int lxc_cmd_stop(const char *name, const char *lxcpath);
 
 /* lxc_cmd_add_state_client    Register a new state client fd in the container's

--- a/src/lxc/commands_utils.h
+++ b/src/lxc/commands_utils.h
@@ -62,7 +62,7 @@ __hidden extern int lxc_add_state_client(int state_client_fd, struct lxc_handler
  *                                     >= 0 client fd
  */
 __hidden extern int lxc_cmd_connect(const char *name, const char *lxcpath,
-				    const char *hashed_sock_name, const char *suffix);
+				    const char *hashed_sock_name, const char *suffix, int rcv_timeout);
 
 __hidden extern void lxc_cmd_notify_state_listeners(const char *name,
                                                     const char *lxcpath,

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -491,7 +491,7 @@ static const char *do_lxcapi_state(struct lxc_container *c)
 	if (!c)
 		return NULL;
 
-	s = lxc_getstate(c->name, c->config_path);
+	s = lxc_getstate(c->name, c->config_path, c->rcv_timeout);
 	return lxc_state2str(s);
 }
 
@@ -501,7 +501,7 @@ static bool is_stopped(struct lxc_container *c)
 {
 	lxc_state_t s;
 
-	s = lxc_getstate(c->name, c->config_path);
+	s = lxc_getstate(c->name, c->config_path, c->rcv_timeout);
 	return (s == STOPPED);
 }
 
@@ -523,7 +523,7 @@ static bool do_lxcapi_freeze(struct lxc_container *c)
 	if (!c || !c->lxc_conf)
 		return false;
 
-	s = lxc_getstate(c->name, c->config_path);
+	s = lxc_getstate(c->name, c->config_path, 0);
 	if (s != FROZEN) {
 		ret = cgroup_freeze(c->name, c->config_path, -1);
 		if (ret == -ENOCGROUP2)
@@ -543,7 +543,7 @@ static bool do_lxcapi_unfreeze(struct lxc_container *c)
 	if (!c || !c->lxc_conf)
 		return false;
 
-	s = lxc_getstate(c->name, c->config_path);
+	s = lxc_getstate(c->name, c->config_path, 0);
 	if (s == FROZEN) {
 		ret = cgroup_unfreeze(c->name, c->config_path, -1);
 		if (ret == -ENOCGROUP2)

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -5257,6 +5257,21 @@ static int do_lxcapi_seccomp_notify_fd_active(struct lxc_container *c)
 
 WRAP_API(int, lxcapi_seccomp_notify_fd_active)
 
+static bool do_lxcapi_set_timeout(struct lxc_container *c, int timeout)
+{
+	if (!c)
+		return false;
+
+	if (!(timeout > 0 || timeout == -1))
+		return ret_set_errno(-1, -EINVAL);
+
+	c->rcv_timeout = (timeout == -1) ? 0 : timeout;
+
+	return true;
+}
+
+WRAP_API_1(bool, lxcapi_set_timeout, int)
+
 struct lxc_container *lxc_container_new(const char *name, const char *configpath)
 {
 	struct lxc_container *c;
@@ -5400,6 +5415,7 @@ struct lxc_container *lxc_container_new(const char *name, const char *configpath
 	c->umount			= lxcapi_umount;
 	c->seccomp_notify_fd		= lxcapi_seccomp_notify_fd;
 	c->seccomp_notify_fd_active	= lxcapi_seccomp_notify_fd_active;
+	c->set_timeout			= lxcapi_set_timeout;
 
 	return c;
 

--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -94,6 +94,12 @@ struct lxc_container {
 	 */
 	struct lxc_conf *lxc_conf;
 
+	/*!
+	 * \private
+	 * SO_RCVTIMEO for LXC client_fd socket.
+	 */
+	int rcv_timeout;
+
 	/* public fields */
 	/*! Human-readable string representing last error */
 	char *error_string;
@@ -866,6 +872,17 @@ struct lxc_container {
 	 * \return file descriptor for the running container's seccomp filter
 	 */
 	int (*seccomp_notify_fd_active)(struct lxc_container *c);
+
+	/*!
+	 * \brief Set response receive timeout for LXC commands
+	 *
+	 * \param c Container
+	 * \param timeout Seconds to wait before returning false.
+	 *  (-1 to wait forever).
+	 *
+	 * \return \c true on success, else \c false.
+	 */
+	bool (*set_timeout)(struct lxc_container *c, int timeout);
 
 	/*!
 	 * \brief Retrieve a pidfd for the container's init process.

--- a/src/lxc/state.c
+++ b/src/lxc/state.c
@@ -52,9 +52,9 @@ lxc_state_t lxc_str2state(const char *state)
 	return -1;
 }
 
-lxc_state_t lxc_getstate(const char *name, const char *lxcpath)
+lxc_state_t lxc_getstate(const char *name, const char *lxcpath, int timeout)
 {
-	return lxc_cmd_get_state(name, lxcpath);
+	return lxc_cmd_get_state(name, lxcpath, timeout);
 }
 
 static int fillwaitedstates(const char *strstates, lxc_state_t *states)

--- a/src/lxc/state.h
+++ b/src/lxc/state.h
@@ -27,7 +27,7 @@ enum {
 	REBOOT_INIT
 };
 
-__hidden extern lxc_state_t lxc_getstate(const char *name, const char *lxcpath);
+__hidden extern lxc_state_t lxc_getstate(const char *name, const char *lxcpath, int timeout);
 
 __hidden extern lxc_state_t lxc_str2state(const char *state);
 __hidden extern const char *lxc_state2str(lxc_state_t state);


### PR DESCRIPTION
lxccontainer set_timeout method allows to set LXC client
timeout for waiting monitor response.

Right now, it's implemented using the SO_RCVTIMEO client
socket option. (But it's the implementation detail that
can be changed in the future.)

See https://github.com/lxc/lxc/issues/4257