### PR TITLE
github: master -> main

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -8,7 +8,7 @@ on:
       - 'meson_options.txt'
       - 'src/**'
     branches:
-      - master
+      - main
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,7 +2,7 @@ name: Coverity build and upload
 on:
   push:
     branches:
-      - master
+      - main
 permissions:
   contents: read
 
@@ -59,7 +59,7 @@ jobs:
             --form token=${TOKEN} \
             --form email=lxc-devel@lists.linuxcontainers.org \
             --form file=@lxc.tgz \
-            --form version=master \
+            --form version=main \
             --form description="${GITHUB_SHA}" \
             https://scan.coverity.com/builds?project=lxc/lxc
         env:


### PR DESCRIPTION
Our main branch is "main" for some time, but
in github scripts we still use "master" which is incorrect and prevent some stuff from working.