### PR TITLE
[nesting] Extend mount permissions in apparmor to allow systemd servi…

### DIFF
--- a/config/apparmor/profiles/lxc-default-with-nesting
+++ b/config/apparmor/profiles/lxc-default-with-nesting
@@ -10,6 +10,12 @@ profile lxc-container-default-with-nesting flags=(attach_disconnected,mediate_de
   mount fstype=proc -> /var/cache/lxc/**,
   mount fstype=sysfs -> /var/cache/lxc/**,
   mount options=(rw,bind),
+  mount options=(rw,rbind) -> /run/systemd/mount-rootfs/,
+  mount options=(rw,rbind) -> /run/systemd/mount-rootfs/**,
+  mount options=(rw,rbind) -> /run/systemd/unit-root/,
+  mount options=(rw,rbind) -> /run/systemd/unit-root/**,
+  mount options=(rw,rshared) -> /,
+  mount options=(rw,nosuid,nodev,noexec) proc -> /run/systemd/unit-root/proc/,
   mount fstype=cgroup -> /sys/fs/cgroup/**,
   mount fstype=cgroup2 -> /sys/fs/cgroup/**,
 }


### PR DESCRIPTION
…ces' restrictions to work

These options allow systemd security features to work. In particular cases, it helps with systemd-logind and program like this

It's only added in nesting profile as nesting implies some leniency anyway. It would pose more risks in privileged or
unprivileged-without-nesting situations.

mount options=(rw,rbind) -> /run/systemd/mount-rootfs/, mount options=(rw,rbind) -> /run/systemd/mount-rootfs/**, mount options=(rw,rbind) -> /run/systemd/unit-root/, mount options=(rw,rbind) -> /run/systemd/unit-root/**, mount options=(rw,rshared) -> /,
mount options=(rw,nosuid,nodev,noexec) proc -> /run/systemd/unit-root/proc/,