### PR TITLE
rename functions which clash with libsystemd's

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1319,7 +1319,7 @@ __noreturn static void do_attach(struct attach_payload *ap)
 	 * here, ignore errors.
 	 */
 	for (int fd = STDIN_FILENO; fd <= STDERR_FILENO; fd++) {
-		ret = fd_cloexec(fd, false);
+		ret = lxc_fd_cloexec(fd, false);
 		if (ret < 0) {
 			SYSERROR("Failed to clear FD_CLOEXEC from file descriptor %d", fd);
 			goto on_error;

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -2445,7 +2445,7 @@ __cgfsng_ops static bool cgfsng_mount(struct cgroup_ops *ops,
 		hierarchy_mnt = must_make_path(cgroup_root, h->at_mnt, NULL);
 		path2 = must_make_path(hierarchy_mnt, h->at_base,
 				       ops->container_cgroup, NULL);
-		ret = mkdir_p(path2, 0755);
+		ret = lxc_mkdir_p(path2, 0755);
 		if (ret < 0 && (errno != EEXIST))
 			return false;
 

--- a/src/lxc/cgroups/cgroup_utils.c
+++ b/src/lxc/cgroups/cgroup_utils.c
@@ -26,7 +26,7 @@ bool unified_cgroup_fd(int fd)
 	struct statfs fs;
 
 	ret = fstatfs(fd, &fs);
-	if (!ret && is_fs_type(&fs, CGROUP2_SUPER_MAGIC))
+	if (!ret && lxc_is_fs_type(&fs, CGROUP2_SUPER_MAGIC))
 		return true;
 
 	return false;

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2597,7 +2597,7 @@ static int mount_entry_create_dir_file(const struct mntent *mntent,
 	}
 
 	if (hasmntopt(mntent, "create=dir")) {
-		ret = mkdir_p(path, 0755);
+		ret = lxc_mkdir_p(path, 0755);
 		if (ret < 0 && errno != EEXIST)
 			return log_error_errno(-1, errno, "Failed to create directory \"%s\"", path);
 	}
@@ -2615,7 +2615,7 @@ static int mount_entry_create_dir_file(const struct mntent *mntent,
 
 	p2 = dirname(p1);
 
-	ret = mkdir_p(p2, 0755);
+	ret = lxc_mkdir_p(p2, 0755);
 	if (ret < 0 && errno != EEXIST)
 		return log_error_errno(-1, errno, "Failed to create directory \"%s\"", path);
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -2770,7 +2770,7 @@ static int set_config_includefiles(const char *key, const char *value,
 		return 0;
 	}
 
-	if (value[strlen(value)-1] == '/' || is_dir(value))
+	if (value[strlen(value)-1] == '/' || lxc_is_dir(value))
 		return do_includedir(value, lxc_conf);
 
 	return lxc_config_read(value, lxc_conf, true);

--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -653,7 +653,7 @@ int set_config_path_item(char **conf_item, const char *value)
 {
 	__do_free char *valdup = NULL;
 
-	valdup = path_simplify(value);
+	valdup = lxc_path_simplify(value);
 	if (!valdup)
 		return -ENOMEM;
 

--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -321,7 +321,7 @@ static int exec_criu(struct cgroup_ops *cgroup_ops, struct lxc_conf *conf,
 				return log_error_errno(-ENOMEM, ENOMEM, "Failed to duplicate limit cgroup path");
 		}
 
-		tmp = path_simplify(cgroup_base_path);
+		tmp = lxc_path_simplify(cgroup_base_path);
 		if (!tmp)
 			return log_error_errno(-ENOMEM, ENOMEM, "Failed to remove extraneous slashes from \"%s\"", cgroup_base_path);
 		free_move_ptr(cgroup_base_path, tmp);
@@ -1224,7 +1224,7 @@ static bool do_dump(struct lxc_container *c, char *mode, struct migrate_opts *op
 		return false;
 	}
 
-	if (mkdir_p(opts->directory, 0700) < 0)
+	if (lxc_mkdir_p(opts->directory, 0700) < 0)
 		goto fail;
 
 	pid = fork();

--- a/src/lxc/file_utils.c
+++ b/src/lxc/file_utils.c
@@ -275,7 +275,7 @@ int print_to_file(const char *file, const char *content)
 	return ret;
 }
 
-int is_dir(const char *path)
+int lxc_is_dir(const char *path)
 {
 	int ret;
 	struct stat statbuf;
@@ -332,7 +332,7 @@ int lxc_make_tmpfile(char *template, bool rm)
 	return move_fd(fd);
 }
 
-bool is_fs_type(const struct statfs *fs, fs_type_magic magic_val)
+bool lxc_is_fs_type(const struct statfs *fs, fs_type_magic magic_val)
 {
 	return (fs->f_type == (fs_type_magic)magic_val);
 }
@@ -346,7 +346,7 @@ bool has_fs_type(const char *path, fs_type_magic magic_val)
 	if (ret < 0)
 		return false;
 
-	return is_fs_type(&sb, magic_val);
+	return lxc_is_fs_type(&sb, magic_val);
 }
 
 bool fhas_fs_type(int fd, fs_type_magic magic_val)
@@ -358,7 +358,7 @@ bool fhas_fs_type(int fd, fs_type_magic magic_val)
 	if (ret < 0)
 		return false;
 
-	return is_fs_type(&sb, magic_val);
+	return lxc_is_fs_type(&sb, magic_val);
 }
 
 FILE *fopen_cloexec(const char *path, const char *mode)
@@ -549,7 +549,7 @@ FILE *fdopen_cached(int fd, const char *mode, void **caller_freed_buffer)
 	return f;
 }
 
-int fd_cloexec(int fd, bool cloexec)
+int lxc_fd_cloexec(int fd, bool cloexec)
 {
 	int oflags, nflags;
 

--- a/src/lxc/file_utils.h
+++ b/src/lxc/file_utils.h
@@ -75,7 +75,7 @@ __hidden extern ssize_t lxc_recvmsg_nointr_iov(int sockfd, struct iovec *iov, si
 
 __hidden extern bool file_exists(const char *f);
 __hidden extern int print_to_file(const char *file, const char *content);
-__hidden extern int is_dir(const char *path);
+__hidden extern int lxc_is_dir(const char *path);
 __hidden extern int lxc_count_file_lines(const char *fn);
 __hidden extern int lxc_make_tmpfile(char *template, bool rm);
 
@@ -83,7 +83,7 @@ __hidden extern int lxc_make_tmpfile(char *template, bool rm);
 typedef __typeof__(((struct statfs *)NULL)->f_type) fs_type_magic;
 __hidden extern bool has_fs_type(const char *path, fs_type_magic magic_val);
 __hidden extern bool fhas_fs_type(int fd, fs_type_magic magic_val);
-__hidden extern bool is_fs_type(const struct statfs *fs, fs_type_magic magic_val);
+__hidden extern bool lxc_is_fs_type(const struct statfs *fs, fs_type_magic magic_val);
 __hidden extern FILE *fopen_cloexec(const char *path, const char *mode);
 __hidden extern ssize_t lxc_sendfile_nointr(int out_fd, int in_fd, off_t *offset, size_t count);
 __hidden extern char *file_to_buf(const char *path, size_t *length);
@@ -93,7 +93,7 @@ static inline int fd_to_fd(int from, int to)
 {
 	return __fd_to_fd(from, to) >= 0;
 }
-__hidden extern int fd_cloexec(int fd, bool cloexec);
+__hidden extern int lxc_fd_cloexec(int fd, bool cloexec);
 __hidden extern int lxc_open_dirfd(const char *dir);
 __hidden extern FILE *fdopen_cached(int fd, const char *mode, void **caller_freed_buffer);
 __hidden extern FILE *fdopen_at(int dfd, const char *path, const char *mode,
@@ -133,7 +133,7 @@ static inline int dup_cloexec(int fd)
 	if (fd_dup < 0)
 		return -errno;
 
-	if (fd_cloexec(fd_dup, true))
+	if (lxc_fd_cloexec(fd_dup, true))
 		return -errno;
 
 	return move_fd(fd_dup);

--- a/src/lxc/lsm/apparmor.c
+++ b/src/lxc/lsm/apparmor.c
@@ -996,14 +996,14 @@ static int load_apparmor_profile(struct lsm_ops *ops, struct lxc_conf *conf, con
 	if (!old_content || old_len != content_len || memcmp(old_content, new_content, content_len) != 0) {
 		char *path;
 
-		ret = mkdir_p(APPARMOR_CACHE_DIR, 0755);
+		ret = lxc_mkdir_p(APPARMOR_CACHE_DIR, 0755);
 		if (ret < 0) {
 			SYSERROR("Error creating AppArmor profile cache directory " APPARMOR_CACHE_DIR);
 			goto out;
 		}
 
 		path = apparmor_dir(conf->name, lxcpath);
-		ret = mkdir_p(path, 0755);
+		ret = lxc_mkdir_p(path, 0755);
 		if (ret < 0) {
 			SYSERROR("Error creating AppArmor profile directory: %s", path);
 			free(path);

--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -4159,7 +4159,7 @@ static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
 
 	i = get_next_index(snappath, c->name);
 
-	if (mkdir_p(snappath, 0755) < 0) {
+	if (lxc_mkdir_p(snappath, 0755) < 0) {
 		ERROR("Failed to create snapshot directory %s", snappath);
 		return -1;
 	}
@@ -4174,7 +4174,7 @@ static int do_lxcapi_snapshot(struct lxc_container *c, const char *commentfile)
 	 */
 	flags = LXC_CLONE_SNAPSHOT | LXC_CLONE_KEEPMACADDR | LXC_CLONE_KEEPNAME |
 		LXC_CLONE_KEEPBDEVTYPE | LXC_CLONE_MAYBE_SNAPSHOT;
-	if (storage_is_dir(c->lxc_conf)) {
+	if (storage_lxc_is_dir(c->lxc_conf)) {
 		ERROR("Snapshot of directory-backed container requested");
 		ERROR("Making a copy-clone.  If you do want snapshots, then");
 		ERROR("please create overlay clone first, snapshot that");
@@ -4608,7 +4608,7 @@ static bool do_add_remove_node(pid_t init_pid, const char *path, bool add,
 		_exit(EXIT_FAILURE);
 
 	directory_path = dirname(tmp);
-	ret = mkdir_p(directory_path, 0755);
+	ret = lxc_mkdir_p(directory_path, 0755);
 	if (ret < 0 && errno != EEXIST) {
 		SYSERROR("Failed to create path \"%s\"", directory_path);
 		free(tmp);
@@ -4978,7 +4978,7 @@ static int create_mount_target(const char *dest, mode_t st_mode)
 	}
 	destdirname = dirname(dirdup);
 
-	ret = mkdir_p(destdirname, 0755);
+	ret = lxc_mkdir_p(destdirname, 0755);
 	if (ret < 0) {
 		SYSERROR("Failed to create \"%s\"", destdirname);
 		free(dirdup);
@@ -5012,7 +5012,7 @@ static int do_lxcapi_mount(struct lxc_container *c, const char *source,
 	char template[PATH_MAX], path[PATH_MAX];
 	pid_t pid, init_pid;
 	struct stat sb;
-	bool is_dir;
+	bool lxc_is_dir;
 	int ret = -1, fd = -EBADF;
 
 	if (!c || !c->lxc_conf) {
@@ -5043,8 +5043,8 @@ static int do_lxcapi_mount(struct lxc_container *c, const char *source,
 		}
 	}
 
-	is_dir = (S_ISDIR(sb.st_mode) != 0);
-	if (is_dir) {
+	lxc_is_dir = (S_ISDIR(sb.st_mode) != 0);
+	if (lxc_is_dir) {
 		sret = mkdtemp(template);
 		if (!sret) {
 			SYSERROR("Could not create shmounts temporary dir");
@@ -5133,7 +5133,7 @@ static int do_lxcapi_mount(struct lxc_container *c, const char *source,
 	if (umount2(template, MNT_DETACH))
 		SYSWARN("Failed to remove temporary mount \"%s\"", template);
 
-	if (is_dir)
+	if (lxc_is_dir)
 		(void)rmdir(template);
 	else
 		(void)unlink(template);

--- a/src/lxc/lxclock.c
+++ b/src/lxc/lxclock.c
@@ -105,7 +105,7 @@ static char *lxclock_name(const char *p, const char *n)
 	if (ret < 0)
 		return NULL;
 
-	ret = mkdir_p(dest, 0755);
+	ret = lxc_mkdir_p(dest, 0755);
 	if (ret < 0)
 		return NULL;
 

--- a/src/lxc/monitor.c
+++ b/src/lxc/monitor.c
@@ -54,7 +54,7 @@ int lxc_monitor_fifo_name(const char *lxcpath, char *fifo_path, size_t fifo_path
 			free(rundir);
 			return -1;
 		}
-		ret = mkdir_p(fifo_path, 0755);
+		ret = lxc_mkdir_p(fifo_path, 0755);
 		if (ret < 0) {
 			ERROR("Unable to create monitor fifo directory %s", fifo_path);
 			free(rundir);

--- a/src/lxc/pam/pam_cgfs.c
+++ b/src/lxc/pam/pam_cgfs.c
@@ -197,7 +197,7 @@ static int do_mkdir(const char *path, mode_t mode)
 }
 
 /* Create directory and (if necessary) its parents. */
-static bool mkdir_parent(const char *root, char *path)
+static bool lxc_mkdir_parent(const char *root, char *path)
 {
 	char *b, orig, *e;
 
@@ -2042,7 +2042,7 @@ static bool cgv1_create_one(struct cgv1_hierarchy *h, const char *cgroup, uid_t 
 			return our_cg;
 		}
 
-		created = mkdir_parent(it->mountpoint, path);
+		created = lxc_mkdir_parent(it->mountpoint, path);
 		if (!created) {
 			free(path);
 			continue;
@@ -2198,7 +2198,7 @@ static bool cgv2_create(const char *cgroup, uid_t uid, gid_t gid, bool *existed)
 		}
 	}
 
-	created = mkdir_parent(v2->mountpoint, path);
+	created = lxc_mkdir_parent(v2->mountpoint, path);
 	if (!created) {
 		free(path);
 		return false;

--- a/src/lxc/storage/dir.c
+++ b/src/lxc/storage/dir.c
@@ -81,7 +81,7 @@ int dir_create(struct lxc_storage *bdev, const char *dest, const char *n,
 	if (!bdev_dest)
 		return ret_errno(ENOMEM);
 
-	ret = mkdir_p(dest, 0755);
+	ret = lxc_mkdir_p(dest, 0755);
 	if (ret < 0)
 		return log_error_errno(-errno, errno, "Failed to create directory \"%s\"", dest);
 

--- a/src/lxc/storage/loop.c
+++ b/src/lxc/storage/loop.c
@@ -165,7 +165,7 @@ int loop_create(struct lxc_storage *bdev, const char *dest, const char *n,
 		return -1;
 	}
 
-	ret = mkdir_p(bdev->dest, 0755);
+	ret = lxc_mkdir_p(bdev->dest, 0755);
 	if (ret < 0) {
 		ERROR("Failed creating directory \"%s\"", bdev->dest);
 		return -1;

--- a/src/lxc/storage/lvm.c
+++ b/src/lxc/storage/lvm.c
@@ -456,7 +456,7 @@ int lvm_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
 		return -1;
 	}
 
-	ret = mkdir_p(new->dest, 0755);
+	ret = lxc_mkdir_p(new->dest, 0755);
 	if (ret < 0) {
 		SYSERROR("Failed to create directory \"%s\"", new->dest);
 		return -1;
@@ -645,7 +645,7 @@ int lvm_create(struct lxc_storage *bdev, const char *dest, const char *n,
 		return -1;
 	}
 
-	ret = mkdir_p(bdev->dest, 0755);
+	ret = lxc_mkdir_p(bdev->dest, 0755);
 	if (ret < 0) {
 		SYSERROR("Failed to create directory \"%s\"", bdev->dest);
 		return -1;

--- a/src/lxc/storage/overlay.c
+++ b/src/lxc/storage/overlay.c
@@ -50,7 +50,7 @@ int ovl_clonepaths(struct lxc_storage *orig, struct lxc_storage *new, const char
 
 	new->dest = must_make_path(lxcpath, cname, "rootfs", NULL);
 
-	ret = mkdir_p(new->dest, 0755);
+	ret = lxc_mkdir_p(new->dest, 0755);
 	if (ret < 0 && errno != EEXIST) {
 		SYSERROR("Failed to create directory \"%s\"", new->dest);
 		return -1;
@@ -68,7 +68,7 @@ int ovl_clonepaths(struct lxc_storage *orig, struct lxc_storage *new, const char
 
 		delta = must_make_path(lxcpath, cname, LXC_OVERLAY_DELTA_PATH, NULL);
 
-		ret = mkdir_p(delta, 0755);
+		ret = lxc_mkdir_p(delta, 0755);
 		if (ret < 0 && errno != EEXIST)
 			return log_error_errno(-errno, errno, "Failed to create directory \"%s\"", delta);
 
@@ -83,7 +83,7 @@ int ovl_clonepaths(struct lxc_storage *orig, struct lxc_storage *new, const char
 		 */
 		work = must_make_path(lxcpath, cname, LXC_OVERLAY_WORK_PATH, NULL);
 
-		ret = mkdir_p(work, 0755);
+		ret = lxc_mkdir_p(work, 0755);
 		if (ret < 0 && errno != EEXIST)
 			return log_error_errno(-errno, errno, "Failed to create directory \"%s\"", work);
 
@@ -142,7 +142,7 @@ int ovl_clonepaths(struct lxc_storage *orig, struct lxc_storage *new, const char
 		odelta++;
 		ndelta = must_make_path(lxcpath, cname, LXC_OVERLAY_DELTA_PATH, NULL);
 
-		ret = mkdir_p(ndelta, 0755);
+		ret = lxc_mkdir_p(ndelta, 0755);
 		if (ret < 0 && errno != EEXIST)
 			return log_error_errno(-errno, errno, "Failed to create directory \"%s\"", ndelta);
 
@@ -150,7 +150,7 @@ int ovl_clonepaths(struct lxc_storage *orig, struct lxc_storage *new, const char
 		 * further up.).
 		 */
 		work = must_make_path(lxcpath, cname, LXC_OVERLAY_WORK_PATH, NULL);
-		ret = mkdir_p(work, 0755);
+		ret = lxc_mkdir_p(work, 0755);
 		if (ret < 0 && errno != EEXIST)
 			return log_error_errno(-errno, errno, "Failed to create directory \"%s\"", ndelta);
 
@@ -191,11 +191,11 @@ int ovl_clonepaths(struct lxc_storage *orig, struct lxc_storage *new, const char
 		 * don't need to record a dependency. If we would restore would
 		 * also fail.
 		 */
-		clean_old_path = path_simplify(oldpath);
+		clean_old_path = lxc_path_simplify(oldpath);
 		if (!clean_old_path)
 			return log_error_errno(-ENOMEM, ENOMEM, "Failed to create clean path for \"%s\"", oldpath);
 
-		clean_new_path = path_simplify(lxcpath);
+		clean_new_path = lxc_path_simplify(lxcpath);
 		if (!clean_new_path)
 			return log_error_errno(-ENOMEM, ENOMEM, "Failed to create clean path for \"%s\"", lxcpath);
 
@@ -271,7 +271,7 @@ int ovl_create(struct lxc_storage *bdev, const char *dest, const char *n,
 
 	delta = must_make_path(tmp, LXC_OVERLAY_DELTA_PATH, NULL);
 
-	ret = mkdir_p(delta, 0755);
+	ret = lxc_mkdir_p(delta, 0755);
 	if (ret < 0 && errno != EEXIST)
 		return log_error_errno(-errno, errno, "Failed to create directory \"%s\"", delta);
 
@@ -298,7 +298,7 @@ int ovl_create(struct lxc_storage *bdev, const char *dest, const char *n,
 	if (ret < 0 || (size_t)ret >= len)
 		return log_error_errno(-EIO, EIO, "Failed to create rootfs path");
 
-	ret = mkdir_p(bdev->dest, 0755);
+	ret = lxc_mkdir_p(bdev->dest, 0755);
 	if (ret < 0 && errno != EEXIST)
 		return log_error_errno(-errno, errno, "Failed to create directory \"%s\"", bdev->dest);
 
@@ -389,7 +389,7 @@ int ovl_mount(struct lxc_storage *bdev)
 	upper++;
 
 	/* if delta doesn't yet exist, create it */
-	ret = mkdir_p(upper, 0755);
+	ret = lxc_mkdir_p(upper, 0755);
 	if (ret < 0 && errno != EEXIST) {
 		SYSERROR("Failed to create directory \"%s\"", upper);
 		free(dup);
@@ -422,7 +422,7 @@ int ovl_mount(struct lxc_storage *bdev)
 		return -22;
 	}
 
-	ret = mkdir_p(work, 0755);
+	ret = lxc_mkdir_p(work, 0755);
 	if (ret < 0 && errno != EEXIST) {
 		SYSERROR("Failed to create directory \"%s\"", work);
 		free(mntdata);
@@ -623,10 +623,10 @@ int ovl_mkdir(const struct mntent *mntent, const struct lxc_rootfs *rootfs,
 	ret = 0;
 	if (upperdir) {
 		if (!rootfs_path)
-			ret = mkdir_p(upperdir, 0755);
+			ret = lxc_mkdir_p(upperdir, 0755);
 		else if (!strncmp(upperdir, lxcpath, dirlen) &&
 			 strncmp(upperdir, rootfs_dir, rootfslen))
-			ret = mkdir_p(upperdir, 0755);
+			ret = lxc_mkdir_p(upperdir, 0755);
 
 		if (ret < 0)
 			SYSWARN("Failed to create directory \"%s\"", upperdir);
@@ -635,10 +635,10 @@ int ovl_mkdir(const struct mntent *mntent, const struct lxc_rootfs *rootfs,
 	ret = 0;
 	if (workdir) {
 		if (!rootfs_path)
-			ret = mkdir_p(workdir, 0755);
+			ret = lxc_mkdir_p(workdir, 0755);
 		else if (!strncmp(workdir, lxcpath, dirlen) &&
 			 strncmp(workdir, rootfs_dir, rootfslen))
-			ret = mkdir_p(workdir, 0755);
+			ret = lxc_mkdir_p(workdir, 0755);
 
 		if (ret < 0)
 			SYSWARN("Failed to create directory \"%s\"", workdir);

--- a/src/lxc/storage/rbd.c
+++ b/src/lxc/storage/rbd.c
@@ -160,7 +160,7 @@ int rbd_create(struct lxc_storage *bdev, const char *dest, const char *n,
 		return -1;
 	}
 
-	ret = mkdir_p(bdev->dest, 0755);
+	ret = lxc_mkdir_p(bdev->dest, 0755);
 	if (ret < 0 && errno != EEXIST) {
 		ERROR("Failed to create directory \"%s\"", bdev->dest);
 		return -1;

--- a/src/lxc/storage/storage.c
+++ b/src/lxc/storage/storage.c
@@ -370,7 +370,7 @@ struct lxc_storage *storage_copy(struct lxc_container *c, const char *cname,
 
 		ret = stat(orig->dest, &sb);
 		if (ret < 0 && errno == ENOENT) {
-			ret = mkdir_p(orig->dest, 0755);
+			ret = lxc_mkdir_p(orig->dest, 0755);
 			if (ret < 0)
 				WARN("Failed to create directory \"%s\"", orig->dest);
 		}
@@ -638,7 +638,7 @@ struct lxc_storage *storage_init(struct lxc_conf *conf)
 	return bdev;
 }
 
-bool storage_is_dir(struct lxc_conf *conf)
+bool storage_lxc_is_dir(struct lxc_conf *conf)
 {
 	struct lxc_storage *orig;
 	char *type = conf->rootfs.bdev_type;

--- a/src/lxc/storage/storage.h
+++ b/src/lxc/storage/storage.h
@@ -94,7 +94,7 @@ struct lxc_storage {
 };
 
 /**
- * storage_is_dir : Check whether the roots is a directory. This function will
+ * storage_lxc_is_dir : Check whether the roots is a directory. This function will
  *                  trust the config file. If the config file key
  *                  lxc.rootfs.path is set to <storage type>:<container path>
  *                  the confile parser will have split this into <storage type>
@@ -105,7 +105,7 @@ struct lxc_storage {
  *                  type specifications.  If the <storage type> prefix is not
  *                  detected liblxc will try to detect the storage type.
  */
-__hidden extern bool storage_is_dir(struct lxc_conf *conf);
+__hidden extern bool storage_lxc_is_dir(struct lxc_conf *conf);
 __hidden extern bool storage_can_backup(struct lxc_conf *conf);
 __hidden extern struct lxc_storage *storage_init(struct lxc_conf *conf);
 __hidden extern struct lxc_storage *storage_copy(struct lxc_container *c, const char *cname,

--- a/src/lxc/storage/zfs.c
+++ b/src/lxc/storage/zfs.c
@@ -293,7 +293,7 @@ bool zfs_copy(struct lxc_conf *conf, struct lxc_storage *orig,
 		TRACE("Created zfs dataset \"%s\"", new->src);
 	}
 
-	ret = mkdir_p(new->dest, 0755);
+	ret = lxc_mkdir_p(new->dest, 0755);
 	if (ret < 0 && errno != EEXIST) {
 		SYSERROR("Failed to create directory \"%s\"", new->dest);
 		return false;
@@ -542,7 +542,7 @@ int zfs_clonepaths(struct lxc_storage *orig, struct lxc_storage *new,
 		return -1;
 	}
 
-	ret = mkdir_p(new->dest, 0755);
+	ret = lxc_mkdir_p(new->dest, 0755);
 	if (ret < 0 && errno != EEXIST) {
 		SYSERROR("Failed to create directory \"%s\"", new->dest);
 		return -1;
@@ -740,7 +740,7 @@ int zfs_create(struct lxc_storage *bdev, const char *dest, const char *n,
 		TRACE("Created zfs dataset \"%s\"", bdev->src);
 	}
 
-	ret = mkdir_p(bdev->dest, 0755);
+	ret = lxc_mkdir_p(bdev->dest, 0755);
 	if (ret < 0 && errno != EEXIST) {
 		SYSERROR("Failed to create directory \"%s\"", bdev->dest);
 		return -1;

--- a/src/lxc/string_utils.c
+++ b/src/lxc/string_utils.c
@@ -187,7 +187,7 @@ char *lxc_string_join(const char *sep, const char **parts, bool use_as_prefix)
 }
 
 /* taken from systemd */
-char *path_simplify(const char *path)
+char *lxc_path_simplify(const char *path)
 {
 	__do_free char *path_new = NULL;
 	char *f, *t;

--- a/src/lxc/string_utils.h
+++ b/src/lxc/string_utils.h
@@ -188,6 +188,6 @@ static inline const char *fdstr(__s64 fd)
 	     (__iterator = __it);                                               \
 	     __iterator = __it = strtok_r(NULL, __separators, &__p))
 
-__hidden extern char *path_simplify(const char *path);
+__hidden extern char *lxc_path_simplify(const char *path);
 
 #endif /* __LXC_STRING_UTILS_H */

--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -590,13 +590,13 @@ static int lxc_terminal_peer_proxy_alloc(struct lxc_terminal *terminal,
 		goto on_error;
 	}
 
-	ret = fd_cloexec(terminal->proxy.ptx, true);
+	ret = lxc_fd_cloexec(terminal->proxy.ptx, true);
 	if (ret < 0) {
 		SYSERROR("Failed to set FD_CLOEXEC flag on proxy terminal ptx");
 		goto on_error;
 	}
 
-	ret = fd_cloexec(terminal->proxy.pty, true);
+	ret = lxc_fd_cloexec(terminal->proxy.pty, true);
 	if (ret < 0) {
 		SYSERROR("Failed to set FD_CLOEXEC flag on proxy terminal pty");
 		goto on_error;
@@ -930,13 +930,13 @@ static int lxc_terminal_create_foreign(struct lxc_conf *conf, struct lxc_termina
 		goto err;
 	}
 
-	ret = fd_cloexec(terminal->ptx, true);
+	ret = lxc_fd_cloexec(terminal->ptx, true);
 	if (ret < 0) {
 		SYSERROR("Failed to set FD_CLOEXEC flag on terminal ptx");
 		goto err;
 	}
 
-	ret = fd_cloexec(terminal->pty, true);
+	ret = lxc_fd_cloexec(terminal->pty, true);
 	if (ret < 0) {
 		SYSERROR("Failed to set FD_CLOEXEC flag on terminal pty");
 		goto err;

--- a/src/lxc/tools/lxc_copy.c
+++ b/src/lxc/tools/lxc_copy.c
@@ -359,7 +359,7 @@ static char *set_mnt_entry(struct mnts *m)
 			goto err;
 	} else if (m->mnt_type == LXC_MNT_BIND) {
 		len = strlen("  none bind,optional,, 0 0") +
-		      strlen(is_dir(m->src) ? "create=dir" : "create=file") +
+		      strlen(lxc_is_dir(m->src) ? "create=dir" : "create=file") +
 		      strlen(m->src) + strlen(m->dest) + strlen(m->options) + 1;
 
 		mntentry = malloc(len);
@@ -368,7 +368,7 @@ static char *set_mnt_entry(struct mnts *m)
 
 		ret = snprintf(mntentry, len, "%s %s none bind,optional,%s,%s 0 0",
 				m->src,	m->dest, m->options,
-				is_dir(m->src) ? "create=dir" : "create=file");
+				lxc_is_dir(m->src) ? "create=dir" : "create=file");
 		if (ret < 0 || (size_t)ret >= len)
 			goto err;
 	}

--- a/src/lxc/tools/lxc_create.c
+++ b/src/lxc/tools/lxc_create.c
@@ -245,7 +245,7 @@ int lxc_create_main(int argc, char *argv[])
 	if (!my_args.lxcpath[0])
 		my_args.lxcpath[0] = lxc_get_global_config_item("lxc.lxcpath");
 
-	if (mkdir_p(my_args.lxcpath[0], 0755))
+	if (lxc_mkdir_p(my_args.lxcpath[0], 0755))
 		exit(EXIT_FAILURE);
 
 	if (geteuid())

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -212,7 +212,7 @@ extern int get_u16(unsigned short *val, const char *arg, int base)
 	return 0;
 }
 
-int mkdir_p(const char *dir, mode_t mode)
+int lxc_mkdir_p(const char *dir, mode_t mode)
 {
 	const char *tmp = dir;
 	const char *orig = dir;
@@ -1690,7 +1690,7 @@ static int process_dead(/* takes */ int status_fd)
 	if (dupfd < 0)
 		return -1;
 
-	if (fd_cloexec(dupfd, true) < 0)
+	if (lxc_fd_cloexec(dupfd, true) < 0)
 		return -1;
 
 	f = fdopen(dupfd, "re");

--- a/src/lxc/utils.h
+++ b/src/lxc/utils.h
@@ -26,7 +26,7 @@
 /* returns 1 on success, 0 if there were any failures */
 __hidden extern int lxc_rmdir_onedev(const char *path, const char *exclude);
 __hidden extern int get_u16(unsigned short *val, const char *arg, int base);
-__hidden extern int mkdir_p(const char *dir, mode_t mode);
+__hidden extern int lxc_mkdir_p(const char *dir, mode_t mode);
 __hidden extern char *get_rundir(void);
 
 /* Define getline() if missing from the C library */

--- a/src/tests/lxc-test-utils.c
+++ b/src/tests/lxc-test-utils.c
@@ -43,12 +43,12 @@
 #include "macro.h"
 #include "utils.h"
 
-void test_path_simplify(void)
+void test_lxc_path_simplify(void)
 {
 	char *s = "/A///B//C/D/E/";
 	char *t;
 
-	t = path_simplify(s);
+	t = lxc_path_simplify(s);
 	if (!t)
 		exit(EXIT_FAILURE);
 
@@ -57,7 +57,7 @@ void test_path_simplify(void)
 
 	s = "/A";
 
-	t = path_simplify(s);
+	t = lxc_path_simplify(s);
 	if (!t)
 		exit(EXIT_FAILURE);
 
@@ -65,7 +65,7 @@ void test_path_simplify(void)
 	free(t);
 
 	s = "";
-	t = path_simplify(s);
+	t = lxc_path_simplify(s);
 	if (!t)
 		exit(EXIT_FAILURE);
 
@@ -74,7 +74,7 @@ void test_path_simplify(void)
 
 	s = "//";
 
-	t = path_simplify(s);
+	t = lxc_path_simplify(s);
 	if (!t)
 		exit(EXIT_FAILURE);
 
@@ -607,7 +607,7 @@ int main(int argc, char *argv[])
 {
 	test_lxc_string_replace();
 	test_lxc_string_in_array();
-	test_path_simplify();
+	test_lxc_path_simplify();
 	test_detect_ramfs_rootfs();
 	test_lxc_safe_uint();
 	test_lxc_safe_int();

--- a/src/tests/mount_injection.c
+++ b/src/tests/mount_injection.c
@@ -391,7 +391,7 @@ static bool lxc_setup_shmount(const char *shmount_path)
 {
 	int ret;
 
-	ret = mkdir_p(shmount_path, 0711);
+	ret = lxc_mkdir_p(shmount_path, 0711);
 	if (ret < 0 && errno != EEXIST) {
 		fprintf(stderr, "Failed to create directory \"%s\"\n", shmount_path);
 		return false;


### PR DESCRIPTION
If statically linking against both liblxc and libsystemd, some function names conflict:

mkdir_p fd_cloexec path_simplify is_dir is_fs_type

Rename those to lxc_\0, as:

for sym in mkdir_p fd_cloexec path_simplify is_dir is_fs_type; do
	git grep "$sym" | awk -F: '{ print $1 }' | sort | uniq | xargs sed -i "s/$sym/lxc_$sym/g"
done

(the above loop wrongly replaces is_dir in meson.build, but c'est la vie)