### PR TITLE
lxc-local: fix broken templates processing

### DIFF
--- a/templates/lxc-local.in
+++ b/templates/lxc-local.in
@@ -18,7 +18,7 @@ MODE="system"
 COMPAT_LEVEL=5
 
 EXCLUDES=""
-TEMPLATE_FILES="${LXC_PATH}/config"
+TEMPLATE_FILES=""
 
 
 # Make sure the usual locations are in PATH
@@ -169,6 +169,14 @@ process_excludes() {
   fi
 }
 
+record_template_file() {
+  if [ -z "${TEMPLATE_FILES}" ]; then
+    TEMPLATE_FILES="$1"
+  else
+    TEMPLATE_FILES="${TEMPLATE_FILES};$1"
+  fi
+}
+
 extract_config() {
   # lxc-create will automatically create a config file at ${LXC_PATH}/config.
   # This function extracts the network config, and any remaining lxc config
@@ -237,6 +245,7 @@ process_config() {
   add_container_config
   add_extra_config
   add_network_config
+  record_template_file "${LXC_PATH}/config"
 }
 
 process_fstab() {
@@ -246,7 +255,7 @@ process_fstab() {
   if [ -e "${fstab}" ]; then
     echo "lxc.mount.fstab = ${LXC_PATH}/fstab" >> "${LXC_PATH}/config"
     cp "${fstab}" "${LXC_PATH}/fstab"
-    TEMPLATE_FILES="${TEMPLATE_FILES};${LXC_PATH}/fstab"
+    record_template_file "${LXC_PATH}/fstab"
   fi
 }
 
@@ -257,7 +266,7 @@ process_templates() {
     while read -r line; do
       fullpath="${LXC_ROOTFS}/${line}"
       [ ! -e "${fullpath}" ] && continue
-      TEMPLATE_FILES="${TEMPLATE_FILES};${fullpath}"
+      record_template_file "${fullpath}"
     done < "${template}"
   fi
 }

--- a/templates/lxc-local.in
+++ b/templates/lxc-local.in
@@ -261,13 +261,13 @@ process_fstab() {
 
 process_templates() {
   # Look for extra templates
-  template="$(relevant_file template)"
-  if [ -e "${template}" ]; then
+  templates="$(relevant_file templates)"
+  if [ -e "${templates}" ]; then
     while read -r line; do
       fullpath="${LXC_ROOTFS}/${line}"
       [ ! -e "${fullpath}" ] && continue
       record_template_file "${fullpath}"
-    done < "${template}"
+    done < "${templates}"
   fi
 }
 

--- a/templates/lxc-local.in
+++ b/templates/lxc-local.in
@@ -265,7 +265,6 @@ process_templates() {
   if [ -e "${templates}" ]; then
     while read -r line; do
       fullpath="${LXC_ROOTFS}/${line}"
-      [ ! -e "${fullpath}" ] && continue
       record_template_file "${fullpath}"
     done < "${templates}"
   fi


### PR DESCRIPTION
Fix bugs which break templates processing in `lxc-local`, apparently introduced in https://github.com/lxc/lxc/pull/4368/commits/f885a3c56047a05436ec4466833465b25e406474.

See individual commits.

Resolves #4436 