### PR TITLE
lxccontainer.h: Move new fields to the end

### DIFF
--- a/src/lxc/lxccontainer.h
+++ b/src/lxc/lxccontainer.h
@@ -94,12 +94,6 @@ struct lxc_container {
 	 */
 	struct lxc_conf *lxc_conf;
 
-	/*!
-	 * \private
-	 * SO_RCVTIMEO for LXC client_fd socket.
-	 */
-	int rcv_timeout;
-
 	/* public fields */
 	/*! Human-readable string representing last error */
 	char *error_string;
@@ -874,17 +868,6 @@ struct lxc_container {
 	int (*seccomp_notify_fd_active)(struct lxc_container *c);
 
 	/*!
-	 * \brief Set response receive timeout for LXC commands
-	 *
-	 * \param c Container
-	 * \param timeout Seconds to wait before returning false.
-	 *  (-1 to wait forever).
-	 *
-	 * \return \c true on success, else \c false.
-	 */
-	bool (*set_timeout)(struct lxc_container *c, int timeout);
-
-	/*!
 	 * \brief Retrieve a pidfd for the container's init process.
 	 *
 	 * \param c Container.
@@ -901,6 +884,23 @@ struct lxc_container {
 	 * \return Mount fd of the container's devpts instance.
 	 */
 	int (*devpts_fd)(struct lxc_container *c);
+
+	/*!
+	 * \private
+	 * SO_RCVTIMEO for LXC client_fd socket.
+	 */
+	int rcv_timeout;
+
+	/*!
+	 * \brief Set response receive timeout for LXC commands
+	 *
+	 * \param c Container
+	 * \param timeout Seconds to wait before returning false.
+	 *  (-1 to wait forever).
+	 *
+	 * \return \c true on success, else \c false.
+	 */
+	bool (*set_timeout)(struct lxc_container *c, int timeout);
 };
 
 /*!


### PR DESCRIPTION
The recent PR to add set_timeout is adding new fields to the `lxc_container` struct, but as that struct is public API, in fact the main struct in our public API, additions should always be appended to it to avoid breaking ABI.