### PR TITLE
confile-vlanid: undefined is not a zero value

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -6209,7 +6209,8 @@ static int get_config_net_veth_vlan_id(const char *key, char *retv, int inlen,
 	else
 		memset(retv, 0, inlen);
 
-	strprint(retv, inlen, "%d", netdev->priv.veth_attr.vlan_id);
+	if (netdev->priv.veth_attr.vlan_id_set)
+		strprint(retv, inlen, "%d", netdev->priv.veth_attr.vlan_id);
 
 	return fulllen;
 }


### PR DESCRIPTION
Full description was in issue: [#4474](https://github.com/lxc/lxc/issues/4474)

Main problem was explained in 'consequence2', if we have a config with undefined (missing) line about vlan.id, after we just load_config then save_config, config file will change it contents and it will have unwanted vlan.id=0 line that cause new set of problems and blocks container from starting.

This change (one condition-line added in code) solves this problem well. Someone already prepared bool value that will mark int(0) value as valid or undefined, and this new line just uses that bool var (**vlan_id_set**), as it was probably intended to be used.

This was patched locally in my own test version 5 months ago and tested/used since then, so I am pretty sure that is valid.