### PR TITLE
Standardize log file create mode to 0640

### DIFF
--- a/src/lxc/log.c
+++ b/src/lxc/log.c
@@ -525,10 +525,10 @@ static int log_open(const char *name)
 	__do_close int fd = -EBADF;
 
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-	fd = lxc_unpriv(open(name, O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, 0660));
+	fd = lxc_unpriv(open(name, O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, 0640));
 #else
 	if (!RUN_ON_OSS_FUZZ && is_in_comm("fuzz-lxc-") <= 0)
-		fd = lxc_unpriv(open(name, O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, 0660));
+		fd = lxc_unpriv(open(name, O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, 0640));
 #endif /* !FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
 	if (fd < 0)
 		return log_error_errno(-errno, errno, "Failed to open log file \"%s\"", name);

--- a/src/lxc/terminal.c
+++ b/src/lxc/terminal.c
@@ -869,7 +869,7 @@ int lxc_terminal_create_log_file(struct lxc_terminal *terminal)
 	if (!terminal->log_path)
 		return 0;
 
-	terminal->log_fd = lxc_unpriv(open(terminal->log_path, O_CLOEXEC | O_RDWR | O_CREAT | O_APPEND, 0600));
+	terminal->log_fd = lxc_unpriv(open(terminal->log_path, O_CLOEXEC | O_RDWR | O_CREAT | O_APPEND, 0640));
 	if (terminal->log_fd < 0) {
 		SYSERROR("Failed to open terminal log file \"%s\"", terminal->log_path);
 		return -1;

--- a/src/lxc/tools/lxc_attach.c
+++ b/src/lxc/tools/lxc_attach.c
@@ -308,7 +308,7 @@ static int lxc_attach_create_log_file(const char *log_file)
 {
 	int fd;
 
-	fd = open(log_file, O_CLOEXEC | O_RDWR | O_CREAT | O_APPEND, 0600);
+	fd = open(log_file, O_CLOEXEC | O_RDWR | O_CREAT | O_APPEND, 0640);
 	if (fd < 0) {
 		ERROR("Failed to open log file \"%s\"", log_file);
 		return -1;


### PR DESCRIPTION
I read through the contributing guidelines and it didn't seem like there was much required except the sign-off line.

I did look at some of the tests but it seems like this kind of change probably doesn't warrant a new test?

I'm not a C developer so this was a manual code-only change.  It makes sense to me but I didn't run locally.

Let me know if you need changes.

Thanks.

Fixes: https://github.com/lxc/lxc/issues/4588