### PR TITLE
tools/lxc_autostart: don't fail when there are no containers

### DIFF
--- a/src/lxc/tools/lxc_autostart.c
+++ b/src/lxc/tools/lxc_autostart.c
@@ -504,7 +504,7 @@ int lxc_autostart_main(int argc, char *argv[])
 	toss_list(cmd_groups_list);
 	free(containers);
 
-	if (failed == count)
+	if (failed > 0 && failed == count)
 		exit(EXIT_FAILURE);	/* Total failure */
 	else if (failed > 0)
 		exit(2);	/* Partial failure */


### PR DESCRIPTION
Fixes: #3847