### PR TITLE
criu: Finalize cgroups after restore

### DIFF
--- a/src/lxc/criu.c
+++ b/src/lxc/criu.c
@@ -1088,6 +1088,15 @@ static void do_restore(struct lxc_container *c, int status_pipe, struct migrate_
 					ERROR("error setting running state after restore");
 					goto out_fini_handler;
 				}
+
+				/*
+				 * Normal startup finalizes cgroup discovery after the
+				 * payload cgroup exists. Do the same after CRIU restore
+				 * so utility controllers such as cgroup v2 freezer are
+				 * available to a later checkpoint of this container.
+				 */
+				cgroup_ops->finalize(cgroup_ops);
+				TRACE("Finished setting up restored cgroups");
 			}
 		} else {
 			ERROR("CRIU was killed with signal %d", WTERMSIG(status));


### PR DESCRIPTION
## Summary

Finalize the container cgroup setup after a successful CRIU restore.

Normal startup finalizes cgroup discovery after the payload cgroup exists. The CRIU restore path marked the container as running but skipped that finalization. As a result, utility cgroup v2 controllers, including freezer, may not be available for a subsequent checkpoint or live migration of the restored container.

## Testing

- Built `liblxc.so.1.9.0` from the current `main` base in Alpine 3.24 using Meson and Ninja.