### PR TITLE
tree-wide: add MFD_EXEC and MFD_NOEXEC_SEAL flags to memfd_create

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -2842,7 +2842,7 @@ FILE *make_anonymous_mount_file(const struct list_head *mount_entries,
 	int ret;
 	struct string_entry *entry;
 
-	fd = memfd_create(".lxc_mount_file", MFD_CLOEXEC);
+	fd = memfd_create(".lxc_mount_file", MFD_NOEXEC_SEAL | MFD_CLOEXEC);
 	if (fd < 0) {
 		char template[] = P_tmpdir "/.lxc_mount_file_XXXXXX";
 
@@ -3890,7 +3890,7 @@ static void turn_into_dependent_mounts(const struct lxc_rootfs *rootfs)
 		return;
 	}
 
-	memfd = memfd_create(".lxc_mountinfo", MFD_CLOEXEC);
+	memfd = memfd_create(".lxc_mountinfo", MFD_NOEXEC_SEAL | MFD_CLOEXEC);
 	if (memfd < 0) {
 		char template[] = P_tmpdir "/.lxc_mountinfo_XXXXXX";
 

--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -401,6 +401,14 @@
 #define MFD_ALLOW_SEALING 0x0002U
 #endif
 
+#ifndef MFD_NOEXEC_SEAL
+#define MFD_NOEXEC_SEAL 0x0008U
+#endif
+
+#ifndef MFD_EXEC
+#define MFD_EXEC 0x0010U
+#endif
+
 /**
  * BUILD_BUG_ON - break compile if a condition is true.
  * @condition: the condition which the compiler should know is false.

--- a/src/lxc/parse.c
+++ b/src/lxc/parse.c
@@ -56,7 +56,7 @@ int lxc_file_for_each_line_mmap(const char *file, lxc_file_cb callback, void *da
 	ssize_t bytes;
 	char *line;
 
-	memfd = memfd_create(".lxc_config_file", MFD_CLOEXEC);
+	memfd = memfd_create(".lxc_config_file", MFD_NOEXEC_SEAL | MFD_CLOEXEC);
 	if (memfd < 0) {
 		char template[] = P_tmpdir "/.lxc_config_file_XXXXXX";
 

--- a/src/lxc/rexec.c
+++ b/src/lxc/rexec.c
@@ -92,7 +92,7 @@ static void lxc_rexec_as_memfd(char **argv, char **envp, const char *memfd_name)
 	ssize_t bytes_sent = 0;
 	struct stat st = {0};
 
-	memfd = memfd_create(memfd_name, MFD_ALLOW_SEALING | MFD_CLOEXEC);
+	memfd = memfd_create(memfd_name, MFD_EXEC | MFD_ALLOW_SEALING | MFD_CLOEXEC);
 	if (memfd < 0) {
 		char template[PATH_MAX];
 

--- a/src/lxc/ringbuf.c
+++ b/src/lxc/ringbuf.c
@@ -34,7 +34,7 @@ int lxc_ringbuf_create(struct lxc_ringbuf *buf, size_t size)
 	if (buf->addr == MAP_FAILED)
 		return -EINVAL;
 
-	memfd = memfd_create(".lxc_ringbuf", MFD_CLOEXEC);
+	memfd = memfd_create(".lxc_ringbuf", MFD_NOEXEC_SEAL | MFD_CLOEXEC);
 	if (memfd < 0) {
 		char template[] = P_tmpdir "/.lxc_ringbuf_XXXXXX";
 


### PR DESCRIPTION
Since Linux kernel 6.3, one of these flags must be passed to avoid a warning being printed in the kernel log:

```
[    1.229444] memfd_create() without MFD_EXEC nor MFD_NOEXEC_SEAL, pid=851 'lxd'
```

Fixes #4315