### PR TITLE
templates: actually create DOWNLOAD_TEMP directory

### DIFF
--- a/templates/lxc-download.in
+++ b/templates/lxc-download.in
@@ -214,9 +214,9 @@ if ! command -V mktemp >/dev/null 2>&1; then
   DOWNLOAD_TEMP="${DOWNLOAD_TEMP}/tmp/lxc-download.$$"
 elif [ -n "${DOWNLOAD_TEMP}" ]; then
   mkdir -p "${DOWNLOAD_TEMP}"
-  DOWNLOAD_TEMP="$(mktemp -p "${DOWNLOAD_TEMP}" -d)"
+  DOWNLOAD_TEMP="$(mktemp --tmpdir="${DOWNLOAD_TEMP}" -d)"
 else
-  DOWNLOAD_TEMP="${DOWNLOAD_TEMP}$(mktemp -d)"
+  DOWNLOAD_TEMP="$(mktemp --tmpdir=${DOWNLOAD_TEMP} -d)"
 fi
 
 # Simply list images


### PR DESCRIPTION
The way 'mktemp' is currently used you will get a temp directory in $TMPDIR or '/tmp' and DOWNLOAD_TEMP will not be pointing to an actual directory. This will result in the wget operations failing and the container will fail to create:

    ERROR: Failed to download http://....

Instead we want to use the '--tmpdir=' option for mktemp to set the base path and this will ensure that the temp directory is created in the correct location and DOWNLOAD_TEMP will be consistent with this location.

Note that we must use '--tmpdir=' and not '-p' as with the former the DIR parameter is optional and use $TMPDIR if not set or else /tmp, while '-p' will fail.

Upstream-Status: Pending
Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>
Signed-off-by: Ferry Toth <ftoth@exalondelft.nl>