### PR TITLE
tests: mount_injection: ensure cleanup on test failure

### DIFF
--- a/src/tests/mount_injection.c
+++ b/src/tests/mount_injection.c
@@ -409,20 +409,24 @@ static void lxc_teardown_shmount(char *shmount_path)
 
 int main(int argc, char *argv[])
 {
+	int ret = EXIT_SUCCESS;
+	
 	if (!lxc_setup_shmount("/tmp/mount_injection_test"))
 		exit(EXIT_FAILURE);
 
 	if (do_priv_container_test()) {
 		fprintf(stderr, "Privileged mount injection test failed\n");
-		exit(EXIT_FAILURE);
+		ret = EXIT_FAILURE;
+		goto out;
 	}
 
 	if (do_unpriv_container_test()) {
 		fprintf(stderr, "Unprivileged mount injection test failed\n");
-		exit(EXIT_FAILURE);
+		ret = EXIT_FAILURE;
+		goto out;
 	}
 
+out:
 	lxc_teardown_shmount("/tmp/mount_injection_test");
-
-	exit(EXIT_SUCCESS);
+	exit(ret);
 }


### PR DESCRIPTION
The mount_injection test was exiting immediately on failure without
calling lxc_teardown_shmount(), leaving /tmp/mount_injection_test
mounted and causing "Device or resource busy" errors when trying to
remove it.

Store the test result and ensure lxc_teardown_shmount() is always called
before exiting, even when tests fail.