### PR TITLE
lvm.c: make sure tp gets freed

### DIFF
--- a/src/lxc/storage/lvm.c
+++ b/src/lxc/storage/lvm.c
@@ -137,6 +137,7 @@ static int do_lvm_create(const char *path, uint64_t size, const char *thinpool)
 			return log_error(-EINVAL, "Failed to detect whether \"%s\" is a thinpool", tp);
 		} else if (!ret) {
 			TRACE("Detected that \"%s\" is not a thinpool", tp);
+			free(tp);
 			tp = NULL;
 		} else {
 			TRACE("Detected \"%s\" is a thinpool", tp);


### PR DESCRIPTION
tp is __do_free.  However, when we detect that it is not a thinpool, we set it to NULL, so that it can't get freed on exit.

coverity id 1461741