### PR TITLE
commands: validate string in lxc_cmd_get_config_item_callback

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -1028,8 +1028,19 @@ static int lxc_cmd_get_config_item_callback(int fd, struct lxc_cmd_req *req,
 	int cilen;
 	struct lxc_config_t *item;
 	struct lxc_cmd_rsp rsp;
+	ssize_t ret;
 
 	memset(&rsp, 0, sizeof(rsp));
+
+	if (req->datalen <= 0) {
+		rsp.ret = -EINVAL;
+		return lxc_cmd_rsp_send_reap(fd, &rsp);
+	}
+
+	ret = validate_string_request(fd, req);
+	if (ret != 0)
+		return ret;
+
 	item = lxc_get_config(req->data);
 	cilen = item->get(req->data, NULL, 0, handler->conf, NULL);
 	if (cilen <= 0)


### PR DESCRIPTION
1. lxc_cmd_get_config_item_callback() passes the raw req->data to lxc_get_config(), but the command server stores req->data as exactly datalen bytes read off the socket, so a client can send data that is not NUL-terminated.
2. match_config_item() then runs strcmp()/strncmp() against the config names and reads past the end of the heap buffer once the bytes match a name prefix (datalen=1, data="l" is enough).

Added a datalen check and reused validate_string_request(), the same guard the get_cgroup callback already applies, so unterminated or empty input is rejected before the lookup.