### PR TITLE
conf: split `lxc.environment` into `runtime` and `hooks`

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -160,3 +160,10 @@ This adds the new options `cgroup2`, `cgroup2:ro`, `cgroup2:force`,
 `cgroup2:ro:force` for the `lxc.mount.auto` configuration key. For example, if
 a user specifies `cgroup2:force` LXC will pre-mount a pure `cgroup2` layout for
 the container even if the host is running with a hybrid layout.
+
+## environment\_runtime\_hooks
+
+This introduces `lxc.environment.runtime` and `lxc.environment.hooks`
+configuration keys to allow environment variables to be applied only to the
+container init process or only to hooks respectively.
+`lxc.environment` remains and still applies to both.

--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -2990,7 +2990,14 @@
       </para>
 
       <para>
-        This configuration parameter can be specified multiple times; once
+        Subkeys are available to narrow the scope of environment variables:
+        <command>lxc.environment.runtime</command> applies only to
+        the container's init process (and all its descendents),
+        and <command>lxc.environment.hooks</command> applies only to hooks.
+      </para>
+
+      <para>
+        These configuration parameters can be specified multiple times; once
         for each environment variable you wish to configure.
       </para>
 
@@ -3001,8 +3008,8 @@
           </term>
           <listitem>
             <para>
-              Specify an environment variable to pass into the container.
-              Example:
+              Environment variables applied both to the container init process
+              and to hooks. Example:
             </para>
             <programlisting>
               lxc.environment = APP_ENV=production
@@ -3015,6 +3022,29 @@
             <programlisting>
               lxc.environment = PATH
             </programlisting>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>
+            <option>lxc.environment.runtime</option>
+          </term>
+          <listitem>
+            <para>
+              Environment variables applied only to the container's init
+              process.
+            </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>
+            <option>lxc.environment.hooks</option>
+          </term>
+          <listitem>
+            <para>
+              Environment variables applied only to hooks.
+            </para>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/src/lxc/api_extensions.h
+++ b/src/lxc/api_extensions.h
@@ -52,6 +52,7 @@ static char *api_extensions[] = {
 	"idmapped_mounts_v2",
 	"core_scheduling",
 	"cgroup2_auto_mounting",
+	"environment_runtime_hooks",
 };
 
 static size_t nr_api_extensions = sizeof(api_extensions) / sizeof(*api_extensions);

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -879,7 +879,11 @@ static int lxc_attach_set_environment(struct attach_context *ctx,
 
 	/* Set container environment variables.*/
 	if (ctx->container->lxc_conf) {
-		ret = lxc_set_environment(ctx->container->lxc_conf);
+		ret = lxc_set_environment(&ctx->container->lxc_conf->environment);
+		if (ret < 0)
+			return -1;
+
+		ret = lxc_set_environment(&ctx->container->lxc_conf->environment_runtime);
 		if (ret < 0)
 			return -1;
 	}

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3209,6 +3209,8 @@ struct lxc_conf *lxc_conf_init(void)
 	new->root_nsuid_map = NULL;
 	new->root_nsgid_map = NULL;
 	INIT_LIST_HEAD(&new->environment);
+	INIT_LIST_HEAD(&new->environment_runtime);
+	INIT_LIST_HEAD(&new->environment_hooks);
 	INIT_LIST_HEAD(&new->limits);
 	INIT_LIST_HEAD(&new->sysctls);
 	INIT_LIST_HEAD(&new->procs);
@@ -4239,18 +4241,18 @@ int lxc_clear_groups(struct lxc_conf *c)
 	return 0;
 }
 
