### PR TITLE
Don't leak an open fd

### DIFF
--- a/src/lxc/storage/storage.c
+++ b/src/lxc/storage/storage.c
@@ -516,6 +516,8 @@ struct lxc_storage *storage_copy(struct lxc_container *c, const char *cname,
 	}
 
 on_success:
+	/* The only caller, copy_storage, doesn't ever close this. */
+	close_prot_errno_disarm(new_rootfs.dfd_idmapped);
 	lxc_storage_put(c->lxc_conf);
 
 	return new;
@@ -524,6 +526,7 @@ on_error_put_new:
 	storage_put(new);
 
 on_error_put_orig:
+	close_prot_errno_disarm(new_rootfs.dfd_idmapped);
 	lxc_storage_put(c->lxc_conf);
 
 	return NULL;


### PR DESCRIPTION
The dfd_idmapped was being dup'd, but not freed.

If we ever change it so that storage_put closes the dfd_idmapped fd, then we'll want to un-do this.  For now, this is a kludgy way to avoid leaking the open fd, but should work.

The new_rootfs->dfd_idmapped gets dup'd from
c->lxc_conf->rootfs.dfd_idmapped.  new_rootfs eventually gets assigned to new->rootfs (where new is a struct storage, usually called 'bdev').  From here there are error paths which free the bdev and return NULL, and a success path that returns bdev.  But neither the error path nor the caller do anything really with the bdev, and storage_put() doesn't close that fd.

So close the dfd_idmapped in both paths.

Coverity id: 1641426