### PR TITLE
lxc-stop: Wait for processes to exit before deleting cgroup

### DIFF
--- a/doc/lxc.container.conf.sgml.in
+++ b/doc/lxc.container.conf.sgml.in
@@ -229,6 +229,29 @@
     </refsect2>
 
     <refsect2>
+      <title>Drain timeout</title>
+      <para>
+        Configures gor how long to wait after the container exits for
+        termination of remaining processes. The container init usually doesn't
+        wait for termination of processes started by lxc-attach although it
+        signals them. The default is 3 seconds.
+          </para>
+          <variablelist>
+        <varlistentry>
+          <term>
+            <option>lxc.stop.drain_timeout</option>
+          </term>
+          <listitem>
+            <para>
+              how many seconds to wait for container processes to exit (use -1
+              for infinite)
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </refsect2>
+
+    <refsect2>
       <title>Init command</title>
       <para>
         Sets the command to use as the init system for the containers.

--- a/src/lxc/cgroups/cgfsng.c
+++ b/src/lxc/cgroups/cgfsng.c
@@ -448,6 +448,80 @@ __cgfsng_ops static void cgfsng_payload_destroy(struct cgroup_ops *ops,
 		SYSWARN("Failed to destroy cgroups");
 }
 
+static int populated_cgroup_events_cb(int fd, uint32_t events, void *cbdata,
+				      struct lxc_async_descr *descr)
+{
+	char buf[512];
+	ssize_t len;
+
+	len = lxc_pread_nointr(fd, buf, sizeof(buf), 0);
+	if (len < 0 || len == sizeof(buf))
+		return LXC_MAINLOOP_ERROR;
+	buf[len] = 0;
+
+	if (strstr(buf, "populated 0\n"))
+		return LXC_MAINLOOP_CLOSE;
+	return LXC_MAINLOOP_CONTINUE;
+}
+
+__cgfsng_ops static int cgfsng_payload_drain(struct cgroup_ops *ops,
+					     struct lxc_handler *handler,
+					     int timeout)
+{
+	__do_close int events_fd = -EBADF;
+	struct lxc_async_descr descr = {};
+	call_cleaner(lxc_mainloop_close) struct lxc_async_descr *descr_ptr = NULL;
+	int ret;
+	struct hierarchy *h;
+
+	/* timeout == 0: caller requested no wait */
+	if (timeout == 0)
+		return 0;
+
+	if (!ops || !ops->unified)
+		return 0;
+
+	h = ops->unified;
+	if (h->dfd_con < 0)
+		return 0;
+
+	events_fd = open_at(h->dfd_con, "cgroup.events",
+			    PROTECT_OPEN, PROTECT_LOOKUP_BENEATH, 0);
+	if (events_fd < 0) {
+		TRACE("cgroup.events not available, skipping drain");
+		return 0;
+	}
+
+	ret = lxc_mainloop_open(&descr);
+	if (ret)
+		return log_error_errno(-1, errno,
+				       "Failed to create epoll instance for cgroup drain");
+	descr_ptr = &descr;
+
+	ret = lxc_mainloop_add_handler_events(&descr, events_fd, EPOLLPRI,
+					      populated_cgroup_events_cb,
+					      default_cleanup_handler,
+					      NULL,
+					      "populated_cgroup_events_cb");
+	if (ret < 0)
+		return log_error_errno(-1, errno,
+				       "Failed to add cgroup.events fd to mainloop");
+
+	/*
+	 * Check the current state after registering with epoll to avoid missing
+	 * a transition that happened before epoll_ctl returned.
+	 */
+	ret = populated_cgroup_events_cb(events_fd, EPOLLPRI, NULL, &descr);
+	if (ret == LXC_MAINLOOP_CLOSE)
+		return 0;
+
+	ret = lxc_mainloop(&descr, timeout < 0 ? timeout : timeout * 1000);
+	if (ret)
+		WARN("Timed out waiting for container cgroup to drain");
+
+	return ret;
+}
+
 static int __cgroup_tree_create(int dfd_base, const char *path, mode_t mode,
 				bool eexist_ignore)
 {
@@ -3569,6 +3643,7 @@ struct cgroup_ops *cgroup_ops_init(struct lxc_conf *conf)
 
 	cgfsng_ops->data_init				= cgfsng_data_init;
 	cgfsng_ops->payload_destroy			= cgfsng_payload_destroy;
+	cgfsng_ops->payload_drain			= cgfsng_payload_drain;
 	cgfsng_ops->monitor_destroy			= cgfsng_monitor_destroy;
 	cgfsng_ops->monitor_create			= cgfsng_monitor_create;
 	cgfsng_ops->monitor_enter			= cgfsng_monitor_enter;

--- a/src/lxc/cgroups/cgroup.h
+++ b/src/lxc/cgroups/cgroup.h
@@ -247,6 +247,7 @@ struct cgroup_ops {
 
 	int (*data_init)(struct cgroup_ops *ops);
 	void (*payload_destroy)(struct cgroup_ops *ops, struct lxc_handler *handler);
+	int (*payload_drain)(struct cgroup_ops *ops, struct lxc_handler *handler, int timeout);
 	void (*monitor_destroy)(struct cgroup_ops *ops, struct lxc_handler *handler);
 	bool (*monitor_create)(struct cgroup_ops *ops, struct lxc_handler *handler);
 	bool (*monitor_enter)(struct cgroup_ops *ops, struct lxc_handler *handler);

--- a/src/lxc/conf.c
+++ b/src/lxc/conf.c
@@ -3090,6 +3090,7 @@ struct lxc_conf *lxc_conf_init(void)
 	memset(&new->console.ringbuf, 0, sizeof(struct lxc_ringbuf));
 	new->maincmd_fd = -1;
 	new->monitor_signal_pdeath = SIGKILL;
+	new->drain_timeout = 3;
 	new->nbd_idx = -1;
 	new->rootfs.mount = strdup(default_rootfs_mount);
 	if (!new->rootfs.mount) {

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -484,6 +484,7 @@ struct lxc_conf {
 	int haltsignal; /* signal used to halt container */
 	int rebootsignal; /* signal used to reboot container */
 	int stopsignal; /* signal used to hard stop container */
+	int drain_timeout; /* seconds to wait for cgroup to drain after stop; -1 = infinite */
 	char *rcfile;	/* Copy of the top level rcfile we read */
 
 	/* Logfile and loglevel can be set in a container config file. Those

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -151,6 +151,7 @@ lxc_config_define(selinux_context_keyring);
 lxc_config_define(signal_halt);
 lxc_config_define(signal_reboot);
 lxc_config_define(signal_stop);
+lxc_config_define(stop_drain_timeout);
 lxc_config_define(start);
 lxc_config_define(tty_max);
 lxc_config_define(tty_dir);
@@ -268,6 +269,7 @@ static struct lxc_config_t config_jump_table[] = {
 	{ "lxc.signal.halt",                true,  set_config_signal_halt,                get_config_signal_halt,                clr_config_signal_halt,                },
 	{ "lxc.signal.reboot",              true,  set_config_signal_reboot,              get_config_signal_reboot,              clr_config_signal_reboot,              },
 	{ "lxc.signal.stop",                true,  set_config_signal_stop,                get_config_signal_stop,                clr_config_signal_stop,                },
+	{ "lxc.stop.drain_timeout",         true,  set_config_stop_drain_timeout,         get_config_stop_drain_timeout,         clr_config_stop_drain_timeout,         },
 	{ "lxc.start.auto",                 true,  set_config_start,                      get_config_start,                      clr_config_start,                      },
 	{ "lxc.start.delay",                true,  set_config_start,                      get_config_start,                      clr_config_start,                      },
 	{ "lxc.start.order",                true,  set_config_start,                      get_config_start,                      clr_config_start,                      },
@@ -1915,6 +1917,24 @@ static int set_config_signal_stop(const char *key, const char *value,
 		return ret_errno(EINVAL);
 
 	lxc_conf->stopsignal = sig_n;
+
+	return 0;
+}
+
+static int set_config_stop_drain_timeout(const char *key, const char *value,
+				    struct lxc_conf *lxc_conf, void *data)
+{
+	int timeout;
+
+	if (lxc_config_value_empty(value)) {
+		lxc_conf->drain_timeout = 3;
+		return 0;
+	}
+
+	if (lxc_safe_int(value, &timeout) < 0)
+		return ret_errno(EINVAL);
+
+	lxc_conf->drain_timeout = timeout;
 
 	return 0;
 }
@@ -4424,6 +4444,12 @@ static int get_config_signal_stop(const char *key, char *retv, int inlen,
 	return lxc_get_conf_int(c, retv, inlen, c->stopsignal);
 }
 
+static int get_config_stop_drain_timeout(const char *key, char *retv, int inlen,
+				    struct lxc_conf *c, void *data)
+{
+	return lxc_get_conf_int(c, retv, inlen, c->drain_timeout);
+}
+
 static int get_config_start(const char *key, char *retv, int inlen,
 			    struct lxc_conf *c, void *data)
 {
@@ -5179,6 +5205,13 @@ static inline int clr_config_signal_stop(const char *key, struct lxc_conf *c,
 					void *data)
 {
 	c->stopsignal = 0;
+	return 0;
+}
+
+static int clr_config_stop_drain_timeout(const char *key, struct lxc_conf *c,
+				    void *data)
+{
+	c->drain_timeout = 3;
 	return 0;
 }
 

--- a/src/lxc/file_utils.c
+++ b/src/lxc/file_utils.c
@@ -255,6 +255,17 @@ ssize_t lxc_pwrite_nointr(int fd, const void *buf, size_t count, off_t offset)
 	return ret;
 }
 
+ssize_t lxc_pread_nointr(int fd, void *buf, size_t count, off_t offset)
+{
+	ssize_t ret;
+
+	do {
+		ret = pread(fd, buf, count, offset);
+	} while (ret < 0 && errno == EINTR);
+
+	return ret;
+}
+
 ssize_t lxc_send_nointr(int sockfd, void *buf, size_t len, int flags)
 {
 	ssize_t ret;

--- a/src/lxc/file_utils.h
+++ b/src/lxc/file_utils.h
@@ -42,6 +42,9 @@ __hidden extern ssize_t lxc_write_nointr(int fd, const void *buf, size_t count) 
 __hidden extern ssize_t lxc_pwrite_nointr(int fd, const void *buf, size_t count, off_t offset)
     __access_r(2, 3);
 
+__hidden extern ssize_t lxc_pread_nointr(int fd, void *buf, size_t count, off_t offset)
+    __access_w(2, 3);
+
 __hidden extern ssize_t lxc_send_nointr(int sockfd, void *buf, size_t len, int flags)
     __access_r(2, 3);
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1139,6 +1139,8 @@ void lxc_end(struct lxc_handler *handler)
 	handler->lsm_ops->cleanup(handler->lsm_ops, handler->conf, handler->lxcpath);
 
 	if (cgroup_ops) {
+		cgroup_ops->payload_drain(cgroup_ops, handler,
+					  handler->conf->drain_timeout);
 		cgroup_ops->payload_destroy(cgroup_ops, handler);
 		cgroup_ops->monitor_destroy(cgroup_ops, handler);
 	}


### PR DESCRIPTION
Even during a clean shutdown, it may happen the container init exits before all container processes have terminated, because processes started by lxc-attach are not descendats of init, thus if init waits using something like:
  while (wait() >= 0);
attached processes won't be waited for.

In a case of unclean shutdown, kernel kills all processes in a response of PID namespace init (NS PID 1) exitting, in which case these killed processes exit after the init process has terminated.

LXC currently waits for the container init to exit, after which it proceeds with container cgroup cleanup, which fails if some processes are still alive leading to the cgroup directory being left behind and preventing the container from being started again.

Extend lxc-stop by new drain-timeout option with default value of 3s, which configures how long lxc-stop should wait for all processes from the container cgroup to exit. This avoids hanging forever, when some of the container processes are in uninterruptible sleep.