### PR TITLE
keep capabilities if init process is not run as root

### DIFF
--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1368,7 +1368,7 @@ __noreturn static void do_attach(struct attach_payload *ap)
 		lxc_seccomp_close_notifier_fd(&conf->seccomp);
 	}
 
-	if (conf->cap_inheritance) {
+	if (conf->nonroot_keepcaps) {
 		ret = lxc_set_keepcaps();
 		if (ret < 0)
 			goto on_error;

--- a/src/lxc/attach.c
+++ b/src/lxc/attach.c
@@ -1368,8 +1368,21 @@ __noreturn static void do_attach(struct attach_payload *ap)
 		lxc_seccomp_close_notifier_fd(&conf->seccomp);
 	}
 
-	if (!lxc_switch_uid_gid(ctx->target_ns_uid, ctx->target_ns_gid))
-		goto on_error;
+	if (conf->cap_inheritance) {
+		ret = lxc_set_keepcaps();
+		if (ret < 0)
+			goto on_error;
+
+		if (!lxc_switch_uid_gid(ctx->target_ns_uid, ctx->target_ns_gid))
+			goto on_error;
+
+		ret = lxc_bounding_as_ambient_caps();
+		if (ret < 0)
+			goto on_error;
+	} else {
+		if (!lxc_switch_uid_gid(ctx->target_ns_uid, ctx->target_ns_gid))
+			goto on_error;
+	}
 
 	put_attach_payload(ap);
 

--- a/src/lxc/caps.c
+++ b/src/lxc/caps.c
@@ -323,4 +323,46 @@ bool lxc_proc_cap_is_set(cap_value_t cap, cap_flag_t flag)
 
 	return lxc_cap_is_set(caps, cap, flag);
 }
+
+int lxc_bounding_as_ambient_caps(void)
+{
+	call_cleaner(cap_free) cap_t caps = NULL;
+	int ret;
+	cap_value_t cap;
+
+	caps = cap_get_proc();
+	if (!caps)
+		return log_error_errno(-1, errno, "Failed to retrieve capabilities");
+
+	for (cap = 0; cap <= CAP_LAST_CAP; cap++) {
+		if (cap_get_bound(cap) <= 0)
+			continue;
+
+		ret = cap_set_flag(caps, CAP_PERMITTED, 1, &cap, CAP_SET);
+		if (ret < 0) {
+			return log_error_errno(ret, errno, "Failed to set cap %d as permitted", cap);
+		}
+		ret = cap_set_flag(caps, CAP_INHERITABLE, 1, &cap, CAP_SET);
+		if (ret < 0) {
+			return log_error_errno(ret, errno, "Failed to set cap %d as inheritable", cap);
+		}
+
+		ret = cap_set_proc(caps);
+		if (ret < 0)
+			return log_error_errno(ret, errno, "Failed to set capabilities");
+
+		cap_set_ambient(cap, CAP_SET);
+	}
+
+	return 0;
+}
+
+int lxc_set_keepcaps(void) {
+	int ret = prctl(PR_SET_KEEPCAPS, prctl_arg(1));
+	if (ret < 0)
+		return log_error_errno(ret, errno, "Failed to set PR_SET_KEEPCAPS");
+
+	return ret;
+}
+
 #endif

--- a/src/lxc/caps.h
+++ b/src/lxc/caps.h
@@ -21,6 +21,8 @@ __hidden extern int lxc_caps_init(void);
 __hidden extern int lxc_caps_last_cap(__u32 *cap);
 __hidden extern bool lxc_proc_cap_is_set(cap_value_t cap, cap_flag_t flag);
 __hidden extern bool lxc_file_cap_is_set(const char *path, cap_value_t cap, cap_flag_t flag);
