### PR TITLE
fix return code of recursive all of cgroup_tree_prune

### DIFF
--- a/src/lxc/cgroups/cgroup_utils.c
+++ b/src/lxc/cgroups/cgroup_utils.c
@@ -83,7 +83,7 @@ int cgroup_tree_prune(int dfd, const char *path)
 
 		ret = cgroup_tree_prune(dfd_dup, direntp->d_name);
 		if (ret < 0)
-			return -errno;
+			return ret;
 	}
 
 	ret = unlinkat(dfd, path, AT_REMOVEDIR);


### PR DESCRIPTION
IMHO, the value to return here is `ret` as it is the value got from recursion. Because this is not a call to a I/O-function, the value of `errno` is unrelated to this call, u.e. undefined.