### PR TITLE
Align columns in lxc-download.in template

### DIFF
--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -241,7 +241,7 @@ if [ "${DOWNLOAD_LIST_IMAGES}" = "true" ] || [ "${DOWNLOAD_INTERACTIVE}" = "true
   # Parse it
   echo ""
   echo "---"
-  printf "DIST\tRELEASE\tARCH\tVARIANT\tBUILD\n"
+  printf "%-15s  %-10s  %-5s  %-7s  %-14s\n" "DIST" "RELEASE" "ARCH" "VARIANT" "BUILD"
   echo "---"
   while IFS=';' read -r f1 f2 f3 f4 f5 f6; do
     [ -n "${DOWNLOAD_DIST}" ] && [ "$f1" != "${DOWNLOAD_DIST}" ] && continue
@@ -250,7 +250,7 @@ if [ "${DOWNLOAD_LIST_IMAGES}" = "true" ] || [ "${DOWNLOAD_INTERACTIVE}" = "true
     [ -n "${DOWNLOAD_VARIANT}" ] && [ "$f4" != "${DOWNLOAD_VARIANT}" ] && continue
     [ -z "${f5}" ] || [ -z "${f6}" ] && continue
 
-    printf "%s\t%s\t%s\t%s\t%s\n" "${f1}" "${f2}" "${f3}" "${f4}" "${f5}"
+    printf "%-15s  %-10s  %-5s  %-7s  %-14s\n" "${f1}" "${f2}" "${f3}" "${f4}" "${f5}"
     unset f1 f2 f3 f4 f5 f6
   done < "${DOWNLOAD_TEMP}/index"
   echo "---"


### PR DESCRIPTION
closes #4380

```
root@motorhead:~# lxc-create -t download -n abContainer2
Downloading the image index

---
DIST             RELEASE     ARCH   VARIANT  BUILD         
---
almalinux        8           amd64  default  20240105_23:08
almalinux        8           arm64  default  20240105_23:08
almalinux        9           amd64  default  20240105_23:08
almalinux        9           arm64  default  20240105_23:08
alpine           3.16        amd64  default  20240105_13:00
alpine           3.16        arm64  default  20240105_13:03
alpine           3.17        amd64  default  20240105_13:00
alpine           3.17        arm64  default  20240105_13:02
alpine           3.18        amd64  default  20240105_13:00
alpine           3.18        arm64  default  20240105_13:02
alpine           3.19        amd64  default  20240105_13:00
alpine           3.19        arm64  default  20240105_13:00
alpine           edge        amd64  default  20240105_13:00
alpine           edge        arm64  default  20240105_13:01
alt              Sisyphus    amd64  default  20240106_01:17
alt              Sisyphus    arm64  default  20240106_01:17
alt              p10         amd64  default  20240106_01:17
alt              p10         arm64  default  20240106_01:17
alt              p9          amd64  default  20240106_01:17
alt              p9          arm64  default  20240106_01:26
amazonlinux      2           amd64  default  20240106_05:09
amazonlinux      2           arm64  default  20240106_05:09
amazonlinux      2023        amd64  default  20240106_05:09
archlinux        current     amd64  default  20240106_04:18
```