### PR TITLE
log: test: fix Clang ASan and TSan issues

### DIFF
--- a/src/tests/concurrent.c
+++ b/src/tests/concurrent.c
@@ -243,7 +243,9 @@ int main(int argc, char *argv[]) {
 						exit(EXIT_FAILURE);
 					}
 				}
+			}
 
+			for (j = 0; j < nthreads; j++) {
 				if (args[j].return_code) {
 					fprintf(stderr, "thread returned error %d\n", args[j].return_code);
 					exit(EXIT_FAILURE);


### PR DESCRIPTION
### ASAN (AddressSanitizer):

ASAN issued a set ODR-violation warnings. Ttest binaries link source code (nl.c and cgroup_utils.c) directly, while simultaneously connecting dynamic library liblxc.so , which leads to duplication of global logger variables (lxc_log_category_*). I  fix this by adding the `__attribute__((weak))` attr

### TSAN (ThreadSanitizer):

Thread Leak was detected in the src/tests/concurrent.c file.
problem was that if one of the threads terminated with an error, main thread called exit(EXIT_FAILURE) before it had time to do pthread_join() for the rest of the threads. I rewrote this section of code (lines 239-251), separating the pthread_join waiting cycle and thread return code checking cycle. After making changes and running the tests again with TSAN, the thread leaks disappeared.

Clang asan log:

[sanitizers.log](https://github.com/user-attachments/files/30967495/sanitizers.log)

Example:

```
--- asan.log.4431 ---
=================================================================
==4431==ERROR: AddressSanitizer: odr-violation (0x556d0d6e7120):
  [1] size=32 'lxc_log_category_nl' ../src/lxc/nl.c:18:1 in /media/devuan/7b0651a1-06b3-47ec-97cb-73b496ab459f/lxc/build-asan/src/tests/lxc-test-list
  [2] size=32 'lxc_log_category_nl' ../src/lxc/nl.c:18:1 in /media/devuan/7b0651a1-06b3-47ec-97cb-73b496ab459f/lxc/build-asan/src/tests/../../liblxc.so.1
These globals were registered at these points:
  [1]:
    #0 0x7f9bf4a534ef in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:410
    #1 0x556d0d6892ec in _sub_I_00099_1.4473 (/media/devuan/7b0651a1-06b3-47ec-97cb-73b496ab459f/lxc/build-asan/src/tests/lxc-test-list+0x1422ec) (BuildId: 8c2e3807c1f4e9b6a1ae5a7cc1a0325a0feb7e52)
    #2 0x7f9bf283409e in call_init ../csu/libc-start.c:145
    #3 0x7f9bf283409e in __libc_start_main_impl ../csu/libc-start.c:347

  [2]:
    #0 0x7f9bf4a534ef in __asan_register_globals ../../../../src/libsanitizer/asan/asan_globals.cpp:410
    #1 0x7f9bf42baf8c in _sub_I_00099_1.35111 (/media/devuan/7b0651a1-06b3-47ec-97cb-73b496ab459f/lxc/build-asan/src/tests/../../liblxc.so.1+0x8baf8c) (BuildId: e84f612c29403fe493721aa0c120d2612a2a074e)
    #2 0x7f9bf51f3fbd in call_init elf/dl-init.c:74
    #3 0x7f9bf51f3fbd in call_init elf/dl-init.c:26

==4431==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'lxc_log_category_nl' at ../src/lxc/nl.c:18:1 in /media/devuan/7b0651a1-06b3-47ec-97cb-73b496ab459f/lxc/build-asan/src/tests/lxc-test-list
==4431==ABORTING
```
