### PR TITLE
network config of unprivileged containers is not shown

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -2219,17 +2219,23 @@ WRAP_API_1(bool, lxcapi_clear_config_item, const char *)
 
 static inline bool enter_net_ns(struct lxc_container *c)
 {
+	bool net_ns_entered;
 	pid_t pid = do_lxcapi_init_pid(c);
 
 	if (pid < 0)
 		return false;
+
+	net_ns_entered = switch_to_ns(pid, "net");
 
 	if ((geteuid() != 0 || (c->lxc_conf && !list_empty(&c->lxc_conf->id_map))) &&
 	    (access("/proc/self/ns/user", F_OK) == 0))
 		if (!switch_to_ns(pid, "user"))
 			return false;
 
-	return switch_to_ns(pid, "net");
+	if (!net_ns_entered)
+		return switch_to_ns(pid, "net");
+
+	return true;
 }
 
 /* Used by qsort and bsearch functions for comparing names. */


### PR DESCRIPTION
When an unprivileged container is running with an inheritted network namespace, then the ip addresses of the container are not shown with 'lxc-ls -f'.

This MR solves  #4496