### PR TITLE
reset root_nsuid_map and root_nsgid_map when idmaps is cleared

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4577,6 +4577,8 @@ define_cleanup_function(struct list_head *, __lxc_free_idmap);
 
 int lxc_clear_idmaps(struct lxc_conf *c)
 {
+	c->root_nsuid_map = NULL;
+	c->root_nsgid_map = NULL;
 	return lxc_free_idmap(&c->id_map);
 }
 


### PR DESCRIPTION
root_nsuid_map and root_nsgid_map can point to entries in id_map. When the id_map is cleared, these parameters could point to wrong memory. So set them to NULL when the idmap is cleared.
this fixes #4356