### PR TITLE
Exit 0 when there's no error

### DIFF
--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -147,7 +147,7 @@ eval set -- "$options"
 
 while :; do
   case "$1" in
-    -h|--help)     usage && exit 1;;
+    -h|--help)     usage && exit 0;;
     -l|--list)     DOWNLOAD_LIST_IMAGES="true"; shift 1;;
     -d|--dist)     DOWNLOAD_DIST="$2"; shift 2;;
     -r|--release)  DOWNLOAD_RELEASE="$2"; shift 2;;
@@ -247,7 +247,7 @@ if [ "${DOWNLOAD_LIST_IMAGES}" = "true" ] || [ "${DOWNLOAD_INTERACTIVE}" = "true
   echo "---"
 
   if [ "${DOWNLOAD_LIST_IMAGES}" = "true" ]; then
-    exit 1
+    exit 0
   fi
 
   # Interactive mode


### PR DESCRIPTION
Running `bash lxc-download.in --help` and `bash lxc-download.in --list` currently results in a non-zero exit code, indicating an error occurred (e.g. wget is not installed to download the image index). This PR changes the exit code for `--help` and `--list` to 0 so that a successful run with these flags can be distinguished from runs where a failure occurred.