### PR TITLE
config: apparmor: add AppArmor profile for lxc-copy

### DIFF
--- a/config/apparmor/meson.build
+++ b/config/apparmor/meson.build
@@ -14,4 +14,11 @@ if libapparmor.found()
         output: 'usr.bin.lxc-start',
         install: true,
         install_dir: join_paths(sysconfdir, 'apparmor.d'))
+
+    configure_file(
+        configuration: dummy_config_data,
+        input: 'usr.bin.lxc-copy',
+        output: 'usr.bin.lxc-copy',
+        install: true,
+        install_dir: join_paths(sysconfdir, 'apparmor.d'))
 endif

--- a/config/apparmor/usr.bin.lxc-copy
+++ b/config/apparmor/usr.bin.lxc-copy
@@ -1,0 +1,5 @@
+#include <tunables/global>
+
+/usr/bin/lxc-copy flags=(attach_disconnected) {
+  #include <abstractions/lxc/start-container>
+}

--- a/config/init/systemd/lxc-apparmor-load
+++ b/config/init/systemd/lxc-apparmor-load
@@ -7,9 +7,11 @@ set -eu
 SYSF=/sys/kernel/security/apparmor/features/mount/mask
 if [ -f $SYSF ]; then
 	if [ -x /lib/apparmor/profile-load ]; then
+		/lib/apparmor/profile-load usr.bin.lxc-copy
 		/lib/apparmor/profile-load usr.bin.lxc-start
 		/lib/apparmor/profile-load lxc-containers
 	elif [ -x /lib/init/apparmor-profile-load ]; then
+		/lib/init/apparmor-profile-load usr.bin.lxc-copy
 		/lib/init/apparmor-profile-load usr.bin.lxc-start
 		/lib/init/apparmor-profile-load lxc-containers
 	fi


### PR DESCRIPTION
lxc-copy can start container as lxc-start does in some cases, so we need to have the same profile for it.