### PR TITLE
lxc/network: define netlink uAPI constants for link properties

### DIFF
--- a/src/lxc/macro.h
+++ b/src/lxc/macro.h
@@ -463,6 +463,14 @@ extern int __build_bug_on_failed;
 #define IFLA_NET_NS_FD 28
 #endif
 
+#ifndef IFLA_PROP_LIST
+#define IFLA_PROP_LIST 52
+#endif
+
+#ifndef IFLA_ALT_IFNAME
+#define IFLA_ALT_IFNAME 53
+#endif
+
 #ifndef IFLA_INFO_KIND
 #define IFLA_INFO_KIND 1
 #endif
@@ -530,6 +538,14 @@ extern int __build_bug_on_failed;
 
 #ifndef RTM_GETNSID
 #define RTM_GETNSID 90
+#endif
+
+#ifndef RTM_NEWLINKPROP
+#define RTM_NEWLINKPROP 108
+#endif
+
+#ifndef RTM_DELLINKPROP
+#define RTM_DELLINKPROP 109
 #endif
 
 #ifndef NLMSG_ERROR


### PR DESCRIPTION
We need to define IFLA_PROP_LIST, IFLA_ALT_IFNAME, RTM_NEWLINKPROP, RTM_DELLINKPROP to stay compatible with older userspaces which may not update their Linux kernel's uAPI headers.

This should fix OSS-Fuzz tests on main branch.