+__hidden extern int lxc_bounding_as_ambient_caps(void);
+__hidden extern int lxc_set_keepcaps(void);
 #else
 static inline int lxc_caps_down(void)
 {
@@ -64,6 +66,17 @@ static inline bool lxc_file_cap_is_set(const char *path, cap_value_t cap,
 {
 	return false;
 }
+
+static inline int lxc_bounding_as_ambiant_caps(void)
+{
+	return 0;
+}
+
+static inline int lxc_set_keepcaps(void)
+{
+	return 0;
+}
+
 #endif
 
 #define lxc_priv(__lxc_function)                          \

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -534,8 +534,9 @@ struct lxc_conf {
 	/* The groups to use for the container. */
 	lxc_groups_t init_groups;
 
-	/* Whether the available caps can be set as inheritable/ambient for the container */
-	bool cap_inheritance;
+	/* Defines whether a privileged container with a nonroot user (init_uid != 0)
+	 * will keep capabilities */
+	bool nonroot_keepcaps;
 
 	/* indicator if the container will be destroyed on shutdown */
 	unsigned int ephemeral;

--- a/src/lxc/conf.h
+++ b/src/lxc/conf.h
@@ -534,6 +534,9 @@ struct lxc_conf {
 	/* The groups to use for the container. */
 	lxc_groups_t init_groups;
 
+	/* Whether the available caps can be set as inheritable/ambient for the container */
+	bool cap_inheritance;
+
 	/* indicator if the container will be destroyed on shutdown */
 	unsigned int ephemeral;
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -92,6 +92,7 @@ lxc_config_define(init_cmd);
 lxc_config_define(init_cwd);
 lxc_config_define(init_gid);
 lxc_config_define(init_uid);
+lxc_config_define(cap_inheritance);
 lxc_config_define(init_groups);
 lxc_config_define(jump_table_net);
 lxc_config_define(keyring_session);
@@ -235,6 +236,7 @@ static struct lxc_config_t config_jump_table[] = {
 	{ "lxc.init.gid",                   true,  set_config_init_gid,                   get_config_init_gid,                   clr_config_init_gid,                   },
 	{ "lxc.init.groups",                true,  set_config_init_groups,                get_config_init_groups,                clr_config_init_groups,                },
 	{ "lxc.init.uid",                   true,  set_config_init_uid,                   get_config_init_uid,                   clr_config_init_uid,                   },
+	{ "lxc.cap.inheritance",            true,  set_config_cap_inheritance,            get_config_cap_inheritance,            clr_config_cap_inheritance,            },
 	{ "lxc.init.cwd",                   true,  set_config_init_cwd,                   get_config_init_cwd,                   clr_config_init_cwd,                   },
 	{ "lxc.keyring.session",            true,  set_config_keyring_session,            get_config_keyring_session,            clr_config_keyring_session             },
 	{ "lxc.log.file",                   true,  set_config_log_file,                   get_config_log_file,                   clr_config_log_file,                   },
@@ -1285,6 +1287,12 @@ static int set_config_init_uid(const char *key, const char *value,
 	lxc_conf->init_uid = init_uid;
 
 	return 0;
+}
+
+static int set_config_cap_inheritance(const char *key, const char *value,
+			       struct lxc_conf *lxc_conf, void *data)
+{
+	return set_config_bool_item(&lxc_conf->cap_inheritance, value, false);
 }
 
 static int set_config_init_gid(const char *key, const char *value,
@@ -4535,6 +4543,12 @@ static int get_config_init_uid(const char *key, char *retv, int inlen,
 	return lxc_get_conf_int(c, retv, inlen, c->init_uid);
 }
 
+static int get_config_cap_inheritance(const char *key, char *retv, int inlen,
+			       struct lxc_conf *c, void *data)
+{
+	return lxc_get_conf_bool(c, retv, inlen, c->cap_inheritance);
+}
+
 static int get_config_init_gid(const char *key, char *retv, int inlen,
 			       struct lxc_conf *c, void *data)
 {
@@ -5265,6 +5279,13 @@ static inline int clr_config_init_uid(const char *key, struct lxc_conf *c,
 				      void *data)
 {
 	c->init_uid = 0;
+	return 0;
+}
+
+static inline int clr_config_cap_inheritance(const char *key, struct lxc_conf *c,
+				      void *data)
+{
+	c->cap_inheritance = false;
 	return 0;
 }
 

--- a/src/lxc/confile.c
+++ b/src/lxc/confile.c
@@ -92,7 +92,7 @@ lxc_config_define(init_cmd);
 lxc_config_define(init_cwd);
 lxc_config_define(init_gid);
 lxc_config_define(init_uid);
-lxc_config_define(cap_inheritance);
+lxc_config_define(nonroot_keepcaps);
 lxc_config_define(init_groups);
 lxc_config_define(jump_table_net);
 lxc_config_define(keyring_session);
@@ -236,7 +236,7 @@ static struct lxc_config_t config_jump_table[] = {
 	{ "lxc.init.gid",                   true,  set_config_init_gid,                   get_config_init_gid,                   clr_config_init_gid,                   },
 	{ "lxc.init.groups",                true,  set_config_init_groups,                get_config_init_groups,                clr_config_init_groups,                },
 	{ "lxc.init.uid",                   true,  set_config_init_uid,                   get_config_init_uid,                   clr_config_init_uid,                   },
-	{ "lxc.cap.inheritance",            true,  set_config_cap_inheritance,            get_config_cap_inheritance,            clr_config_cap_inheritance,            },
+	{ "lxc.cap.nonroot",                true,  set_config_nonroot_keepcaps,           get_config_nonroot_keepcaps,           clr_config_nonroot_keepcaps,           },
 	{ "lxc.init.cwd",                   true,  set_config_init_cwd,                   get_config_init_cwd,                   clr_config_init_cwd,                   },
 	{ "lxc.keyring.session",            true,  set_config_keyring_session,            get_config_keyring_session,            clr_config_keyring_session             },
 	{ "lxc.log.file",                   true,  set_config_log_file,                   get_config_log_file,                   clr_config_log_file,                   },
@@ -1289,10 +1289,10 @@ static int set_config_init_uid(const char *key, const char *value,
 	return 0;
 }
 
-static int set_config_cap_inheritance(const char *key, const char *value,
+static int set_config_nonroot_keepcaps(const char *key, const char *value,
 			       struct lxc_conf *lxc_conf, void *data)
 {
-	return set_config_bool_item(&lxc_conf->cap_inheritance, value, false);
+	return set_config_bool_item(&lxc_conf->nonroot_keepcaps, value, false);
 }
 
 static int set_config_init_gid(const char *key, const char *value,
@@ -4543,10 +4543,10 @@ static int get_config_init_uid(const char *key, char *retv, int inlen,
 	return lxc_get_conf_int(c, retv, inlen, c->init_uid);
 }
 
-static int get_config_cap_inheritance(const char *key, char *retv, int inlen,
+static int get_config_nonroot_keepcaps(const char *key, char *retv, int inlen,
 			       struct lxc_conf *c, void *data)
 {
-	return lxc_get_conf_bool(c, retv, inlen, c->cap_inheritance);
+	return lxc_get_conf_bool(c, retv, inlen, c->nonroot_keepcaps);
 }
 
 static int get_config_init_gid(const char *key, char *retv, int inlen,
@@ -5282,10 +5282,10 @@ static inline int clr_config_init_uid(const char *key, struct lxc_conf *c,
 	return 0;
 }
 
-static inline int clr_config_cap_inheritance(const char *key, struct lxc_conf *c,
+static inline int clr_config_nonroot_keepcaps(const char *key, struct lxc_conf *c,
 				      void *data)
 {
-	c->cap_inheritance = false;
+	c->nonroot_keepcaps = false;
 	return 0;
 }
 

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1616,19 +1616,35 @@ static int do_start(void *data)
 			goto out_warn_father;
 	}
 
-	if (!lxc_switch_uid_gid(new_uid, new_gid))
-		goto out_warn_father;
+	if (handler->conf->cap_inheritance) {
+		NOTICE("Inherit capabilities");
+		ret = lxc_set_keepcaps();
+		if (ret < 0)
+			goto out_warn_father;
+
+		if (!lxc_switch_uid_gid(new_uid, new_gid))
+			goto out_warn_father;
+
+		ret = lxc_bounding_as_ambient_caps();
+		if (ret < 0) {
+			ERROR("Failed to set bounding capabilities as ambiant");
+			goto out_warn_father;
+		}
+	} else {
+		if (!lxc_switch_uid_gid(new_uid, new_gid))
+			goto out_warn_father;
+
+		ret = lxc_ambient_caps_down();
+		if (ret < 0) {
+			ERROR("Failed to clear ambient capabilities");
+			goto out_warn_father;
+		}
+	}
 
 	ret = prctl(PR_SET_DUMPABLE, prctl_arg(1), prctl_arg(0),
 		    prctl_arg(0), prctl_arg(0));
 	if (ret < 0)
 		goto out_warn_father;
-
-	ret = lxc_ambient_caps_down();
-	if (ret < 0) {
-		ERROR("Failed to clear ambient capabilities");
-		goto out_warn_father;
-	}
 
 	if (handler->conf->monitor_signal_pdeath != SIGKILL) {
 		ret = lxc_set_death_signal(handler->conf->monitor_signal_pdeath,

--- a/src/lxc/start.c
+++ b/src/lxc/start.c
@@ -1616,8 +1616,8 @@ static int do_start(void *data)
 			goto out_warn_father;
 	}
 
-	if (handler->conf->cap_inheritance) {
-		NOTICE("Inherit capabilities");
+	if (handler->conf->nonroot_keepcaps) {
+		NOTICE("Keep capabilities");
 		ret = lxc_set_keepcaps();
 		if (ret < 0)
 			goto out_warn_father;


### PR DESCRIPTION
Proposed solution for https://github.com/lxc/lxc/issues/4719

If the init process is not run as root, then all capabilities will be dropped.

This adds an option to let the container inherit the requested capabilities when the init process is not root:

lxc.cap.inheritance=1