### PR TITLE
lxc/conf,start: fix setting container_ttys environment variable

### DIFF
--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -971,15 +971,6 @@ static int lxc_create_ttys(struct lxc_handler *handler)
 		}
 	}
 
-	if (conf->ttys.tty_names) {
-		ret = setenv("container_ttys", conf->ttys.tty_names, 1);
-		if (ret < 0) {
-			SYSERROR("Failed to set \"container_ttys=%s\"", conf->ttys.tty_names);
-			goto on_error;
-		}
-		TRACE("Set \"container_ttys=%s\"", conf->ttys.tty_names);
-	}
-
 	return 0;
 
 on_error:

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1372,7 +1372,7 @@ static int do_start(void *data)
 	}
 
 	if (handler->conf->ttys.tty_names) {
-		ret = putenv(handler->conf->ttys.tty_names);
+		ret = setenv("container_ttys", handler->conf->ttys.tty_names, 1);
 		if (ret < 0) {
 			SYSERROR("Failed to set environment variable for container ptys");
 			goto out_warn_father;


### PR DESCRIPTION
Commit eae44ce19931 ("conf: fix append_ttyname()") changed the format of `conf->ttys.tty_names`, where the `container_ttys=` prefix was removed.

This seems to have been taken into account in `lxc_create_ttys()` in `src/lxc/conf.c`, however that's not enough. `do_start()` in `src/lxc/start.c` clears the environment, and then does `putenv(...)` directly on the value of `tty_names`. As it no longer has the `container_ttys=` prefix, this call doesn't have the intended effect.

This behaviour is also confirmed via `ltrace` when doing `lxc-start`:

	[pid 53587] liblxc.so.1->setenv("container_ttys", "pts/1 pts/2 pts/3 pts/4", 1) = 0
	[pid 53587] liblxc.so.1->clearenv(0, 1, 0, 0)                                   = 0
	[pid 53587] liblxc.so.1->putenv("container=lxc")                                = 0
	[pid 53587] liblxc.so.1->putenv("pts/1 pts/2 pts/3 pts/4")                      = 0

Given that `do_start()` clears the environment anyway, there is no reason for another `setenv()` call in `lxc_create_ttys()`, and a fix is required for `putenv()` in `do_start()`.

Change the `putenv()` call to `setenv()` in `do_start()` to account for the change of format in `conf->ttys.tty_names`. Remove extraneous `setenv()` from `lxc_create_ttys()`.

Fixes #4198

Fixes: eae44ce19931 ("conf: fix append_ttyname()")

---

If this gets accepted, I believe it needs to be applied to `stable-6.0` and `stable-5.0` branches as well.