### PR TITLE
Enable systemd to create /var/lib/lxc at runtime with StateDirectory

### DIFF
--- a/config/init/systemd/lxc.service.in
+++ b/config/init/systemd/lxc.service.in
@@ -13,6 +13,7 @@ ExecStop=@LIBEXECDIR@/lxc/lxc-containers stop
 ExecReload=@LIBEXECDIR@/lxc/lxc-apparmor-load
 # Environment=BOOTUP=serial
 # Environment=CONSOLETYPE=serial
+StateDirectory=lxc
 Delegate=yes
 
 [Install]

--- a/config/init/systemd/lxc@.service.in
+++ b/config/init/systemd/lxc@.service.in
@@ -13,6 +13,7 @@ ExecStart=@BINDIR@/lxc-start -F -n %i
 ExecStop=@BINDIR@/lxc-stop -n %i
 # Environment=BOOTUP=serial
 # Environment=CONSOLETYPE=serial
+StateDirectory=lxc
 Delegate=yes
 
 [Install]


### PR DESCRIPTION
This change adds the StateDirectory= directive in the systemd unit file to ensure that the /var/lib/lxc directory is automatically created and managed by systemd during service startup.

The StateDirectory= option instructs systemd to create a persistent state directory under /var/lib/. This is particularly useful in scenarios where the directory may be missing at first boot — such as on OSTree-based Linux distributions, which typically ship with empty /var directory as part of their immutable root filesystem.

By adding StateDirectory=lxc, systemd will handle the creation of /var/lib/lxc on first boot, ensuring that the service can start reliably even when the directory is not present initially.

Co-developed-by: Vishwas Udupa <vudupa@qti.qualcomm.com>
Co-developed-by: Raghuvarya S <raghuvar@qti.qualcomm.com>