### PR TITLE
Added support Runit and Dinit init systems

### DIFF
--- a/config/init/dinit/lxc-containers.in
+++ b/config/init/dinit/lxc-containers.in
@@ -1,0 +1,5 @@
+type = scripted
+command = @LIBEXECDIR@/lxc/lxc-containers start
+stop-command = @LIBEXECDIR@/lxc/lxc-containers stop
+waits-for = lxc-net
+smooth-recovery = true

--- a/config/init/dinit/lxc-monitord.in
+++ b/config/init/dinit/lxc-monitord.in
@@ -1,0 +1,3 @@
+type = process
+command = @LIBEXECDIR@/lxc/lxc-monitord --daemon
+smooth-recovery = true

--- a/config/init/dinit/lxc-net.in
+++ b/config/init/dinit/lxc-net.in
@@ -1,0 +1,5 @@
+type = scripted
+command = @LIBEXECDIR@/lxc/lxc-net start
+stop-command = @LIBEXECDIR@/lxc/lxc-net stop
+waits-for = network
+smooth-recovery = true

--- a/config/init/dinit/lxc.in
+++ b/config/init/dinit/lxc.in
@@ -1,0 +1,5 @@
+type = scripted
+command = @LIBEXECDIR@/lxc/lxc-containers start
+stop-command = @LIBEXECDIR@/lxc/lxc-containers stop
+waits-for = lxc-net
+smooth-recovery = true

--- a/config/init/dinit/lxc@.in
+++ b/config/init/dinit/lxc@.in
@@ -1,0 +1,5 @@
+type = process
+command = @BINDIR@/lxc-start -F -n $1
+stop-command = @BINDIR@/lxc-stop -n $1
+waits-for = lxc-net
+smooth-recovery = true

--- a/config/init/dinit/meson.build
+++ b/config/init/dinit/meson.build
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+if 'dinit' in init_script
+    dinit_service_dir = get_option('dinit-servicedir')
+    if dinit_service_dir == ''
+        dinit_service_dir = join_paths(sysconfdir, 'dinit.d')
+    endif
+
+    configure_file(
+        configuration: conf,
+        input: 'lxc.in',
+        output: 'lxc',
+        install: true,
+        install_dir: dinit_service_dir)
+
+    configure_file(
+        configuration: conf,
+        input: 'lxc-containers.in',
+        output: 'lxc-containers',
+        install: true,
+        install_dir: dinit_service_dir)
+
+    configure_file(
+        configuration: conf,
+        input: 'lxc-net.in',
+        output: 'lxc-net',
+        install: true,
+        install_dir: dinit_service_dir)
+
+    configure_file(
+        configuration: conf,
+        input: 'lxc-monitord.in',
+        output: 'lxc-monitord',
+        install: true,
+        install_dir: dinit_service_dir)
+
+    configure_file(
+        configuration: conf,
+        input: 'lxc@.in',
+        output: 'lxc@',
+        install: true,
+        install_dir: dinit_service_dir)
+endif

--- a/config/init/runit/lxc-containers/finish.in
+++ b/config/init/runit/lxc-containers/finish.in
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec @LIBEXECDIR@/lxc/lxc-containers stop

--- a/config/init/runit/lxc-containers/meson.build
+++ b/config/init/runit/lxc-containers/meson.build
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+configure_file(
+    configuration: conf,
+    input: 'run.in',
+    output: 'run',
+    install: true,
+    install_dir: join_paths(runit_service_dir, 'lxc-containers'),
+    install_mode: 'rwxr-xr-x')
+
+configure_file(
+    configuration: conf,
+    input: 'finish.in',
+    output: 'finish',
+    install: true,
+    install_dir: join_paths(runit_service_dir, 'lxc-containers'),
+    install_mode: 'rwxr-xr-x')

--- a/config/init/runit/lxc-containers/run.in
+++ b/config/init/runit/lxc-containers/run.in
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+@LIBEXECDIR@/lxc/lxc-containers start
+exec pause 2>/dev/null || exec sleep infinity

--- a/config/init/runit/lxc-monitord/meson.build
+++ b/config/init/runit/lxc-monitord/meson.build
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+configure_file(
+    configuration: conf,
+    input: 'run.in',
+    output: 'run',
+    install: true,
+    install_dir: join_paths(runit_service_dir, 'lxc-monitord'),
+    install_mode: 'rwxr-xr-x')

--- a/config/init/runit/lxc-monitord/run.in
+++ b/config/init/runit/lxc-monitord/run.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec @LIBEXECDIR@/lxc/lxc-monitord --daemon

--- a/config/init/runit/lxc-net/finish.in
+++ b/config/init/runit/lxc-net/finish.in
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec @LIBEXECDIR@/lxc/lxc-net stop

--- a/config/init/runit/lxc-net/meson.build
+++ b/config/init/runit/lxc-net/meson.build
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+configure_file(
+    configuration: conf,
+    input: 'run.in',
+    output: 'run',
+    install: true,
+    install_dir: join_paths(runit_service_dir, 'lxc-net'),
+    install_mode: 'rwxr-xr-x')
+
+configure_file(
+    configuration: conf,
+    input: 'finish.in',
+    output: 'finish',
+    install: true,
+    install_dir: join_paths(runit_service_dir, 'lxc-net'),
+    install_mode: 'rwxr-xr-x')

--- a/config/init/runit/lxc-net/run.in
+++ b/config/init/runit/lxc-net/run.in
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+@LIBEXECDIR@/lxc/lxc-net start
+exec pause 2>/dev/null || exec sleep infinity

--- a/config/init/runit/meson.build
+++ b/config/init/runit/meson.build
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+if 'runit' in init_script
+    runit_service_dir = get_option('runit-servicedir')
+    if runit_service_dir == ''
+        runit_service_dir = join_paths(sysconfdir, 'sv')
+    endif
+
+    subdir('lxc-containers')
+    subdir('lxc-net')
+    subdir('lxc-monitord')
+endif

--- a/meson.build
+++ b/meson.build
@@ -939,6 +939,12 @@ if want_install_init
     if 'openrc' in init_script
         subdir('config/init/openrc')
     endif
+    if 'runit' in init_script
+        subdir('config/init/runit')
+    endif
+    if 'dinit' in init_script
+        subdir('config/init/dinit')
+    endif
     subdir('config/sysconfig')
 endif
 if want_selinux

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,13 +15,19 @@ option('examples', type: 'boolean', value: true,
 
 # was --init-script in autotools
 option('init-script', type: 'array',
-       choices: ['systemd', 'sysvinit', 'openrc'], value: ['systemd'],
+       choices: ['systemd', 'sysvinit', 'openrc', 'runit', 'dinit'], value: ['systemd'],
        description: 'init script')
 
 # was --systemd-unidir in autotools
 # If set to "", the value is taken from the running systemd instance.
 option('systemd-unitdir', type: 'string', value: '',
        description: 'systemd system unit directory')
+
+option('runit-servicedir', type: 'string', value: '',
+       description: 'runit service directory')
+
+option('dinit-servicedir', type: 'string', value: '',
+       description: 'dinit service directory')
 
 # was --{disable,enable}-liburing in autotools
 option('io-uring-event-loop', type: 'boolean', value: false,


### PR DESCRIPTION
Affected Linux and BSD distros:
- Gentoo Linux
- FreeBSD (dinit)
- OpenBSD (dinit)
- Devuan
- Void Linux
- antiX
- Chimera Linux (dinit)
- Artix Linux (dinit)