### PR TITLE
Fallback to XDG_RUNTIME_DIR when /run not found

### DIFF
--- a/src/lxc/utils.c
+++ b/src/lxc/utils.c
@@ -253,10 +253,8 @@ char *get_rundir(void)
 	const char *homedir;
 	struct stat sb;
 
-	if (stat(RUNTIME_PATH, &sb) < 0)
-		return NULL;
-
-	if (geteuid() == sb.st_uid || getegid() == sb.st_gid)
+	if ((stat(RUNTIME_PATH, &sb) == 0) &&
+	    (geteuid() == sb.st_uid || getegid() == sb.st_gid))
 		return strdup(RUNTIME_PATH);
 
 	static_rundir = getenv("XDG_RUNTIME_DIR");


### PR DESCRIPTION
Instead of return null immediately when RUNTIME_PATH not found, fallback to XDG_RUNTIME_DIR or HOME.