### PR TITLE
Fix parse config more 2gb (32bit truncation POSIX st_size type)

### DIFF
--- a/src/lxc/parse.c
+++ b/src/lxc/parse.c
@@ -91,7 +91,7 @@ int lxc_file_for_each_line_mmap(const char *file, lxc_file_cb callback, void *da
 		goto on_error;
 	}
 
-	if (st.st_size > INT_MAX) {
+	if (st.st_size > SSIZE_MAX - 1) {
 		SYSERROR("Excessively large config file \"%s\"", file);
 		goto on_error;
 	}


### PR DESCRIPTION
References:
- https://unix.stackexchange.com/questions/621157/why-is-the-type-of-stat-st-size-not-unsigned-int
- https://community.unix.com/t/read-wont-allow-me-to-read-files-larger-than-2-gig-on-a-64bit/256376