### PR TITLE
tree-wide: use container_uses_namespace() in more places

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -564,7 +564,7 @@ __cgfsng_ops static void cgfsng_payload_destroy(struct cgroup_ops *ops,
 	 * monitor is root we can assume that it is privileged enough to remove
 	 * the cgroups it created when the container started.
 	 */
-	if (!list_empty(&handler->conf->id_map) && !handler->am_root) {
+	if (container_uses_namespace(handler, CLONE_NEWUSER) && !handler->am_root) {
 		struct generic_userns_exec_data wrap = {
 			.conf			= handler->conf,
 			.path_prune		= ops->container_limit_cgroup,

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -620,7 +620,7 @@ int lxc_rootfs_prepare_parent(struct lxc_handler *handler)
 	int ret;
 	const char *path_source;
 
-	if (list_empty(&handler->conf->id_map))
+	if (!container_uses_namespace(handler, CLONE_NEWUSER))
 		return 0;
 
 	if (is_empty_string(rootfs->mnt_opts.userns_path))
@@ -4117,7 +4117,7 @@ static int lxc_rootfs_prepare_child(struct lxc_handler *handler)
 	int dfd_idmapped = -EBADF;
 	int ret;
 
-	if (list_empty(&handler->conf->id_map))
+	if (!container_uses_namespace(handler, CLONE_NEWUSER))
 		return 0;
 
 	if (is_empty_string(rootfs->mnt_opts.userns_path))

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -4290,7 +4290,7 @@ int lxc_sync_fds_parent(struct lxc_handler *handler)
 	if (ret < 0)
 		return syserror_ret(ret, "Failed to receive tty info from child process");
 
-	if (handler->ns_clone_flags & CLONE_NEWNET) {
+	if (container_uses_namespace(handler, CLONE_NEWNET)) {
 		ret = lxc_network_recv_name_and_ifindex_from_child(handler);
 		if (ret < 0)
 			return syserror_ret(ret, "Failed to receive names and ifindices for network devices from child");
@@ -4320,7 +4320,7 @@ int lxc_sync_fds_child(struct lxc_handler *handler)
 	if (ret < 0)
 		return syserror_ret(ret, "Failed to send tty file descriptors to parent");
 
-	if (handler->ns_clone_flags & CLONE_NEWNET) {
+	if (container_uses_namespace(handler, CLONE_NEWNET)) {
 		ret = lxc_network_send_name_and_ifindex_to_parent(handler);
 		if (ret < 0)
 			return syserror_ret(ret, "Failed to send network device names and ifindices to parent");
@@ -4382,7 +4382,7 @@ int lxc_setup(struct lxc_handler *handler)
 			return log_error(-1, "Failed to setup container keyring");
 	}
 
-	if (handler->ns_clone_flags & CLONE_NEWNET) {
+	if (container_uses_namespace(handler, CLONE_NEWNET)) {
 		ret = lxc_network_recv_from_parent(handler);
 		if (ret < 0)
 			return log_error(-1, "Failed to receive veth names from parent");

--- a/src/lxc/network.c
+++ b/src/lxc/network.c
@@ -3763,7 +3763,7 @@ int lxc_restore_phys_nics_to_netns(struct lxc_handler *handler)
 	 * If we weren't asked to clone a new network namespace, there's
 	 * nothing to restore.
 	 */
-	if (!(handler->ns_clone_flags & CLONE_NEWNET))
+	if (!container_uses_namespace(handler, CLONE_NEWNET))
 		return 0;
 
 	/* We need CAP_NET_ADMIN in the parent namespace in order to setns() to

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1400,7 +1400,7 @@ static int do_start(void *data)
 	 * we switched to root in the new user namespace further above. Only
 	 * drop groups if we can, so ensure that we have necessary privilege.
 	 */
-	if (list_empty(&handler->conf->id_map)) {
+	if (!container_uses_namespace(handler, CLONE_NEWUSER)) {
 		#if HAVE_LIBCAP
 		if (lxc_proc_cap_is_set(CAP_SETGID, CAP_EFFECTIVE))
 		#endif


### PR DESCRIPTION
While playing with [isolated user namespaces](https://github.com/mihalicyn/isolated-userns) and LXC I've noticed that we have a few different ways to determine if a container uses user namespace or not depending on the context. While in some cases it's reasonable, in most other cases it makes no sense. In this simple PR I converted most places to use an old `container_uses_namespace()` helper. Some less-trivial cases left untouched, because converting them require adding some extra fields on the structures or passing more arguments down the stack which makes no sense right now (as isolated user namespaces stuff is not upstreamed in the Linux kernel anyways).

No functional changes intended.