### PR TITLE
lxc/mainloop: prevent IOWait accounting for io_uring POLL-ing

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -274,6 +274,9 @@ if want_io_uring
     if cc.has_function('io_uring_prep_poll_add', prefix: '#include <liburing.h>', dependencies: liburing) == false
         error('liburing version does not support IORING_POLL_ADD_MULTI')
     endif
+    if cc.has_function('io_uring_set_iowait', prefix: '#include <liburing.h>', dependencies: liburing)
+        srcconf.set10('HAVE_LIBURING_SET_IOWAIT', true)
+    endif
     pkgconfig_libs += liburing
     liblxc_dependencies += liburing
 

--- a/src/lxc/mainloop.c
+++ b/src/lxc/mainloop.c
@@ -138,6 +138,18 @@ static inline int __io_uring_open(struct lxc_async_descr *descr)
 		goto on_error;
 	}
 
+#if HAVE_LIBURING_SET_IOWAIT
+	/*
+	 * By default, when we enter uring to wait for CQs, kernel will
+	 * set current->in_iowait to 1. This behavior is not always
+	 * desirable. In our case we use io_uring for POLL-ing, and setting
+	 * current->in_iowait makes no sense and increases IOWait counters
+	 * and can make a system administrator nervous (see issue #4364).
+	 */
+	if (io_uring_set_iowait(descr->ring, 0))
+		TRACE("io_uring_set_iowait is not supported by the kernel");
+#endif
+
 	descr->type = LXC_MAINLOOP_IO_URING;
 	TRACE("Created io-uring instance");
 	return 0;


### PR DESCRIPTION
See also https://github.com/torvalds/linux/commit/07754bfd9aee59063f8549f6e4d455eae636ecc7

Fixes: #4364