### PR TITLE
Ensure do_lxcapi_unfreeze returns false when getstate errors

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -540,6 +540,11 @@ static bool do_lxcapi_unfreeze(struct lxc_container *c)
 		return false;
 
 	s = lxc_getstate(c->name, c->config_path, 0);
+
+    if (s < 0) {
+        return false;
+    }
+
 	// Prevent lxc from unexpectedly exiting when executing freeze,
 	// causing the container to be in the FREEZING state,
 	// making normal life cycle management impossible.


### PR DESCRIPTION
Resolves #4600 

This change addresses false positives in do_lxcapi_unfreeze when lxc_getstate fails. 

The intended behavior is that if lxc_getstate fails and returns a status code less than 0, the unfreeze operation cannot be performed. This scenario should return false. 