### PR TITLE
lxc-download, lxc-local: preserve xattrs on unpack

### DIFF
--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -414,7 +414,7 @@ fi
 if [ "${IS_BSD_TAR}" = "true" ]; then
   tar ${EXCLUDES} --numeric-owner -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
 else
-  tar  --anchored ${EXCLUDES} --numeric-owner -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
+  tar --anchored ${EXCLUDES} --numeric-owner --xattrs-include='*' -xpJf "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
 fi
 
 mkdir -p "${LXC_ROOTFS}/dev/pts/"

--- a/templates/lxc-local.in
+++ b/templates/lxc-local.in
@@ -338,7 +338,7 @@ unpack_rootfs() {
     echo "Excludes: ${EXCLUDES}"
   fi
 
-  tar --anchored ${EXCLUDES} --numeric-owner -xpJf "${LXC_FSTREE}" -C "${LXC_ROOTFS}"
+  tar --anchored ${EXCLUDES} --numeric-owner --xattrs-include='*' -xpJf "${LXC_FSTREE}" -C "${LXC_ROOTFS}"
 
   prepare_rootfs
 }


### PR DESCRIPTION
Update `tar` invocation to preserve all xattrs when unpacking the rootfs, notably retaining `security.capability` xattrs (e.g. for `ping`, `newuidmap`)

Note: `bsdtar` already preserves xattrs with `-p`

Related / analogous:
- https://github.com/lxc/incus/commit/38778dfb6fbda86ddf2ec273968364e7d9d55bd7
- https://github.com/lxc/distrobuilder/pull/340/commits/ed7c50e2988d6dc2db1d01d25dce491765825350