### PR TITLE
lxc/criu: restore cgroup limits and freezer on restore

### DIFF
--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -939,6 +939,21 @@ static void do_restore(struct lxc_container *c, int status_pipe, struct migrate_
 		goto out_fini_handler;
 	}
 
+	if (!cgroup_ops->payload_delegate_controllers(cgroup_ops)) {
+		ERROR("Failed to delegate controllers to payload cgroup");
+		goto out_fini_handler;
+	}
+
+	if (!cgroup_ops->setup_limits(cgroup_ops, handler)) {
+		ERROR("Failed to setup cgroup limits");
+		goto out_fini_handler;
+	}
+
+	if (!cgroup_ops->chown(cgroup_ops, handler->conf))
+		goto out_fini_handler;
+
+	cgroup_ops->finalize(cgroup_ops);
+
 	if (!restore_net_info(c)) {
 		ERROR("failed restoring network info");
 		goto out_fini_handler;


### PR DESCRIPTION
When performing `lxc-checkpoint -r` there were two bugs I observed.

1. The freezer cgroup wasn't restored properly, causing subsequent `lxc-checkpoint` calls to fail during the checkpoint faze due to missing freezer cgroup. Meaning after restoring a container, it needs to be shutdown before checkpointing it again.
2. cgroup limits were not applied after restore, for example, if `/sys/fs/cgroup/memory.max` was set to `2147483648`, after restoring it would just show the value `max`.

Fixes #4643 

This issue was also present for LXC 6.0.5 (where I originally wrote the patch for). If you plan to release hotfixes for 6.x let me know. I can submit another PR on that branch, since one more line needs to be added for `setup_limits_legacy`, which is missing here since 7.x has dropped cgroup v1 support.

I have also observed one more issue, but I assume that has nothing to do with this project. However, I would still like to leave a question here. If the container is using OpenRC as its init system. After restoring, PID 1 (init) will spike the CPU to 100%. Some errors due to epoll. Mainly what happens is that `/run/openrc/init.ctl` is RW before checkpoint. After checkpointing in `files.img` (inside the dump), it is set to RO.

I have manually fixed this in my workflow by:
1. walking `files.img`
2. setting `/run/openrc/init.ctl` to RW

Then after performing restore, container behaves normally, no CPU pinning.