### PR TITLE
lxc/tools: set default log_priority to ERROR

### DIFF
--- a/src/lxc/tools/lxc_autostart.c
+++ b/src/lxc/tools/lxc_autostart.c
@@ -85,6 +85,8 @@ Options:\n\
 	.parser   = my_parser,
 	.checker  = NULL,
 	.timeout = 60,
+	.log_priority = "ERROR",
+	.log_file     = "none",
 };
 
 static int list_contains_entry(char *str_ptr, struct lxc_list *p1) {

--- a/src/lxc/tools/lxc_copy.c
+++ b/src/lxc/tools/lxc_copy.c
@@ -112,6 +112,8 @@ Options :\n\
 	.daemonize = 1,
 	.quiet = false,
 	.tmpfs = false,
+	.log_priority = "ERROR",
+	.log_file     = "none",
 };
 
 static struct mnts *add_mnt(struct mnts **mnts, unsigned int *num,

--- a/src/lxc/tools/lxc_info.c
+++ b/src/lxc/tools/lxc_info.c
@@ -81,6 +81,8 @@ Options :\n\
 	.options  = my_longopts,
 	.parser   = my_parser,
 	.checker  = NULL,
+	.log_priority = "ERROR",
+	.log_file     = "none",
 };
 
 static void str_chomp(char *buf)

--- a/src/lxc/tools/lxc_ls.c
+++ b/src/lxc/tools/lxc_ls.c
@@ -186,6 +186,8 @@ Options :\n\
 	.options = my_longopts,
 	.parser = my_parser,
 	.ls_nesting = 0,
+	.log_priority = "ERROR",
+	.log_file     = "none",
 };
 
 int __attribute__((weak, alias("lxc_ls_main"))) main(int argc, char *argv[]);

--- a/src/lxc/tools/lxc_monitor.c
+++ b/src/lxc/tools/lxc_monitor.c
@@ -69,6 +69,8 @@ Options :\n\
 	.parser   = my_parser,
 	.checker  = NULL,
 	.lxcpath_additional = -1,
+	.log_priority = "ERROR",
+	.log_file     = "none",
 };
 
 static void close_fds(struct pollfd *fds, nfds_t nfds)

--- a/src/lxc/tools/lxc_snapshot.c
+++ b/src/lxc/tools/lxc_snapshot.c
@@ -51,6 +51,8 @@ Options :\n\
 	.parser = my_parser,
 	.checker = NULL,
 	.task = SNAP,
+	.log_priority = "ERROR",
+	.log_file     = "none",
 };
 
 static int do_snapshot(struct lxc_container *c, char *commentfile);

--- a/src/lxc/tools/lxc_top.c
+++ b/src/lxc/tools/lxc_top.c
@@ -116,6 +116,8 @@ Options :\n\
 	.parser   = my_parser,
 	.checker  = NULL,
 	.lxcpath_additional = -1,
+	.log_priority = "ERROR",
+	.log_file     = "none",
 };
 
 static void stdin_tios_restore(void)


### PR DESCRIPTION
For some reason, we don't have default log_priority set for many tools which leads to the situation when tools can fail silently even if error occurs.

Fixes: #4405