### PR TITLE
meson.build: fix openat2 include typo, fix with glibc-2.43 +FORTIFY

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -571,7 +571,7 @@ foreach ident: [
     ['move_mount',        '''#include <sys/mount.h>'''],
     ['openat2',           '''#include <sys/types.h>
                              #include <sys/stat.h>
-                             #include <fctnl.h>'''],
+                             #include <fcntl.h>'''],
     ['open_tree',         '''#include <sys/mount.h>'''],
     ['personality',       '''#include <sys/personality.h>'''],
     ['pidfd_open',        '''#include <stdlib.h>


### PR DESCRIPTION
Closes: https://github.com/lxc/lxc/issues/4641