### PR TITLE
initutils: use PRIu64 for uint64_t in setproctitle

### DIFF
--- a/src/lxc/initutils.c
+++ b/src/lxc/initutils.c
@@ -224,7 +224,7 @@ int setproctitle(char *title)
 	 * PR_SET_MM_MAP requires us to set it all at once, so we have to
 	 * figure it out anyway.
 	 */
-	unsigned long start_data, end_data, start_brk, start_code, end_code,
+	uint64_t start_data, end_data, start_brk, start_code, end_code,
 	    start_stack, arg_start, arg_end, env_start, env_end, brk_val;
 	struct prctl_mm_map prctl_map;
 
@@ -253,7 +253,7 @@ int setproctitle(char *title)
 	if (!buf_ptr)
 		return -1;
 
-	i = sscanf(buf_ptr, "%lu %lu %lu", &start_code, &end_code, &start_stack);
+	i = sscanf(buf_ptr, "%" PRIu64 " %" PRIu64 " %" PRIu64, &start_code, &end_code, &start_stack);
 	if (i != 3)
 		return -1;
 
@@ -267,7 +267,7 @@ int setproctitle(char *title)
 	if (!buf_ptr)
 		return -1;
 
-	i = sscanf(buf_ptr, "%lu %lu %lu %*u %*u %lu %lu", &start_data,
+	i = sscanf(buf_ptr, "%" PRIu64 " %" PRIu64 " %" PRIu64 " %*u %*u %" PRIu64 " %" PRIu64, &start_data,
 		   &end_data, &start_brk, &env_start, &env_end);
 	if (i != 5)
 		return -1;


### PR DESCRIPTION
```
Kernel UAPI provides as with the following declaration:
/*
 * This structure provides new memory descriptor
 * map which mostly modifies /proc/pid/stat[m]
 * output for a task. This mostly done in a
 * sake of checkpoint/restore functionality. */ struct prctl_mm_map {
	__u64	start_code;		/* code section bounds */
	__u64	end_code;
	__u64	start_data;		/* data section bounds */
	__u64	end_data;
	__u64	start_brk;		/* heap for brk() syscall */
	__u64	brk;
	__u64	start_stack;		/* stack starts at */
	__u64	arg_start;		/* command line arguments bounds */
	__u64	arg_end;
	__u64	env_start;		/* environment variables bounds */
	__u64	env_end;
	__u64	*auxv;			/* auxiliary vector */
	__u32	auxv_size;		/* vector size */
	__u32	exe_fd;			/* /proc/$pid/exe link file */
};

Let's use appropriate types/format specifiers everywhere.

Issue #4268
```