### PR TITLE
Ignore some confs when certain deps are not enabled

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -1249,7 +1249,8 @@ static int set_config_seccomp_profile(const char *key, const char *value,
 #if HAVE_SECCOMP
 	return set_config_path_item(&lxc_conf->seccomp.seccomp, value);
 #else
-	return ret_errno(ENOSYS);
+	WARN("Ignoring seccomp profile: \"%s\" because seccomp is disabled or libseccomp not found")
+	return 0;
 #endif
 }
 
@@ -2490,9 +2491,13 @@ static int add_cap_entry(struct lxc_conf *conf, char *caps, bool keep)
 		ret = parse_cap(token, &cap);
 		if (ret < 0) {
 			if (ret != -2)
+#if HAVE_LIBCAP
 				return syserror_set(-EINVAL, "Invalid capability specified: %s", token);
 
 			INFO("Ignoring unknown capability \"%s\"", token);
+#else
+				WARN("Ignoring capability \"%s\"", token);
+#endif
 			continue;
 		}
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -729,6 +729,7 @@ int lxc_handler_mainloop(struct lxc_async_descr *descr, struct lxc_handler *hand
 	int ret;
 	pthread_t thread;
 
+#if HAVE_DECL_SECCOMP_NOTIFY_FD
 	/* Skip protection if a seccomp proxy is setup. */
 	if (!handler || !handler->conf || handler->conf->seccomp.notifier.proxy_fd > 0) {
 		/* Landlock not supported when seccomp notify is in use. */
@@ -737,6 +738,7 @@ int lxc_handler_mainloop(struct lxc_async_descr *descr, struct lxc_handler *hand
 		/* We don't need to use thread then */
 		return lxc_mainloop(descr, -1);
 	}
+#endif
 
 	INFO("Spawning monitor as a thread for Landlock confinement");
 


### PR DESCRIPTION
before:

```
[root@localhost ~]# lxc-start ubuntu
lxc-start: ubuntu: ../src/lxc/parse.c: lxc_file_for_each_line_mmap: 136 Failed to parse config file "/data/share/share/lxc/config/common.conf" at line "lxc.cap.drop = mac_admin mac_override sys_time sys_module sys_rawio"
lxc-start: ubuntu: ../src/lxc/parse.c: lxc_file_for_each_line_mmap: 136 Failed to parse config file "/data/share/var/lib/lxc/ubuntu/config" at line "lxc.include = /data/share/share/lxc/config/common.conf"
...
lxc-start: ubuntu: ../src/lxc/parse.c: lxc_file_for_each_line_mmap: 136 Failed to parse config file "/data/share/share/lxc/config/common.conf" at line "lxc.seccomp.profile = /data/share/share/lxc/config/common.seccomp"
lxc-start: ubuntu: ../src/lxc/parse.c: lxc_file_for_each_line_mmap: 136 Failed to parse config file "/data/share/var/lib/lxc/ubuntu/config" at line "lxc.include = /data/share/share/lxc/config/common.conf"
Failed to load config for ubuntu
lxc-start: ubuntu: ../src/lxc/tools/lxc_start.c: lxc_start_main: 241 Failed to create lxc_container
```

after:

```
1761116361.586  root 30699 30699 W lxc     : ../src/lxc/conf.c:2939: parse_cap - Success - capabilities are disabled or libcap not found
1761116361.586  root 30699 30699 W lxc     : ../src/lxc/confile.c:2495: add_cap_entry - Success - Ignoring capability "sys_rawio"
1761116361.586  root 30699 30699 W lxc     : ../src/lxc/confile.c:1252: set_config_seccomp_profile - Success - Ignoring seccomp profile: "/data/share/share/lxc/config/common.seccomp" because seccomp is disabled or libseccomp not found"
```