### PR TITLE
Update lxc-execute.sgml.in

### DIFF
--- a/doc/lxc-execute.sgml.in
+++ b/doc/lxc-execute.sgml.in
@@ -124,7 +124,7 @@
 	</term>
 	<listitem>
 	  <para>
-	    Executes the <replaceable>command</replaceable> with user ID
+	    Executes the <replaceable>command</replaceable> with user ID (use numerical value)
 	    <replaceable>uid</replaceable> inside the container.
 	  </para>
 	</listitem>
@@ -136,7 +136,7 @@
 	</term>
 	<listitem>
 	  <para>
-	    Executes the <replaceable>command</replaceable> with group ID
+	    Executes the <replaceable>command</replaceable> with group ID (use numerical value)
 	    <replaceable>gid</replaceable> inside the container.
 	  </para>
 	</listitem>


### PR DESCRIPTION
add hint to use numerical values for uid and gid