### PR TITLE
tools: lxc-info: Print memory and cpu utilization on cgroup2 system

### DIFF
--- a/src/lxc/rexec.c
+++ b/src/lxc/rexec.c
@@ -23,25 +23,27 @@
 #define LXC_MEMFD_REXEC_SEALS \
 	(F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE)
 
-static int push_vargs(char *data, int data_length, char ***output)
+static int push_vargs(const char *data, int data_length, char ***output)
 {
-	int num = 0;
-	char *cur = data;
+	int i, j, nmemb;
+	char *end;
 
 	if (!data || *output)
 		return -1;
 
-	*output = must_realloc(NULL, sizeof(**output));
+	for (nmemb = i = 0; i < data_length; i++)
+		if (!data[i]) nmemb++;
 
-	while (cur < data + data_length) {
-		num++;
-		*output = must_realloc(*output, (num + 1) * sizeof(**output));
+	*output = realloc(NULL, (nmemb + 1) * sizeof(char*) + data_length);
+	end = (char *)&(*output)[nmemb + 1];
+	memcpy(end, data, data_length);
 
-		(*output)[num - 1] = cur;
-		cur += strlen(cur) + 1;
-	}
-	(*output)[num] = NULL;
-	return num;
+	(*output)[0] = end;
+	for (i = j = 0; i < data_length; i++)
+		if (!end[i]) (*output)[++j] = &end[i + 1];
+	(*output)[j] = NULL;
+
+	return nmemb;
 }
 
 static int parse_argv(char ***argv)
@@ -55,11 +57,7 @@ static int parse_argv(char ***argv)
 		return -1;
 
 	ret = push_vargs(cmdline, cmdline_size, argv);
-	if (ret <= 0)
-		return -1;
-
-	move_ptr(cmdline);
-	return 0;
+	return ret <= 0 ? -1 : 0;
 }
 
 static int is_memfd(void)
@@ -171,7 +169,7 @@ extern char **environ;
 
 int lxc_rexec(const char *memfd_name)
 {
-	__do_free_string_list char **argv = NULL;
+	__do_free char **argv = NULL;
 	int ret;
 
 	ret = is_memfd();


### PR DESCRIPTION
Emulate the cgroup1 behavior by calculating memory.kmem.usage_in_bytes and memory.usage_in_bytes using information provided in memory.stat.