### PR TITLE
sysconfig/lxc: remove false comment

### DIFF
--- a/config/sysconfig/lxc.in
+++ b/config/sysconfig/lxc.in
@@ -23,6 +23,6 @@ OPTIONS=
 #	If you want to kill containers fast, use -k
 STOPOPTS="-a -A -s"
 
-USE_LXC_BRIDGE="false"  # overridden in lxc-net
+USE_LXC_BRIDGE="false"
 
 [ ! -f @LXC_DISTRO_SYSCONF@/lxc-net ] || . @LXC_DISTRO_SYSCONF@/lxc-net


### PR DESCRIPTION
I tested running `lxc-net` and this setting was not overridden. Changing this setting did affect if `lxcbr0` was created. If this setting is supposed to be ignored in `lxc-net`, I can create a bug report for it.