### PR TITLE
 fix(init): propagate lxc-autostart exit status in lxc-containers

### DIFF
--- a/config/init/common/lxc-containers.in
+++ b/config/init/common/lxc-containers.in
@@ -87,7 +87,9 @@ case "$1" in
 
         # Start autoboot containers first then the NULL group "onboot,".
         "$bindir"/lxc-autostart $OPTIONS $BOOTGROUPS
+        res=$?
         rm -f "$lockdir"/lxc
+        exit $res
     ;;
 
     stop)


### PR DESCRIPTION
## Description
This PR addresses an issue where the `lxc-containers` helper script masks the exit status of the `lxc-autostart` command and always returns `0` upon starting. 

Since systemd (via `lxc.service`), SysVinit, and OpenRC utilize this script to initialize and autostart containers, the service manager would report that the unit successfully started even when container autostarting partially or completely failed. As a consequence, failures during startup went unnoticed by monitoring tools and administrators relying on service exit status.

Fixes https://github.com/lxc/lxc/issues/4661
### Changes
- Updated the `start)` case block in `config/init/common/lxc-containers.in`.
- Cached the exit code of `lxc-autostart` to a local variable `res` (using `res=$?`).
- Executed the transient lock file cleanup command `rm -f "$lockdir"/lxc`.
- Explicitly called `exit $res` to return the original exit status of `lxc-autostart` back to the invoking init wrapper.

---

## Technical Context & Impact
- **Lock File Semantics**: The lock file `/var/lock/subsys/lxc` (or `/var/lock/lxc`) acts as a transient lock to prevent concurrent container startup runs. Removing it at the end of the start block is a necessary cleanup step regardless of success or failure. By caching `$?` first, we prevent `rm` from overwriting the exit code.
- **Portability**: This solution is fully POSIX compliant and uses standard syntax that works across different shells (such as `dash`, `bash`, or generic `sh`).
- **Init Systems Affected**: 
  - **Systemd** (`Type=oneshot` service `lxc.service` using `lxc-containers start`)
  - **SysVinit** (delegates to `lxc-containers start`)
  - **OpenRC** (delegates to `lxc-containers start`)

---

## Verification & Testing
- Built/configured the build tree utilizing Meson. Verified that macro expansion correctly generates `build/config/init/common/lxc-containers`.
- Manually verified that the script correctly returns non-zero values on failures of `lxc-autostart` and `0` on successful runs.
- Verified that lock file cleanup continues to run properly.
