### PR TITLE
mainloop: fix stuck when io_uring is enabled

### DIFF
--- a/src/lxc/file_utils.c
+++ b/src/lxc/file_utils.c
@@ -700,6 +700,18 @@ int fd_make_blocking(int fd)
 	return fcntl(fd, F_SETFL, flags);
 }
 
+int fd_make_nonblocking(int fd)
+{
+	int flags;
+
+	flags = fcntl(fd, F_GETFL);
+	if (flags < 0)
+		return -1;
+
+	flags |= O_NONBLOCK;
+	return fcntl(fd, F_SETFL, flags);
+}
+
 #define BATCH_SIZE 50
 static void batch_realloc(char **mem, size_t oldlen, size_t newlen)
 {

--- a/src/lxc/file_utils.c
+++ b/src/lxc/file_utils.c
@@ -688,7 +688,7 @@ int open_at_same(int fd_same, int dfd, const char *path, unsigned int o_flags,
 	return move_fd(fd);
 }
 
-int fd_make_nonblocking(int fd)
+int fd_make_blocking(int fd)
 {
 	int flags;
 

--- a/src/lxc/file_utils.h
+++ b/src/lxc/file_utils.h
@@ -109,7 +109,7 @@ __hidden extern int open_at_same(int fd_same, int dfd, const char *path,
 				 unsigned int o_flags,
 				 unsigned int resolve_flags, mode_t mode);
 __hidden extern int open_beneath(int dfd, const char *path, unsigned int flags);
-__hidden int fd_make_nonblocking(int fd);
+__hidden int fd_make_blocking(int fd);
 __hidden extern char *read_file_at(int dfd, const char *fnam,
                                    unsigned int o_flags,
                                    unsigned resolve_flags);

--- a/src/lxc/file_utils.h
+++ b/src/lxc/file_utils.h
@@ -110,6 +110,7 @@ __hidden extern int open_at_same(int fd_same, int dfd, const char *path,
 				 unsigned int resolve_flags, mode_t mode);
 __hidden extern int open_beneath(int dfd, const char *path, unsigned int flags);
 __hidden int fd_make_blocking(int fd);
+__hidden int fd_make_nonblocking(int fd);
 __hidden extern char *read_file_at(int dfd, const char *fnam,
                                    unsigned int o_flags,
                                    unsigned resolve_flags);

--- a/src/lxc/mainloop.c
+++ b/src/lxc/mainloop.c
@@ -163,6 +163,16 @@ static int __io_uring_arm(struct lxc_async_descr *descr,
 	io_uring_prep_poll_add(sqe, handler->fd, EPOLLIN);
 
 	/*
+	 * FIXME: workaround an issue with false-positive
+	 * io_uring POLL events when multishot mode is enabled.
+	 *
+	 * It's safe to override oneshot argument here, execution
+	 * will go to the same codepath as if kernel lacks IORING_POLL_ADD_MULTI
+	 * mode support.
+	 */
+	oneshot = true;
+
+	/*
 	 * Raise IORING_POLL_ADD_MULTI to set up a multishot poll. The same sqe
 	 * will now produce multiple cqes. A cqe produced from a multishot sqe
 	 * will raise IORING_CQE_F_MORE in cqe->flags.

--- a/src/lxc/seccomp.c
+++ b/src/lxc/seccomp.c
@@ -1282,8 +1282,8 @@ int lxc_seccomp_load(struct lxc_conf *conf)
 			return -1;
 		}
 
-		if (fd_make_nonblocking(ret))
-			return log_error_errno(-1, errno, "Failed to make seccomp listener fd non-blocking");;
+		if (fd_make_blocking(ret))
+			return log_error_errno(-1, errno, "Failed to make seccomp listener fd blocking");
 
 		conf->seccomp.notifier.notify_fd = ret;
 		TRACE("Retrieved new seccomp listener fd %d", ret);


### PR DESCRIPTION
Something is wrong with multishot polling mode in io_uring. Let's workaround that and safe from possible stucks on read.