### PR TITLE
confile_utils: fix incorrect multiply_overflow test

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -2963,18 +2963,18 @@ static int set_config_time_offset_boot(const char *key, const char *value,
 
 	unit = lxc_trim_whitespace_in_place(buf);
 	if (strequal(unit, "h")) {
-		if (!multiply_overflow(offset, 3600, &lxc_conf->timens.s_boot))
+		if (multiply_overflow(offset, 3600, &lxc_conf->timens.s_boot))
 			return ret_errno(EOVERFLOW);
 	} else if (strequal(unit, "m")) {
-		if (!multiply_overflow(offset, 60, &lxc_conf->timens.s_boot))
+		if (multiply_overflow(offset, 60, &lxc_conf->timens.s_boot))
 			return ret_errno(EOVERFLOW);
 	} else if (strequal(unit, "s")) {
 		lxc_conf->timens.s_boot = offset;
 	} else if (strequal(unit, "ms")) {
-		if (!multiply_overflow(offset, 1000000, &lxc_conf->timens.ns_boot))
+		if (multiply_overflow(offset, 1000000, &lxc_conf->timens.ns_boot))
 			return ret_errno(EOVERFLOW);
 	} else if (strequal(unit, "us")) {
-		if (!multiply_overflow(offset, 1000, &lxc_conf->timens.ns_boot))
+		if (multiply_overflow(offset, 1000, &lxc_conf->timens.ns_boot))
 			return ret_errno(EOVERFLOW);
 	} else if (strequal(unit, "ns")) {
 		lxc_conf->timens.ns_boot = offset;
@@ -3002,18 +3002,18 @@ static int set_config_time_offset_monotonic(const char *key, const char *value,
 
 	unit = lxc_trim_whitespace_in_place(buf);
 	if (strequal(unit, "h")) {
-		if (!multiply_overflow(offset, 3600, &lxc_conf->timens.s_monotonic))
+		if (multiply_overflow(offset, 3600, &lxc_conf->timens.s_monotonic))
 			return ret_errno(EOVERFLOW);
 	} else if (strequal(unit, "m")) {
-		if (!multiply_overflow(offset, 60, &lxc_conf->timens.s_monotonic))
+		if (multiply_overflow(offset, 60, &lxc_conf->timens.s_monotonic))
 			return ret_errno(EOVERFLOW);
 	} else if (strequal(unit, "s")) {
 		lxc_conf->timens.s_monotonic = offset;
 	} else if (strequal(unit, "ms")) {
-		if (!multiply_overflow(offset, 1000000, &lxc_conf->timens.ns_monotonic))
+		if (multiply_overflow(offset, 1000000, &lxc_conf->timens.ns_monotonic))
 			return ret_errno(EOVERFLOW);
 	} else if (strequal(unit, "us")) {
-		if (!multiply_overflow(offset, 1000, &lxc_conf->timens.ns_monotonic))
+		if (multiply_overflow(offset, 1000, &lxc_conf->timens.ns_monotonic))
 			return ret_errno(EOVERFLOW);
 	} else if (strequal(unit, "ns")) {
 		lxc_conf->timens.ns_monotonic = offset;

--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -2073,14 +2073,7 @@ int fix_stdio_permissions(uid_t uid)
 
 bool multiply_overflow(int64_t base, uint64_t mult, int64_t *res)
 {
-	if (base > 0 && base > (int64_t)(INT64_MAX / mult))
-		return false;
-
-	if (base < 0 && base < (int64_t)(INT64_MIN / mult))
-		return false;
-
-	*res = (int64_t)(base * mult);
-	return true;
+	return __builtin_mul_overflow(base, mult, res);
 }
 
 int print_r(int fd, const char *path)


### PR DESCRIPTION
The check of multiplication overflow to set time offsets (boottime and monotonic) is not correct and does not allow any valid negative value to be accepted.
This commit changes the detection of the multiplication overflow to accept valid negative values for time offsets. 