### PR TITLE
meson: fix build on NixOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
           meson setup build \
                 -Dtests=true \
                 -Dpam-cgroup=true \
+                -Dtools-multicall=true \
                 -Dwerror=true \
                 -Db_lto_mode=default
           ninja -C build

--- a/src/lxc/cmd/meson.build
+++ b/src/lxc/cmd/meson.build
@@ -46,7 +46,7 @@ cmd_lxc_init_static_sources = files(
     '../string_utils.c',
     '../string_utils.h') + include_sources
 
-cmd_lxc_monitord_sources = files('lxc_monitord.c') + include_sources + netns_ifaddrs_sources
+cmd_lxc_monitord_sources = files('lxc_monitord.c')
 cmd_lxc_user_nic_sources = files('lxc_user_nic.c') + cmd_common_sources + netns_ifaddrs_sources
 cmd_lxc_usernsexec_sources = files('lxc_usernsexec.c') + cmd_common_sources + netns_ifaddrs_sources
 
@@ -88,8 +88,8 @@ cmd_programs += executable(
     'lxc-monitord',
     cmd_lxc_monitord_sources,
     include_directories: liblxc_includes,
-    dependencies: liblxc_dep,
-    link_with: [liblxc_static],
+    dependencies: liblxc_dependencies,
+    link_whole: [liblxc_static],
     install: true,
     install_dir: lxclibexec)
 

