### PR TITLE
LXC attach exit on SIGCHLD corrections and ignore-param

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1430,6 +1430,19 @@ static inline void lxc_attach_terminal_close_log(struct lxc_terminal *terminal)
 	close_prot_errno_disarm(terminal->log_fd);
 }
 
+void lxc_attach_sig_handler(int signum)
+{
+	if (signum == SIGCHLD) {
+		/* SIG_IGN for SIGTERM will:
+		 *   - prevent shell from printing 'pid terminated' message
+		 *   - makes the program exit with code 0 (not 143)
+		 *   - NOT really disable SIGTERM from terminating the program
+		 */
+		signal(SIGTERM, SIG_IGN);
+		raise(SIGTERM);
+	}
+}
+
 int lxc_attach(struct lxc_container *container, lxc_attach_exec_t exec_function,
 	       void *exec_payload, lxc_attach_options_t *options,
 	       pid_t *attached_process)
@@ -1741,6 +1754,10 @@ int lxc_attach(struct lxc_container *container, lxc_attach_exec_t exec_function,
 		goto close_mainloop;
 
 	TRACE("Transient process %d exited", pid);
+
+	/* After trans-proc exit, add SIGCHLD handler if option flag is set */
+	if (options->attach_flags & LXC_ATTACH_SIGCHLD_EXIT)
+		signal(SIGCHLD, lxc_attach_sig_handler);
 
 	/* We will always have to reap the attached process now. */
 	to_cleanup_pid = attached_pid;

--- a/src/lxc/attach_options.h
+++ b/src/lxc/attach_options.h
@@ -55,6 +55,8 @@ enum {
 	LXC_ATTACH_SETGROUPS             = 0x00200000, /*!< Set additional group ids specified in @groups. */
 #define LXC_ATTACH_SETGROUPS             LXC_ATTACH_SETGROUPS
 
+	LXC_ATTACH_SIGCHLD_EXIT          = 0x00400000, /*!< Exit on SIGCHLD */
+#define LXC_ATTACH_SIGCHLD_EXIT          LXC_ATTACH_SIGCHLD_EXIT
 
 	/* We have 16 bits for things that are on by default and 16 bits that
 	 * are off by default, that should be sufficient to keep binary


### PR DESCRIPTION
TRY2: 

- not using exit() nor _exit()  but raise(SIGTERM) as it works ok, cause clean deleting and restoring PTY
- setting signal handler moved down in code after verified transient process exit (so transient process can not fire sigchld anymore that caused race condition)
- added option flag 'LXC_ATTACH_SIGCHLD_EXIT' that is OFF by default, so API function `->attach()` and code other than lxc-attach tool command will behave as before.
- tool **lxc-attach** puts this flag to ON by default, and for lxc-attach new command line parameter introduced `--sigchld-ignore (-G)`, which can overide this new behaviour by leaving flag LXC_ATTACH_SIGCHLD_EXIT to value OFF.

original issue: https://github.com/lxc/lxc/issues/4507 
than code is [reverted back](https://github.com/lxc/lxc/pull/4517) because of regressions - that I hope are solved here. @mihalicyn should check if this is acceptable

Not sure will this new parameter be used in reality, maybe already existent 'LXC_ATTACH_TERMINAL' could be used and enough (api will not have it by default and only lxc-attach tool set it), so maybe just this few lines could be enough:
https://github.com/lxc/lxc/compare/main...asainkujovic:lxc:sigchld_try2