### PR TITLE
Fix return from fn stack

### DIFF
--- a/src/lxc/lxccontainer.c
+++ b/src/lxc/lxccontainer.c
@@ -3533,23 +3533,22 @@ static int copy_storage(struct lxc_container *c0, struct lxc_container *c,
 			const char *newtype, int flags, const char *bdevdata,
 			uint64_t newsize)
 {
-	struct lxc_storage *bdev;
+	char *bdev_src = NULL;
 	bool need_rdep;
 
 	if (should_default_to_snapshot(c0, c))
 		flags |= LXC_CLONE_SNAPSHOT;
 
-	bdev = storage_copy(c0, c->name, c->config_path, newtype, flags,
+	bdev_src = storage_copy(c0, c->name, c->config_path, newtype, flags,
 			    bdevdata, newsize, &need_rdep);
-	if (!bdev) {
+	if (!bdev_src) {
 		ERROR("Error copying storage.");
 		return -1;
 	}
 
 	/* Set new rootfs. */
 	free(c->lxc_conf->rootfs.path);
-	c->lxc_conf->rootfs.path = strdup(bdev->src);
-	storage_put(bdev);
+	c->lxc_conf->rootfs.path = bdev_src;
 
 	if (!c->lxc_conf->rootfs.path) {
 		ERROR("Out of memory while setting storage path.");

--- a/src/lxc/storage/storage.c
+++ b/src/lxc/storage/storage.c
@@ -296,12 +296,13 @@ bool storage_can_backup(struct lxc_conf *conf)
 /* If we're not snapshotting, then storage_copy becomes a simple case of mount
  * the original, mount the new, and rsync the contents.
  */
-struct lxc_storage *storage_copy(struct lxc_container *c, const char *cname,
-				 const char *lxcpath, const char *bdevtype,
-				 int flags, const char *bdevdata,
-				 uint64_t newsize, bool *needs_rdep)
+char *storage_copy(struct lxc_container *c, const char *cname,
+		   const char *lxcpath, const char *bdevtype,
+		   int flags, const char *bdevdata,
+		   uint64_t newsize, bool *needs_rdep)
 {
 	int ret;
+	char *ret_str;
 	const char *src_no_prefix;
 	struct lxc_storage *new, *orig;
 	bool snap = (flags & LXC_CLONE_SNAPSHOT);
@@ -520,7 +521,9 @@ on_success:
 	close_prot_errno_disarm(new_rootfs.dfd_idmapped);
 	lxc_storage_put(c->lxc_conf);
 
-	return new;
+	ret_str = must_copy_string(new->src);
+	storage_put(new);
+	return ret_str;
 
 on_error_put_new:
 	storage_put(new);

--- a/src/lxc/storage/storage.h
+++ b/src/lxc/storage/storage.h
@@ -103,10 +103,10 @@ struct lxc_storage {
 __hidden extern bool storage_lxc_is_dir(struct lxc_conf *conf);
 __hidden extern bool storage_can_backup(struct lxc_conf *conf);
 __hidden extern struct lxc_storage *storage_init(struct lxc_conf *conf);
-__hidden extern struct lxc_storage *storage_copy(struct lxc_container *c, const char *cname,
-						 const char *lxcpath, const char *bdevtype,
-						 int flags, const char *bdevdata, uint64_t newsize,
-						 bool *needs_rdep);
+__hidden extern char *storage_copy(struct lxc_container *c, const char *cname,
+				   const char *lxcpath, const char *bdevtype,
+				   int flags, const char *bdevdata, uint64_t newsize,
+				   bool *needs_rdep);
 __hidden extern struct lxc_storage *storage_create(const char *dest, const char *type,
 						   const char *cname, struct bdev_specs *specs,
 						   const struct lxc_conf *conf);


### PR DESCRIPTION
storage_copy builds a struct lxc_storage on the stack, and returns a pointer to that on success to its caller.  That's could be a huge issue, except that its only caller quickly makes a copy of the -> src and then releases it.

Still, to avoid a future user actually overwriting the struct and then continuing to use it, let's fix this now.  There's no point returning the whole lxc_storage struct anyway.  Just return a copy of the bdev->src.