### PR TITLE
lxc/process_utils.h: use strsignal() or sys_siglist[] for Non-GNU dis…

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -570,6 +570,8 @@ foreach ident: [
                              #include <mntent.h>'''],
     ['setns',             '''#include <sched.h>'''],
     ['sigdescr_np',       '''#include <string.h>'''],
+    ['strsignal',         '''#include <string.h>'''],
+    ['sys_siglist',       '''#include <signal.h>'''],
     ['signalfd',          '''#include <sys/signalfd.h>'''],
     ['statvfs',           '''#include <sys/statvfs.h>'''],
     ['statx',             '''#include <sys/types.h>
@@ -624,6 +626,8 @@ foreach tuple: [
     ['setmntent'],
     ['setns'],
     ['sigdescr_np'],
+    ['strsignal'],
+    ['sys_siglist'],
     ['signalfd'],
     ['statx'],
     ['statvfs'],

--- a/src/lxc/process_utils.h
+++ b/src/lxc/process_utils.h
@@ -300,6 +300,10 @@ static inline const char *signal_name(int sig)
 
 #if HAVE_SIGDESCR_NP
 	s = sigdescr_np(sig);
+#elif HAVE_STRSIGNAL
+	s = strsignal(sig);
+#elif HAVE_SYS_SIGLIST
+	s = sys_siglist[sig];
 #else
 	s = "UNSUPPORTED";
 #endif


### PR DESCRIPTION
…tros

use strsignal() for Non-GNU and sys_siglist[] for nothing, even if sys_siglist[] has been marked as deprecated by Glibc