### PR TITLE
meson.build: add -ffat-lto-objects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -204,7 +204,6 @@ possible_cc_flags = [
     '-Wunused-but-set-variable',
     '-Wno-unused-parameter',
     '-Wfloat-equal',
-    '-Wsuggest-attribute=noreturn',
     '-Werror=return-type',
     '-Werror=incompatible-pointer-types',
     '-Wformat=2',


### PR DESCRIPTION
Otherwise, if we generate a static library, lintian warns that it has no code sections.  See

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=977596