### PR TITLE
src/confile: fix values of lxc.cap.keep and lxc.cap.drop

### DIFF
--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -4309,6 +4309,9 @@ static int get_config_cap_drop(const char *key, char *retv, int inlen,
 	int len, fulllen = 0;
 	struct cap_entry *cap;
 
+	if (c->caps.keep)
+		return fulllen;
+
 	if (!retv)
 		inlen = 0;
 	else
@@ -4326,6 +4329,9 @@ static int get_config_cap_keep(const char *key, char *retv, int inlen,
 {
 	int len, fulllen = 0;
 	struct cap_entry *cap;
+
+	if (!c->caps.keep)
+		return fulllen;
 
 	if (!retv)
 		inlen = 0;


### PR DESCRIPTION
```
localhost ~ # lxc-info ubuntu -c lxc.cap.drop
lxc.cap.drop = mac_admin
mac_override
sys_time
sys_module
sys_rawio
localhost ~ # lxc-info ubuntu -c lxc.cap.keep
lxc.cap.keep =
```

The opposite:
```
localhost ~ # lxc-info ubuntu -c lxc.cap.keep
lxc.cap.keep = chown
dac_override
dac_read_search
fowner
fsetid
kill
setgid
setuid
setpcap
linux_immutable
net_bind_service
net_broadcast
net_admin
net_raw
ipc_lock
ipc_owner
sys_chroot
sys_ptrace
sys_pacct
sys_admin
sys_boot
sys_nice
sys_resource
sys_tty_config
mknod
lease
audit_write
audit_control
setfcap
syslog
wake_alarm
block_suspend
audit_read
perfmon
bpf
checkpoint_restore

localhost ~ # lxc-info ubuntu -c lxc.cap.drop
lxc.cap.drop =
```

Fixed #4473 