### PR TITLE
initutils: setproctitle use sbrk syscall instead of brk

### DIFF
--- a/src/lxc/initutils.c
+++ b/src/lxc/initutils.c
@@ -285,7 +285,7 @@ int setproctitle(char *title)
 	arg_start = (unsigned long)proctitle;
 	arg_end = arg_start + len;
 
-	brk_val = syscall(__NR_brk, 0);
+	brk_val = syscall(__NR_sbrk, 0);
 
 	prctl_map = (struct prctl_mm_map){
 	    .start_code = start_code,


### PR DESCRIPTION
brk() is sets program break address, to get a current program break address we have to use sbrk() as `sbrk(0)`, because sbrk takes increment but not an address as an argument

Issue #4268

Signed-off-by: Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>