### PR TITLE
Avoid null pointer dereference when using shared rootfs

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -341,6 +341,10 @@ int lxc_rootfs_init(struct lxc_conf *conf, bool userns)
 	ret = lxc_storage_prepare(conf);
 	if (ret)
 		return syserror_set(-EINVAL, "Failed to prepare rootfs storage");
+
+	if (!rootfs->storage)
+		return log_trace(0, "Not pinning because container does not have storage");
+
 	type = rootfs->storage->type;
 
 	if (!type)


### PR DESCRIPTION
rootfs->storage not set by lxc_storage_prepare when using a shared rootfs.

Fixes: https://github.com/lxc/lxc/issues/4476

Tested on Fedora 41 Beta with 6.0.2 via patched rpm rebuild.