### PR TITLE
Add libarchive tar support for lxc download

### DIFF
--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -384,10 +384,18 @@ fi
 # Unpack the rootfs
 echo "Unpacking the rootfs"
 
+IS_BSD_TAR="false"
+if tar --version | grep -sq "bsdtar"; then
+    IS_BSD_TAR="true"
+fi
+
 EXCLUDES=""
 excludelist=$(relevant_file excludes)
 if [ -f "${excludelist}" ]; then
   while read -r line; do
+    if [ ${IS_BSD_TAR} = "true" ]; then
+      line="^${line}"
+    fi
     EXCLUDES="${EXCLUDES} --exclude=${line}"
   done < "${excludelist}"
 fi
@@ -397,7 +405,11 @@ fi
 # is to use a function wrapper, but the latter can't be used here as the args
 # are dynamic. We thus need to ignore the warning brought by shellcheck.
 # shellcheck disable=SC2086
-tar  --anchored ${EXCLUDES} --numeric-owner -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
+if [ "${IS_BSD_TAR}" = "true" ]; then
+  tar ${EXCLUDES} --numeric-owner -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
+else
+  tar  --anchored ${EXCLUDES} --numeric-owner -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
+fi
 
 mkdir -p "${LXC_ROOTFS}/dev/pts/"
 


### PR DESCRIPTION
This patch fixes unpacking images when the system provided tar is libarchive (bsd-tar). bsd-tar  doesn't support 'exclude' flags (--anchored) like gnu-tar does. Instead each exclude path is prepended with ^ to simulate behavior of --anchored when bsd tar is detected.