### PR TITLE
README: Correct 'armvl7' to 'armv7l'

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ features. This includes (but isn't limited to):
 - ppc, ppc64, ppc64le
 - riscv64
 - s390x
-- armvl7, arm64
+- armv7l, arm64
 - loongarch64
 
 LXC also supports at least the following C standard libraries:


### PR DESCRIPTION
Use the correct designation for the armv7l arch, as also reflected in src/lxc/confile.c.

Smaller nit that was the result of series of misconfigurations due to the mistake of using armvl7 in our configurations instead of armv7l.