### PR TITLE
Update console perms to 0600

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -1856,7 +1856,7 @@ int fix_stdio_permissions(uid_t uid)
 			continue;
 		}
 
-		ret = fchmod(std_fds[i], 0700);
+		ret = fchmod(std_fds[i], 0600);
 		if (ret) {
 			SYSTRACE("Failed to chmod standard I/O file descriptor %d", std_fds[i]);
 			fret = -1;


### PR DESCRIPTION
Closes #4338

We should not give execute permissions to console output.