### PR TITLE
Add Meson option for enabling API documentation generation with Doxygen

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -72,3 +72,16 @@ if want_mans
             install_dir: join_paths(mandir, 'man' + page[1]))
     endforeach
 endif
+
+# API Docs (Doxygen)
+if want_api_docs
+    doxygen = find_program('doxygen', required: true)
+
+    api_docs = custom_target(
+        'api-docs',
+        input: files('api/Doxyfile'),
+        output: 'api-docs.stamp',
+        command: [doxygen, '@INPUT@'],
+        build_by_default: true
+    )
+endif

--- a/meson.build
+++ b/meson.build
@@ -133,6 +133,7 @@ want_install_init = get_option('install-init-files')
 want_io_uring = get_option('io-uring-event-loop')
 want_pam_cgroup = get_option('pam-cgroup')
 want_mans = get_option('man')
+want_api_docs = get_option('api-docs')
 want_tests = get_option('tests')
 want_tools = get_option('tools')
 want_tools_multicall = get_option('tools-multicall')
@@ -339,6 +340,12 @@ if not sgml2man.found()
     elif want_mans
         error('missing required docbook2x or docbook-utils dependency')
     endif
+endif
+
+## API Docs.
+doxygen = find_program('doxygen', required: false)
+if not doxygen.found() and want_api_docs
+    error('missing required doxygen dependency')
 endif
 
 ## Threads.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -31,6 +31,10 @@ option('io-uring-event-loop', type: 'boolean', value: false,
 option('man', type: 'boolean', value: true,
        description: 'build and install manpages')
 
+# was --{disable,enable}-api-docs in autotools
+option('api-docs', type: 'boolean', value: false,
+       description: 'build and install API documentation (Doxygen)')
+
 # was --{disable,enable}-pam in autotools
 option('pam-cgroup', type: 'boolean', value: false,
        description: 'build and install the pam cgroup module')


### PR DESCRIPTION
This PR adds a Meson build option, api-docs, to enable automatic API documentation generation using Doxygen. This resolves #4156 