### PR TITLE
cmd/lxc-user-nic: prevent OOB read in name_is_in_groupnames

### DIFF
--- a/src/lxc/cmd/lxc_user_nic.c
+++ b/src/lxc/cmd/lxc_user_nic.c
@@ -216,7 +216,10 @@ static char **get_groupnames(void)
 
 static bool name_is_in_groupnames(char *name, char **groupnames)
 {
-	while (groupnames) {
+	if (!groupnames)
+		return false;
+
+	while (*groupnames) {
 		if (!strcmp(name, *groupnames))
 			return true;
 		groupnames++;


### PR DESCRIPTION
We need to be more careful when iterating an array of strings in name_is_in_groupnames. First of all, groupnames can be NULL (this was checked), but then, we need to check for *groupnames instead of groupnames in while-condition.

Bug was here since lxc-2.0.0.

Fixes: af59ff2eede7 ("Changed parsing of allotments. Now parses top-to-bottom regardless of user or group")