### PR TITLE
Fix "lxc-copy with overlayfs throws an error"

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3468,6 +3468,10 @@ static void copy_rdepends(struct lxc_container *c, struct lxc_container *c0)
 		return;
 	}
 
+	if (!file_exists(path0)) {
+		return;
+	}
+	
 	if (copy_file(path0, path1) < 0) {
 		INFO("Error copying reverse dependencies");
 		return;


### PR DESCRIPTION
This PR fixes the issue brought up in #4514 

I was able to recreate the error that was brought up by @graysky2. As indicated by the output, the /var/lib/lxc/ow/lxc_rdepends file does not exist. It seems plausible that this is because there are no reverse dependencies for this container, so there was no reason for the file to ever be created. When creating the clone of the container, the file is created and tries to copy the original file into it. Since there was no original file it errors and prints (this error does not get bubbled up further into the program which is why the snapshot is still created). The function copy_rdepends, handles the logic for copying the file, so I think it would be reasonable to check if the file exists before calling copy_file, logging if it does not exist.

Closes #4514 