### PR TITLE
fix possible clang compile error on AARCH

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -503,7 +503,11 @@ int func (void) {
 }
 '''
 
-have_func_strerror_r_char_p = cc.compiles(code, name : 'strerror_r() returns char *')
+    if cc.get_id() == 'clang'
+        have_func_strerror_r_char_p = cc.compiles(code, args : '-Wno-error=unused-command-line-argument', name : 'strerror_r() returns char *')
+    else
+        have_func_strerror_r_char_p = cc.compiles(code, name : 'strerror_r() returns char *')
+    endif
 endif
 
 srcconf.set10('STRERROR_R_CHAR_P', have_func_strerror_r_char_p)


### PR DESCRIPTION
this fix issue #4480 
When I use clang to build on openEuler-24.03-LTS(aarch64),I got the error:

```c
[  112s] [2/1785] Compiling C object src/lxc/liblxc.a.p/error.c.o
[  112s] FAILED: src/lxc/liblxc.a.p/error.c.o 
[  112s] clang -Isrc/lxc/liblxc.a.p -Isrc/lxc -I../src/lxc -I. -I.. -Isrc -I../src -Isrc/include -I../src/include -I../src/lxc/json -I../src/lxc/cgroups -I../src/lxc/storage -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu11 -O0 -g -include config.h -O2 -g -grecord-gcc-switches -pipe -fstack-protector-strong -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS --config /usr/lib/rpm/generic-hardened-clang.cfg -fasynchronous-unwind-tables -fstack-clash-protection -fsigned-char -fPIC -pthread -fvisibility=default -MD -MQ src/lxc/liblxc.a.p/error.c.o -MF src/lxc/liblxc.a.p/error.c.o.d -o src/lxc/liblxc.a.p/error.c.o -c ../src/lxc/error.c
[  112s] clang: warning: argument unused during compilation: '-fstack-clash-protection' [-Wunused-command-line-argument]
[  112s] In file included from ../src/lxc/error.c:10:
[  112s] ../src/lxc/log.h:310:6: error: conflicting types for 'strerror_r'
[  112s]   310 |         int strerror_r(int errnum, char *buf, size_t buflen);
[  112s]       |             ^
[  112s] /usr/include/string.h:444:14: note: previous declaration is here
[  112s]   444 | extern char *strerror_r (int __errnum, char *__buf, size_t __buflen)
[  112s]       |              ^
[  112s] 1 error generated.
```

And I find

```c
[   94s] Checking if "strerror_r() returns char *" compiles: NO 
```

The bug comes from `meson.build`

```c
    code = '''
#define _GNU_SOURCE
#include <string.h>
int func (void) {
    char error_string[256];
    char *ptr = strerror_r (-2, error_string, 256);
    char c = *strerror_r (-2, error_string, 256);
    return c != 0 && ptr != (void*) 0L;
}
'''

have_func_strerror_r_char_p = cc.compiles(code, name : 'strerror_r() returns char *')
```

Actually the result of "Checking if "strerror_r() returns char *" compiles"on my system(openEuler-24.03-LTS) should be YES.

I finally find the reason of the bug is:the argument '-fstack-clash-protection' for clang is currently not supported in aarch,so when enabling '-Werror',the warning will turn to be an error,that's why `cc.compiles(code, name : 'strerror_r() returns char *')`return unexpected error.


Besides,there's no option'`-Wunused-command-line-argument`'in gcc,so I use if to separate clang and gcc situation.


Please fix the possible error anyway,you can take my modifying suggestion or use a better method.

Thanks!