### PR TITLE
tests/lxc-test-lxc-attach: Increase sleep time

### DIFF
--- a/src/tests/lxc-test-lxc-attach
+++ b/src/tests/lxc-test-lxc-attach
@@ -221,7 +221,7 @@ busybox tee --help >/dev/null 2>&1 || FAIL "missing busybox's tee applet"
 
 out=$(mktemp /tmp/out_XXXX)
 BS=1000000
-( sleep 3; echo "echo DATASTART ; dd if=/dev/urandom bs=$BS count=1 status=none | hexdump | tee /root/large-data.txt ; echo DATAEND" ; sleep 1 ) | \
+( sleep 3; echo "echo DATASTART ; dd if=/dev/urandom bs=$BS count=1 status=none | hexdump | tee /root/large-data.txt ; echo DATAEND" ; sleep 3 ) | \
 	script -q -e -c "lxc-attach -n busy -l trace -o \"${ATTACH_LOG}\"" | \
 	sed -n '/DATASTART/,/DATAEND/{/DATASTART/d;/DATAEND/d;s/[\r\n]*$//;p}' > $out
 


### PR DESCRIPTION
I've recently greatly expanded the test suite run in Debian's packaging of lxc, and `lxc-test-lxc-attach` hangs forever on riscv64 architectures. (Seen in [CI autopkgtests](https://ci.debian.net/packages/l/lxc/testing/riscv64/70562684/) as well as in a local riscv64 VM).

It appears that a single second sleep isn't sufficient to work around the busybox pipe closure bug, and the test hangs forever. Increasing to three seconds reliability allows the test to pass as expected.