### PR TITLE
meson.build: set `LXC_DISTRO_SYSCONF` when `-Dspecfile=true`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -151,7 +151,7 @@ want_dbus = get_option('dbus')
 
 # Set sysconfdir
 fs = import('fs')
-if want_install_init
+if want_install_init or want_spec
     distrosysconfdir = get_option('distrosysconfdir')
     if distrosysconfdir != ''
         distrosysconfdir = join_paths(sysconfdir, distrosysconfdir)


### PR DESCRIPTION
Before the change, the `setup` meson step would fail when disabling the `install-init-files` option:

	$ meson setup -Dinstall-init-files=false build
	<snip>
	meson.build:936:44: ERROR: Entry LXC_DISTRO_SYSCONF not in configuration data.

This is because setting the `LXC_DISTRO_SYSCONF` option is conditional and requires `install-init-files` to be enabled.

Meanwhile the `specfile` option (default enabled) also requires the variable above, resulting in a failure when it is unset.

Amend the conditional to also set `LXC_DISTRO_SYSCONF` when `specfile` option is `true`.

Fixes: 872db5424363 ("build: add more options for customizing install")