### PR TITLE
lxcmntent: cleanning the buffer before get data in getmntent_r

### DIFF
--- a/src/include/lxcmntent.c
+++ b/src/include/lxcmntent.c
@@ -82,6 +82,8 @@ struct mntent *getmntent_r(FILE *stream, struct mntent *mp, char *buffer, int bu
 	do {
 		char *end_ptr;
 
+		memset((void *)buffer, 0x0, (size_t bufsiz));
+
 		if (!fgets(buffer, bufsiz, stream))
 			return NULL;
 


### PR DESCRIPTION
The buffer in getmntent_r used in other functions before (e.g. src/lxc/criu.c exec_criu()). We observed that on some platforms, criu cannot run succesfully due to parameters was wrong. After checking the parameters, we found that the the buffer contains old data and those old data also insert to criu's arguments. So add a cleanning the old data in buffer by memset before using fget.