### PR TITLE
build: Check if P_PIDFD is defined

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -521,6 +521,17 @@ foreach ccattr: [
     srcconf.set10('HAVE_COMPILER_ATTR_' + ccattr.underscorify().to_upper(), cc.has_function_attribute(ccattr))
 endforeach
 
+## P_PIDFD
+test_code = '''
+#include <sys/wait.h>
+void func() { siginfo_t s; int r = waitid(P_PIDFD, 0, &s, 0); }
+'''
+if cc.compiles(test_code, name: 'waitid(P_PIDFD, ...)')
+    srcconf.set('HAVE_P_PIDFD', 1)
+  else
+    srcconf.set('HAVE_P_PIDFD', 0)
+endif
+
 ## Headers.
 foreach ident: [
     ['bpf',               '''#include <sys/syscall.h>

--- a/src/lxc/process_utils.h
+++ b/src/lxc/process_utils.h
@@ -139,7 +139,7 @@
 #endif
 
 /* waitid */
-#if !HAVE_SYS_PIDFD_H
+#if !HAVE_P_PIDFD
 #ifndef P_PIDFD
 #define P_PIDFD 3
 #endif


### PR DESCRIPTION
It is defined in enum 'idtype_t' in some environment in which causes an error like:
```
../git/src/lxc/process_utils.h:144:17: error: expected identifier before numeric constant
  144 | #define P_PIDFD 3
      |                 ^
```