-int lxc_clear_environment(struct lxc_conf *c)
+int lxc_clear_environment(struct list_head *environment)
 {
 	struct environment_entry *env, *nenv;
 
-	list_for_each_entry_safe(env, nenv, &c->environment, head) {
+	list_for_each_entry_safe(env, nenv, environment, head) {
 		list_del(&env->head);
 		free(env->key);
 		free(env->val);
 		free(env);
 	}
 
-	INIT_LIST_HEAD(&c->environment);
+	INIT_LIST_HEAD(environment);
 	return 0;
 }
 
@@ -4359,7 +4361,7 @@ void lxc_conf_free(struct lxc_conf *conf)
 	lxc_clear_mount_entries(conf);
 	lxc_clear_idmaps(conf);
 	lxc_clear_groups(conf);
-	lxc_clear_environment(conf);
+	lxc_clear_environment(&conf->environment);
 	lxc_clear_limits(conf, "lxc.prlimit");
 	lxc_clear_sysctls(conf, "lxc.sysctl");
 	lxc_clear_procs(conf, "lxc.proc");
@@ -5210,11 +5212,11 @@ void suggest_default_idmap(void)
 	ERROR("lxc.idmap = g 0 %u %u", gid, grange);
 }
 
-int lxc_set_environment(const struct lxc_conf *conf)
+int lxc_set_environment(const struct list_head *environment)
 {
 	struct environment_entry *env;
 
-	list_for_each_entry(env, &conf->environment, head) {
+	list_for_each_entry(env, environment, head) {
 		int ret;
 
 		ret = setenv(env->key, env->val, 1);

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -506,9 +506,16 @@ struct lxc_conf {
 	unsigned int monitor_unshare;
 	unsigned int monitor_signal_pdeath;
 
-	/* list of environment variables we'll add to the container when
-	 * started */
+	/* list of environment variables to provide to both the container's init
+	 * process and hooks */
 	struct list_head environment;
+
+	/* list of environment variables to provide to the container's init
+	 * process */
+	struct list_head environment_runtime;
+
+	/* list of environment variables to provide to container hooks */
+	struct list_head environment_hooks;
 
 	/* text representation of the config file */
 	char *unexpanded_config;
@@ -599,7 +606,7 @@ __hidden extern int lxc_clear_automounts(struct lxc_conf *c);
 __hidden extern int lxc_clear_hooks(struct lxc_conf *c, const char *key);
 __hidden extern int lxc_clear_idmaps(struct lxc_conf *c);
 __hidden extern int lxc_clear_groups(struct lxc_conf *c);
-__hidden extern int lxc_clear_environment(struct lxc_conf *c);
+__hidden extern int lxc_clear_environment(struct list_head *environment);
 __hidden extern int lxc_clear_limits(struct lxc_conf *c, const char *key);
 __hidden extern int lxc_delete_autodev(struct lxc_handler *handler);
 __hidden extern int lxc_clear_autodev_tmpfs_size(struct lxc_conf *c);
@@ -710,7 +717,7 @@ static inline int lxc_personality(personality_t persona)
 	return personality(persona);
 }
 
-__hidden extern int lxc_set_environment(const struct lxc_conf *conf);
+__hidden extern int lxc_set_environment(const struct list_head *environment);
 __hidden extern int parse_cap(const char *cap_name, __u32 *cap);
 
 #endif /* __LXC_CONF_H */

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1451,7 +1451,11 @@ static int do_start(void *data)
 	 * to allow them to be used by the various hooks, such as the start
 	 * hook below.
 	 */
-	ret = lxc_set_environment(handler->conf);
+	ret = lxc_set_environment(&handler->conf->environment);
+	if (ret < 0)
+		goto out_warn_father;
+
+	ret = lxc_set_environment(&handler->conf->environment_hooks);
 	if (ret < 0)
 		goto out_warn_father;
 
@@ -1552,7 +1556,11 @@ static int do_start(void *data)
 	if (ret < 0)
 		SYSERROR("Failed to clear environment.");
 
-	ret = lxc_set_environment(handler->conf);
+	ret = lxc_set_environment(&handler->conf->environment);
+	if (ret < 0)
+		goto out_warn_father;
+
+	ret = lxc_set_environment(&handler->conf->environment_runtime);
 	if (ret < 0)
 		goto out_warn_father;
 


### PR DESCRIPTION
Introduce `lxc.environment.runtime` to set environment variables only
for the container init process and `lxc.environment.hooks` to set
environment variables only for hooks. Leave the original
`lxc.environment` unchanged. It still applies to everything.

This is needed in Proxmox Virtual Environment for containers created from OCI images that specify custom environment variables.
See: https://lore.proxmox.com/pve-devel/20250908150224.155373-6-f.schauer@proxmox.com/