### PR TITLE
lxc/network: save/restore physical network interfaces altnames

### DIFF
--- a/src/lxc/confile_utils.c
+++ b/src/lxc/confile_utils.c
@@ -434,6 +434,9 @@ void lxc_clear_netdev(struct lxc_netdev *netdev)
 			lxc_list_del(cur);
 			free(cur);
 		}
+	} else if (netdev->type == LXC_NET_PHYS) {
+		free_string_list(netdev->priv.phys_attr.altnames);
+		netdev->priv.phys_attr.altnames = NULL;
 	}
 
 	head = netdev->head;

--- a/src/lxc/network.h
+++ b/src/lxc/network.h
@@ -106,6 +106,7 @@ struct ifla_ipvlan {
  */
 struct ifla_phys {
 	int ifindex;
+	char **altnames;
 	int mtu;
 };
 


### PR DESCRIPTION
When we add a "physical" (i.e. external) network interface into container,
we should memorize all its altnames. Once we have to move netdev back
to host (e.g. on container stop or reboot), we need to restore all
old altnames.

Fixes: https://github.com/lxc/lxc/issues/4646