### PR TITLE
process_utils: Remove P_PIDFD macro

### DIFF
--- a/src/lxc/process_utils.h
+++ b/src/lxc/process_utils.h
@@ -138,13 +138,6 @@
 #define CLONE_NEWTIME 0x00000080 /* New time namespace */
 #endif
 
-/* waitid */
-#if !HAVE_SYS_PIDFD_H
-#ifndef P_PIDFD
-#define P_PIDFD 3
-#endif
-#endif
-
 #ifndef CLONE_ARGS_SIZE_VER0
 #define CLONE_ARGS_SIZE_VER0 64 /* sizeof first published struct */
 #endif


### PR DESCRIPTION
It is already defined as enum in sys/wait.h. Redefining it as a macro would end up a build error if !HAVE_SYS_PIDFD_H, eg.
```
../git/src/lxc/process_utils.h:144:17: error: expected identifier before numeric constant
  144 | #define P_PIDFD 3
      |          
```       ^