### PR TITLE
Fix infinite loop caused by failure to close inherited file descriptors.

### DIFF
--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -352,9 +352,10 @@ restart:
 		}
 
 		if (closeall) {
-			if (close(fd))
-				SYSINFO("Closed inherited fd %d", fd);
-			else
+			if (close(fd)) {
+				WARN("Could not close fd %d. Continuing...", fd);
+				continue;
+			} else
 				INFO("Closed inherited fd %d", fd);
 			closedir(dir);
 			goto restart;


### PR DESCRIPTION
This patch modifies the lxc_check_inherited function to avoid hangs when closing inherited file descriptors. In case it finds a close failure, it continues with the next file descriptor following a best effort strategy.

Issue is tracked in https://github.com/lxc/lxc/issues/4655.