### PR TITLE
lxc/lxccontainer: specify file mode in open() call inside mod_rdep

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2705,7 +2705,7 @@ static bool mod_rdep(struct lxc_container *c0, struct lxc_container *c, bool inc
 		/* Here we know that we have or can use an lxc-snapshot file
 		 * using the new format. */
 		if (inc) {
-			fd = open(path, O_APPEND | O_WRONLY | O_CREAT | O_CLOEXEC);
+			fd = open(path, O_APPEND | O_WRONLY | O_CREAT | O_CLOEXEC, 0644);
 			if (fd < 0)
 				goto out;
 


### PR DESCRIPTION
We must explicitly specify file mode in open(.. O_CREAT ..).

Let's set 0644, while previously it was 0666 [1] which seems too much.

[1] https://sourceware.org/git/?p=glibc.git;a=blob;f=libio/fileops.c;h=4db4a76f755b1f3b766dc47c669c09242395ec95;hb=HEAD#l216

Fixes: Coverity 1596044