### PR TITLE
cgfsng: fix reboots when using dbus

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1521,6 +1521,9 @@ static int unpriv_systemd_create_scope(struct cgroup_ops *ops, struct lxc_conf *
 		dbus_threads_initialized = true;
 	}
 
+	if (conf->cgroup_meta.systemd_scope != NULL)
+		return log_error(true, "Already in a scope, must be a reboot.");
+
 	connection = open_systemd();
 	if (connection == NULL)
 		return log_error(false, "Failed opening dbus connection");


### PR DESCRIPTION
When using dbus on a systemd system, we ask systemd to create a "scope" for us to run in.  We send a dbus message, and wait for the reply saying it is created.

When we reboot, we were re-sending the request to create the scope.  However, the scope still exists, because or single lxc-monitor (originally lxc-start) thread is still under the 'lxc.pivot' sub-directory of the scope.

But, on reboot, our lxc_conf already has our scope recorded! So, just check whether that is set, and skip scope creation if so.

With this patch, i can reboot ad nauseum with no apparent problems.

We could probably move this check to the top of the function, but for now this fixes the bug.