--- a/src/lxc/tools/meson.build
+++ b/src/lxc/tools/meson.build
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-tools_common_sources = files('arguments.c', 'arguments.h') + include_sources + netns_ifaddrs_sources
+tools_common_sources = files('arguments.c', 'arguments.h') + include_sources
+tools_common_sources_for_dynamic_link = tools_common_sources + netns_ifaddrs_sources
 
 tools_commands_dynamic_link = ['attach', 'autostart', 'cgroup', 'checkpoint', 'config',
     'console', 'copy', 'create', 'destroy', 'device', 'execute', 'freeze',
@@ -15,7 +16,7 @@ if want_tools
     foreach cmd : tools_commands_dynamic_link
         public_programs += executable(
             'lxc-' + cmd,
-            files('lxc_' + cmd + '.c') + tools_common_sources + liblxc_ext_sources,
+            files('lxc_' + cmd + '.c') + tools_common_sources_for_dynamic_link + liblxc_ext_sources,
             dependencies: liblxc_dependencies,
             include_directories: liblxc_includes,
             c_args: ['-DNO_LXC_CONF'],
@@ -26,16 +27,16 @@ if want_tools
     foreach cmd : tools_commands_static_link
         public_programs += executable(
             'lxc-' + cmd,
-            files('lxc_' + cmd + '.c') + tools_common_sources,
+            files('lxc_' + cmd + '.c') + files('arguments.c', 'arguments.h'),
             dependencies: liblxc_dependencies,
             include_directories: liblxc_includes,
-            link_with: [liblxc_static],
+            link_whole: [liblxc_static],
             install: true)
     endforeach
 endif
 
 if want_tools_multicall
-    tools_all_sources = files('lxc_multicall.c') + tools_common_sources
+    tools_all_sources = files('lxc_multicall.c') + tools_common_sources_for_dynamic_link
     foreach cmd : tools_commands
         tools_all_sources += files('lxc_' + cmd + '.c')
     endforeach


### PR DESCRIPTION
It was reported recently that on NixOS LXC fails to build with the following errors:
```
[135/139] Linking target src/lxc/cmd/lxc-monitord
FAILED: src/lxc/cmd/lxc-monitord
gcc  -o src/lxc/cmd/lxc-monitord src/lxc/cmd/lxc-monitord.p/lxc_monitord.c.o src/lxc/cmd/lxc-monitord.p/.._.._include_netns_ifaddrs.c.o -flto -Wl,--no-undefined -pie -Wl,--no-as-needed -Wl,--gc-sections -Wl,-z,relro -Wl,-z,now -fstack-protector -fstack-protector-strong -Wl,-fuse-ld=gold -Wl,--warn-common '-Wl,-rpath,$ORIGIN/../../..' -Wl,-rpath-link,/home/adam/git/lxc/build/ -Wl,--start-group src/lxc/liblxc.a liblxc.so.1.8.0 /nix/store/jnlxl2ry9y03vq4skhm26igfd84xwa93-dbus-1.14.10-lib/lib/libdbus-1.so -pthread /nix/store/iglb2fmla149fbprj6fb18swfls033q4-libseccomp-2.5.4-lib/lib/libseccomp.so /nix/store/5mfk83ikgk62gv0xj95xylnkf0f52chv-libselinux-3.3/lib/libselinux.so /nix/store/wp5c5sjlvm6nxavvs1prdnw5n41mgciq-libapparmor-3.1.6/lib/libapparmor.so /nix/store/c7rf6w8xvxc4423m9rsgq5nsqhknshvy-openssl-3.0.12/lib/libssl.so /nix/store/c7rf6w8xvxc4423m9rsgq5nsqhknshvy-openssl-3.0.12/lib/libcrypto.so /nix/store/lmj8lfkd8h448grf1nf92lsm5gm2fnf6-libcap-2.69-lib/lib/libcap.so -lutil -Wl,--end-group
../src/lxc/cmd/lxc_monitord.c:67: error: undefined reference to 'lxc_monitor_fifo_name'
../src/lxc/cmd/lxc_monitord.c:104: error: undefined reference to 'lxc_monitor_fifo_name'
../src/lxc/cmd/lxc_monitord.c:140: error: undefined reference to 'lxc_read_nointr'
../src/lxc/cmd/lxc_monitord.c:193: error: undefined reference to 'lxc_mainloop_add_handler'
../src/lxc/cmd/lxc_monitord.c:219: error: undefined reference to 'lxc_monitor_sock_name'
../src/lxc/cmd/lxc_monitord.c:222: error: undefined reference to 'lxc_abstract_unix_open'
../src/lxc/cmd/lxc_monitord.c:236: error: undefined reference to 'lxc_monitor_sock_name'
../src/lxc/cmd/lxc_monitord.c:258: error: undefined reference to 'lxc_abstract_unix_close'
../src/lxc/cmd/lxc_monitord.c:277: error: undefined reference to 'lxc_read_nointr'
../src/lxc/cmd/lxc_monitord.c:284: error: undefined reference to 'lxc_write_nointr'
../src/lxc/cmd/lxc_monitord.c:297: error: undefined reference to 'lxc_mainloop_add_handler'
../src/lxc/cmd/lxc_monitord.c:306: error: undefined reference to 'lxc_mainloop_add_handler'
../src/lxc/cmd/lxc_monitord.c:343: error: undefined reference to 'lxc_global_config_value'
../src/lxc/cmd/lxc_monitord.c:351: error: undefined reference to 'lxc_safe_int'
../src/lxc/cmd/lxc_monitord.c:388: error: undefined reference to 'lxc_mainloop_open'
../src/lxc/cmd/lxc_monitord.c:405: error: undefined reference to 'lxc_write_nointr'
../src/lxc/cmd/lxc_monitord.c:420: error: undefined reference to 'lxc_mainloop'
../src/lxc/cmd/lxc_monitord.c:442: error: undefined reference to 'lxc_mainloop_close'
../src/include/netns_ifaddrs.c:430: error: undefined reference to 'addattr'
collect2: error: ld returned 1 exit status
[137/139] Linking target src/lxc/tools/lxc
FAILED: src/lxc/tools/lxc
gcc  -o src/lxc/tools/lxc src/lxc/tools/lxc.p/lxc_multicall.c.o src/lxc/tools/lxc.p/arguments.c.o src/lxc/tools/lxc.p/.._.._include_netns_ifaddrs.c.o src/lxc/tools/lxc.p/lxc_attach.c.o src/lxc/tools/lxc.p/lxc_autostart.c.o src/lxc/tools/lxc.p/lxc_cgroup.c.o src/lxc/tools/lxc.p/lxc_checkpoint.c.o src/lxc/tools/lxc.p/lxc_config.c.o src/lxc/tools/lxc.p/lxc_console.c.o src/lxc/tools/lxc.p/lxc_copy.c.o src/lxc/tools/lxc.p/lxc_create.c.o src/lxc/tools/lxc.p/lxc_destroy.c.o src/lxc/tools/lxc.p/lxc_device.c.o src/lxc/tools/lxc.p/lxc_execute.c.o src/lxc/tools/lxc.p/lxc_freeze.c.o src/lxc/tools/lxc.p/lxc_info.c.o src/lxc/tools/lxc.p/lxc_ls.c.o src/lxc/tools/lxc.p/lxc_snapshot.c.o src/lxc/tools/lxc.p/lxc_start.c.o src/lxc/tools/lxc.p/lxc_stop.c.o src/lxc/tools/lxc.p/lxc_top.c.o src/lxc/tools/lxc.p/lxc_unfreeze.c.o src/lxc/tools/lxc.p/lxc_unshare.c.o src/lxc/tools/lxc.p/lxc_wait.c.o src/lxc/tools/lxc.p/lxc_monitor.c.o -flto -Wl,--no-undefined -pie -Wl,--no-as-needed -Wl,--gc-sections -Wl,-z,relro -Wl,-z,now -fstack-protector -fstack-protector-strong -Wl,-fuse-ld=gold -Wl,--warn-common '-Wl,-rpath,$ORIGIN/../../..' -Wl,-rpath-link,/home/adam/git/lxc/build/ -Wl,--start-group src/lxc/liblxc.a liblxc.so.1.8.0 /nix/store/jnlxl2ry9y03vq4skhm26igfd84xwa93-dbus-1.14.10-lib/lib/libdbus-1.so -pthread /nix/store/iglb2fmla149fbprj6fb18swfls033q4-libseccomp-2.5.4-lib/lib/libseccomp.so /nix/store/5mfk83ikgk62gv0xj95xylnkf0f52chv-libselinux-3.3/lib/libselinux.so /nix/store/wp5c5sjlvm6nxavvs1prdnw5n41mgciq-libapparmor-3.1.6/lib/libapparmor.so /nix/store/c7rf6w8xvxc4423m9rsgq5nsqhknshvy-openssl-3.0.12/lib/libssl.so /nix/store/c7rf6w8xvxc4423m9rsgq5nsqhknshvy-openssl-3.0.12/lib/libcrypto.so /nix/store/lmj8lfkd8h448grf1nf92lsm5gm2fnf6-libcap-2.69-lib/lib/libcap.so -lutil -Wl,--end-group
../src/lxc/tools/arguments.c:214: error: undefined reference to 'remove_trailing_slashes'
../src/include/netns_ifaddrs.c:430: error: undefined reference to 'addattr'
../src/lxc/tools/lxc_attach.c:41: error: undefined reference to 'lxc_rexec'
../src/lxc/tools/lxc_attach.c:165: error: undefined reference to 'lxc_namespace_2_std_identifiers'
../src/lxc/tools/lxc_attach.c:168: error: undefined reference to 'lxc_fill_namespace_flags'
../src/lxc/tools/lxc_attach.c:202: error: undefined reference to 'lxc_safe_uint'
../src/lxc/tools/lxc_attach.c:206: error: undefined reference to 'lxc_safe_uint'
../src/lxc/tools/lxc_attach.c:331: error: undefined reference to 'lxc_caps_init'
../src/lxc/tools/lxc_attach.c:442: error: undefined reference to 'lxc_wait_for_pid_status'
../src/lxc/tools/lxc_autostart.c:48: error: undefined reference to 'lxc_safe_long'
```

at the same time everything works just fine on Ubuntu 20/22.

Let's workaround this for now by using `link_whole` instead of `link_with`, which means that we are explicitly asking all symbols to be linked (independent from if they are used or not). It's not a big deal, as this two binaries are big anyways. It's in my TODO to refactor all this build mess, but it's just too hard to make it at once and it requires a lot of changes and code reshuffling.

It's still interesting what's the difference between NixOS and Ubuntu in that regard. From what I found during debugging is that meson on NixOS (version 1.3.2) generates dependency files differently from how meason on Ubuntu does (version 0.61.2). Likely there is a problem, but it's a matter of further investigation.

Fixes: #4427