### PR TITLE
commands: validate datalen in lxc_cmd_console_log_callback

### DIFF
--- a/src/lxc/commands.c
+++ b/src/lxc/commands.c
@@ -1554,6 +1554,12 @@ static int lxc_cmd_console_log_callback(int fd, struct lxc_cmd_req *req,
 	rsp.ret = -EFAULT;
 	rsp.datalen = 0;
 	rsp.data = NULL;
+
+	if (req->datalen != sizeof(struct lxc_cmd_console_log) || !req->data) {
+		rsp.ret = -EINVAL;
+		goto out;
+	}
+
 	if (buffer_size <= 0)
 		goto out;
 


### PR DESCRIPTION
1. lxc_cmd_console_log_callback() reads req->data as a fixed struct lxc_cmd_console_log without checking req->datalen, while the command server only allocates and receives req->datalen bytes for req->data.
2. LXC_CMD_CONSOLE_LOG is exempted from the LXC_CMD_DATA_MAX check in lxc_cmd_handler(), so a client can send it with a datalen smaller than sizeof(struct lxc_cmd_console_log). With datalen of 0 req->data is left as the pointer value taken off the wire, and with a small positive datalen (e.g. 8 < 24) the callback reads read_max and write_logfile past the heap allocation.
3. Reject a request whose datalen does not match the struct size before the struct is dereferenced, matching add_state_client and add_bpf_device_cgroup which already validate their fixed-size payloads.

Confirmed the out-of-bounds read under ASAN by exercising the callback's field-access pattern against an 8-byte buffer.