### PR TITLE
lxc-net.in: fix nftables syntax for IPv6 NAT

### DIFF
--- a/config/init/common/lxc-net.in
+++ b/config/init/common/lxc-net.in
@@ -92,7 +92,7 @@ start_nftables() {
 add table ip6 lxc;
 flush table ip6 lxc;
 add chain ip6 lxc postrouting { type nat hook postrouting priority 100; };
-add rule ip6 lxc postrouting ip saddr ${LXC_IPV6_NETWORK} ip daddr != ${LXC_IPV6_NETWORK} counter masquerade;
+add rule ip6 lxc postrouting ip6 saddr ${LXC_IPV6_NETWORK} ip6 daddr != ${LXC_IPV6_NETWORK} counter masquerade;
 "
     fi
     NFT_RULESET="${NFT_RULESET};


### PR DESCRIPTION
The nftables masquarade rule for IPv6 was using the IPv4 syntax. This resulted in the following error when starting the lxc-net.service with LXC_IPV6_NAT="true" and nftables:

    Feb 11 18:54:54 pc lxc-net[4936]: Error: conflicting protocols specified: ip6 vs. ip
    Feb 11 18:54:54 pc lxc-net[4936]:                              ^^^^^^^^
    Feb 11 18:54:54 pc lxc-net[4917]: Failed to setup lxc-net.
    Feb 11 18:54:54 pc systemd[1]: lxc-net.service: Main process exited, code=exited, status=1/FAILURE
    Feb 11 18:54:54 pc systemd[1]: lxc-net.service: Failed with result 'exit-code'.
    Feb 11 18:54:54 pc systemd[1]: Failed to start LXC network bridge setup.

Signed-off-by: Quentin Lyons <36303164+n0p90@users.noreply.github.com>