### PR TITLE
Add checks for "lxc-net fails when kernel has no IPv6"

### DIFF
--- a/config/init/common/lxc-net.in
+++ b/config/init/common/lxc-net.in
@@ -63,6 +63,10 @@ _ifup() {
 
 start_ipv6() {
     LXC_IPV6_ARG=""
+    [ -e /proc/sys/net/ipv6 ] || return 0
+    [ -f /proc/sys/net/ipv6/conf/${LXC_BRIDGE}/disable_ipv6 ] &&
+        [ "$(cat /proc/sys/net/ipv6/conf/${LXC_BRIDGE}/disable_ipv6)" -eq 1 ] &&
+            return 0
     [ "${LXC_IPV6_ENABLE}" = "true" ] || return 0
 
     if [ -n "$LXC_IPV6_ADDR" ] && [ -n "$LXC_IPV6_MASK" ] && [ -n "$LXC_IPV6_NETWORK" ]; then


### PR DESCRIPTION
This PR fixes the error that was brought up in #4577 