### PR TITLE
containers in the FREEZING state also need to be unfreeze

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -544,7 +544,10 @@ static bool do_lxcapi_unfreeze(struct lxc_container *c)
 		return false;
 
 	s = lxc_getstate(c->name, c->config_path, 0);
-	if (s == FROZEN) {
+	// Prevent lxc from unexpectedly exiting when executing freeze,
+	// causing the container to be in the FREEZING state,
+	// making normal life cycle management impossible.
+	if (s == FROZEN || s == FREEZING) {
 		ret = cgroup_unfreeze(c->name, c->config_path, -1);
 		if (ret == -ENOCGROUP2)
 			ret = lxc_unfreeze(c->lxc_conf, c->name, c->config_path);


### PR DESCRIPTION
When lxc is doing cgroup_freeze,：
```c
int cgroup_freeze(const char *name, const char *lxcpath, int timeout)
{
	__do_close int unified_fd = -EBADF;
	int ret;

	if (is_empty_string(name) || is_empty_string(lxcpath))
		return ret_errno(EINVAL);

	unified_fd = lxc_cmd_get_limit_cgroup2_fd(name, lxcpath);
	if (unified_fd < 0)
		return ret_errno(ENOCGROUP2);

	lxc_cmd_notify_state_listeners(name, lxcpath, FREEZING);
	ret = __cgroup_freeze(unified_fd, timeout);
	lxc_cmd_notify_state_listeners(name, lxcpath, !ret ? FROZEN : RUNNING);
	return ret;
}
```

if the lxc process is killed after setting the container status to FREEZING, the container status will be abnormal, unfreezing operation will not be possible, and normal life cycle management will not be possible. Therefore, containers in the FREEZING state also need to be unfreeze