### PR TITLE
criu: use strnprintf for the --cgroup-root argument

### DIFF
--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -326,13 +326,13 @@ static int exec_criu(struct cgroup_ops *cgroup_ops, struct lxc_conf *conf,
 			if (!controllers)
 				return log_error_errno(-ENOMEM, ENOMEM, "Failed to join controllers");
 
-			ret = sprintf(buf, "%s:%s", controllers, cgroup_base_path);
+			ret = strnprintf(buf, sizeof(buf), "%s:%s", controllers, cgroup_base_path);
 		} else {
 			WARN("No cgroup controllers configured in container's cgroup %s", cgroup_base_path);
-			ret = sprintf(buf, "%s", cgroup_base_path);
+			ret = strnprintf(buf, sizeof(buf), "%s", cgroup_base_path);
 		}
-		if (ret < 0 || (size_t)ret >= sizeof(buf))
-			return log_error_errno(-EIO, EIO, "sprintf of cgroup root arg failed");
+		if (ret < 0)
+			return log_error_errno(-EIO, EIO, "Failed to build cgroup root arg");
 
 		DECLARE_ARG("--cgroup-root");
 		DECLARE_ARG(buf);


### PR DESCRIPTION
1. exec_criu() builds the --cgroup-root argument with sprintf() into a fixed char buf[4096] from the joined controller list and the container's cgroup path.
2. The `ret >= sizeof(buf)` guard runs only after sprintf() has written, so a cgroup path long enough to push controllers + ":" + path past 4096 overflows the stack buffer before the check can reject it.

Switched both calls to strnprintf(buf, sizeof(buf), ...), already used for this buffer elsewhere in the same function, so over-long input truncates and returns < 0 and the existing guard rejects it before any out-of-bounds write.