### PR TITLE
Add loong64 to list of recognized architectures

### DIFF
--- a/config/bash/_lxc.in
+++ b/config/bash/_lxc.in
@@ -285,7 +285,7 @@ _lxc_attach() {
             ;;
         --arch | -a )
             # https://github.com/lxc/lxc/blob/stable-4.0/src/tests/arch_parse.c#L37
-            COMPREPLY=( $( compgen -W 'arm armel armhf armv7l athlon i386 i486 i586 i686 linux32 mips mipsel ppc powerpc x86 aarch64 amd64 arm64 linux64 loongarch64 mips64 mips64el ppc64 ppc64el ppc64le powerpc64 riscv64 s390x x86_64' -- "${cur}" ) )
+            COMPREPLY=( $( compgen -W 'arm armel armhf armv7l athlon i386 i486 i586 i686 linux32 mips mipsel ppc powerpc x86 aarch64 amd64 arm64 linux64 loongarch64 loong64 mips64 mips64el ppc64 ppc64el ppc64le powerpc64 riscv64 s390x x86_64' -- "${cur}" ) )
             return
             ;;
         --elevated-privileges | -e )

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -3275,6 +3275,7 @@ int lxc_config_parse_arch(const char *arch, signed long *persona)
 		{ "arm64",         PER_LINUX   },
 		{ "linux64",       PER_LINUX   },
 		{ "loongarch64",   PER_LINUX   },
+		{ "loong64",       PER_LINUX   },
 		{ "mips64",        PER_LINUX   },
 		{ "mips64el",      PER_LINUX   },
 		{ "ppc64",         PER_LINUX   },

--- a/src/tests/arch_parse.c
+++ b/src/tests/arch_parse.c
@@ -25,11 +25,11 @@
 #endif
 
 static const char *const arches[] = {
-    "arm",       "armel",    "armhf",    "armv7l",   "athlon",     "i386",         "i486",
-    "i586",      "i686",     "linux32",  "mips",     "mipsel",     "ppc",          "powerpc",
-    "x86",       "aarch64",  "amd64",    "arm64",    "linux64",    "loongarch64",  "mips64",
-    "mips64el",  "ppc64",    "ppc64el",  "ppc64le",  "powerpc64",  "riscv64",      "s390x",
-    "x86_64",
+    "arm",     "armel",     "armhf",    "armv7l",   "athlon",   "i386",         "i486",
+    "i586",    "i686",      "linux32",  "mips",     "mipsel",   "ppc",          "powerpc",
+    "x86",     "aarch64",   "amd64",    "arm64",    "linux64",  "loongarch64",  "loong64",
+    "mips64",  "mips64el",  "ppc64",    "ppc64el",  "ppc64le",  "powerpc64",    "riscv64",
+    "s390x",   "x86_64",
 };
 
 static bool parse_valid_architectures(void)


### PR DESCRIPTION
Debian refers to the loong architecture as "loong64".