### PR TITLE
Add lxc.rootfs.overlay namespace and implicit lowerdir mounts

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -1505,6 +1505,71 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
         <varlistentry>
           <term>
+            <option>lxc.rootfs.overlay.upperdir</option>
+          </term>
+          <listitem>
+            <para>
+              this option can be used as an alternative to lxc.rootfs.path for specifying
+              the upperdir for the rootfs overlay mount. It must be used in conjunction
+              with lxc.rootfs.overlay.lower.[i].path.
+            </para>
+              a pathname is used for this option, for example
+              <filename>/home/joe/.local/share/lxc/my-container/upper</filename>
+            <para>
+            </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>
+            <option>lxc.rootfs.overlay.lower.[i].path</option>
+          </term>
+          <listitem>
+            <para>
+              specify the lower path for the ith lowerdir in the overlay
+            </para>
+            <para>
+              For specifying a directory, a pathname can be used. For a fuse
+              mount, the following syntax is used:
+              <filename>fuse:fuse_binary:[arg_1]:[arg_2]:...:[arg_n]:source</filename>
+              The arguments to the <filename>fuse_binary</filename> are specified with
+              trailing colon-separated values. Before calling the
+              <filename>fuse_binary</filename>, the colons are replaced with spaces.
+              <filename>source</filename> is not a special argument, it just denotes the
+              source of the fuse mount, (e.g. the squash archive for squashfs, the remote
+              filesystem for sshfs).
+              The mount point is auto-generated in
+              <filename>LCX_PATH/LXC_NAME/overlay/lower-[i]</filename> and it is appended
+              to the <filename>fuse_binary</filename> command line.
+              For example, for an unprivileged container "my-container",
+              <filename>fuse:/usr/bin/squashfuse:/home/joe/rootfs.sqhs</filename>
+              will call <filename>/usr/bin/squashfuse /home/joe/rootfs.sqhs
+              /home/joe/.local/share/lxc/my-container/overlay/lower-0</filename>
+            </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>
+            <option>lxc.rootfs.overlay.lower.[i].mount_options</option>
+          </term>
+          <listitem>
+            <para>
+              specify the mount options for this lower path
+            </para>
+            <para>
+              In case the lower path is specified as <filename>fuse:</filename>, these mount
+              options will be passed to the <filename>fuse_binary</filename> prepending "-o"
+              to them. The mount options are a list of comma-separated values and are passed
+              as-is to the <filename>fuse_binary</filename>. For example, <filename>allow_other,ro
+              </filename> will be passed to the <filename>fuse_binary</filename> as
+              <filename>-o allow_other,ro</filename>.
+            </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>
             <option>lxc.rootfs.mount</option>
           </term>
           <listitem>

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -228,6 +228,27 @@ struct lxc_mount_options {
 	char *raw_options;
 };
 
+#define MAX_LOWERDIRS 64
+#define MAX_LOWER_OPTION_LEN 256
+#define MAX_LOWER_PATH_LEN (4 * PATH_MAX)
+
+/* Defines a structure to store the overlay data
+ * @used              : whether this configuration is used
+ * @lower_path        : an array of lower paths, as provided by the user
+ * @lower_options     : an array of lower options
+ * @lower_resolved    : the resulting lower path after it has been mounted
+ * @upperdir          : the upperdir for this overlay
+ * @workdir           : the workdir for this overlay
+ */
+struct lxc_overlay {
+	bool used;
+	char *lower_path[MAX_LOWERDIRS];
+	char *lower_mount_options[MAX_LOWERDIRS];
+	char *lower_resolved[MAX_LOWERDIRS];
+	char *upperdir;
+};
+
+
 /* Defines a structure to store the rootfs location, the
  * optionals pivot_root, rootfs mount paths
  * @path         : the rootfs source (directory or device)
@@ -255,6 +276,7 @@ struct lxc_rootfs {
 	bool managed;
 	struct lxc_mount_options mnt_opts;
 	struct lxc_storage *storage;
+	struct lxc_overlay overlay;
 };
 
 /*

--- a/src/lxc/string_utils.c
+++ b/src/lxc/string_utils.c
@@ -82,6 +82,19 @@ const char **lxc_va_arg_list_to_argv_const(va_list ap, size_t skip)
 	return (const char **)lxc_va_arg_list_to_argv(ap, skip, 0);
 }
 
+size_t lxc_char_replace(const char needle, const char replacement,
+			char *haystack) {
+	size_t i;
+	size_t count = 0;
+	for (i = 0; i < strlen(haystack); i++) {
+		if (haystack[i] == needle) {
+			haystack[i] = replacement;
+			count++;
+		}
+	}
+	return count;
+}
+
 char *lxc_string_replace(const char *needle, const char *replacement,
 			 const char *haystack)
 {

--- a/src/lxc/string_utils.h
+++ b/src/lxc/string_utils.h
@@ -30,6 +30,8 @@ __hidden extern const char **lxc_va_arg_list_to_argv_const(va_list ap, size_t sk
  * Some simple string functions; if they return pointers, they are allocated
  * buffers.
  */
+__hidden extern size_t lxc_char_replace(const char needle, const char replacement,
+					char *haystack);
 __hidden extern char *lxc_string_replace(const char *needle, const char *replacement,
 					 const char *haystack);
 __hidden extern bool lxc_string_in_array(const char *needle, const char **haystack);


### PR DESCRIPTION
Implement the new lxc.rootfs.overlay option namespace and the implicit lowerdir mounts for overlay mounts as described in #4238

Example:
lxc.rootfs.overlay.lowerdir.0 = fuse:/usr/bin/squashfuse:/home/amiculas/.local/share/lxc/my-container/rootfs.sqhs lxc.rootfs.overlay.upperdir = /home/amiculas/.local/share/lxc/my-container/upperdir

This will mount the squashfs image /home/amiculas/.local/share/lxc/my-container/rootfs.sqhs in the generated path /home/amiculas/.local/share/lxc/my-container/overlay/lowerdir-0 and then create an overlay with the upperdir /home/amiculas/.local/share/lxc/my-container/upperdir

Signed-off-by: Ariel Miculas <amiculas@cisco.com>