### PR TITLE
Fixed cgroup2 path issue in LXC-Top

### DIFF
--- a/src/lxc/tools/lxc_top.c
+++ b/src/lxc/tools/lxc_top.c
@@ -41,10 +41,18 @@ struct cpu_stats {
 };
 
 struct mem_stats {
+	union {
+		struct {
+			uint64_t swap_used;
+			uint64_t swap_limit;
+		}; /* v2 only */
+		struct {
+			uint64_t memsw_used;
+			uint64_t memsw_limit;
+		}; /* v1 only */
+	};
 	uint64_t used;
 	uint64_t limit;
-	uint64_t swap_used;
-	uint64_t swap_limit;
 	uint64_t kmem_used;
 	uint64_t kmem_limit;
 };
@@ -362,12 +370,12 @@ out:
 
 static int cg1_mem_stats(struct lxc_container *c, struct mem_stats *mem)
 {
-	mem->used       = stat_get_int(c, "memory.usage_in_bytes");
-	mem->limit      = stat_get_int(c, "memory.limit_in_bytes");
-	mem->swap_used  = stat_get_int(c, "memory.memsw.usage_in_bytes");
-	mem->swap_limit = stat_get_int(c, "memory.memsw.limit_in_bytes");
-	mem->kmem_used  = stat_get_int(c, "memory.kmem.usage_in_bytes");
-	mem->kmem_limit = stat_get_int(c, "memory.kmem.limit_in_bytes");
+	mem->used        = stat_get_int(c, "memory.usage_in_bytes");
+	mem->limit       = stat_get_int(c, "memory.limit_in_bytes");
+	mem->memsw_used  = stat_get_int(c, "memory.memsw.usage_in_bytes");
+	mem->memsw_limit = stat_get_int(c, "memory.memsw.limit_in_bytes");
+	mem->kmem_used   = stat_get_int(c, "memory.kmem.usage_in_bytes");
+	mem->kmem_limit  = stat_get_int(c, "memory.kmem.limit_in_bytes");
 	return mem->used > 0 ? 0 : -1;
 }
 
@@ -423,6 +431,7 @@ static void stats_get(struct lxc_container *c, struct container_stats *ct, struc
 		/* only with cgroups v1 */
 		cg1_get_blk_stats(c, "blkio.throttle.io_serviced", &ct->stats->io_serviced);
 	}
+
 
 	if (total) {
 		total->mem.used       += ct->stats->mem.used;

--- a/src/lxc/tools/lxc_top.c
+++ b/src/lxc/tools/lxc_top.c
@@ -373,14 +373,13 @@ static int cg1_mem_stats(struct lxc_container *c, struct mem_stats *mem)
 
 static int cg2_mem_stats(struct lxc_container *c, struct mem_stats *mem)
 {
-	mem->used       = stat_get_int(c, "memory.current");
-	mem->limit      = stat_get_int(c, "memory.max");
-	mem->swap_used  = stat_get_int(c, "memory.swap.current");
-	mem->swap_limit = stat_get_int(c, "memory.swap.max");
-	/* TODO: find the kernel usage */
-	mem->kmem_used  = 0;
+	mem->used          = stat_get_int(c, "memory.current");
+	mem->limit         = stat_get_int(c, "memory.max");
+	mem->swap_used     = stat_get_int(c, "memory.swap.current");
+	mem->swap_limit    = stat_get_int(c, "memory.swap.max");
+	mem->kmem_used     = stat_match_get_int(c, "memory.stat", "kernel", 1);
 	/* does not exist in cgroup v2 */
-	mem->kmem_limit = 0;
+	// mem->kmem_limit = 0;
 	return mem->used > 0 ? 0 : -1;
 }
 

--- a/src/lxc/tools/lxc_top.c
+++ b/src/lxc/tools/lxc_top.c
@@ -732,7 +732,7 @@ int lxc_top_main(int argc, char *argv[])
 			stats_print_header(&total);
 		}
 
-		for (i = 0; i < active_cnt && i < (ct_print_cnt || batch); i++) {
+		for (i = 0; i < active_cnt && ((i < ct_print_cnt) || batch); i++) {
 			stats_print(container_stats[i].c->name, container_stats[i].stats, &total);
 			printf("\n");
 		}

--- a/src/lxc/tools/lxc_top.c
+++ b/src/lxc/tools/lxc_top.c
@@ -732,7 +732,7 @@ int lxc_top_main(int argc, char *argv[])
 			stats_print_header(&total);
 		}
 
-		for (i = 0; i < active_cnt && i < ct_print_cnt; i++) {
+		for (i = 0; i < active_cnt && i < (ct_print_cnt || batch); i++) {
 			stats_print(container_stats[i].c->name, container_stats[i].stats, &total);
 			printf("\n");
 		}


### PR DESCRIPTION
We implimented some of the functionality to convert the cgroup paths to cgroup2 paths. However, we do not know how to tell whether system is using cgroup or cgroup2. In addition, some of the paths for cgroup did not have cgroup2 equivalents in the incus directory. 

Fixes #4376
Fixes https://github.com/lxc/lxc/issues/3372