### PR TITLE
lxc_storage_prepare(): Fix ephemeral copies

### DIFF
--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -233,7 +233,7 @@ struct lxc_mount_options {
  * @path         : the rootfs source (directory or device)
  * @mount        : where it is mounted
  * @buf		 : static buffer to construct paths
- * @bdev_type     : optional backing store type
+ * @__bdev_type    : optional backing store type
  * @managed      : whether it is managed by LXC
  * @dfd_mnt	 : fd for @mount
  * @dfd_dev : fd for /dev of the container
@@ -251,7 +251,7 @@ struct lxc_rootfs {
 	int dfd_dev;
 
 	char buf[PATH_MAX];
-	char *bdev_type;
+	char *__bdev_type;
 	bool managed;
 	struct lxc_mount_options mnt_opts;
 	struct lxc_storage *storage;

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -2795,14 +2795,14 @@ static int set_config_rootfs_path(const char *key, const char *value,
 		return ret_errno(ENOMEM);
 
 	/* Split <storage type>:<container path> into <storage type> and
-	 * <container path>. Set "rootfs.bdev_type" to <storage type> and
+	 * <container path>. Set "rootfs.__bdev_type" to <storage type> and
 	 * "rootfs.path" to <container path>.
 	 */
 	tmp = strchr(dup, ':');
 	if (tmp) {
 		*tmp = '\0';
 
-		ret = set_config_path_item(&lxc_conf->rootfs.bdev_type, dup);
+		ret = set_config_path_item(&lxc_conf->rootfs.__bdev_type, dup);
 		if (ret < 0)
 			return ret_errno(ENOMEM);
 

--- a/src/lxc/storage/storage.c
+++ b/src/lxc/storage/storage.c
@@ -215,7 +215,7 @@ static const struct lxc_storage_type *storage_query(struct lxc_conf *conf)
 	size_t i;
 	const struct lxc_storage_type *bdev;
 	const char *path = conf->rootfs.path;
-	const char *type = conf->rootfs.bdev_type;
+	const char *type = conf->rootfs.__bdev_type;
 
 	bdev = get_storage_by_name(path, type);
 	if (bdev)
@@ -641,7 +641,7 @@ struct lxc_storage *storage_init(struct lxc_conf *conf)
 bool storage_lxc_is_dir(struct lxc_conf *conf)
 {
 	struct lxc_storage *orig;
-	char *type = conf->rootfs.bdev_type;
+	const char *type = conf->rootfs.__bdev_type;
 	bool bret = false;
 
 	if (type)

--- a/src/lxc/storage/storage.h
+++ b/src/lxc/storage/storage.h
@@ -98,7 +98,7 @@ struct lxc_storage {
  *                  trust the config file. If the config file key
  *                  lxc.rootfs.path is set to <storage type>:<container path>
  *                  the confile parser will have split this into <storage type>
- *                  and <container path> and set the <bdev_type> member in the
+ *                  and <container path> and set the <__bdev_type> member in the
  *                  lxc_rootfs struct to <storage type> and the <path> member
  *                  will be set to a clean <container path> without the <storage
  *                  type> prefix. This is the new, clean way of handling storage


### PR DESCRIPTION
It appears that `rootfs->bdev_type` wasn't actually being set anywhere, other than if it comes from a config file.

Fixes: #4199