### PR TITLE
lxc-net: Even more random IPv6 subnet

### DIFF
--- a/config/init/common/lxc-net.in
+++ b/config/init/common/lxc-net.in
@@ -21,10 +21,11 @@ LXC_DOMAIN=""
 LXC_USE_NFT="true"
 
 # IPv6 connectivity
+LXC_IPV6_PREFIX=$( (echo LXC_IPV6_PREFIX; cat /etc/machine-id 2>/dev/null) | sha256sum | sed -e 's/^\(..\)\(....\)\(....\)\(....\).*/fd\1:\2:\3:\4/')
 LXC_IPV6_ENABLE="true"
-LXC_IPV6_ADDR="fc42:5009:ba4b:5ab0::1"
+LXC_IPV6_ADDR="${LXC_IPV6_PREFIX}::1"
 LXC_IPV6_MASK="64"
-LXC_IPV6_NETWORK="fc42:5009:ba4b:5ab0::/64"
+LXC_IPV6_NETWORK="${LXC_IPV6_PREFIX}::/${LXC_IPV6_MASK}"
 LXC_IPV6_NAT="true"
 
 [ ! -f $distrosysconfdir/lxc ] || . $distrosysconfdir/lxc


### PR DESCRIPTION
Generate a stable IPv6 prefix based on the content of /etc/machin-id. This way the subnet on every machine will be different but stable between reboots and software updates.

Note: Although in section 3.1 of RFC 4193[1] the Prefix is declared to be FC00::/7, the L bit declared to be 1. Hence ULA prefixes always start with FD.

[1] https://datatracker.ietf.org/doc/html/rfc4193#section-3.1

Follow-up-to: 31012d49a ("lxc-net: Replace random IPv6 subnet")