### PR TITLE
Fix issue where lxc-start takes a long time to start up on a cgroup v2 system without systemd.

### DIFF
--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -1521,6 +1521,9 @@ static int unpriv_systemd_create_scope(struct cgroup_ops *ops, struct lxc_conf *
 	__attribute__((__cleanup__(_dbus_connection_free))) DBusConnection *connection = NULL;
 	unsigned int len;
 
+	if (!file_exists("/run/systemd/system"))
+		return log_info(SYSTEMD_SCOPE_UNSUPP, "Not a systemd system or systemd not running");
+
 	if (geteuid() == 0)
 		return log_info(SYSTEMD_SCOPE_UNSUPP, "Running privileged, not using a systemd unit");
 


### PR DESCRIPTION
Fixes https://github.com/lxc/lxc/issues/4657

I believe this has to be a compile-time fix: non-systemd systems won't have the systemd dependencies, causing a compile failure.