### PR TITLE
oci: resolve cross-filesystem blob caching failure

### DIFF
--- a/templates/lxc-oci.in
+++ b/templates/lxc-oci.in
@@ -223,6 +223,18 @@ getcwd() {
   return
 }
 
+is_same_mountpoint() {
+  local path1="$1"
+  local path2="$2"
+  local mount1
+  local mount2
+
+  # make sure bind mounts are covered
+  mount1=$(df --output=target "$path1" | tail -n 1)
+  mount2=$(df --output=target "$path2" | tail -n 1)
+  [ "$mount1" = "$mount2" ]
+}
+
 usage() {
   cat <<EOF
 LXC container template for OCI images
@@ -332,6 +344,14 @@ if [ "${OCI_USE_CACHE}" = "true" ]; then
 else
   DOWNLOAD_BASE="$OCI_DIR"
 fi
+
+if [ "${OCI_USE_CACHE}" = "true" ]; then
+  if ! is_same_mountpoint "$LXC_PATH" "$DOWNLOAD_BASE"; then
+    OCI_USE_CACHE="false"
+    DOWNLOAD_BASE="$OCI_DIR"
+  fi
+fi
+
 mkdir -p "${DOWNLOAD_BASE}"
 
 # Trap all exit signals


### PR DESCRIPTION
This commit addresses an issue in the OCI template where `lxc-create` fails if OCI-cache directory for blob caching is not on the same mount as the destination OCI directory. `lxc-create` bails when skopeo tries to create a hard-link across the two and fails.

For example, if `/var/lib/lxc` is a bind mountpoint of a random directory then skopeo fails to hard-link across `/var/cache/lxc` and `/var/lib/lxc`

This commit introduces a check where if both directories are on not the same mount points, it disables blob caching in skopeo and continues.