### PR TITLE
meson.build: fix open_how include with glibc-2.43+

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -678,6 +678,7 @@ endforeach
 
 ## Types.
 decl_headers = '''
+#include <fcntl.h>
 #include <uchar.h>
 #include <sys/mount.h>
 #include <sys/stat.h>

--- a/src/lxc/open_utils.h
+++ b/src/lxc/open_utils.h
@@ -25,6 +25,8 @@ struct open_how {
 	__u64 mode;
 	__u64 resolve;
 };
+#else
+#include <fcntl.h>
 #endif
 
 /* how->resolve flags for openat2(2). */


### PR DESCRIPTION
For fixing #4644 