### PR TITLE
Update lxc-attach.sgml.in

### DIFF
--- a/doc/lxc-attach.sgml.in
+++ b/doc/lxc-attach.sgml.in
@@ -266,7 +266,7 @@
 	</term>
 	<listitem>
 	  <para>
-	    Executes the <replaceable>command</replaceable> with user ID
+	    Executes the <replaceable>command</replaceable> with user ID (use numerical value)
 	    <replaceable>uid</replaceable> inside the container.
 	  </para>
 	</listitem>
@@ -278,7 +278,7 @@
 	</term>
 	<listitem>
 	  <para>
-	    Executes the <replaceable>command</replaceable> with group ID
+	    Executes the <replaceable>command</replaceable> with group ID (use numerical value)
 	    <replaceable>gid</replaceable> inside the container.
 	  </para>
 	</listitem>


### PR DESCRIPTION
added hint to use numerical value for uid and gid