### PR TITLE
Add x32 to the list of recognized architectures

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -3268,6 +3268,7 @@ int lxc_config_parse_arch(const char *arch, signed long *persona)
 		{ "mipsel",        PER_LINUX32 },
 		{ "ppc",           PER_LINUX32 },
 		{ "powerpc",       PER_LINUX32 },
+		{ "x32",           PER_LINUX32 },
 		{ "x86",           PER_LINUX32 },
 		{ "aarch64",       PER_LINUX   },
 		{ "amd64",         PER_LINUX   },


### PR DESCRIPTION
LXC supports x32 containers, but currently creation of those containers is broken:

```
lxc-create: x32-test: ../src/lxc/confile.c: set_config_personality: 1432 Invalid argument - Unsupported personality "x32"
lxc-create: x32-test: ../src/lxc/parse.c: lxc_file_for_each_line_mmap: 129 Failed to parse config file "/var/lib/lxc/x32-test/config" at line "lxc.arch = x32"
lxc-create: x32-test: ../src/lxc/tools/lxc_create.c: main: 317 Failed to create container x32-test
```

The underlying support is still there, it's just an issue when parsing the container's config.

With this change, I can successfully create and use x32 containers on a Debian sid amd64 host booted with `syscall.x32=y`, running lxc 5.0.3.